### PR TITLE
feat(#686): removed invite member button

### DIFF
--- a/apps/web/src/app/[lang]/dho/[id]/_components/navigation-tabs.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/navigation-tabs.tsx
@@ -16,7 +16,7 @@ export function NavigationTabs({
 }) {
   return (
     <Tabs value={activeTab} className="w-full mt-16">
-      <TabsList className="w-full mb-7">
+      <TabsList className="w-full mb-4">
         <TabsTrigger
           asChild
           value="agreements"

--- a/apps/web/src/app/[lang]/dho/[id]/agreements/page.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/agreements/page.tsx
@@ -19,7 +19,7 @@ export default async function AgreementsPage(props: PageProps) {
   const basePath = `/${lang}/dho/${id}`;
 
   return (
-    <div className="flex flex-col gap-4">
+    <div className="flex flex-col gap-6 py-4">
       <NavigationTabs lang={lang} id={id} activeTab="agreements" />
       <DocumentSection
         basePath={`${basePath}/discussions`}

--- a/apps/web/src/app/[lang]/dho/[id]/membership/page.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/membership/page.tsx
@@ -22,7 +22,7 @@ export default async function MembershipPage(props: PageProps) {
   const basePath = getDhoPathMembership(lang as Locale, id as string);
 
   return (
-    <div>
+    <div className="flex flex-col gap-6 py-4">
       <NavigationTabs lang={lang} id={id} activeTab="membership" />
       <OuterSpacesSection />
       <InnerSpacesSection basePath={`${basePath}/space`} />

--- a/apps/web/src/app/[lang]/dho/[id]/treasury/page.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/treasury/page.tsx
@@ -19,7 +19,7 @@ export default async function TreasuryPage(props: PageProps) {
   const basePath = getDhoPathTreasury(lang as Locale, id as string);
 
   return (
-    <div>
+    <div className="flex flex-col gap-6 py-4">
       <NavigationTabs lang={lang} id={id} activeTab="treasury" />
       <AssetsSection basePath={`${basePath}/token`} />
       <RequestsSection />

--- a/packages/epics/src/agreements/components/agreements-section.tsx
+++ b/packages/epics/src/agreements/components/agreements-section.tsx
@@ -33,7 +33,7 @@ export const AgreementsSection: FC<AgreementsSectionProps> = ({
   } = useAgreementsSection({ useDocuments });
 
   return (
-    <div className="flex flex-col w-full justify-center items-center">
+    <div className="flex flex-col w-full justify-center items-center gap-4">
       <SectionFilter
         value={activeFilter}
         onChange={setActiveFilter}

--- a/packages/epics/src/people/components/members-section.tsx
+++ b/packages/epics/src/people/components/members-section.tsx
@@ -25,7 +25,7 @@ export const MembersSection: FC<MemberSectionProps> = ({
     useMembersSection({ useMembers });
 
   return (
-    <div className="flex flex-col w-full justify-center items-center">
+    <div className="flex flex-col w-full justify-center items-center gap-4">
       <SectionFilter
         value={'all'}
         onChange={(value) =>

--- a/packages/epics/src/people/components/members-section.tsx
+++ b/packages/epics/src/people/components/members-section.tsx
@@ -7,8 +7,6 @@ import {
   SectionLoadMore,
   SectionTabs,
 } from '@hypha-platform/ui/server';
-import { Button } from '@hypha-platform/ui';
-import { PlusIcon } from '@radix-ui/react-icons';
 
 import { MembersList } from './members-list';
 import { useMembersSection } from '../hooks/use-members-section';
@@ -36,12 +34,7 @@ export const MembersSection: FC<MemberSectionProps> = ({
         count={pagination?.total || 0}
         label="Members"
         sortOptions={sortOptions}
-      >
-        <Button className="ml-2">
-          <PlusIcon className="mr-2" />
-          Invite member
-        </Button>
-      </SectionFilter>
+      />
       {pagination?.total === 0 ? null : (
         <SectionTabs
           activeTab="all"

--- a/packages/epics/src/proposals/components/proposals-section.tsx
+++ b/packages/epics/src/proposals/components/proposals-section.tsx
@@ -33,7 +33,7 @@ export const ProposalsSection: FC<ProposalSectionProps> = ({
   } = useProposalsSection({ useDocuments });
 
   return (
-    <div className="flex flex-col w-full justify-center items-center">
+    <div className="flex flex-col w-full justify-center items-center gap-4">
       <SectionFilter
         value={activeFilter}
         onChange={setActiveFilter}

--- a/packages/epics/src/spaces/components/inner-spaces-section.tsx
+++ b/packages/epics/src/spaces/components/inner-spaces-section.tsx
@@ -26,7 +26,7 @@ export const InnerSpacesSection: FC<InnerSpacesSectionProps> = ({
   } = useSpacesSection();
 
   return (
-    <div className="flex flex-col w-full justify-center items-center">
+    <div className="flex flex-col w-full justify-center items-center gap-4">
       <SectionFilter
         value={activeSort}
         onChange={setSort}

--- a/packages/epics/src/spaces/components/outer-spaces-section.tsx
+++ b/packages/epics/src/spaces/components/outer-spaces-section.tsx
@@ -22,7 +22,7 @@ export const OuterSpacesSection: FC<OuterSpacesSectionProps> = () => {
   } = useSpacesSection();
 
   return (
-    <div className="flex flex-col w-full justify-center items-center">
+    <div className="flex flex-col w-full justify-center items-center gap-4">
       <SectionFilter
         value={activeSort}
         onChange={setSort}

--- a/packages/epics/src/treasury/components/assets/assets-section.tsx
+++ b/packages/epics/src/treasury/components/assets/assets-section.tsx
@@ -29,7 +29,7 @@ export const AssetsSection: FC<AssetSectionProps> = ({ basePath }) => {
   } = useAssetsSection();
 
   return (
-    <div className="flex flex-col w-full justify-center items-center">
+    <div className="flex flex-col w-full justify-center items-center gap-4">
       <SectionFilter
         value={activeFilter}
         onChange={setActiveFilter}

--- a/packages/epics/src/treasury/components/payouts/payouts-section.tsx
+++ b/packages/epics/src/treasury/components/payouts/payouts-section.tsx
@@ -25,7 +25,7 @@ export const PayoutsSection: FC<PayoutSectionProps> = () => {
   } = usePayoutsSection();
 
   return (
-    <div className="flex flex-col w-full justify-center items-center">
+    <div className="flex flex-col w-full justify-center items-center gap-4">
       <SectionFilter
         value={activeFilter}
         onChange={setActiveFilter}

--- a/packages/epics/src/treasury/components/requests/requests-section.tsx
+++ b/packages/epics/src/treasury/components/requests/requests-section.tsx
@@ -22,7 +22,7 @@ export const RequestsSection: FC<RequestsSectionProps> = () => {
   } = useRequestsSection();
 
   return (
-    <div className="flex flex-col w-full justify-center items-center">
+    <div className="flex flex-col w-full justify-center items-center gap-4">
       <SectionFilter
         value={activeSort}
         onChange={setSort}


### PR DESCRIPTION
Removed the "Invite member" button from the MembersSection component.

### What changed?

- Removed the Button import from `@hypha-platform/ui`
- Removed the PlusIcon import from `@radix-ui/react-icons`
- Changed the SectionFilter component from being used with children to being self-closing
- Removed the "Invite member" button that was previously rendered inside the SectionFilter component

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Removed the "Invite member" button from the Members section, simplifying the interface.
  
- **Style**
  - Adjusted spacing in various components, enhancing layout consistency by adding gaps and padding in the Agreements, Membership, Treasury, Proposals, and Assets sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->