### PR TITLE
Feat/623 reorganization agreements tab

### DIFF
--- a/apps/web/src/app/[lang]/dho/[id]/@aside/(.)agreements/[documentSlug]/page.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@aside/(.)agreements/[documentSlug]/page.tsx
@@ -19,10 +19,9 @@ export default function Agreements() {
         onSetActiveFilter={() => console.log('set active filter')}
         content={document?.description || ''}
         creator={{
-          avatarUrl:
-            'https://images.unsplash.com/photo-1544005313-94ddf0286df2?&w=64&h=64&dpr=2&q=70&crop=faces&fit=crop',
-          name: 'Jane',
-          surname: 'Doe',
+          avatarUrl: document?.creator?.avatarUrl || '',
+          name: document?.creator?.name || '',
+          surname: document?.creator?.surname || '',
         }}
         title={document?.title}
         commitment={50}

--- a/apps/web/src/app/[lang]/dho/[id]/@aside/(.)proposals/[documentSlug]/page.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@aside/(.)proposals/[documentSlug]/page.tsx
@@ -22,10 +22,9 @@ export default function Agreements() {
         onSetActiveFilter={() => console.log('set active filter')}
         content={document?.description}
         creator={{
-          avatar:
-            'https://images.unsplash.com/photo-1544005313-94ddf0286df2?&w=64&h=64&dpr=2&q=70&crop=faces&fit=crop',
-          name: 'Jane',
-          surname: 'Doe',
+          avatar: document?.creator?.avatarUrl || '',
+          name: document?.creator?.name || '',
+          surname: document?.creator?.surname || '',
         }}
         title={document?.title}
         status={document?.state}

--- a/apps/web/src/app/[lang]/dho/[id]/agreements/[documentSlug]/page.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/agreements/[documentSlug]/page.tsx
@@ -22,10 +22,9 @@ export default function Agreements(props: PageProps) {
       onSetActiveFilter={() => console.log('set active filter')}
       content={document?.description || ''}
       creator={{
-        avatarUrl:
-          'https://images.unsplash.com/photo-1544005313-94ddf0286df2?&w=64&h=64&dpr=2&q=70&crop=faces&fit=crop',
-        name: 'Jane',
-        surname: 'Doe',
+        avatarUrl: document?.creator?.avatarUrl || '',
+        name: document?.creator?.name || '',
+        surname: document?.creator?.surname || '',
       }}
       title={document?.title}
       commitment={50}

--- a/apps/web/src/app/[lang]/dho/[id]/agreements/page.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/agreements/page.tsx
@@ -22,18 +22,31 @@ export default async function AgreementsPage(props: PageProps) {
     <div className="flex flex-col gap-6 py-4">
       <NavigationTabs lang={lang} id={id} activeTab="agreements" />
       <DocumentSection
-        basePath={`${basePath}/discussions`}
+        basePath={`${basePath}/proposals`}
         useDocuments={useSpaceDocuments}
-        documentState="discussion"
+        documentState="onVoting"
+        label="On Voting"
       />
-      <ProposalsSection
+      <DocumentSection
+        basePath={`${basePath}/agreements`}
+        useDocuments={useSpaceDocuments}
+        documentState="active"
+        label="Active"
+      />
+      <DocumentSection
+        basePath={`${basePath}/agreements`}
+        useDocuments={useSpaceDocuments}
+        documentState="completed"
+        label="Completed"
+      />
+      {/* <ProposalsSection
         basePath={`${basePath}/proposals`}
         useDocuments={useSpaceDocuments}
       />
       <AgreementsSection
         basePath={`${basePath}/agreements`}
         useDocuments={useSpaceDocuments}
-      />
+      /> */}
     </div>
   );
 }

--- a/apps/web/src/app/[lang]/dho/[id]/agreements/page.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/agreements/page.tsx
@@ -1,9 +1,5 @@
 import { Locale } from '@hypha-platform/i18n';
-import {
-  AgreementsSection,
-  ProposalsSection,
-  DocumentSection,
-} from '@hypha-platform/epics';
+import { DocumentSection } from '@hypha-platform/epics';
 import { NavigationTabs } from '../_components/navigation-tabs';
 import { useSpaceDocuments } from '@web/hooks/use-space-documents';
 
@@ -24,29 +20,21 @@ export default async function AgreementsPage(props: PageProps) {
       <DocumentSection
         basePath={`${basePath}/proposals`}
         useDocuments={useSpaceDocuments}
-        documentState="onVoting"
-        label="On Voting"
+        documentState="proposal"
+        label="Proposals"
       />
       <DocumentSection
         basePath={`${basePath}/agreements`}
         useDocuments={useSpaceDocuments}
-        documentState="active"
-        label="Active"
+        documentState="agreement"
+        label="Agreements"
       />
       <DocumentSection
         basePath={`${basePath}/agreements`}
         useDocuments={useSpaceDocuments}
-        documentState="completed"
-        label="Completed"
+        documentState="agreement"
+        label="History"
       />
-      {/* <ProposalsSection
-        basePath={`${basePath}/proposals`}
-        useDocuments={useSpaceDocuments}
-      />
-      <AgreementsSection
-        basePath={`${basePath}/agreements`}
-        useDocuments={useSpaceDocuments}
-      /> */}
     </div>
   );
 }

--- a/apps/web/src/app/[lang]/dho/[id]/proposals/[documentSlug]/page.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/proposals/[documentSlug]/page.tsx
@@ -23,12 +23,10 @@ export default function Proposal(props: PageProps) {
       onReject={() => console.log('reject')}
       onSetActiveFilter={() => console.log('set active filter')}
       content={document?.description}
-      // TODO: connect to api
       creator={{
-        avatar:
-          'https://images.unsplash.com/photo-1544005313-94ddf0286df2?&w=64&h=64&dpr=2&q=70&crop=faces&fit=crop',
-        name: 'Jane',
-        surname: 'Doe',
+        avatar: document?.creator?.avatarUrl || '',
+        name: document?.creator?.name || '',
+        surname: document?.creator?.surname || '',
       }}
       title={document?.title}
       commitment={50}

--- a/apps/web/src/app/[lang]/profile/page.tsx
+++ b/apps/web/src/app/[lang]/profile/page.tsx
@@ -86,7 +86,7 @@ export default function Profile() {
           <DocumentSection
             basePath=""
             useDocuments={useSpaceDocuments}
-            documentState="discussion"
+            documentState="completed"
           />
         </TabsContent>
       </Tabs>

--- a/apps/web/src/app/[lang]/profile/page.tsx
+++ b/apps/web/src/app/[lang]/profile/page.tsx
@@ -86,7 +86,7 @@ export default function Profile() {
           <DocumentSection
             basePath=""
             useDocuments={useSpaceDocuments}
-            documentState="completed"
+            documentState="proposal"
           />
         </TabsContent>
       </Tabs>

--- a/apps/web/src/hooks/use-space-documents.ts
+++ b/apps/web/src/hooks/use-space-documents.ts
@@ -46,8 +46,36 @@ export const useSpaceDocuments: UseDocuments = ({
     { revalidateOnFocus: true },
   );
 
+  const getDocumentBadges = (document: Document) => {
+    switch (document.state) {
+      case 'proposal':
+        return [
+          {
+            label: 'Proposal',
+            className: 'capitalize',
+            variant: 'solid',
+            colorVariant: 'accent',
+          },
+          {
+            label: 'On voting',
+            className: 'capitalize',
+            variant: 'outline',
+            colorVariant: 'warn',
+          },
+        ];
+      // TODO: added badges for other states when we have a completion state
+    }
+  };
+
+  const parsedData = response?.data.map((document: Document) => {
+    return {
+      ...document,
+      badges: getDocumentBadges(document),
+    };
+  });
+
   return {
-    documents: response?.data || [],
+    documents: parsedData || [],
     pagination: response?.pagination,
     isLoading,
   };

--- a/apps/web/src/hooks/use-space-documents.ts
+++ b/apps/web/src/hooks/use-space-documents.ts
@@ -15,10 +15,12 @@ export const useSpaceDocuments: UseDocuments = ({
   page = 1,
   pageSize = 4,
   filter,
+  activeTab,
 }: {
   page?: number;
   pageSize?: number;
   filter?: FilterParams<Pick<Document, 'state'>>;
+  activeTab?: string;
 }): UseDocumentsReturn => {
   const spaceSlug = useSpaceSlug();
 

--- a/packages/core/src/governance/types.ts
+++ b/packages/core/src/governance/types.ts
@@ -1,3 +1,9 @@
+export type Creator = {
+  avatarUrl?: string;
+  name?: string;
+  surname?: string;
+};
+
 export enum DocumentState {
   DISCUSSION = 'discussion',
   PROPOSAL = 'proposal',
@@ -13,4 +19,5 @@ export type Document = {
   state: DocumentState;
   createdAt: Date;
   updatedAt: Date;
+  creator?: Creator;
 };

--- a/packages/epics/src/governance/components/document-grid.container.tsx
+++ b/packages/epics/src/governance/components/document-grid.container.tsx
@@ -5,14 +5,16 @@ type DocumentGridContainerProps = {
   basePath: string;
   pagination: UseDocumentsProps;
   useDocuments: UseDocuments;
+  activeTab: string;
 };
 
 export const DocumentGridContainer = ({
   basePath,
   pagination,
   useDocuments,
+  activeTab,
 }: DocumentGridContainerProps) => {
-  const { documents, isLoading } = useDocuments({ ...pagination });
+  const { documents, isLoading } = useDocuments({ ...pagination, activeTab });
   return (
     <DocumentGrid
       documents={documents}

--- a/packages/epics/src/governance/components/document-section.tsx
+++ b/packages/epics/src/governance/components/document-section.tsx
@@ -12,7 +12,6 @@ import { PlusIcon } from '@radix-ui/react-icons';
 import Link from 'next/link';
 import { DocumentState, UseDocuments } from '..';
 import { DocumentGridContainer } from './document-grid.container';
-import { useDocumentsFilter } from '../hooks/use-documents-filter';
 
 type DocumentSectionProps = {
   basePath: string;
@@ -25,7 +24,6 @@ export const DocumentSection: FC<DocumentSectionProps> = ({
   useDocuments,
   documentState,
 }) => {
-  const { filter } = useDocumentsFilter({ documentState: documentState });
   const {
     pages,
     activeFilter,
@@ -34,6 +32,9 @@ export const DocumentSection: FC<DocumentSectionProps> = ({
     loadMore,
     pagination,
     sortOptions,
+    tabs,
+    activeTab,
+    setActiveTab,
   } = useDocumentsSection({ useDocuments, documentState: documentState });
 
   return (
@@ -54,9 +55,9 @@ export const DocumentSection: FC<DocumentSectionProps> = ({
       </SectionFilter>
       {pagination?.totalPages === 0 ? null : (
         <SectionTabs
-          activeTab={activeFilter}
-          setActiveTab={setActiveFilter}
-          tabs={filter || []}
+          activeTab={activeTab}
+          setActiveTab={setActiveTab}
+          tabs={tabs || []}
         />
       )}
       {pagination?.totalPages === 0 ? (
@@ -73,6 +74,7 @@ export const DocumentSection: FC<DocumentSectionProps> = ({
                 filter: { state: documentState },
               }}
               useDocuments={useDocuments}
+              activeTab={activeTab}
             />
           ))}
         </div>

--- a/packages/epics/src/governance/components/document-section.tsx
+++ b/packages/epics/src/governance/components/document-section.tsx
@@ -12,7 +12,6 @@ import { PlusIcon } from '@radix-ui/react-icons';
 import Link from 'next/link';
 import { DocumentState, UseDocuments } from '..';
 import { DocumentGridContainer } from './document-grid.container';
-import { FILTER_BY_STATE } from '../constants';
 
 type DocumentSectionProps = {
   basePath: string;
@@ -40,7 +39,7 @@ export const DocumentSection: FC<DocumentSectionProps> = ({
     setActiveTab,
   } = useDocumentsSection({
     useDocuments,
-    documentState: FILTER_BY_STATE[documentState] as DocumentState,
+    documentState: documentState,
   });
 
   return (
@@ -78,7 +77,7 @@ export const DocumentSection: FC<DocumentSectionProps> = ({
                 page: index + 1,
                 pageSize: 3,
                 filter: {
-                  state: FILTER_BY_STATE[documentState] as DocumentState,
+                  state: documentState,
                 },
               }}
               useDocuments={useDocuments}

--- a/packages/epics/src/governance/components/document-section.tsx
+++ b/packages/epics/src/governance/components/document-section.tsx
@@ -12,17 +12,20 @@ import { PlusIcon } from '@radix-ui/react-icons';
 import Link from 'next/link';
 import { DocumentState, UseDocuments } from '..';
 import { DocumentGridContainer } from './document-grid.container';
+import { FILTER_BY_STATE } from '../constants';
 
 type DocumentSectionProps = {
   basePath: string;
   useDocuments: UseDocuments;
   documentState: DocumentState;
+  label?: string;
 };
 
 export const DocumentSection: FC<DocumentSectionProps> = ({
   basePath,
   useDocuments,
   documentState,
+  label,
 }) => {
   const {
     pages,
@@ -35,7 +38,10 @@ export const DocumentSection: FC<DocumentSectionProps> = ({
     tabs,
     activeTab,
     setActiveTab,
-  } = useDocumentsSection({ useDocuments, documentState: documentState });
+  } = useDocumentsSection({
+    useDocuments,
+    documentState: FILTER_BY_STATE[documentState] as DocumentState,
+  });
 
   return (
     <div className="flex flex-col justify-around items-center gap-4">
@@ -43,7 +49,7 @@ export const DocumentSection: FC<DocumentSectionProps> = ({
         value={activeFilter}
         onChange={setActiveFilter}
         count={pagination?.total || 0}
-        label={`${documentState}s`}
+        label={label || ''}
         sortOptions={sortOptions}
       >
         <Link href={`${basePath}/create`} scroll={false}>
@@ -71,7 +77,9 @@ export const DocumentSection: FC<DocumentSectionProps> = ({
               pagination={{
                 page: index + 1,
                 pageSize: 3,
-                filter: { state: documentState },
+                filter: {
+                  state: FILTER_BY_STATE[documentState] as DocumentState,
+                },
               }}
               useDocuments={useDocuments}
               activeTab={activeTab}

--- a/packages/epics/src/governance/constants.ts
+++ b/packages/epics/src/governance/constants.ts
@@ -1,0 +1,5 @@
+export const FILTER_BY_STATE = {
+  onVoting: 'proposal',
+  active: 'agreement',
+  completed: 'agreement',
+};

--- a/packages/epics/src/governance/constants.ts
+++ b/packages/epics/src/governance/constants.ts
@@ -1,5 +1,0 @@
-export const FILTER_BY_STATE = {
-  onVoting: 'proposal',
-  active: 'agreement',
-  completed: 'agreement',
-};

--- a/packages/epics/src/governance/hooks/types.ts
+++ b/packages/epics/src/governance/hooks/types.ts
@@ -14,6 +14,7 @@ export type UseDocumentsProps = {
   page?: number;
   filter?: FilterParams<Pick<Document, 'state'>>;
   pageSize?: number;
+  activeTab?: string;
 };
 
 export type UseDocuments = (props: UseDocumentsProps) => UseDocumentsReturn;

--- a/packages/epics/src/governance/hooks/use-documents-section.ts
+++ b/packages/epics/src/governance/hooks/use-documents-section.ts
@@ -4,6 +4,25 @@ import { DocumentState, UseDocuments } from '../../governance';
 
 const sortOptions = SORT_OPTIONS;
 
+export const tabs = [
+  {
+    label: 'All',
+    value: 'all',
+  },
+  {
+    label: 'Hypha Space',
+    value: 'hypha-space',
+  },
+  {
+    label: 'EOS Space',
+    value: 'eos-space',
+  },
+  {
+    label: 'Hypha Energy',
+    value: 'hypha-energy',
+  },
+];
+
 export const useDocumentsSection = ({
   useDocuments,
   documentState,
@@ -13,6 +32,7 @@ export const useDocumentsSection = ({
 }) => {
   const [activeFilter, setActiveFilter] = React.useState('all');
   const [pages, setPages] = React.useState(1);
+  const [activeTab, setActiveTab] = React.useState('all');
 
   const { isLoading, pagination } = useDocuments({
     page: pages,
@@ -38,5 +58,8 @@ export const useDocumentsSection = ({
     activeFilter,
     setActiveFilter,
     sortOptions,
+    tabs,
+    activeTab,
+    setActiveTab,
   };
 };

--- a/packages/epics/src/governance/hooks/use-documents-section.ts
+++ b/packages/epics/src/governance/hooks/use-documents-section.ts
@@ -42,7 +42,7 @@ export const useDocumentsSection = ({
 
   React.useEffect(() => {
     setPages(1);
-  }, [activeFilter]);
+  }, [activeFilter, activeTab]);
 
   const loadMore = React.useCallback(() => {
     if (!pagination?.hasNextPage) return;

--- a/packages/epics/src/governance/types.ts
+++ b/packages/epics/src/governance/types.ts
@@ -1,1 +1,1 @@
-export type DocumentState = 'discussion' | 'proposal' | 'agreement';
+export type DocumentState = 'onVoting' | 'active' | 'completed';

--- a/packages/epics/src/governance/types.ts
+++ b/packages/epics/src/governance/types.ts
@@ -1,1 +1,1 @@
-export type DocumentState = 'onVoting' | 'active' | 'completed';
+export type DocumentState = 'proposal' | 'agreement' | 'discussion';

--- a/packages/epics/src/people/components/person-label.tsx
+++ b/packages/epics/src/people/components/person-label.tsx
@@ -3,9 +3,9 @@ import { Text } from '@radix-ui/themes';
 import { PersonAvatar } from './person-avatar';
 
 export interface Creator {
-  name: string;
-  surname: string;
-  avatarUrl: string;
+  name?: string;
+  surname?: string;
+  avatarUrl?: string;
 }
 
 interface PersonLabelProps {


### PR DESCRIPTION
Restructured the agreements page to display documents in three categories: "On Voting", "Active", and "Completed".

### What changed?

- Replaced the previous `ProposalsSection` and `AgreementsSection` with three `DocumentSection` components
- Added document state filtering with new categories: "onVoting", "active", and "completed"
- Created a mapping between UI states and backend document states in `FILTER_BY_STATE`
- Added badges to documents based on their state (e.g., "Proposal" and "On voting" badges)
- Implemented tab navigation for filtering documents by space (All, Hypha Space, EOS Space, Hypha Energy)
- Updated the `useSpaceDocuments` hook to support the new document state structure

#623 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Revamped the Agreements page to clearly classify documents into “Proposals” and “Agreements”, enhancing document organization.
  - Introduced intuitive tabbed navigation for filtering documents across different spaces.
  - Added visual badges on document cards to provide quick insights into their current status.
  - Enhanced creator information on document details by dynamically displaying creator data.

- **Refactor**
  - Streamlined state and label management to ensure a consistent and enhanced document viewing experience.
  - Updated document state terminology for clarity and improved user understanding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->