### PR TITLE
fix(#660): remove hypha genossenschaft from footer

### DIFF
--- a/packages/ui/src/organisms/footer.tsx
+++ b/packages/ui/src/organisms/footer.tsx
@@ -149,12 +149,6 @@ export const Footer = () => {
             </Button>
           </div>
         </div>
-        <div
-          className="pb-4 text-gray-400 text-center md:text-left"
-          style={{ fontSize: '12px' }}
-        >
-          Hypha Genossenschaft, Birkenweg 6, 9490, Vaduz Liechtenstein.
-        </div>
       </Container>
     </div>
   );


### PR DESCRIPTION
fix #660

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the footer by removing the displayed address, streamlining the visible content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->