### PR TITLE
Feat/678 token payout field array

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -82,6 +82,10 @@ const nextConfig = {
       {
         protocol: 'https',
         hostname: 'github.githubassets.com'
+      },
+      {
+        protocol: 'https',
+        hostname: 'raw.githubusercontent.com'
       }
     ],
   },

--- a/packages/epics/src/agreements/components/token-payout-field-array.stories.tsx
+++ b/packages/epics/src/agreements/components/token-payout-field-array.stories.tsx
@@ -3,10 +3,25 @@ import { within } from '@storybook/testing-library';
 import { expect } from '@storybook/jest';
 
 import { TokenPayoutFieldArray } from './token-payout-field-array';
+import { Form } from '@hypha-platform/ui';
+import { useForm } from 'react-hook-form';
+import { ReactNode } from 'react';
+
+const FormDecorator = ({ children }: { children: ReactNode }) => {
+  const methods = useForm();
+  return <Form {...methods}>{children}</Form>;
+};
 
 const meta = {
   component: TokenPayoutFieldArray,
   title: 'Epics/Agreements/TokenPayoutFieldArray',
+  decorators: [
+    (Story) => (
+      <FormDecorator>
+        <Story />
+      </FormDecorator>
+    ),
+  ],
 } satisfies Meta<typeof TokenPayoutFieldArray>;
 
 export default meta;

--- a/packages/epics/src/agreements/components/token-payout-field-array.stories.tsx
+++ b/packages/epics/src/agreements/components/token-payout-field-array.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { within } from '@storybook/testing-library';
+import { expect } from '@storybook/jest';
+
+import { TokenPayoutFieldArray } from './token-payout-field-array';
+
+const meta = {
+  component: TokenPayoutFieldArray,
+  title: 'Epics/Agreements/TokenPayoutFieldArray',
+} satisfies Meta<typeof TokenPayoutFieldArray>;
+
+export default meta;
+
+type Story = StoryObj<typeof TokenPayoutFieldArray>;
+
+export const Default: Story = {
+  args: {
+    tokens: [
+      {
+        icon: 'https://raw.githubusercontent.com/spothq/cryptocurrency-icons/refs/heads/master/svg/icon/btc.svg',
+        symbol: 'BTC',
+        name: 'Bitcoin',
+      },
+      {
+        icon: 'https://raw.githubusercontent.com/spothq/cryptocurrency-icons/refs/heads/master/svg/icon/eth.svg',
+        symbol: 'ETH',
+        name: 'Ethereum',
+      },
+    ],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(canvas.getByText(/Payment Request/i)).toBeTruthy();
+    expect(canvas.getByText(/\Add/i)).toBeTruthy();
+  },
+};

--- a/packages/epics/src/agreements/components/token-payout-field-array.stories.tsx
+++ b/packages/epics/src/agreements/components/token-payout-field-array.stories.tsx
@@ -46,6 +46,6 @@ export const Default: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     expect(canvas.getByText(/Payment Request/i)).toBeTruthy();
-    expect(canvas.getByText(/\Add/i)).toBeTruthy();
+    expect(canvas.getByText(/Add/i)).toBeTruthy();
   },
 };

--- a/packages/epics/src/agreements/components/token-payout-field-array.tsx
+++ b/packages/epics/src/agreements/components/token-payout-field-array.tsx
@@ -1,47 +1,55 @@
-import { useState } from 'react';
 import { Button } from '@hypha-platform/ui';
-import { TokenPayoutField, Token, TokenPayout } from './token-payout-field';
+import { TokenPayoutField, Token } from './token-payout-field';
 import { PlusIcon } from '@radix-ui/react-icons';
