### PR TITLE
Feat/680 make an agreement proposal form

### DIFF
--- a/apps/web/src/app/[lang]/dho/[id]/@aside/(.)agreements/create/loading.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@aside/(.)agreements/create/loading.tsx
@@ -1,19 +1,18 @@
 'use client';
 
 import { CreateAgreementForm } from '@hypha-platform/epics';
-import { useParams } from 'next/navigation';
 import { SidePanel } from '../../_components/side-panel';
+import { useMe } from '@web/hooks/use-me';
 
 export default function Loading() {
-  const { lang, id } = useParams();
-
+  const { person } = useMe();
   return (
     <SidePanel>
       <CreateAgreementForm
         creator={{
-          avatar: '',
-          name: '',
-          surname: '',
+          avatar: person?.avatarUrl || '',
+          name: person?.name || '',
+          surname: person?.surname || '',
         }}
         closeUrl={``}
         onCreate={() => {

--- a/apps/web/src/app/[lang]/dho/[id]/@aside/(.)agreements/create/loading.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@aside/(.)agreements/create/loading.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { CreateAgreementForm } from '@hypha-platform/epics';
+import { useParams } from 'next/navigation';
+import { SidePanel } from '../../_components/side-panel';
+
+export default function Loading() {
+  const { lang, id } = useParams();
+
+  return (
+    <SidePanel>
+      <CreateAgreementForm
+        creator={{
+          avatar: '',
+          name: '',
+          surname: '',
+        }}
+        closeUrl={``}
+        onCreate={() => {
+          console.log('Publish proposal');
+        }}
+        isLoading={true}
+      />
+    </SidePanel>
+  );
+}

--- a/apps/web/src/app/[lang]/dho/[id]/@aside/(.)agreements/create/page.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@aside/(.)agreements/create/page.tsx
@@ -3,16 +3,18 @@
 import { CreateAgreementForm } from '@hypha-platform/epics';
 import { useParams } from 'next/navigation';
 import { SidePanel } from '../../_components/side-panel';
+import { useMe } from '@web/hooks/use-me';
 
 export default function CreateAgreement() {
   const { lang, id } = useParams();
+  const { person } = useMe();
   return (
     <SidePanel>
       <CreateAgreementForm
         creator={{
-          avatar: 'https://github.com/shadcn.png',
-          name: 'Name',
-          surname: 'Surname',
+          avatar: person?.avatarUrl || '',
+          name: person?.name || '',
+          surname: person?.surname || '',
         }}
         closeUrl={`/${lang}/dho/${id}/agreements`}
         onCreate={() => {

--- a/apps/web/src/app/[lang]/dho/[id]/@aside/(.)agreements/create/page.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@aside/(.)agreements/create/page.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { CreateAgreementForm } from '@hypha-platform/epics';
+import { useParams } from 'next/navigation';
+import { SidePanel } from '../../_components/side-panel';
+
+export default function CreateAgreement() {
+  const { lang, id } = useParams();
+  return (
+    <SidePanel>
+      <CreateAgreementForm
+        creator={{
+          avatar: 'https://github.com/shadcn.png',
+          name: 'Name',
+          surname: 'Surname',
+        }}
+        closeUrl={`/${lang}/dho/${id}/agreements`}
+        onCreate={() => {
+          console.log('Publish proposal');
+        }}
+        isLoading={false}
+      />
+    </SidePanel>
+  );
+}

--- a/apps/web/src/app/[lang]/dho/[id]/_components/select-create-action.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/select-create-action.tsx
@@ -26,7 +26,7 @@ export const CREATE_ACTIONS = [
     title: 'Make an Agreement',
     description:
       'Define and formalize a mutual understanding, policy, or decision among members of the space.',
-    href: '#',
+    href: 'agreements/create',
     icon: <CheckCircledIcon />,
   },
   {

--- a/apps/web/src/app/[lang]/dho/[id]/agreements/create/page.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/agreements/create/page.tsx
@@ -2,16 +2,17 @@
 
 import { CreateAgreementForm } from '@hypha-platform/epics';
 import { useParams } from 'next/navigation';
+import { useMe } from '@web/hooks/use-me';
 
 export default function CreateAgreement() {
   const { lang, id } = useParams();
-
+  const { person } = useMe();
   return (
     <CreateAgreementForm
       creator={{
-        avatar: 'https://github.com/shadcn.png',
-        name: 'Name',
-        surname: 'Surname',
+        avatar: person?.avatarUrl || '',
+        name: person?.name || '',
+        surname: person?.surname || '',
       }}
       closeUrl={`/${lang}/dho/${id}/agreements`}
       onCreate={() => {

--- a/apps/web/src/app/[lang]/dho/[id]/agreements/create/page.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/agreements/create/page.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { CreateAgreementForm } from '@hypha-platform/epics';
+import { useParams } from 'next/navigation';
+
+export default function CreateAgreement() {
+  const { lang, id } = useParams();
+
+  return (
+    <CreateAgreementForm
+      creator={{
+        avatar: 'https://github.com/shadcn.png',
+        name: 'Name',
+        surname: 'Surname',
+      }}
+      closeUrl={`/${lang}/dho/${id}/agreements`}
+      onCreate={() => {
+        console.log('Publish proposal');
+      }}
+      isLoading={false}
+    />
+  );
+}

--- a/packages/core/src/governance/index.ts
+++ b/packages/core/src/governance/index.ts
@@ -1,2 +1,3 @@
 export * from './types';
 export * from './errors';
+export * from './validation';

--- a/packages/core/src/governance/validation.ts
+++ b/packages/core/src/governance/validation.ts
@@ -1,0 +1,39 @@
+import { DEFAULT_IMAGE_ACCEPT } from '@core/assets';
+import { z } from 'zod';
+
+const ALLOWED_IMAGE_FILE_SIZE = 5 * 1024 * 1024;
+
+const createAgreementWeb2Props = {
+  title: z.string().min(1).max(50),
+  description: z.string().min(1).max(300),
+};
+
+export const schemaCreateAgreementWeb2 = z.object(createAgreementWeb2Props);
+
+export const createAgreementWeb2FileUrls = {
+  leadImage: z.string().url('Lead Image URL must be a valid URL').optional(),
+};
+
+export const schemaCreateAgreementWeb2FileUrls = z.object(
+  createAgreementWeb2FileUrls,
+);
+
+export const createAgreementFiles = {
+  leadImage: z
+    .instanceof(File)
+    .refine(
+      (file) => file.size <= ALLOWED_IMAGE_FILE_SIZE,
+      'File size must be less than 5MB',
+    )
+    .refine(
+      (file) => DEFAULT_IMAGE_ACCEPT.includes(file.type),
+      'File must be an image (JPEG, PNG, GIF, WEBP)',
+    )
+    .optional(),
+};
+
+export const schemaCreateAgreementFiles = z.object(createAgreementFiles);
+
+export const schemaCreateAgreement = z.object({
+  ...createAgreementWeb2Props,
+});

--- a/packages/epics/src/agreements/components/create-agreement-form.stories.tsx
+++ b/packages/epics/src/agreements/components/create-agreement-form.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { CreateAgreementForm } from './create-agreement-form';
+import { within } from '@storybook/testing-library';
+import { expect } from '@storybook/jest';
+
+const meta = {
+  component: CreateAgreementForm,
+  title: 'Epics/Agreements/CreateAgreementForm',
+} satisfies Meta<typeof CreateAgreementForm>;
+
+export default meta;
+
+type Story = StoryObj<typeof CreateAgreementForm>;
+
+export const Default: Story = {
+  args: {
+    creator: {
+      avatar: 'https://github.com/shadcn.png',
+      name: 'Name',
+      surname: 'Surname',
+    },
+    isLoading: false,
+    onCreate: () => {
+      console.log('Publish proposal');
+    },
+    closeUrl: '/',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(canvas.getByText(/Name Surname/gi)).toBeTruthy();
+  },
+};

--- a/packages/epics/src/agreements/components/create-agreement-form.tsx
+++ b/packages/epics/src/agreements/components/create-agreement-form.tsx
@@ -1,0 +1,148 @@
+'use client';
+
+import { useForm } from 'react-hook-form';
+import {
+  Button,
+  Textarea,
+  Input,
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormMessage,
+  UploadLeadImage,
+  Separator,
+  Badge,
+} from '@hypha-platform/ui';
+import { RxCross1 } from 'react-icons/rx';
+import { Text } from '@radix-ui/themes';
+import { Creator } from '@hypha-platform/graphql/rsc';
+import { PersonAvatar } from '../../people/components/person-avatar';
+import { ALLOWED_IMAGE_FILE_SIZE } from '@core/space';
+
+import Link from 'next/link';
+
+import clsx from 'clsx';
+
+export type CreateAgreementFormProps = {
+  creator?: Creator;
+  isLoading?: boolean;
+  closeUrl: string;
+  onCreate: () => void;
+};
+
+export const CreateAgreementForm = ({
+  creator,
+  isLoading,
+  closeUrl,
+  onCreate,
+}: CreateAgreementFormProps) => {
+  const form = useForm({
+    defaultValues: {
+      title: '',
+      description: '',
+      leadImage: undefined,
+    },
+  });
+
+  return (
+    <Form {...form}>
+      <form
+        onSubmit={form.handleSubmit(onCreate)}
+        className={clsx('flex flex-col gap-5', isLoading && 'opacity-50')}
+      >
+        <div className="flex gap-5 justify-between">
+          <div className="flex items-center gap-3">
+            <PersonAvatar
+              size="lg"
+              isLoading={isLoading}
+              avatarSrc={creator?.avatar}
+              userName={`${creator?.name} ${creator?.surname}`}
+            />
+            <div className="flex justify-between items-center w-full">
+              <div className="flex flex-col">
+                <Badge className="w-fit" colorVariant="accent">
+                  Agreement
+                </Badge>
+                <FormField
+                  control={form.control}
+                  name="title"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormControl>
+                        <Input
+                          placeholder="Type a title..."
+                          className="border-0 text-4 p-0 placeholder:text-4 bg-inherit"
+                          disabled={isLoading}
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <Text className="text-1 text-neutral-11">
+                  {creator?.name} {creator?.surname}
+                </Text>
+              </div>
+            </div>
+          </div>
+          <Button
+            variant="ghost"
+            colorVariant="neutral"
+            className="flex items-center"
+            asChild
+          >
+            <Link href={closeUrl} scroll={false}>
+              <RxCross1 className="ml-2" />
+              Close
+            </Link>
+          </Button>
+        </div>
+        <Separator />
+        <FormField
+          control={form.control}
+          name="leadImage"
+          render={({ field }) => (
+            <FormItem>
+              <FormControl>
+                <UploadLeadImage
+                  onChange={field.onChange}
+                  maxFileSize={ALLOWED_IMAGE_FILE_SIZE}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="description"
+          render={({ field }) => (
+            <FormItem>
+              <FormControl>
+                <Textarea
+                  disabled={isLoading}
+                  placeholder="Type a brief description here..."
+                  {...field}
+                />
+              </FormControl>
+              <FormDescription />
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <div className="flex justify-end w-full">
+          <Button
+            type="submit"
+            variant={isLoading ? 'outline' : 'default'}
+            disabled={isLoading}
+          >
+            Publish
+          </Button>
+        </div>
+      </form>
+    </Form>
+  );
+};

--- a/packages/epics/src/agreements/components/create-agreement-form.tsx
+++ b/packages/epics/src/agreements/components/create-agreement-form.tsx
@@ -20,16 +20,22 @@ import { Text } from '@radix-ui/themes';
 import { Creator } from '@hypha-platform/graphql/rsc';
 import { PersonAvatar } from '../../people/components/person-avatar';
 import { ALLOWED_IMAGE_FILE_SIZE } from '@core/space';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { createAgreementFiles, schemaCreateAgreement } from '@core/governance';
 
 import Link from 'next/link';
 
 import clsx from 'clsx';
 
+const schemaCreateAgreementForm =
+  schemaCreateAgreement.extend(createAgreementFiles);
+
 export type CreateAgreementFormProps = {
   creator?: Creator;
   isLoading?: boolean;
   closeUrl: string;
-  onCreate: () => void;
+  onCreate: (values: z.infer<typeof schemaCreateAgreementForm>) => void;
 };
 
 export const CreateAgreementForm = ({
@@ -38,7 +44,8 @@ export const CreateAgreementForm = ({
   closeUrl,
   onCreate,
 }: CreateAgreementFormProps) => {
-  const form = useForm({
+  const form = useForm<z.infer<typeof schemaCreateAgreementForm>>({
+    resolver: zodResolver(schemaCreateAgreementForm),
     defaultValues: {
       title: '',
       description: '',

--- a/packages/epics/src/agreements/components/index.ts
+++ b/packages/epics/src/agreements/components/index.ts
@@ -3,3 +3,4 @@ export * from './agreement-card';
 export * from './agreements-section';
 export * from './agreement-detail';
 export * from './agreement-head';
+export * from './create-agreement-form';


### PR DESCRIPTION
Added the ability to create agreements with a new form component and corresponding pages.

### What changed?

- Created a new `CreateAgreementForm` component in the epics package with form fields for title, description, and lead image
- Added Storybook configuration for the new form component
- Implemented agreement creation pages in both full page and side panel variants
- Added loading state for the side panel version
- Updated the "Make an Agreement" action in the select-create-action component to link to the new creation page


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a dedicated agreement creation interface with an interactive form that guides users through submission.
  - Added a distinct loading view to provide clear feedback during processing.
  - Updated navigation so that the "Make an Agreement" action now routes users directly to the agreement creation page.
  - Implemented validation for agreement-related data to enhance submission accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->