### PR TITLE
feat(#688): wallet button has been hid in top menu

### DIFF
--- a/apps/web/src/app/[lang]/dho/new/layout.tsx
+++ b/apps/web/src/app/[lang]/dho/new/layout.tsx
@@ -23,10 +23,11 @@ export default async function DhoLayout(props: {
             label: 'My Projects',
             href: `/${lang}/my-projects`,
           },
-          {
-            label: 'Wallet',
-            href: `/${lang}/wallet`,
-          },
+          // #688 hide wallet button
+          // {
+          //   label: 'Wallet',
+          //   href: `/${lang}/wallet`,
+          // },
         ]}
       />
       <div className="fixed bottom-0 right-0 flex-grow p-10 overflow-y-auto top-9 left-20 bg-background/5">

--- a/apps/web/src/app/[lang]/dho/new/layout.tsx
+++ b/apps/web/src/app/[lang]/dho/new/layout.tsx
@@ -23,11 +23,6 @@ export default async function DhoLayout(props: {
             label: 'My Projects',
             href: `/${lang}/my-projects`,
           },
-          // #688 hide wallet button
-          // {
-          //   label: 'Wallet',
-          //   href: `/${lang}/wallet`,
-          // },
         ]}
       />
       <div className="fixed bottom-0 right-0 flex-grow p-10 overflow-y-auto top-9 left-20 bg-background/5">

--- a/apps/web/src/app/[lang]/wallet/layout.tsx
+++ b/apps/web/src/app/[lang]/wallet/layout.tsx
@@ -27,10 +27,11 @@ export default async function DhoLayout(props: {
             label: 'My Spaces',
             href: `/${lang}/my-spaces`,
           },
-          {
-            label: 'Wallet',
-            href: `/${lang}/wallet`,
-          },
+          // #688 hide wallet button
+          // {
+          //   label: 'Wallet',
+          //   href: `/${lang}/wallet`,
+          // },
         ]}
       >
         <MenuTop.RightSlot>

--- a/apps/web/src/app/[lang]/wallet/layout.tsx
+++ b/apps/web/src/app/[lang]/wallet/layout.tsx
@@ -27,11 +27,6 @@ export default async function DhoLayout(props: {
             label: 'My Spaces',
             href: `/${lang}/my-spaces`,
           },
-          // #688 hide wallet button
-          // {
-          //   label: 'Wallet',
-          //   href: `/${lang}/wallet`,
-          // },
         ]}
       >
         <MenuTop.RightSlot>

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -78,10 +78,11 @@ export default async function RootLayout({
                   label: 'My Spaces',
                   href: `/${lang}/my-spaces`,
                 },
-                {
-                  label: 'Wallet',
-                  href: `/${lang}/wallet`,
-                },
+                // #688 hide wallet button
+                // {
+                //   label: 'Wallet',
+                //   href: `/${lang}/wallet`,
+                // },
               ]}
             >
               <MenuTop.RightSlot>

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -78,11 +78,6 @@ export default async function RootLayout({
                   label: 'My Spaces',
                   href: `/${lang}/my-spaces`,
                 },
-                // #688 hide wallet button
-                // {
-                //   label: 'Wallet',
-                //   href: `/${lang}/wallet`,
-                // },
               ]}
             >
               <MenuTop.RightSlot>


### PR DESCRIPTION
Removed the Wallet navigation button from multiple layouts.

### What changed?

- Commented out the Wallet navigation button in three layout files:
  - `apps/web/src/app/[lang]/dho/new/layout.tsx`
  - `apps/web/src/app/[lang]/wallet/layout.tsx`
  - `apps/web/src/app/layout.tsx`
- Added a comment referencing issue #688 to explain why the button was hidden

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Removed the "Wallet" menu option from the top navigation, streamlining the interface while leaving other navigation items unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->