### PR TITLE
Feat/685 membership view latest design

### DIFF
--- a/apps/web/src/app/[lang]/dho/[id]/membership/page.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/membership/page.tsx
@@ -1,6 +1,5 @@
 import { Locale } from '@hypha-platform/i18n';
 import {
-  OuterSpacesSection,
   InnerSpacesSection,
   MembersSection,
 } from '@hypha-platform/epics';
@@ -24,7 +23,6 @@ export default async function MembershipPage(props: PageProps) {
   return (
     <div className="flex flex-col gap-6 py-4">
       <NavigationTabs lang={lang} id={id} activeTab="membership" />
-      <OuterSpacesSection />
       <InnerSpacesSection basePath={`${basePath}/space`} />
       <MembersSection basePath={`${basePath}/person`} useMembers={useMembers} />
     </div>

--- a/apps/web/src/app/[lang]/dho/[id]/membership/page.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/membership/page.tsx
@@ -1,13 +1,12 @@
 import { Locale } from '@hypha-platform/i18n';
-import {
-  InnerSpacesSection,
-  MembersSection,
-} from '@hypha-platform/epics';
+import { MembersSection, SubspaceSection } from '@hypha-platform/epics';
 
 import { useMembers } from '@web/hooks/use-members';
 
 import { NavigationTabs } from '../_components/navigation-tabs';
 import { getDhoPathMembership } from './constants';
+import { createSpaceService } from '@core/space/server';
+import { getDhoPathAgreements } from '../agreements/constants';
 
 type PageProps = {
   params: Promise<{ lang: Locale; id: string }>;
@@ -20,10 +19,16 @@ export default async function MembershipPage(props: PageProps) {
 
   const basePath = getDhoPathMembership(lang as Locale, id as string);
 
+  const spaces = await createSpaceService().getAll();
+
   return (
     <div className="flex flex-col gap-6 py-4">
       <NavigationTabs lang={lang} id={id} activeTab="membership" />
-      <InnerSpacesSection basePath={`${basePath}/space`} />
+      <SubspaceSection
+        spaces={spaces}
+        lang={lang}
+        getDhoPathAgreements={getDhoPathAgreements}
+      />
       <MembersSection basePath={`${basePath}/person`} useMembers={useMembers} />
     </div>
   );

--- a/packages/epics/src/people/components/members-section.tsx
+++ b/packages/epics/src/people/components/members-section.tsx
@@ -32,7 +32,7 @@ export const MembersSection: FC<MemberSectionProps> = ({
           console.debug('members-section onChange', { value })
         }
         count={pagination?.total || 0}
-        label="Members"
+        label="Individuals"
         sortOptions={sortOptions}
       />
       {pagination?.total === 0 ? null : (

--- a/packages/epics/src/spaces/components/index.ts
+++ b/packages/epics/src/spaces/components/index.ts
@@ -10,3 +10,4 @@ export * from './space-card';
 export * from './space-group-slider';
 export * from './space-search';
 export * from './subspace-detail';
+export * from './subspace-section';

--- a/packages/epics/src/spaces/components/subspace-section.stories.tsx
+++ b/packages/epics/src/spaces/components/subspace-section.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { SubspaceSection } from './subspace-section';
+
+const meta = {
+  component: SubspaceSection,
+  title: 'Epics/Spaces/SubspaceSection',
+} satisfies Meta<typeof SubspaceSection>;
+
+export default meta;
+
+type Story = StoryObj<typeof SubspaceSection>;
+
+export const Default: Story = {};

--- a/packages/epics/src/spaces/components/subspace-section.tsx
+++ b/packages/epics/src/spaces/components/subspace-section.tsx
@@ -1,0 +1,78 @@
+import { Text } from '@radix-ui/themes';
+import { FilterMenu, Button } from '@hypha-platform/ui';
+import Link from 'next/link';
+import { PlusIcon } from '@radix-ui/react-icons';
+import { SpaceCard } from '@hypha-platform/epics';
+import { Space } from '@core/space';
+import { Locale } from '@hypha-platform/i18n';
+
+interface SubspaceSectionProps {
+  getDhoPathAgreements: (lang: Locale, id: string) => string;
+  spaces: Space[];
+  lang: Locale;
+}
+
+type OptionType = {
+  label: string;
+  value: string;
+};
+
+type SpacesFilterType = {
+  value: string;
+  options: OptionType[];
+};
+
+const filterSettings: SpacesFilterType = {
+  value: 'most-recent',
+  options: [
+    { label: 'All', value: 'all' },
+    { label: 'Most recent', value: 'most-recent' },
+  ],
+};
+
+export const SubspaceSection = ({
+  spaces,
+  lang,
+  getDhoPathAgreements,
+}: SubspaceSectionProps) => {
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="justify-between items-center flex">
+        <Text className="text-4">Sub-spaces | {spaces.length}</Text>
+        <div className="flex items-center">
+          <FilterMenu
+            value={filterSettings.value}
+            options={filterSettings.options}
+          />
+          <Link href={`/${lang}/my-spaces/create`} scroll={false}>
+            <Button className="ml-2">
+              <PlusIcon className="mr-2" />
+              Create
+            </Button>
+          </Link>
+        </div>
+      </div>
+      <div
+        data-testid="sub-spaces-container"
+        className="grid grid-cols-1 sm:grid-cols-2 gap-3"
+      >
+        {spaces.map((space) => (
+          <div key={space.id} className="mb-1">
+            <Link href={getDhoPathAgreements(lang, space.slug as string)}>
+              <SpaceCard
+                description={space.description as string}
+                icon={space.logoUrl || '/placeholder/space-avatar-image.png'}
+                leadImage={
+                  space.leadImage || '/placeholder/space-lead-image.png'
+                }
+                members={0}
+                agreements={0}
+                title={space.title as string}
+              />
+            </Link>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
Replaced separate OuterSpaces and InnerSpaces sections with a unified SubspaceSection component and renamed "Members" to "Individuals" in the MembersSection.

### What changed?

- Created a new `SubspaceSection` component that displays all subspaces in a grid layout
- Replaced the separate `OuterSpacesSection` and `InnerSpacesSection` with the new unified `SubspaceSection` in the membership page
- Changed the label in `MembersSection` from "Members" to "Individuals"
- Added story for `SubspaceSection` component
- Integrated space data fetching in the membership page using `createSpaceService().getAll()`
- Added proper linking from subspaces to their respective agreement pages


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated the membership page to showcase a consolidated subspace section with dynamic space listings, filtering options, and a dedicated button to create new spaces.
  - Revised the members filter label from "Members" to "Individuals" for improved clarity.
  - Introduced a new Storybook story for the `SubspaceSection` component to facilitate testing and documentation.
  
- **Enhancements**
  - Added export capabilities for the `SubspaceSection` component to improve accessibility within the module.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->