### PR TITLE
fix: make agreement and proposals loading pages like client component

### DIFF
--- a/apps/web/src/app/[lang]/dho/[id]/@aside/(.)agreements/[documentSlug]/loading.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@aside/(.)agreements/[documentSlug]/loading.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { AgreementDetail } from '@hypha-platform/epics';
 import { SidePanel } from '../../_components/side-panel';
 

--- a/apps/web/src/app/[lang]/dho/[id]/@aside/(.)proposals/[documentSlug]/loading.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@aside/(.)proposals/[documentSlug]/loading.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { ProposalDetail } from '@hypha-platform/epics';
 import { SidePanel } from '../../_components/side-panel';
 


### PR DESCRIPTION
Added 'use client' directive to loading components for agreements and proposals.

### What changed?

Added the 'use client' directive at the top of two loading component files:
- `apps/web/src/app/[lang]/dho/[id]/@aside/(.)agreements/[documentSlug]/loading.tsx`
- `apps/web/src/app/[lang]/dho/[id]/@aside/(.)proposals/[documentSlug]/loading.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Adjusted the rendering approach for dynamic sections to ensure they operate reliably on the client, promoting a smoother interactive experience for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->