### PR TITLE
feat(#376): Setup pagination

### DIFF
--- a/.github/actions/detect-changes/action.yml
+++ b/.github/actions/detect-changes/action.yml
@@ -1,0 +1,17 @@
+name: 'Detect Repository Changes'
+description: 'Detects changes in specific paths of the repository'
+
+outputs:
+  has_migrations:
+    description: 'Whether there are changes in migration files'
+    value: ${{ steps.changes.outputs.migrations }}
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: dorny/paths-filter@v3
+      id: changes
+      with:
+        filters: |
+          migrations:
+            - 'packages/storage-postgres/migrations/**'

--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Delete Neon Branch
-        uses: neondatabase/delete-branch-action@v3.1.3
+        uses: neondatabase/delete-branch-action@v3
         with:
           project_id: ${{ secrets.NEON_PROJECT_ID }}
           branch: preview/pr-${{ github.event.number }}-${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -121,12 +121,10 @@ jobs:
       - run: pnpm run format:check
 
       - name: Get branch name
-        if: needs.detect-changes.outputs.has_migrations == 'true'
         id: branch-name
         uses: tj-actions/branch-names@v8
 
       - name: Create Neon Branch
-        if: needs.detect-changes.outputs.has_migrations == 'true'
         id: create-branch
         uses: neondatabase/create-branch-action@v5
         with:

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -57,7 +57,7 @@ jobs:
         uses: neondatabase/create-branch-action@v5
         with:
           project_id: ${{ env.NEON_PROJECT_ID }}
-          # parent: dev # optional (defaults to your primary branch)
+          parent: main
           branch_name: preview/pr-${{ github.event.number }}-${{ steps.branch-name.outputs.current_branch }}
           username: ${{ env.NEON_DATABASE_USERNAME }}
           database: ${{ env.NEON_DATABASE_NAME }}
@@ -129,7 +129,7 @@ jobs:
         uses: neondatabase/create-branch-action@v5
         with:
           project_id: ${{ env.NEON_PROJECT_ID }}
-          # parent: dev # optional (defaults to your primary branch)
+          parent: main
           branch_name: test/pr-${{ github.event.number }}-${{ steps.branch-name.outputs.current_branch }}
           username: ${{ env.NEON_DATABASE_USERNAME }}
           database: ${{ env.NEON_DATABASE_NAME }}
@@ -145,7 +145,7 @@ jobs:
       - run: npx nx affected --parallel 1 -t e2e
 
       - name: Delete Neon Branch
-        uses: neondatabase/delete-branch-action@v3.1.3
+        uses: neondatabase/delete-branch-action@v3
         with:
           project_id: ${{ secrets.NEON_PROJECT_ID }}
           branch: test/pr-${{ github.event.number }}-${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -11,11 +11,20 @@ env:
   DEFAULT_DB_URL: ${{ secrets.POSTGRES_URL }}
 
 jobs:
-  deploy-preview:
-    permissions: write-all
+  detect-changes:
     runs-on: ubuntu-latest
     outputs:
-      branch_db_url: ${{ steps.set-db-url.outputs.url }}
+      has_migrations: ${{ steps.detect.outputs.has_migrations }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Detect Changes
+        id: detect
+        uses: ./.github/actions/detect-changes
+
+  deploy-preview:
+    needs: detect-changes
+    permissions: write-all
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
@@ -37,20 +46,13 @@ jobs:
       - run: pnpm i
       - uses: nrwl/nx-set-shas@v4
 
-      - uses: dorny/paths-filter@v3
-        id: changes
-        with:
-          filters: |
-            migrations:
-              - 'packages/storage-postgres/migrations/**'
-
       - name: Get branch name
-        if: steps.changes.outputs.migrations == 'true'
+        if: needs.detect-changes.outputs.has_migrations == 'true'
         id: branch-name
         uses: tj-actions/branch-names@v8
 
       - name: Create Neon Branch
-        if: steps.changes.outputs.migrations == 'true'
+        if: needs.detect-changes.outputs.has_migrations == 'true'
         id: create-branch
         uses: neondatabase/create-branch-action@v5
         with:
@@ -68,19 +70,19 @@ jobs:
         run: vercel pull --yes --environment=preview --token=${{ env.VERCEL_TOKEN }}
 
       - name: Run Migrations
-        if: steps.changes.outputs.migrations == 'true'
+        if: needs.detect-changes.outputs.has_migrations == 'true'
         run: |
           echo "BRANCH_DB_URL: ${{ steps.create-branch.outputs.db_url_with_pooler }}" >> .env
           npx nx run storage-postgres:migrate:production
 
       - name: Run Seeds
-        if: steps.changes.outputs.migrations == 'true'
+        if: needs.detect-changes.outputs.has_migrations == 'true'
         run: |
           echo "BRANCH_DB_URL: ${{ steps.create-branch.outputs.db_url_with_pooler }}" >> .env
           npx nx run storage-postgres:seed:production
 
       - name: Post Schema Diff Comment to PR
-        if: steps.changes.outputs.migrations == 'true'
+        if: needs.detect-changes.outputs.has_migrations == 'true'
         uses: neondatabase/schema-diff-action@v1
         with:
           project_id: ${{ secrets.NEON_PROJECT_ID }}
@@ -94,88 +96,9 @@ jobs:
         id: deploy
         run: echo preview_url=$(vercel deploy --prebuilt --token=${{ env.VERCEL_TOKEN }}) >> $GITHUB_OUTPUT
 
-      - name: Comment URL to PR
-        uses: actions/github-script@v6
-        id: comment-deployment-url-script
-        with:
-          script: |
-            // Get pull requests that are open for current ref.
-            const pullRequests = await github.rest.pulls.list({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                state: 'open',
-                head: `${context.repo.owner}:${context.ref.replace('refs/heads/', '')}`
-            })
-
-            // Set issue number for following calls from context (if on pull request event) or from above variable.
-            const issueNumber = context.issue.number || pullRequests.data[0].number
-
-            // Retrieve existing bot comments for the PR
-            const {data: comments} = await github.rest.issues.listComments({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issueNumber,
-            })
-            const botComment = comments.find(comment => {
-                return comment.user.type === 'Bot' && comment.body.includes('The latest updates on your projects')
-            })
-
-            const previewUrl = '${{ steps.deploy.outputs.preview_url }}'
-            const projectName = context.repo.repo
-            const currentTime = new Date().toLocaleString('en-US', {
-                timeZone: 'UTC',
-                month: 'short',
-                day: 'numeric',
-                year: 'numeric',
-                hour: 'numeric',
-                minute: '2-digit',
-                hour12: true
-            })
-
-            const tableHeader = '| Name | Status | Preview | Comments | Updated (UTC) |'
-            const tableDivider = '| :--- | :----- | :------ | :------- | :------ |'
-            const tableRow = `| **${projectName}** | ✅ Ready ([Inspect](${previewUrl})) | [Visit Preview](${previewUrl}) | 💬 [**Add feedback**](https://vercel.live/open-feedback/${previewUrl.split('//')[1]}?via=pr-comment-feedback-link) | ${currentTime} |`
-
-            const output = [
-                '**The latest updates on your projects**. Learn more about [Vercel for Git ↗︎](https://vercel.link/github-learn-more)',
-                '',
-                tableHeader,
-                tableDivider,
-                tableRow
-            ].join('\n')
-
-            // If we have a comment, update it, otherwise create a new one
-            if (botComment) {
-                github.rest.issues.updateComment({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    comment_id: botComment.id,
-                    body: output
-                })
-            } else {
-                github.rest.issues.createComment({
-                    issue_number: issueNumber,
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    body: output
-                })
-            }
-
-      # Set DB URL regardless of migrations
-      - name: Set DB URL
-        id: set-db-url
-        run: |
-          if [ "${{ steps.changes.outputs.migrations }}" == "true" ]; then
-            echo "url=${{ steps.create-branch.outputs.db_url_with_pooler }}" >> $GITHUB_OUTPUT
-          else
-            echo "url=${{ env.DEFAULT_DB_URL }}" >> $GITHUB_OUTPUT
-          fi
-
   main:
-    needs: deploy-preview
+    needs: [deploy-preview, detect-changes]
     runs-on: ubuntu-latest
-    env:
-      BRANCH_DB_URL: ${{ needs.deploy-preview.outputs.branch_db_url }}
 
     steps:
       - uses: actions/checkout@v4
@@ -197,9 +120,35 @@ jobs:
 
       - run: pnpm run format:check
 
+      - name: Get branch name
+        if: needs.detect-changes.outputs.has_migrations == 'true'
+        id: branch-name
+        uses: tj-actions/branch-names@v8
+
+      - name: Create Neon Branch
+        if: needs.detect-changes.outputs.has_migrations == 'true'
+        id: create-branch
+        uses: neondatabase/create-branch-action@v5
+        with:
+          project_id: ${{ env.NEON_PROJECT_ID }}
+          # parent: dev # optional (defaults to your primary branch)
+          branch_name: test/pr-${{ github.event.number }}-${{ steps.branch-name.outputs.current_branch }}
+          username: ${{ env.NEON_DATABASE_USERNAME }}
+          database: ${{ env.NEON_DATABASE_NAME }}
+          api_key: ${{ env.NEON_API_KEY }}
+
       - run: npx nx affected -t lint test build
+        env:
+          BRANCH_DB_URL: ${{ needs.create-branch.outputs.db_url_with_pooler }}
 
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps
 
       - run: npx nx affected --parallel 1 -t e2e
+
+      - name: Delete Neon Branch
+        uses: neondatabase/delete-branch-action@v3.1.3
+        with:
+          project_id: ${{ secrets.NEON_PROJECT_ID }}
+          branch: test/pr-${{ github.event.number }}-${{ github.event.pull_request.head.ref }}
+          api_key: ${{ secrets.NEON_API_KEY }}

--- a/packages/core/project.json
+++ b/packages/core/project.json
@@ -5,5 +5,24 @@
   "projectType": "library",
   "tags": [],
   "// targets": "to see all targets run: nx show project core --web",
-  "targets": {}
+  "targets": {
+    "test": {
+      "executor": "@nx/vite:test",
+      "outputs": ["{workspaceRoot}/coverage/packages/core"],
+      "options": {
+        "passWithNoTests": true,
+        "reportsDirectory": "../../coverage/packages/core"
+      },
+      "configurations": {
+        "local": {
+          "dependsOn": ["db:start"],
+          "env": {
+            "BRANCH_DB_URL": "postgres://postgres:postgres@localhost:5432/postgres",
+            "DEFAULT_DB_URL": "postgres://postgres:postgres@localhost:5432/postgres"
+          }
+        },
+        "production": {}
+      }
+    }
+  }
 }

--- a/packages/core/src/components/people/repository-postgres.spec.ts
+++ b/packages/core/src/components/people/repository-postgres.spec.ts
@@ -8,8 +8,7 @@ import {
 import { eq } from 'drizzle-orm';
 import { PeopleRepositoryPostgres } from './repository-postgres';
 
-// TODO: enable after we have test branches #384
-describe.skip('PeopleRepositoryPostgres', () => {
+describe('PeopleRepositoryPostgres', () => {
   const repository = new PeopleRepositoryPostgres(db);
 
   const peopleToDelete = [];

--- a/packages/core/src/components/people/repository-postgres.spec.ts
+++ b/packages/core/src/components/people/repository-postgres.spec.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import {
+  db,
+  documents,
+  memberships,
+  people,
+} from '@hypha-platform/storage-postgres';
+import { eq } from 'drizzle-orm';
+import { PeopleRepositoryPostgres } from './repository-postgres';
+
+// TODO: enable after we have test branches #384
+describe.skip('PeopleRepositoryPostgres', () => {
+  const repository = new PeopleRepositoryPostgres(db);
+
+  const peopleToDelete = [];
+
+  beforeEach(async () => {
+    // Delete in correct order to handle foreign key constraints
+    await db.delete(memberships);
+    await db.delete(documents);
+    await db.delete(people);
+  });
+
+  // Clean up the database before each test
+  afterAll(async () => {
+    for (const id of peopleToDelete) {
+      // Delete memberships first
+      await db.delete(memberships).where(eq(memberships.personId, id));
+      // Then delete the person
+      await db.delete(people).where(eq(people.id, id));
+    }
+  });
+
+  describe('findAll', () => {
+    it('should return paginated results', async () => {
+      // Arrange: Insert test data
+      const testPeople = [
+        {
+          name: 'John',
+          surname: 'Doe',
+          email: 'john@example.com',
+          slug: 'john-doe',
+        },
+        {
+          name: 'Jane',
+          surname: 'Smith',
+          email: 'jane@example.com',
+          slug: 'jane-smith',
+        },
+        {
+          name: 'Bob',
+          surname: 'Johnson',
+          email: 'bob@example.com',
+          slug: 'bob-johnson',
+        },
+      ];
+
+      const dbPeople = await db.insert(people).values(testPeople).returning();
+      peopleToDelete.push(...dbPeople.map((person) => person.id));
+
+      // Act: Call findAll with pagination
+      const result = await repository.findAll({
+        pagination: { page: 1, pageSize: 2 },
+      });
+
+      // Assert
+      expect(result.data).toHaveLength(2);
+      expect(result.pagination).toEqual({
+        total: 3,
+        page: 1,
+        pageSize: 2,
+        totalPages: 2,
+        hasNextPage: true,
+        hasPreviousPage: false,
+      });
+
+      // Verify the returned data structure
+      expect(result.data[0]).toMatchObject({
+        name: expect.any(String),
+        surname: expect.any(String),
+        email: expect.any(String),
+        slug: expect.any(String),
+        id: expect.any(Number),
+      });
+    });
+
+    it('should return empty results when no people exist', async () => {
+      // Act
+      const result = await repository.findAll({
+        pagination: { page: 1, pageSize: 10 },
+      });
+
+      // Assert
+      expect(result.data).toHaveLength(0);
+      expect(result.pagination).toEqual({
+        total: 0,
+        page: 1,
+        pageSize: 10,
+        totalPages: 0,
+        hasNextPage: false,
+        hasPreviousPage: false,
+      });
+    });
+  });
+});

--- a/packages/core/src/components/people/repository-postgres.ts
+++ b/packages/core/src/components/people/repository-postgres.ts
@@ -37,10 +37,10 @@ export class PeopleRepositoryPostgres implements PeopleRepository {
   }
 
   async findAll(
-    config: PeopleFindAllConfig = { pagination: { page: 1, pageSize: 10 } },
+    config: PeopleFindAllConfig,
   ): Promise<PaginatedResponse<Person>> {
     const {
-      pagination: { page, pageSize, filter },
+      pagination: { page = 1, pageSize = 10 },
     } = config;
 
     const offset = (page - 1) * pageSize;
@@ -93,12 +93,10 @@ export class PeopleRepositoryPostgres implements PeopleRepository {
 
   async findBySpaceId(
     { spaceId }: { spaceId: number },
-    config: PeopleFindBySpaceConfig = {
-      pagination: { page: 1, pageSize: 10 },
-    },
+    config: PeopleFindBySpaceConfig,
   ): Promise<PaginatedResponse<Person>> {
     const {
-      pagination: { page, pageSize, filter },
+      pagination: { page = 1, pageSize = 10 },
     } = config;
 
     const offset = (page - 1) * pageSize;
@@ -150,7 +148,7 @@ export class PeopleRepositoryPostgres implements PeopleRepository {
     config: PeopleFindBySpaceConfig,
   ): Promise<PaginatedResponse<Person>> {
     const {
-      pagination: { page, pageSize, filter },
+      pagination: { page = 1, pageSize = 10 },
     } = config;
 
     const offset = (page - 1) * pageSize;

--- a/packages/core/src/components/people/repository-postgres.ts
+++ b/packages/core/src/components/people/repository-postgres.ts
@@ -59,7 +59,7 @@ export class PeopleRepositoryPostgres implements PeopleRepository {
         nickname: people.nickname,
         createdAt: people.createdAt,
         updatedAt: people.updatedAt,
-        total: sql<number>`count(*) over()`,
+        total: sql<number>`cast(count(*) over() as integer)`,
       })
       .from(people)
       .limit(pageSize)
@@ -117,7 +117,7 @@ export class PeopleRepositoryPostgres implements PeopleRepository {
         nickname: people.nickname,
         createdAt: people.createdAt,
         updatedAt: people.updatedAt,
-        total: sql<number>`count(*) over()`,
+        total: sql<number>`cast(count(*) over() as integer)`,
       })
       .from(people)
       .innerJoin(memberships, eq(memberships.personId, people.id))
@@ -169,7 +169,7 @@ export class PeopleRepositoryPostgres implements PeopleRepository {
         nickname: people.nickname,
         createdAt: people.createdAt,
         updatedAt: people.updatedAt,
-        total: sql<number>`count(*) over()`,
+        total: sql<number>`cast(count(*) over() as integer)`,
       })
       .from(people)
       .innerJoin(memberships, eq(memberships.personId, people.id))

--- a/packages/core/src/components/people/repository.ts
+++ b/packages/core/src/components/people/repository.ts
@@ -1,7 +1,12 @@
 import { Person } from './types';
+import { PaginationParams, PaginatedResponse } from '@hypha-platform/core';
+
+export type PeopleFindAllConfig = {
+  pagination: PaginationParams<Person>;
+};
 
 export interface PeopleRepository {
-  findAll(): Promise<Person[]>;
+  findAll(config: PeopleFindAllConfig): Promise<PaginatedResponse<Person>>;
   findById(id: number): Promise<Person | null>;
   findBySpaceId({ spaceId }: { spaceId: number }): Promise<Person[]>;
   findBySlug({ slug }: { slug: string }): Promise<Person>;

--- a/packages/core/src/components/people/repository.ts
+++ b/packages/core/src/components/people/repository.ts
@@ -5,10 +5,21 @@ export type PeopleFindAllConfig = {
   pagination: PaginationParams<Person>;
 };
 
+export type PeopleFindBySpaceConfig = {
+  pagination: PaginationParams<Person>;
+};
+
 export interface PeopleRepository {
   findAll(config: PeopleFindAllConfig): Promise<PaginatedResponse<Person>>;
   findById(id: number): Promise<Person | null>;
-  findBySpaceId({ spaceId }: { spaceId: number }): Promise<Person[]>;
+  findBySpaceId(
+    { spaceId }: { spaceId: number },
+    config: PeopleFindBySpaceConfig,
+  ): Promise<PaginatedResponse<Person>>;
+  findBySpaceSlug(
+    { spaceSlug }: { spaceSlug: string },
+    config: PeopleFindBySpaceConfig,
+  ): Promise<PaginatedResponse<Person>>;
   findBySlug({ slug }: { slug: string }): Promise<Person>;
   create(person: Person): Promise<Person>;
   update(person: Person): Promise<Person>;

--- a/packages/core/src/components/people/repository.ts
+++ b/packages/core/src/components/people/repository.ts
@@ -1,5 +1,5 @@
+import { PaginatedResponse, PaginationParams } from '../../shared';
 import { Person } from './types';
-import { PaginationParams, PaginatedResponse } from '@hypha-platform/core';
 
 export type PeopleFindAllConfig = {
   pagination: PaginationParams<Person>;

--- a/packages/core/src/components/people/service.ts
+++ b/packages/core/src/components/people/service.ts
@@ -6,7 +6,7 @@ import {
 import { Container } from '../../container/types';
 import { Tokens } from '../../container/tokens';
 import { Person } from './types';
-import { PaginatedResponse } from '@hypha-platform/core';
+import { PaginatedResponse } from '../../shared';
 
 export class PeopleService {
   private repository: PeopleRepository;

--- a/packages/core/src/components/people/service.ts
+++ b/packages/core/src/components/people/service.ts
@@ -1,4 +1,8 @@
-import { PeopleRepository, PeopleFindAllConfig } from './repository';
+import {
+  PeopleRepository,
+  PeopleFindAllConfig,
+  PeopleFindBySpaceConfig,
+} from './repository';
 import { Container } from '../../container/types';
 import { Tokens } from '../../container/tokens';
 import { Person } from './types';
@@ -11,8 +15,20 @@ export class PeopleService {
     this.repository = container.get(Tokens.PeopleRepository);
   }
 
-  async findBySpaceId({ spaceId }: { spaceId: number }): Promise<Person[]> {
-    return this.repository.findBySpaceId({ spaceId });
+  async findBySpaceId(
+    { spaceId }: { spaceId: number },
+    config: PeopleFindBySpaceConfig = {
+      pagination: { page: 1, pageSize: 10 },
+    },
+  ): Promise<PaginatedResponse<Person>> {
+    return this.repository.findBySpaceId({ spaceId }, config);
+  }
+
+  async findBySpaceSlug(
+    { spaceSlug }: { spaceSlug: string },
+    config: PeopleFindBySpaceConfig,
+  ): Promise<PaginatedResponse<Person>> {
+    return this.repository.findBySpaceSlug({ spaceSlug }, config);
   }
 
   async findBySlug({ slug }: { slug: string }): Promise<Person> {

--- a/packages/core/src/components/people/service.ts
+++ b/packages/core/src/components/people/service.ts
@@ -1,7 +1,8 @@
-import { PeopleRepository } from './repository';
+import { PeopleRepository, PeopleFindAllConfig } from './repository';
 import { Container } from '../../container/types';
 import { Tokens } from '../../container/tokens';
 import { Person } from './types';
+import { PaginatedResponse } from '@hypha-platform/core';
 
 export class PeopleService {
   private repository: PeopleRepository;
@@ -22,8 +23,10 @@ export class PeopleService {
     return this.repository.create(person);
   }
 
-  async readAll(): Promise<Person[]> {
-    return this.repository.findAll();
+  async readAll(
+    config: PeopleFindAllConfig,
+  ): Promise<PaginatedResponse<Person>> {
+    return this.repository.findAll(config);
   }
 
   async update(person: Person): Promise<Person> {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,5 +5,6 @@ export * from './container';
 export * from './container/tokens';
 export * from './context/types';
 export * from './components';
+export * from './shared';
 
 export { defaultConfig } from './config/defaults';

--- a/packages/core/src/shared/index.ts
+++ b/packages/core/src/shared/index.ts
@@ -1,0 +1,1 @@
+export * from './types';

--- a/packages/core/src/shared/types.ts
+++ b/packages/core/src/shared/types.ts
@@ -1,0 +1,23 @@
+export type PaginationMetadata = {
+  total: number;
+  page: number;
+  pageSize: number;
+  totalPages: number;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+};
+
+export type PaginatedResponse<T> = {
+  data: T[];
+  pagination: PaginationMetadata;
+};
+
+export type FilterParams<T> = {
+  [key in keyof T]?: string;
+};
+
+export type PaginationParams<T> = {
+  page?: number;
+  pageSize?: number;
+  filter?: FilterParams<T>;
+};

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vite';
+import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+
+export default defineConfig({
+  cacheDir: '../../node_modules/.vite/core',
+  plugins: [nxViteTsPaths()],
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    reporters: ['default'],
+    coverage: {
+      reportsDirectory: '../../coverage/packages/core',
+      provider: 'v8',
+    },
+  },
+});

--- a/packages/epics/src/membership/actions/fetch-members.ts
+++ b/packages/epics/src/membership/actions/fetch-members.ts
@@ -1,12 +1,17 @@
 'use server';
 
 import { getContainer, defaultConfig } from '@hypha-platform/core';
-import { PeopleService } from '@hypha-platform/core';
+import { PeopleService, PeopleFindBySpaceConfig } from '@hypha-platform/core';
 
-export const fetchMembers = async ({ spaceId }: { spaceId: number }) => {
+export const fetchSpaceMemberBySpaceSlug = async (
+  { spaceSlug }: { spaceSlug: string },
+  config: PeopleFindBySpaceConfig = {
+    pagination: { page: 1, pageSize: 10 },
+  },
+) => {
   const container = getContainer(defaultConfig);
   const peopleService = new PeopleService(container);
-  const people = await peopleService.findBySpaceId({ spaceId });
+  const people = await peopleService.findBySpaceSlug({ spaceSlug }, config);
 
   return people;
 };

--- a/packages/epics/src/membership/hooks/use-members.ts
+++ b/packages/epics/src/membership/hooks/use-members.ts
@@ -6,8 +6,9 @@ import {
   PaginationMetadata,
   FilterParams,
 } from '@hypha-platform/graphql/rsc';
-import { fetchMembers } from '../actions/fetch-members';
+import { fetchSpaceMemberBySpaceSlug } from '../actions/fetch-members';
 import { Person } from '@hypha-platform/core';
+import { useSpaceSlug } from '../../space/hooks/use-space-slug';
 
 type UseMembersReturn = {
   members: Person[];
@@ -22,12 +23,18 @@ export const useMembers = ({
   page?: number;
   filter?: FilterParams<MemberItem>;
 }): UseMembersReturn => {
-  const { data: members, isLoading } = useSWR(['members', page, filter], () =>
-    fetchMembers({ spaceId: 1 }),
+  const spaceSlug = useSpaceSlug();
+
+  const { data: response, isLoading } = useSWR(['members', page, filter], () =>
+    fetchSpaceMemberBySpaceSlug(
+      { spaceSlug },
+      { pagination: { page, pageSize: 10 } },
+    ),
   );
 
   return {
-    members: members || [],
+    members: response?.data || [],
+    pagination: response?.pagination,
     isLoading,
   };
 };

--- a/packages/epics/src/space/hooks/use-space-slug.ts
+++ b/packages/epics/src/space/hooks/use-space-slug.ts
@@ -1,0 +1,7 @@
+import { useParams } from 'next/navigation';
+
+export const useSpaceSlug = () => {
+  const params = useParams();
+  console.debug('params', params);
+  return params.id as string;
+};


### PR DESCRIPTION
## Implement Pagination for Member Fetching

### Changes
- Added pagination support for member fetching operations in People repository and service
- Introduced new types for pagination (PaginatedResponse, PaginationParams)
- Updated member fetching to use space slug instead of space ID
- Added proper pagination metadata in API responses
- Refactored member fetching hooks to handle paginated responses

### Default Pagination
- Page size: 10 items
- Starting page: 1

## Tickets

closes #376, closes #384