### PR TITLE
feat(#640): customize not found page

### DIFF
--- a/apps/web/src/app/[lang]/layout.tsx
+++ b/apps/web/src/app/[lang]/layout.tsx
@@ -13,8 +13,8 @@ export default async function RootLayout({
   aside: React.ReactNode;
 }) {
   return (
-    <div className="pt-9 w-screen flex justify-normal">
-      <div className="w-full">{children}</div>
+    <div className="pt-9 w-screen h-full flex justify-normal">
+      <div className="w-full h-full">{children}</div>
       {aside}
     </div>
   );

--- a/apps/web/src/app/[lang]/not-found.tsx
+++ b/apps/web/src/app/[lang]/not-found.tsx
@@ -1,32 +1,21 @@
-'use client';
-
 import { Button } from '@hypha-platform/ui';
 import { GlobeIcon } from '@radix-ui/react-icons';
-import { useParams, useRouter } from 'next/navigation';
+import Link from 'next/link';
 
-export default function NotFound() {
-  const router = useRouter();
-  const { lang } = useParams();
-
-  const transitionToExploreSpaces = () => {
-    router.push(`/${lang}/my-spaces`);
-  };
-
+export default async function NotFound() {
   return (
-    <div className="flex flex-col justify-center items-center gap-6 font-medium">
+    <div className="flex flex-col justify-center items-center gap-6 font-medium h-full py-64">
       <span className="text-9">Oooops! We couldn’t find this page</span>
       <span className="text-4 text-neutral-11">
         The page you are looking for might have been removed, had its name
         changed, or is temporarily unavailable
       </span>
-      <Button
-        colorVariant="accent"
-        className="gap-2"
-        onClick={transitionToExploreSpaces}
-      >
-        <GlobeIcon />
-        Explore Spaces
-      </Button>
+      <Link href="/network">
+        <Button colorVariant="accent" className="gap-2">
+          <GlobeIcon />
+          Explore Spaces
+        </Button>
+      </Link>
     </div>
   );
 }

--- a/apps/web/src/app/[lang]/not-found.tsx
+++ b/apps/web/src/app/[lang]/not-found.tsx
@@ -1,8 +1,32 @@
+'use client';
+
+import { Button } from '@hypha-platform/ui';
+import { GlobeIcon } from '@radix-ui/react-icons';
+import { useParams, useRouter } from 'next/navigation';
+
 export default function NotFound() {
+  const router = useRouter();
+  const { lang } = useParams();
+
+  const transitionToExploreSpaces = () => {
+    router.push(`/${lang}/my-spaces`);
+  };
+
   return (
-    <div>
-      <h2>Not Found</h2>
-      <p>Could not find the requested resource</p>
+    <div className="flex flex-col justify-center items-center gap-6 font-medium">
+      <span className="text-9">Oooops! We couldn’t find this page</span>
+      <span className="text-4 text-neutral-11">
+        The page you are looking for might have been removed, had its name
+        changed, or is temporarily unavailable
+      </span>
+      <Button
+        colorVariant="accent"
+        className="gap-2"
+        onClick={transitionToExploreSpaces}
+      >
+        <GlobeIcon />
+        Explore Spaces
+      </Button>
     </div>
   );
 }

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -87,7 +87,7 @@ export default async function RootLayout({
               </MenuTop.RightSlot>
             </MenuTop>
             <NextSSRPlugin routerConfig={extractRouterConfig(fileRouter)} />
-            {children}
+            <div className="mb-auto">{children}</div>
             <Footer />
           </EvmProvider>
         </ThemeProvider>

--- a/packages/ui/src/layouts/html.tsx
+++ b/packages/ui/src/layouts/html.tsx
@@ -16,7 +16,9 @@ export const Html: React.FC<{
           sizes="192x192"
         />
       </head>
-      <body className="flex flex-col w-full h-full">{children}</body>
+      <body className="flex flex-col w-full h-screen justify-between">
+        {children}
+      </body>
     </html>
   );
 };


### PR DESCRIPTION
Enhanced the 404 Not Found page with a more user-friendly interface and added navigation to the Explore Spaces section.

### What changed?

- Converted the Not Found component to a client component by adding 'use client' directive
- Added a more descriptive error message with improved styling
- Implemented a button that redirects users to the "my-spaces" page
- Incorporated the GlobeIcon from Radix UI for the button
- Used the current language parameter from the URL to maintain language context during navigation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Revamped the "Not Found" page with a modern, engaging design.
	- Introduced a prominent message stating "Oooops! We couldn’t find this page" along with descriptive text for better user guidance.
	- Added a styled button that navigates users to the "/network" route for easier content exploration.
- **Layout Improvements**
	- Enhanced layout structure to ensure full height utilization for better visual alignment and spacing.
	- Updated rendering structure for improved layout and styling of child elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->