### PR TITLE
Feat/595 governance new components

### DIFF
--- a/packages/epics/src/discussions/components/discussion-head.stories.tsx
+++ b/packages/epics/src/discussions/components/discussion-head.stories.tsx
@@ -14,7 +14,7 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     creator: {
-      avatar: 'https://github.com/shadcn.png',
+      avatarUrl: 'https://github.com/shadcn.png',
       name: 'Name',
       surname: 'Surname',
     },

--- a/packages/epics/src/governance/components/document-card.tsx
+++ b/packages/epics/src/governance/components/document-card.tsx
@@ -65,7 +65,7 @@ export const DocumentCard: React.FC<DocumentCardProps & Document> = ({
           >
             <CardTitle>{title}</CardTitle>
           </Skeleton>
-          <div className="mt-2">
+          <div className="space-y-2">
             <PersonLabel isLoading={isLoading} creator={creator} />
           </div>
         </div>

--- a/packages/epics/src/governance/components/document-card.tsx
+++ b/packages/epics/src/governance/components/document-card.tsx
@@ -33,7 +33,7 @@ export const DocumentCard: React.FC<DocumentCardProps & Document> = ({
   interactions,
 }) => {
   return (
-    <Card className="h-full w-full">
+    <Card className="h-full w-full space-y-5">
       <CardHeader className="p-0 rounded-tl-md rounded-tr-md overflow-hidden h-[150px]">
         <Skeleton
           loading={isLoading}
@@ -50,13 +50,9 @@ export const DocumentCard: React.FC<DocumentCardProps & Document> = ({
           />
         </Skeleton>
       </CardHeader>
-      <CardContent className="pt-5 relative">
-        <div className="flex flex-col items-start mb-5">
-          <BadgesList
-            className="mb-2"
-            isLoading={isLoading}
-            badges={badges ?? []}
-          />
+      <CardContent className="relative space-y-4">
+        <div className="flex flex-col items-start space-y-2">
+          <BadgesList isLoading={isLoading} badges={badges ?? []} />
           <Skeleton
             className="min-w-full"
             width="120px"
@@ -65,11 +61,9 @@ export const DocumentCard: React.FC<DocumentCardProps & Document> = ({
           >
             <CardTitle>{title}</CardTitle>
           </Skeleton>
-          <div className="space-y-2">
-            <PersonLabel isLoading={isLoading} creator={creator} />
-          </div>
+          <PersonLabel isLoading={isLoading} creator={creator} />
         </div>
-        <div className="flex flex-grow text-1 text-neutral-11 mb-4">
+        <div className="flex flex-grow text-1 text-neutral-11">
           <Skeleton
             className="min-w-full"
             width="200px"

--- a/packages/epics/src/governance/components/document-card.tsx
+++ b/packages/epics/src/governance/components/document-card.tsx
@@ -11,16 +11,16 @@ import { type Creator } from '../../people/components/person-label';
 import { type BadgeItem, BadgesList } from '@hypha-platform/ui';
 
 interface Document {
-  title: string;
+  title?: string;
   description?: string;
 }
 
 interface DocumentCardProps {
   isLoading: boolean;
   leadImage?: string;
-  creator: Creator;
+  creator?: Creator;
   badges?: BadgeItem[];
-  interactions: React.ReactNode;
+  interactions?: React.ReactNode;
 }
 
 export const DocumentCard: React.FC<DocumentCardProps & Document> = ({
@@ -44,7 +44,7 @@ export const DocumentCard: React.FC<DocumentCardProps & Document> = ({
           <Image
             className="rounded-tl-xl rounded-tr-xl object-cover w-full h-full"
             src={leadImage || '/placeholder/document-lead-image.png'}
-            alt={title}
+            alt={title || ''}
             width={250}
             height={150}
           />

--- a/packages/epics/src/governance/components/document-card.tsx
+++ b/packages/epics/src/governance/components/document-card.tsx
@@ -65,7 +65,9 @@ export const DocumentCard: React.FC<DocumentCardProps & Document> = ({
           >
             <CardTitle>{title}</CardTitle>
           </Skeleton>
-          <PersonLabel isLoading={isLoading} creator={creator} />
+          <div className="mt-2">
+            <PersonLabel isLoading={isLoading} creator={creator} />
+          </div>
         </div>
         <div className="flex flex-grow text-1 text-neutral-11 mb-4">
           <Skeleton

--- a/packages/epics/src/governance/components/document-details-head.stories.tsx
+++ b/packages/epics/src/governance/components/document-details-head.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { DocumentDetailsHead } from './document-details-head';
+import { within } from '@storybook/testing-library';
+import { expect } from '@storybook/jest';
+
+const meta = {
+  component: DocumentDetailsHead,
+  title: 'Epics/Governance/DocumentDetailsHead',
+} satisfies Meta<typeof DocumentDetailsHead>;
+
+export default meta;
+
+type Story = StoryObj<typeof DocumentDetailsHead>;
+
+export const Default: Story = {
+  args: {
+    creator: {
+      name: 'Name',
+      surname: 'Surname',
+      avatarUrl: 'https://github.com/shadcn.png',
+    },
+    isLoading: false,
+    title: 'Title',
+    badges: [
+      {
+        label: 'agreement',
+        className: 'capitalize',
+        variant: 'solid',
+        colorVariant: 'accent',
+      },
+      {
+        label: '50%',
+        variant: 'outline',
+        colorVariant: 'accent',
+      },
+    ],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(canvas.getByText(/Title/gi)).toBeTruthy();
+  },
+};

--- a/packages/epics/src/governance/components/document-details-head.tsx
+++ b/packages/epics/src/governance/components/document-details-head.tsx
@@ -43,7 +43,7 @@ export const DocumentDetailsHead: React.FC<
             </Text>
           </Skeleton>
           <PersonLabel
-            isLoading={isLoading ?? false}
+            isLoading={isLoading}
             creator={creator}
             hasAvatar={false}
           />

--- a/packages/epics/src/governance/components/document-details-head.tsx
+++ b/packages/epics/src/governance/components/document-details-head.tsx
@@ -3,6 +3,7 @@ import { type Creator } from '../../people/components/person-label';
 import { type BadgeItem, BadgesList } from '@hypha-platform/ui';
 import { PersonAvatar } from '../../people/components/person-avatar';
 import { Text } from '@radix-ui/themes';
+import { PersonLabel } from '../../people/components/person-label';
 
 interface DocumentDetailsHeadProps {
   isLoading?: boolean;
@@ -41,12 +42,11 @@ export const DocumentDetailsHead: React.FC<
               {title}
             </Text>
           </Skeleton>
-
-          <Skeleton height="16px" width="80px" loading={isLoading}>
-            <Text className="text-1 text-neutral-11">
-              {creator?.name} {creator?.surname}
-            </Text>
-          </Skeleton>
+          <PersonLabel
+            isLoading={isLoading ?? false}
+            creator={creator}
+            hasAvatar={false}
+          />
         </div>
       </div>
     </div>

--- a/packages/epics/src/governance/components/document-details-head.tsx
+++ b/packages/epics/src/governance/components/document-details-head.tsx
@@ -1,0 +1,57 @@
+import { Skeleton } from '@hypha-platform/ui';
+import { type Creator } from '../../people/components/person-label';
+import { type BadgeItem, BadgesList } from '@hypha-platform/ui';
+import { PersonAvatar } from '../../people/components/person-avatar';
+import { Text } from '@radix-ui/themes';
+
+interface DocumentDetailsHeadProps {
+  isLoading?: boolean;
+  creator?: Creator;
+  badges?: BadgeItem[];
+}
+
+interface Document {
+  id?: number;
+  creatorId?: number;
+  title?: string;
+  description?: string;
+}
+
+export const DocumentDetailsHead: React.FC<DocumentDetailsHeadProps & Document> = ({
+  isLoading,
+  title,
+  creator,
+  badges,
+}) => {
+  return (
+    <div className="w-full h-full p-5 flex items-center space-x-3">
+      <PersonAvatar
+        avatarSrc={creator?.avatarUrl}
+        userName={`${creator?.name} ${creator?.surname}`}
+        isLoading={isLoading}
+        size="lg"
+      />
+      <div className="flex justify-between items-center w-full">
+        <div className="grid">
+          <BadgesList isLoading={isLoading} badges={badges ?? []} />
+          <Skeleton
+            height="26px"
+            width="160px"
+            loading={isLoading}
+            className="my-1"
+          >
+            <Text className="text-4 text-ellipsis overflow-hidden text-nowrap mr-3">
+              {title}
+            </Text>
+          </Skeleton>
+
+          <Skeleton height="16px" width="80px" loading={isLoading}>
+            <Text className="text-1 text-neutral-11">
+              {creator?.name} {creator?.surname}
+            </Text>
+          </Skeleton>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/packages/epics/src/governance/components/document-details-head.tsx
+++ b/packages/epics/src/governance/components/document-details-head.tsx
@@ -17,12 +17,9 @@ interface Document {
   description?: string;
 }
 
-export const DocumentDetailsHead: React.FC<DocumentDetailsHeadProps & Document> = ({
-  isLoading,
-  title,
-  creator,
-  badges,
-}) => {
+export const DocumentDetailsHead: React.FC<
+  DocumentDetailsHeadProps & Document
+> = ({ isLoading, title, creator, badges }) => {
   return (
     <div className="w-full h-full p-5 flex items-center space-x-3">
       <PersonAvatar

--- a/packages/epics/src/governance/components/document-grid.stories.tsx
+++ b/packages/epics/src/governance/components/document-grid.stories.tsx
@@ -1,0 +1,102 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { DocumentGrid } from './document-grid';
+import { within } from '@storybook/testing-library';
+import { expect } from '@storybook/jest';
+
+const meta = {
+  component: DocumentGrid,
+  title: 'Epics/Governance/DocumentGrid',
+} satisfies Meta<typeof DocumentGrid>;
+
+export default meta;
+
+type Story = StoryObj<typeof DocumentGrid>;
+
+export const Default: Story = {
+  args: {
+    isLoading: false,
+    basePath: '',
+    documents: [
+      {
+        title: 'Title 1',
+        description:
+          'Lorem ipsum dolor sit amet, consectetur adipiscing elit. In sed dolor malesuada, placerat risus eget, vulputate elit. Fusce pulvinar augue et ornare iaculis.',
+        leadImage: '',
+        creator: {
+          name: 'Name',
+          surname: 'Surname',
+          avatarUrl: 'https://github.com/shadcn.png',
+        },
+        badges: [
+          {
+            label: 'agreement',
+            className: 'capitalize',
+            variant: 'solid',
+            colorVariant: 'accent',
+          },
+          {
+            label: '50%',
+            variant: 'outline',
+            colorVariant: 'accent',
+          },
+        ],
+        slug: 'test-slug',
+      },
+      {
+        title: 'Title 2',
+        description:
+          'Lorem ipsum dolor sit amet, consectetur adipiscing elit. In sed dolor malesuada, placerat risus eget, vulputate elit. Fusce pulvinar augue et ornare iaculis.',
+        leadImage: '',
+        creator: {
+          name: 'Name',
+          surname: 'Surname',
+          avatarUrl: 'https://github.com/shadcn.png',
+        },
+        badges: [
+          {
+            label: 'agreement',
+            className: 'capitalize',
+            variant: 'solid',
+            colorVariant: 'accent',
+          },
+          {
+            label: '50%',
+            variant: 'outline',
+            colorVariant: 'accent',
+          },
+        ],
+        slug: 'test-slug',
+      },
+      {
+        title: 'Title 3',
+        description:
+          'Lorem ipsum dolor sit amet, consectetur adipiscing elit. In sed dolor malesuada, placerat risus eget, vulputate elit. Fusce pulvinar augue et ornare iaculis.',
+        leadImage: '',
+        creator: {
+          name: 'Name',
+          surname: 'Surname',
+          avatarUrl: 'https://github.com/shadcn.png',
+        },
+        badges: [
+          {
+            label: 'agreement',
+            className: 'capitalize',
+            variant: 'solid',
+            colorVariant: 'accent',
+          },
+          {
+            label: '50%',
+            variant: 'outline',
+            colorVariant: 'accent',
+          },
+        ],
+        slug: 'test-slug',
+      },
+    ],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(canvas.getByText(/Title 1/gi)).toBeTruthy();
+  },
+};

--- a/packages/epics/src/governance/components/document-grid.tsx
+++ b/packages/epics/src/governance/components/document-grid.tsx
@@ -1,0 +1,42 @@
+import { type BadgeItem } from '@hypha-platform/ui';
+import { type Creator } from '../../people/components/person-label';
+import { DocumentCard } from './document-card';
+import Link from 'next/link';
+
+interface Document {
+  title?: string;
+  description?: string;
+  leadImage?: string;
+  creator?: Creator;
+  badges?: BadgeItem[];
+  slug?: string;
+  interactions?: React.ReactNode;
+}
+
+interface DocumentGridProps {
+  isLoading: boolean;
+  basePath: string;
+  documents: Document[];
+}
+
+export const DocumentGrid = ({
+  isLoading = true,
+  basePath,
+  documents,
+}: DocumentGridProps) => {
+  return (
+    <div className="w-full">
+      <div className="w-full grid grid-cols-1 sm:grid-cols-3 space-x-2">
+        {documents.map((document) => (
+          <Link
+            href={`${basePath}/${document.slug}`}
+            key={document.slug}
+            scroll={false}
+          >
+            <DocumentCard {...document} isLoading={isLoading} />
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/packages/epics/src/governance/components/document-list-card.stories.tsx
+++ b/packages/epics/src/governance/components/document-list-card.stories.tsx
@@ -23,7 +23,6 @@ export const Default: Story = {
     },
     isLoading: false,
     title: 'Title',
-    state: 'agreement',
     badges: [
       {
         label: 'agreement',

--- a/packages/epics/src/governance/components/document-list-card.tsx
+++ b/packages/epics/src/governance/components/document-list-card.tsx
@@ -12,8 +12,6 @@ interface DocumentListCardProps {
 }
 
 interface Document {
-  id?: number;
-  creatorId?: number;
   title?: string;
   description?: string;
 }

--- a/packages/epics/src/governance/components/document-list-card.tsx
+++ b/packages/epics/src/governance/components/document-list-card.tsx
@@ -13,7 +13,6 @@ interface DocumentListCardProps {
 
 interface Document {
   title?: string;
-  description?: string;
 }
 
 export const DocumentListCard: React.FC<DocumentListCardProps & Document> = ({

--- a/packages/epics/src/governance/components/document-list-card.tsx
+++ b/packages/epics/src/governance/components/document-list-card.tsx
@@ -6,26 +6,21 @@ import { Text } from '@radix-ui/themes';
 
 interface DocumentListCardProps {
   isLoading?: boolean;
-  creator: Creator;
+  creator?: Creator;
   badges?: BadgeItem[];
   interactions?: React.ReactNode;
 }
 
 interface Document {
-  id: number;
-  creatorId: number;
-  title: string;
+  id?: number;
+  creatorId?: number;
+  title?: string;
   description?: string;
-  slug: string;
-  state: 'agreement' | 'discussion' | 'proposal';
-  createdAt: Date;
-  updatedAt: Date;
 }
 
 export const DocumentListCard: React.FC<DocumentListCardProps & Document> = ({
   isLoading,
   title,
-  state,
   creator,
   badges,
   interactions,

--- a/packages/epics/src/governance/components/document-list.stories.tsx
+++ b/packages/epics/src/governance/components/document-list.stories.tsx
@@ -1,0 +1,102 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { DocumentList } from './document-list';
+import { within } from '@storybook/testing-library';
+import { expect } from '@storybook/jest';
+
+const meta = {
+  component: DocumentList,
+  title: 'Epics/Governance/DocumentList',
+} satisfies Meta<typeof DocumentList>;
+
+export default meta;
+
+type Story = StoryObj<typeof DocumentList>;
+
+export const Default: Story = {
+  args: {
+    isLoading: false,
+    basePath: '',
+    documents: [
+      {
+        title: 'Title 1',
+        description:
+          'Lorem ipsum dolor sit amet, consectetur adipiscing elit. In sed dolor malesuada, placerat risus eget, vulputate elit. Fusce pulvinar augue et ornare iaculis.',
+        leadImage: '',
+        creator: {
+          name: 'Name',
+          surname: 'Surname',
+          avatarUrl: 'https://github.com/shadcn.png',
+        },
+        badges: [
+          {
+            label: 'agreement',
+            className: 'capitalize',
+            variant: 'solid',
+            colorVariant: 'accent',
+          },
+          {
+            label: '50%',
+            variant: 'outline',
+            colorVariant: 'accent',
+          },
+        ],
+        slug: 'test-slug',
+      },
+      {
+        title: 'Title 2',
+        description:
+          'Lorem ipsum dolor sit amet, consectetur adipiscing elit. In sed dolor malesuada, placerat risus eget, vulputate elit. Fusce pulvinar augue et ornare iaculis.',
+        leadImage: '',
+        creator: {
+          name: 'Name',
+          surname: 'Surname',
+          avatarUrl: 'https://github.com/shadcn.png',
+        },
+        badges: [
+          {
+            label: 'agreement',
+            className: 'capitalize',
+            variant: 'solid',
+            colorVariant: 'accent',
+          },
+          {
+            label: '50%',
+            variant: 'outline',
+            colorVariant: 'accent',
+          },
+        ],
+        slug: 'test-slug',
+      },
+      {
+        title: 'Title 3',
+        description:
+          'Lorem ipsum dolor sit amet, consectetur adipiscing elit. In sed dolor malesuada, placerat risus eget, vulputate elit. Fusce pulvinar augue et ornare iaculis.',
+        leadImage: '',
+        creator: {
+          name: 'Name',
+          surname: 'Surname',
+          avatarUrl: 'https://github.com/shadcn.png',
+        },
+        badges: [
+          {
+            label: 'agreement',
+            className: 'capitalize',
+            variant: 'solid',
+            colorVariant: 'accent',
+          },
+          {
+            label: '50%',
+            variant: 'outline',
+            colorVariant: 'accent',
+          },
+        ],
+        slug: 'test-slug',
+      },
+    ],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(canvas.getByText(/Title 1/gi)).toBeTruthy();
+  },
+};

--- a/packages/epics/src/governance/components/document-list.tsx
+++ b/packages/epics/src/governance/components/document-list.tsx
@@ -1,0 +1,81 @@
+import { DocumentCard } from './document-card';
+import { DocumentListCard } from './document-list-card';
+import { UseDocuments } from '../../governance';
+import Link from 'next/link';
+import { cn } from '@hypha-platform/lib/utils';
+
+interface DocumentListProps {
+  page: number;
+  basePath: string;
+  useDocuments: UseDocuments;
+  hasGridView: boolean;
+}
+
+interface GridLoadersProps {
+  isLoading: boolean;
+}
+
+interface ListLoadersProps {
+  isLoading: boolean;
+}
+
+export const DocumentList = ({
+  page,
+  basePath,
+  useDocuments,
+  hasGridView,
+}: DocumentListProps) => {
+  const { documents, isLoading } = useDocuments({
+    page,
+    filter: { state: '' },
+  });
+
+  const GridLoaders = ({ isLoading }: GridLoadersProps) => {
+    return isLoading ? (
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-2 mt-2">
+        <DocumentCard isLoading={isLoading} />
+        <DocumentCard isLoading={isLoading} />
+        <DocumentCard isLoading={isLoading} />
+      </div>
+    ) : null;
+  };
+
+  const ListLoaders = ({ isLoading }: ListLoadersProps) => {
+    return isLoading ? (
+      <div>
+        <DocumentListCard isLoading={isLoading} />
+        <DocumentListCard isLoading={isLoading} />
+        <DocumentListCard isLoading={isLoading} />
+      </div>
+    ) : null;
+  };
+
+  return (
+    <div className="w-full">
+      <div
+        className={cn(
+          hasGridView ? '' : 'grid grid-cols-1 sm:grid-cols-3 gap-2 mt-2',
+        )}
+      >
+        {documents.map((document) => (
+          <Link
+            href={`${basePath}/${document.slug}`}
+            key={document.slug}
+            scroll={false}
+          >
+            {hasGridView ? (
+              <DocumentListCard {...document} isLoading={isLoading} />
+            ) : (
+              <DocumentCard {...document} isLoading={isLoading} />
+            )}
+          </Link>
+        ))}
+      </div>
+      {hasGridView ? (
+        <GridLoaders isLoading={isLoading} />
+      ) : (
+        <ListLoaders isLoading={isLoading} />
+      )}
+    </div>
+  );
+};

--- a/packages/epics/src/governance/components/document-list.tsx
+++ b/packages/epics/src/governance/components/document-list.tsx
@@ -1,81 +1,40 @@
-import { DocumentCard } from './document-card';
 import { DocumentListCard } from './document-list-card';
-import { UseDocuments } from '../../governance';
+import { type BadgeItem } from '@hypha-platform/ui';
+import { type Creator } from '../../people/components/person-label';
 import Link from 'next/link';
-import { cn } from '@hypha-platform/lib/utils';
+
+interface Document {
+  title?: string;
+  description?: string;
+  leadImage?: string;
+  creator?: Creator;
+  badges?: BadgeItem[];
+  slug?: string;
+  interactions?: React.ReactNode;
+}
 
 interface DocumentListProps {
-  page: number;
+  isLoading: boolean;
   basePath: string;
-  useDocuments: UseDocuments;
-  hasGridView: boolean;
-}
-
-interface GridLoadersProps {
-  isLoading: boolean;
-}
-
-interface ListLoadersProps {
-  isLoading: boolean;
+  documents: Document[];
 }
 
 export const DocumentList = ({
-  page,
+  isLoading = true,
   basePath,
-  useDocuments,
-  hasGridView,
+  documents,
 }: DocumentListProps) => {
-  const { documents, isLoading } = useDocuments({
-    page,
-    filter: { state: '' },
-  });
-
-  const GridLoaders = ({ isLoading }: GridLoadersProps) => {
-    return isLoading ? (
-      <div className="grid grid-cols-1 sm:grid-cols-3 gap-2 mt-2">
-        <DocumentCard isLoading={isLoading} />
-        <DocumentCard isLoading={isLoading} />
-        <DocumentCard isLoading={isLoading} />
-      </div>
-    ) : null;
-  };
-
-  const ListLoaders = ({ isLoading }: ListLoadersProps) => {
-    return isLoading ? (
-      <div>
-        <DocumentListCard isLoading={isLoading} />
-        <DocumentListCard isLoading={isLoading} />
-        <DocumentListCard isLoading={isLoading} />
-      </div>
-    ) : null;
-  };
-
   return (
-    <div className="w-full">
-      <div
-        className={cn(
-          hasGridView ? 'grid grid-cols-1 sm:grid-cols-3 gap-2 mt-2' : '',
-        )}
-      >
-        {documents.map((document) => (
-          <Link
-            href={`${basePath}/${document.slug}`}
-            key={document.slug}
-            scroll={false}
-          >
-            {hasGridView ? (
-              <DocumentCard {...document} isLoading={isLoading} />
-            ) : (
-              <DocumentListCard {...document} isLoading={isLoading} />
-            )}
-          </Link>
-        ))}
-      </div>
-      {hasGridView ? (
-        <GridLoaders isLoading={isLoading} />
-      ) : (
-        <ListLoaders isLoading={isLoading} />
-      )}
+    <div className="w-full space-y-2 flex flex-col">
+      {documents.map((document) => (
+        <Link
+          href={`${basePath}/${document.slug}`}
+          key={document.slug}
+          scroll={false}
+        >
+          <DocumentListCard {...document} isLoading={isLoading} />
+        </Link>
+      ))}
     </div>
   );
 };

--- a/packages/epics/src/governance/components/document-list.tsx
+++ b/packages/epics/src/governance/components/document-list.tsx
@@ -54,7 +54,7 @@ export const DocumentList = ({
     <div className="w-full">
       <div
         className={cn(
-          hasGridView ? '' : 'grid grid-cols-1 sm:grid-cols-3 gap-2 mt-2',
+          hasGridView ? 'grid grid-cols-1 sm:grid-cols-3 gap-2 mt-2' : '',
         )}
       >
         {documents.map((document) => (
@@ -64,9 +64,9 @@ export const DocumentList = ({
             scroll={false}
           >
             {hasGridView ? (
-              <DocumentListCard {...document} isLoading={isLoading} />
-            ) : (
               <DocumentCard {...document} isLoading={isLoading} />
+            ) : (
+              <DocumentListCard {...document} isLoading={isLoading} />
             )}
           </Link>
         ))}

--- a/packages/epics/src/people/components/person-label.tsx
+++ b/packages/epics/src/people/components/person-label.tsx
@@ -10,7 +10,7 @@ export interface Creator {
 
 interface PersonLabelProps {
   creator?: Creator;
-  isLoading: boolean;
+  isLoading?: boolean;
   hasAvatar?: boolean;
 }
 
@@ -23,7 +23,7 @@ export const PersonLabel = ({
     <div className="flex items-center">
       {hasAvatar ? (
         <PersonAvatar
-          className="mr-2"
+          className="space-x-2"
           isLoading={isLoading}
           size="sm"
           avatarSrc={creator?.avatarUrl}

--- a/packages/epics/src/people/components/person-label.tsx
+++ b/packages/epics/src/people/components/person-label.tsx
@@ -20,10 +20,9 @@ export const PersonLabel = ({
   hasAvatar = true,
 }: PersonLabelProps) => {
   return (
-    <div className="flex items-center">
+    <div className="flex items-center space-x-2">
       {hasAvatar ? (
         <PersonAvatar
-          className="space-x-2"
           isLoading={isLoading}
           size="sm"
           avatarSrc={creator?.avatarUrl}

--- a/packages/epics/src/people/components/person-label.tsx
+++ b/packages/epics/src/people/components/person-label.tsx
@@ -20,9 +20,10 @@ export const PersonLabel = ({
   hasAvatar = true,
 }: PersonLabelProps) => {
   return (
-    <div className="mt-2 flex items-center">
+    <div className="flex items-center">
       {hasAvatar ? (
         <PersonAvatar
+          className="mr-2"
           isLoading={isLoading}
           size="sm"
           avatarSrc={creator?.avatarUrl}
@@ -30,8 +31,8 @@ export const PersonLabel = ({
         />
       ) : null}
 
-      <Skeleton width="50px" height="16px" className="ml-2" loading={isLoading}>
-        <Text className="ml-2 text-1 text-neutral-11">
+      <Skeleton width="50px" height="16px" loading={isLoading}>
+        <Text className="text-1 text-neutral-11">
           {creator?.name} {creator?.surname}
         </Text>
       </Skeleton>

--- a/packages/storage-postgres/src/seed.ts
+++ b/packages/storage-postgres/src/seed.ts
@@ -7,13 +7,13 @@ import { documents, memberships, people, schema, spaces } from './schema';
 
 const AVATAR_URLS = Array.from({ length: 10 }, () => faker.image.avatar());
 const SPACE_LOGO_URLS = Array.from({ length: 10 }, () =>
-  faker.image.url({
+  faker.image.urlPicsumPhotos({
     width: 120,
     height: 120,
   }),
 );
 const SPACE_LEAD_IMAGE_URLS = Array.from({ length: 10 }, () =>
-  faker.image.url({
+  faker.image.urlPicsumPhotos({
     width: 762,
     height: 150,
   }),


### PR DESCRIPTION
Added new document components and updated existing ones to improve flexibility with optional props.

### What`s done?

- Created new `DocumentDetailsHead` component with corresponding story
- Created new `DocumentList` component for displaying documents in grid or list view
- Updated `DocumentCard` and `DocumentListCard` components to make several props optional:
  - Made `title`, `creator`, and `interactions` optional in `DocumentCard`
  - Made `creator` optional in `DocumentListCard`
  - Removed required `state` prop from `DocumentListCard`
- Fixed avatar property name in `discussion-head.stories.tsx` from `avatar` to `avatarUrl`
