### PR TITLE
fix(learn): build issue when adding new content

### DIFF
--- a/apps/learn/project.json
+++ b/apps/learn/project.json
@@ -12,12 +12,20 @@
         "cwd": "apps/learn"
       }
     },
+    "reset-next": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "rm -rf .next",
+        "cwd": "apps/learn"
+      }
+    },
     "build": {
       "executor": "nx:run-commands",
       "options": {
         "command": "next build",
         "cwd": "apps/learn"
-      }
+      },
+      "dependsOn": ["reset-next"]
     },
     "build-pages-index": {
       "executor": "nx:run-commands",


### PR DESCRIPTION
# Build Pipeline Temp Fix

for some reason the build command fails when adding new files. A temp fix seems to be resetting the next cache before build. Will investigate further.

## Changes

1. Clean build artifacts (reset-next)
2. Make build depend on `reset-next` task

## Related Issues

- [ ] #243 