### PR TITLE
feat(#405): implement get all spaces by member id

### DIFF
--- a/apps/web/src/app/[lang]/dho/[id]/@aside/(.)membership/person/[slug]/loading.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@aside/(.)membership/person/[slug]/loading.tsx
@@ -1,5 +1,5 @@
-import { SidePanel } from '../../../_components/side-panel';
 import { MemberDetail } from '@hypha-platform/epics';
+import { SidePanel } from '@web/app/[lang]/@aside/_components/side-panel';
 
 export default function Loading() {
   return (

--- a/apps/web/src/app/[lang]/dho/[id]/@aside/(.)membership/person/[slug]/page.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@aside/(.)membership/person/[slug]/page.tsx
@@ -1,6 +1,4 @@
 'use client';
-// TODO: refactor
-import { useSpaces } from 'packages/epics/src/membership/hooks/use-spaces';
 
 import { useParams } from 'next/navigation';
 
@@ -15,10 +13,6 @@ import { getDhoPathMembership } from '@web/app/[lang]/dho/[id]/membership/consta
 export default function Member() {
   const { slug, id, lang } = useParams();
   const { person, isLoading } = useMemberBySlug(slug as string);
-  const { spaces } = useSpaces({
-    page: 1,
-    sort: { sort: 'all' },
-  });
 
   return (
     <SidePanel>
@@ -35,7 +29,7 @@ export default function Member() {
         }}
         isLoading={isLoading}
         basePath={getDhoPathAgreements(lang as Locale, id as string)}
-        spaces={spaces}
+        spaces={[]}
       />
     </SidePanel>
   );

--- a/apps/web/src/app/api/v1/people/[personSlug]/spaces/route.ts
+++ b/apps/web/src/app/api/v1/people/[personSlug]/spaces/route.ts
@@ -1,0 +1,27 @@
+import { createPeopleService, createSpaceService } from '@hypha-platform/core';
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(
+  _: NextRequest,
+  { params }: { params: Promise<{ personSlug: string }> },
+) {
+  const { personSlug } = await params;
+  console.debug(`GET /api/v1/people/${personSlug}/spaces`);
+  try {
+    // First, get the person by slug
+    const peopleService = createPeopleService();
+    const person = await peopleService.findBySlug({ slug: personSlug });
+
+    // Then, get all spaces for this person using their ID
+    const spaceService = createSpaceService();
+    const spaces = await spaceService.getAllByMemberId(person.id);
+
+    return NextResponse.json(spaces);
+  } catch (error) {
+    console.error('Failed to fetch spaces for person:', error);
+    return NextResponse.json(
+      { error: 'Failed to fetch spaces for person' },
+      { status: 500 },
+    );
+  }
+}

--- a/packages/core/src/components/space/repository-memory.ts
+++ b/packages/core/src/components/space/repository-memory.ts
@@ -27,4 +27,25 @@ export class SpaceInMemoryRepository implements SpaceRepository {
       leadImage: 'https://example.com/lead-image.png',
     };
   }
+
+  async findAllByMemberId(memberId: number): Promise<Space[]> {
+    return [
+      {
+        id: 1,
+        slug: 'mock-space-1',
+        title: 'Mock Space 1',
+        description: 'Mock Space 1 for member ' + memberId,
+        logoUrl: 'https://example.com/logo.png',
+        leadImage: 'https://example.com/lead-image.png',
+      },
+      {
+        id: 2,
+        slug: 'mock-space-2',
+        title: 'Mock Space 2',
+        description: 'Mock Space 2 for member ' + memberId,
+        logoUrl: 'https://example.com/logo.png',
+        leadImage: 'https://example.com/lead-image.png',
+      },
+    ];
+  }
 }

--- a/packages/core/src/components/space/repository-postgres.ts
+++ b/packages/core/src/components/space/repository-postgres.ts
@@ -1,5 +1,5 @@
 import { asc, eq } from 'drizzle-orm';
-import { db, spaces } from '@hypha-platform/storage-postgres';
+import { db, spaces, memberships } from '@hypha-platform/storage-postgres';
 import { Space } from './types';
 import { SpaceRepository } from './repository';
 
@@ -17,5 +17,16 @@ export class SpacePostgresRepository implements SpaceRepository {
   async findBySlug(slug: string): Promise<Space | null> {
     const results = await db.select().from(spaces).where(eq(spaces.slug, slug));
     return results[0] || null;
+  }
+
+  async findAllByMemberId(memberId: number): Promise<Space[]> {
+    const results = await db
+      .select()
+      .from(spaces)
+      .innerJoin(memberships, eq(memberships.spaceId, spaces.id))
+      .where(eq(memberships.personId, memberId))
+      .orderBy(asc(spaces.title));
+
+    return results.map((row) => row.spaces);
   }
 }

--- a/packages/core/src/components/space/repository.ts
+++ b/packages/core/src/components/space/repository.ts
@@ -5,4 +5,5 @@ export interface SpaceRepository extends Repository {
   findById(id: number): Promise<Space | null>;
   findBySlug(slug: string): Promise<Space | null>;
   findAll(): Promise<Space[]>;
+  findAllByMemberId(memberId: number): Promise<Space[]>;
 }

--- a/packages/core/src/components/space/service.ts
+++ b/packages/core/src/components/space/service.ts
@@ -23,6 +23,10 @@ export class SpaceService {
     return space;
   }
 
+  async getAllByMemberId(memberId: number): Promise<Space[]> {
+    return this.repository.findAllByMemberId(memberId);
+  }
+
   async getBySlug({ slug }: { slug: string }): Promise<Space> {
     const space = await this.repository.findBySlug(slug);
     if (!space) {


### PR DESCRIPTION
API Implementation detail example for: #405

## API `GET /api/v1/people/[personSlug]/spaces/`

```
[
  {
    "id": 6,
    "logoUrl": "https://picsum.photos/seed/4bEz04XUHo/120/120",
    "leadImage": "https://loremflickr.com/762/150?lock=695680271438240",
    "title": "Esses, Volkert and Tim",
    "description": "Etiam euismod mauris non est iaculis dignissim. ",
    "slug": "5VcTRQBwsU91fd0oxw",
    "createdAt": "2026-03-01T19:30:52.786Z",
    "updatedAt": "2022-06-15T19:53:51.302Z"
  },
  {
    "id": 3,
    "logoUrl": "https://loremflickr.com/120/120?lock=4993950387994398",
    "leadImage": "https://loremflickr.com/762/150?lock=6610748257384521",
    "title": "Salvas, Mcguiness and Montalvan",
    "description": "Maecenas non augue nibh. ",
    "slug": "2nlbwELrjV2A9UqX",
    "createdAt": "2022-10-09T13:39:48.646Z",
    "updatedAt": "2023-08-21T16:36:41.456Z"
  }
]
```