+import { useFieldArray, useFormContext } from 'react-hook-form';
+import React from 'react';
 
 interface TokenPayoutFieldArrayProps {
   tokens: Token[];
-  onChange: (value: TokenPayout[]) => void;
+  name?: string;
 }
 
 export const TokenPayoutFieldArray = ({
   tokens,
-  onChange,
+  name = 'payouts',
 }: TokenPayoutFieldArrayProps) => {
-  const [fields, setFields] = useState<TokenPayout[]>([
-    { amount: '', token: null },
-  ]);
+  const { control, watch } = useFormContext();
 
-  const updateField = (index: number, newValue: TokenPayout) => {
-    const newFields = [...fields];
-    newFields[index] = newValue;
-    setFields(newFields);
-    onChange(newFields);
-  };
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name,
+  });
 
-  const addField = () => {
-    const newFields = [...fields, { amount: '', token: null }];
-    setFields(newFields);
-    onChange(newFields);
-  };
+  // Watch the entire field array for changes
+  const payouts = watch(name);
+  console.debug('TokenPayoutFieldArray', { payouts });
+
+  const handleAddField = React.useCallback(() => {
+    append({ amount: '', token: null });
+  }, []);
 
   return (
     <div className="flex flex-col gap-2 w-full">
       {fields.map((field, index) => (
-        <div key={index} className="flex items-end gap-2">
-          <TokenPayoutField
-            value={field}
-            onChange={(newValue) => updateField(index, newValue)}
-            tokens={tokens}
-          />
+        <div key={field.id} className="flex items-end gap-2">
+          <div className="flex-1">
+            <TokenPayoutField
+              arrayFieldName={name}
+              arrayFieldIndex={index}
+              tokens={tokens}
+            />
+          </div>
+          <Button
+            variant="ghost"
+            colorVariant="error"
+            onClick={() => remove(index)}
+          >
+            Remove
+          </Button>
         </div>
       ))}
       <div className="flex justify-end w-full">
-        <Button className="w-fit" onClick={addField} variant="ghost">
+        <Button className="w-fit" onClick={handleAddField} variant="ghost">
           <PlusIcon />
           Add
         </Button>

--- a/packages/epics/src/agreements/components/token-payout-field-array.tsx
+++ b/packages/epics/src/agreements/components/token-payout-field-array.tsx
@@ -1,0 +1,51 @@
+import { useState } from 'react';
+import { Button } from '@hypha-platform/ui';
+import { TokenPayoutField, Token, TokenPayout } from './token-payout-field';
+import { PlusIcon } from '@radix-ui/react-icons';
+
+interface TokenPayoutFieldArrayProps {
+  tokens: Token[];
+  onChange: (value: TokenPayout[]) => void;
+}
+
+export const TokenPayoutFieldArray = ({
+  tokens,
+  onChange,
+}: TokenPayoutFieldArrayProps) => {
+  const [fields, setFields] = useState<TokenPayout[]>([
+    { amount: '', token: null },
+  ]);
+
+  const updateField = (index: number, newValue: TokenPayout) => {
+    const newFields = [...fields];
+    newFields[index] = newValue;
+    setFields(newFields);
+    onChange(newFields);
+  };
+
+  const addField = () => {
+    const newFields = [...fields, { amount: '', token: null }];
+    setFields(newFields);
+    onChange(newFields);
+  };
+
+  return (
+    <div className="flex flex-col gap-2 w-full">
+      {fields.map((field, index) => (
+        <div key={index} className="flex items-end gap-2">
+          <TokenPayoutField
+            value={field}
+            onChange={(newValue) => updateField(index, newValue)}
+            tokens={tokens}
+          />
+        </div>
+      ))}
+      <div className="flex justify-end w-full">
+        <Button className="w-fit" onClick={addField} variant="ghost">
+          <PlusIcon />
+          Add
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/packages/epics/src/agreements/components/token-payout-field.stories.tsx
+++ b/packages/epics/src/agreements/components/token-payout-field.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { TokenPayoutField } from './token-payout-field';
+import { within } from '@storybook/testing-library';
+import { expect } from '@storybook/jest';
+
+const meta = {
+  component: TokenPayoutField,
+  title: 'Epics/Agreements/TokenPayoutField',
+} satisfies Meta<typeof TokenPayoutField>;
+
+export default meta;
+
+type Story = StoryObj<typeof TokenPayoutField>;
+
+export const Default: Story = {
+  args: {
+    tokens: [
+      {
+        icon: 'https://raw.githubusercontent.com/spothq/cryptocurrency-icons/refs/heads/master/svg/icon/btc.svg',
+        symbol: 'BTC',
+        name: 'Bitcoin',
+      },
+      {
+        icon: 'https://raw.githubusercontent.com/spothq/cryptocurrency-icons/refs/heads/master/svg/icon/eth.svg',
+        symbol: 'ETH',
+        name: 'Ethereum',
+      },
+    ],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(canvas.getByText(/Payment Request/gi)).toBeTruthy();
+  },
+};

--- a/packages/epics/src/agreements/components/token-payout-field.stories.tsx
+++ b/packages/epics/src/agreements/components/token-payout-field.stories.tsx
@@ -3,6 +3,8 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { TokenPayoutField } from './token-payout-field';
 import { within } from '@storybook/testing-library';
 import { expect } from '@storybook/jest';
+import { useState } from 'react';
+import type { Token } from './token-payout-field';
 
 const meta = {
   component: TokenPayoutField,
@@ -14,6 +16,17 @@ export default meta;
 type Story = StoryObj<typeof TokenPayoutField>;
 
 export const Default: Story = {
+  render: (args) => {
+    const [value, setValue] = useState<{
+      amount: string;
+      token: Token | null;
+    }>({
+      amount: '',
+      token: null,
+    });
+
+    return <TokenPayoutField {...args} value={value} onChange={setValue} />;
+  },
   args: {
     tokens: [
       {

--- a/packages/epics/src/agreements/components/token-payout-field.stories.tsx
+++ b/packages/epics/src/agreements/components/token-payout-field.stories.tsx
@@ -3,12 +3,26 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { TokenPayoutField } from './token-payout-field';
 import { within } from '@storybook/testing-library';
 import { expect } from '@storybook/jest';
-import { useState } from 'react';
+import { ReactNode, useState } from 'react';
 import type { Token } from './token-payout-field';
+import { useForm } from 'react-hook-form';
+import { Form } from '@hypha-platform/ui';
+
+const FormDecorator = ({ children }: { children: ReactNode }) => {
+  const methods = useForm();
+  return <Form {...methods}>{children}</Form>;
+};
 
 const meta = {
   component: TokenPayoutField,
   title: 'Epics/Agreements/TokenPayoutField',
+  decorators: [
+    (Story) => (
+      <FormDecorator>
+        <Story />
+      </FormDecorator>
+    ),
+  ],
 } satisfies Meta<typeof TokenPayoutField>;
 
 export default meta;
@@ -16,18 +30,9 @@ export default meta;
 type Story = StoryObj<typeof TokenPayoutField>;
 
 export const Default: Story = {
-  render: (args) => {
-    const [value, setValue] = useState<{
-      amount: string;
-      token: Token | null;
-    }>({
-      amount: '',
-      token: null,
-    });
-
-    return <TokenPayoutField {...args} value={value} onChange={setValue} />;
-  },
   args: {
+    arrayFieldIndex: 0,
+    arrayFieldName: 'payout',
     tokens: [
       {
         icon: 'https://raw.githubusercontent.com/spothq/cryptocurrency-icons/refs/heads/master/svg/icon/btc.svg',

--- a/packages/epics/src/agreements/components/token-payout-field.tsx
+++ b/packages/epics/src/agreements/components/token-payout-field.tsx
@@ -1,0 +1,84 @@
+import { useState } from 'react';
+import { DollarSignIcon } from 'lucide-react';
+import { ChevronDownIcon } from '@radix-ui/themes';
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  Input,
+  Image,
+} from '@hypha-platform/ui';
+
+interface Token {
+  icon: string;
+  symbol: string;
+  name: string;
+}
+
+interface TokenPayoutFieldProps {
+  tokens: Token[];
+}
+
+export const TokenPayoutField = ({ tokens }: TokenPayoutFieldProps) => {
+  const [selectedToken, setSelectedToken] = useState<Token | null>(null);
+
+  return (
+    <div className="flex justify-between w-full">
+      <label className="text-2 text-neutral-11">Payment Request</label>
+      <div className="flex gap-2 items-center">
+        <Input
+          type="number"
+          leftIcon={<DollarSignIcon size={'16px'} />}
+          placeholder="Type an amount"
+        />
+        <DropdownMenu>
+          <DropdownMenuTrigger>
+            <Button
+              variant="outline"
+              colorVariant="neutral"
+              className="flex justify-between items-center gap-2 min-w-[140px]"
+            >
+              <div className="flex items-center gap-2">
+                {selectedToken ? (
+                  <>
+                    <Image
+                      src={selectedToken.icon}
+                      width={20}
+                      height={20}
+                      alt={`${selectedToken.name} icon`}
+                    />
+                    <span className="text-2 text-neutral-11">
+                      {selectedToken.symbol}
+                    </span>
+                  </>
+                ) : (
+                  <span className="text-2 text-neutral-11">Select a token</span>
+                )}
+              </div>
+              <ChevronDownIcon />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent>
+            {tokens?.map((token) => (
+              <DropdownMenuItem
+                key={token.symbol}
+                onSelect={() => setSelectedToken(token)}
+              >
+                <Image
+                  src={token.icon}
+                  width={24}
+                  height={24}
+                  alt={`${token.name} icon`}
+                  className="mr-2"
+                />
+                <span className="text-2 text-neutral-11">{token.symbol}</span>
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    </div>
+  );
+};

--- a/packages/epics/src/agreements/components/token-payout-field.tsx
+++ b/packages/epics/src/agreements/components/token-payout-field.tsx
@@ -9,6 +9,7 @@ import {
   Input,
   Image,
 } from '@hypha-platform/ui';
+import { useFormContext } from 'react-hook-form';
 
 export interface Token {
   icon: string;
@@ -22,22 +23,31 @@ export interface TokenPayout {
 }
 
 export interface TokenPayoutFieldProps {
-  value: TokenPayout;
-  onChange: (value: TokenPayout) => void;
+  arrayFieldName: string;
+  arrayFieldIndex: number;
   tokens: Token[];
 }
 
 export const TokenPayoutField = ({
-  value,
-  onChange,
+  arrayFieldName,
+  arrayFieldIndex,
   tokens,
 }: TokenPayoutFieldProps) => {
-  const handleAmountChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    onChange({ ...value, amount: e.target.value });
-  };
+  const { register, watch, setValue } = useFormContext();
+  console.debug('TokenPayoutField', {
+    [arrayFieldName]: watch(arrayFieldName),
+  });
 
+  // Define field names
+  const amountFieldName = `${arrayFieldName}.${arrayFieldIndex}.amount`;
+  const tokenFieldName = `${arrayFieldName}.${arrayFieldIndex}.token`;
+
+  // Watch the token field value
+  const selectedToken = watch(tokenFieldName);
+
+  // Handle token selection
   const handleTokenChange = (token: Token) => {
-    onChange({ ...value, token });
+    setValue(tokenFieldName, token, { shouldValidate: true });
   };
 
   return (
@@ -45,9 +55,8 @@ export const TokenPayoutField = ({
       <label className="text-2 text-neutral-11">Payment Request</label>
       <div className="flex gap-2 items-center">
         <Input
+          {...register(amountFieldName)}
           type="number"
-          value={value.amount}
-          onChange={handleAmountChange}
           leftIcon={<DollarSignIcon size="16px" />}
           placeholder="Type an amount"
         />
@@ -59,16 +68,16 @@ export const TokenPayoutField = ({
               className="flex justify-between items-center gap-2 min-w-[140px]"
             >
               <div className="flex items-center gap-2">
-                {value.token ? (
+                {selectedToken ? (
                   <>
                     <Image
-                      src={value.token.icon}
+                      src={selectedToken.icon}
                       width={20}
                       height={20}
-                      alt={`${value.token.name} icon`}
+                      alt={`${selectedToken.name} icon`}
                     />
                     <span className="text-2 text-neutral-11">
-                      {value.token.symbol}
+                      {selectedToken.symbol}
                     </span>
                   </>
                 ) : (

--- a/packages/epics/src/agreements/components/token-payout-field.tsx
+++ b/packages/epics/src/agreements/components/token-payout-field.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { DollarSignIcon } from 'lucide-react';
 import { ChevronDownIcon } from '@radix-ui/themes';
 import {
@@ -11,18 +10,35 @@ import {
   Image,
 } from '@hypha-platform/ui';
 
-interface Token {
+export interface Token {
   icon: string;
   symbol: string;
   name: string;
 }
 
-interface TokenPayoutFieldProps {
+export interface TokenPayout {
+  amount: string;
+  token: Token | null;
+}
+
+export interface TokenPayoutFieldProps {
+  value: TokenPayout;
+  onChange: (value: TokenPayout) => void;
   tokens: Token[];
 }
 
-export const TokenPayoutField = ({ tokens }: TokenPayoutFieldProps) => {
-  const [selectedToken, setSelectedToken] = useState<Token | null>(null);
+export const TokenPayoutField = ({
+  value,
+  onChange,
+  tokens,
+}: TokenPayoutFieldProps) => {
+  const handleAmountChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    onChange({ ...value, amount: e.target.value });
+  };
+
+  const handleTokenChange = (token: Token) => {
+    onChange({ ...value, token });
+  };
 
   return (
     <div className="flex justify-between w-full">
@@ -30,7 +46,9 @@ export const TokenPayoutField = ({ tokens }: TokenPayoutFieldProps) => {
       <div className="flex gap-2 items-center">
         <Input
           type="number"
-          leftIcon={<DollarSignIcon size={'16px'} />}
+          value={value.amount}
+          onChange={handleAmountChange}
+          leftIcon={<DollarSignIcon size="16px" />}
           placeholder="Type an amount"
         />
         <DropdownMenu>
@@ -41,16 +59,16 @@ export const TokenPayoutField = ({ tokens }: TokenPayoutFieldProps) => {
               className="flex justify-between items-center gap-2 min-w-[140px]"
             >
               <div className="flex items-center gap-2">
-                {selectedToken ? (
+                {value.token ? (
                   <>
                     <Image
-                      src={selectedToken.icon}
+                      src={value.token.icon}
                       width={20}
                       height={20}
-                      alt={`${selectedToken.name} icon`}
+                      alt={`${value.token.name} icon`}
                     />
                     <span className="text-2 text-neutral-11">
-                      {selectedToken.symbol}
+                      {value.token.symbol}
                     </span>
                   </>
                 ) : (
@@ -61,10 +79,10 @@ export const TokenPayoutField = ({ tokens }: TokenPayoutFieldProps) => {
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent>
-            {tokens?.map((token) => (
+            {tokens.map((token) => (
               <DropdownMenuItem
                 key={token.symbol}
-                onSelect={() => setSelectedToken(token)}
+                onSelect={() => handleTokenChange(token)}
               >
                 <Image
                   src={token.icon}


### PR DESCRIPTION
Added token payout components for agreements with cryptocurrency support.

### What changed?

- Added `TokenPayoutField` component that allows users to input an amount and select a cryptocurrency token
- Added `TokenPayoutFieldArray` component that manages multiple token payout fields with an "Add" button
- Created Storybook stories for both components to showcase their functionality
- Updated Next.js config to allow images from `raw.githubusercontent.com` for cryptocurrency icons

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a "Token Payout Field" component, allowing users to input payment amounts and select from available tokens.
  - Added a "Token Payout Field Array" component for managing multiple token payout entries with the ability to add new fields.
- **Storybook**
  - Added interactive Storybook stories and tests for both the Token Payout Field and Token Payout Field Array components.
- **Chores**
  - Updated configuration to allow loading images from raw.githubusercontent.com.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->