### PR TITLE
feat(#686): fixed some spacing

### DIFF
--- a/apps/web/src/app/[lang]/dho/[id]/_components/navigation-tabs.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/navigation-tabs.tsx
@@ -16,7 +16,7 @@ export function NavigationTabs({
 }) {
   return (
     <Tabs value={activeTab} className="w-full mt-16">
-      <TabsList className="w-full mb-7">
+      <TabsList className="w-full mb-4">
         <TabsTrigger
           asChild
           value="agreements"

--- a/apps/web/src/app/[lang]/dho/[id]/agreements/page.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/agreements/page.tsx
@@ -19,7 +19,7 @@ export default async function AgreementsPage(props: PageProps) {
   const basePath = `/${lang}/dho/${id}`;
 
   return (
-    <div className="flex flex-col gap-4">
+    <div className="flex flex-col gap-6 py-4">
       <NavigationTabs lang={lang} id={id} activeTab="agreements" />
       <DocumentSection
         basePath={`${basePath}/discussions`}

--- a/apps/web/src/app/[lang]/dho/[id]/membership/page.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/membership/page.tsx
@@ -22,7 +22,7 @@ export default async function MembershipPage(props: PageProps) {
   const basePath = getDhoPathMembership(lang as Locale, id as string);
 
   return (
-    <div>
+    <div className="flex flex-col gap-6 py-4">
       <NavigationTabs lang={lang} id={id} activeTab="membership" />
       <OuterSpacesSection />
       <InnerSpacesSection basePath={`${basePath}/space`} />

--- a/apps/web/src/app/[lang]/dho/[id]/treasury/page.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/treasury/page.tsx
@@ -19,7 +19,7 @@ export default async function TreasuryPage(props: PageProps) {
   const basePath = getDhoPathTreasury(lang as Locale, id as string);
 
   return (
-    <div>
+    <div className="flex flex-col gap-6 py-4">
       <NavigationTabs lang={lang} id={id} activeTab="treasury" />
       <AssetsSection basePath={`${basePath}/token`} />
       <RequestsSection />

--- a/packages/epics/src/agreements/components/agreements-section.tsx
+++ b/packages/epics/src/agreements/components/agreements-section.tsx
@@ -33,7 +33,7 @@ export const AgreementsSection: FC<AgreementsSectionProps> = ({
   } = useAgreementsSection({ useDocuments });
 
   return (
-    <div className="flex flex-col w-full justify-center items-center">
+    <div className="flex flex-col w-full justify-center items-center gap-4">
       <SectionFilter
         value={activeFilter}
         onChange={setActiveFilter}

--- a/packages/epics/src/people/components/members-section.tsx
+++ b/packages/epics/src/people/components/members-section.tsx
@@ -25,7 +25,7 @@ export const MembersSection: FC<MemberSectionProps> = ({
     useMembersSection({ useMembers });
 
   return (
-    <div className="flex flex-col w-full justify-center items-center">
+    <div className="flex flex-col w-full justify-center items-center gap-4">
       <SectionFilter
         value={'all'}
         onChange={(value) =>

--- a/packages/epics/src/proposals/components/proposals-section.tsx
+++ b/packages/epics/src/proposals/components/proposals-section.tsx
@@ -33,7 +33,7 @@ export const ProposalsSection: FC<ProposalSectionProps> = ({
   } = useProposalsSection({ useDocuments });
 
   return (
-    <div className="flex flex-col w-full justify-center items-center">
+    <div className="flex flex-col w-full justify-center items-center gap-4">
       <SectionFilter
         value={activeFilter}
         onChange={setActiveFilter}

--- a/packages/epics/src/spaces/components/inner-spaces-section.tsx
+++ b/packages/epics/src/spaces/components/inner-spaces-section.tsx
@@ -26,7 +26,7 @@ export const InnerSpacesSection: FC<InnerSpacesSectionProps> = ({
   } = useSpacesSection();
 
   return (
-    <div className="flex flex-col w-full justify-center items-center">
+    <div className="flex flex-col w-full justify-center items-center gap-4">
       <SectionFilter
         value={activeSort}
         onChange={setSort}

--- a/packages/epics/src/spaces/components/outer-spaces-section.tsx
+++ b/packages/epics/src/spaces/components/outer-spaces-section.tsx
@@ -22,7 +22,7 @@ export const OuterSpacesSection: FC<OuterSpacesSectionProps> = () => {
   } = useSpacesSection();
 
   return (
-    <div className="flex flex-col w-full justify-center items-center">
+    <div className="flex flex-col w-full justify-center items-center gap-4">
       <SectionFilter
         value={activeSort}
         onChange={setSort}

--- a/packages/epics/src/treasury/components/assets/assets-section.tsx
+++ b/packages/epics/src/treasury/components/assets/assets-section.tsx
@@ -29,7 +29,7 @@ export const AssetsSection: FC<AssetSectionProps> = ({ basePath }) => {
   } = useAssetsSection();
 
   return (
-    <div className="flex flex-col w-full justify-center items-center">
+    <div className="flex flex-col w-full justify-center items-center gap-4">
       <SectionFilter
         value={activeFilter}
         onChange={setActiveFilter}

--- a/packages/epics/src/treasury/components/payouts/payouts-section.tsx
+++ b/packages/epics/src/treasury/components/payouts/payouts-section.tsx
@@ -25,7 +25,7 @@ export const PayoutsSection: FC<PayoutSectionProps> = () => {
   } = usePayoutsSection();
 
   return (
-    <div className="flex flex-col w-full justify-center items-center">
+    <div className="flex flex-col w-full justify-center items-center gap-4">
       <SectionFilter
         value={activeFilter}
         onChange={setActiveFilter}

--- a/packages/epics/src/treasury/components/requests/requests-section.tsx
+++ b/packages/epics/src/treasury/components/requests/requests-section.tsx
@@ -22,7 +22,7 @@ export const RequestsSection: FC<RequestsSectionProps> = () => {
   } = useRequestsSection();
 
   return (
-    <div className="flex flex-col w-full justify-center items-center">
+    <div className="flex flex-col w-full justify-center items-center gap-4">
       <SectionFilter
         value={activeSort}
         onChange={setSort}


### PR DESCRIPTION
Improved spacing and layout consistency across DHO pages and section components.

### What changed?

- Reduced the margin-bottom of the TabsList from 7 to 4 in navigation-tabs.tsx
- Added consistent padding and gap spacing to DHO pages (agreements, membership, treasury)
- Added a consistent gap of 4 to all section components:
  - AgreementsSection
  - MembersSection
  - ProposalsSection
  - InnerSpacesSection
  - OuterSpacesSection
  - AssetsSection
  - PayoutsSection
  - RequestsSection