### PR TITLE
feat: added missing deposit funds link in select-create-action menu

### DIFF
--- a/apps/web/src/app/[lang]/dho/[id]/_components/select-create-action.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/select-create-action.tsx
@@ -40,7 +40,7 @@ export const CREATE_ACTIONS = [
     title: 'Deposit Funds',
     description:
       'Deposit funds into your treasury by copying the treasury address or scanning the QR code.',
-    href: '#',
+    href: 'treasury/deposit',
     icon: <PlusCircledIcon />,
   },
 ];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the "Deposit Funds" action to navigate to the correct page instead of a placeholder link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->