### PR TITLE
Feat/680 make an agreement web3 integration

### DIFF
--- a/apps/web/src/app/[lang]/dho/[id]/@aside/governance/create/loading.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@aside/governance/create/loading.tsx
@@ -13,7 +13,11 @@ export default function AsideCreateAgreementPage() {
         message={<></>}
         className="-m-9"
       >
-        <CreateAgreementForm spaceId={undefined} successfulUrl="" web3SpaceId={undefined} />
+        <CreateAgreementForm
+          spaceId={undefined}
+          successfulUrl=""
+          web3SpaceId={undefined}
+        />
       </LoadingBackdrop>
     </SidePanel>
   );

--- a/apps/web/src/app/[lang]/dho/[id]/@aside/governance/create/loading.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@aside/governance/create/loading.tsx
@@ -13,7 +13,7 @@ export default function AsideCreateAgreementPage() {
         message={<></>}
         className="-m-9"
       >
-        <CreateAgreementForm spaceId={undefined} successfulUrl="" />
+        <CreateAgreementForm spaceId={undefined} successfulUrl="" web3SpaceId={undefined} />
       </LoadingBackdrop>
     </SidePanel>
   );

--- a/apps/web/src/app/[lang]/dho/[id]/@aside/governance/create/page.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@aside/governance/create/page.tsx
@@ -15,12 +15,14 @@ export default async function CreateAgreementPage({ params }: PageProps) {
   const spaceFromDb = await spaceService.getBySlug({ slug: id });
 
   const spaceId = spaceFromDb.id;
+  const web3SpaceId = spaceFromDb.web3SpaceId;
 
   return (
     <SidePanel>
       <CreateAgreementForm
         successfulUrl={getDhoPathGovernance(lang as Locale, id)}
         spaceId={spaceId}
+        web3SpaceId={web3SpaceId}
       />
     </SidePanel>
   );

--- a/apps/web/src/app/[lang]/dho/[id]/@aside/governance/proposal/[documentSlug]/page.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@aside/governance/proposal/[documentSlug]/page.tsx
@@ -28,6 +28,8 @@ export default function Agreements() {
         title={document?.title}
         status={document?.state}
         isLoading={isLoading}
+        leadImage={document?.leadImage}
+        attachments={document?.attachments}
       />
     </SidePanel>
   );

--- a/packages/core/src/generated.ts
+++ b/packages/core/src/generated.ts
@@ -1,4 +1,231 @@
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// AgreementsImplementation
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * [__View Contract on Base Basescan__](https://basescan.org/address/0x83B5d4F555A68126bB302685e67767Bb7a2985F0)
+ */
+export const agreementsImplementationAbi = [
+  { type: 'constructor', inputs: [], stateMutability: 'nonpayable' },
+  {
+    type: 'error',
+    inputs: [{ name: 'target', internalType: 'address', type: 'address' }],
+    name: 'AddressEmptyCode',
+  },
+  {
+    type: 'error',
+    inputs: [
+      { name: 'implementation', internalType: 'address', type: 'address' },
+    ],
+    name: 'ERC1967InvalidImplementation',
+  },
+  { type: 'error', inputs: [], name: 'ERC1967NonPayable' },
+  { type: 'error', inputs: [], name: 'FailedCall' },
+  { type: 'error', inputs: [], name: 'InvalidInitialization' },
+  { type: 'error', inputs: [], name: 'NotInitializing' },
+  {
+    type: 'error',
+    inputs: [{ name: 'owner', internalType: 'address', type: 'address' }],
+    name: 'OwnableInvalidOwner',
+  },
+  {
+    type: 'error',
+    inputs: [{ name: 'account', internalType: 'address', type: 'address' }],
+    name: 'OwnableUnauthorizedAccount',
+  },
+  { type: 'error', inputs: [], name: 'UUPSUnauthorizedCallContext' },
+  {
+    type: 'error',
+    inputs: [{ name: 'slot', internalType: 'bytes32', type: 'bytes32' }],
+    name: 'UUPSUnsupportedProxiableUUID',
+  },
+  {
+    type: 'event',
+    anonymous: false,
+    inputs: [
+      {
+        name: 'spaceId',
+        internalType: 'uint256',
+        type: 'uint256',
+        indexed: true,
+      },
+      {
+        name: 'proposalId',
+        internalType: 'uint256',
+        type: 'uint256',
+        indexed: true,
+      },
+      {
+        name: 'executor',
+        internalType: 'address',
+        type: 'address',
+        indexed: false,
+      },
+    ],
+    name: 'AgreementAccepted',
+  },
+  {
+    type: 'event',
+    anonymous: false,
+    inputs: [
+      {
+        name: 'version',
+        internalType: 'uint64',
+        type: 'uint64',
+        indexed: false,
+      },
+    ],
+    name: 'Initialized',
+  },
+  {
+    type: 'event',
+    anonymous: false,
+    inputs: [
+      {
+        name: 'previousOwner',
+        internalType: 'address',
+        type: 'address',
+        indexed: true,
+      },
+      {
+        name: 'newOwner',
+        internalType: 'address',
+        type: 'address',
+        indexed: true,
+      },
+    ],
+    name: 'OwnershipTransferred',
+  },
+  {
+    type: 'event',
+    anonymous: false,
+    inputs: [
+      {
+        name: 'implementation',
+        internalType: 'address',
+        type: 'address',
+        indexed: true,
+      },
+    ],
+    name: 'Upgraded',
+  },
+  {
+    type: 'function',
+    inputs: [],
+    name: 'UPGRADE_INTERFACE_VERSION',
+    outputs: [{ name: '', internalType: 'string', type: 'string' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [
+      { name: '_spaceId', internalType: 'uint256', type: 'uint256' },
+      { name: '_proposalId', internalType: 'uint256', type: 'uint256' },
+    ],
+    name: 'acceptAgreement',
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    inputs: [{ name: '_spaceId', internalType: 'uint256', type: 'uint256' }],
+    name: 'getSpaceProposals',
+    outputs: [{ name: '', internalType: 'uint256[]', type: 'uint256[]' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [
+      { name: '_spaceId', internalType: 'uint256', type: 'uint256' },
+      { name: '_proposalId', internalType: 'uint256', type: 'uint256' },
+    ],
+    name: 'hasProposal',
+    outputs: [{ name: '', internalType: 'bool', type: 'bool' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [
+      { name: 'initialOwner', internalType: 'address', type: 'address' },
+    ],
+    name: 'initialize',
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    inputs: [],
+    name: 'owner',
+    outputs: [{ name: '', internalType: 'address', type: 'address' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [],
+    name: 'proxiableUUID',
+    outputs: [{ name: '', internalType: 'bytes32', type: 'bytes32' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [],
+    name: 'renounceOwnership',
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    inputs: [
+      { name: '_spaceFactory', internalType: 'address', type: 'address' },
+    ],
+    name: 'setContracts',
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    inputs: [],
+    name: 'spaceFactory',
+    outputs: [
+      { name: '', internalType: 'contract IDAOSpaceFactory', type: 'address' },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [{ name: 'newOwner', internalType: 'address', type: 'address' }],
+    name: 'transferOwnership',
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    inputs: [
+      { name: 'newImplementation', internalType: 'address', type: 'address' },
+      { name: 'data', internalType: 'bytes', type: 'bytes' },
+    ],
+    name: 'upgradeToAndCall',
+    outputs: [],
+    stateMutability: 'payable',
+  },
+] as const
+
+/**
+ * [__View Contract on Base Basescan__](https://basescan.org/address/0x83B5d4F555A68126bB302685e67767Bb7a2985F0)
+ */
+export const agreementsImplementationAddress = {
+  8453: '0x83B5d4F555A68126bB302685e67767Bb7a2985F0',
+} as const
+
+/**
+ * [__View Contract on Base Basescan__](https://basescan.org/address/0x83B5d4F555A68126bB302685e67767Bb7a2985F0)
+ */
+export const agreementsImplementationConfig = {
+  address: agreementsImplementationAddress,
+  abi: agreementsImplementationAbi,
+} as const
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // DAOProposalsImplementation
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -322,6 +549,13 @@ export const daoProposalsImplementationAbi = [
   },
   {
     type: 'function',
+    inputs: [],
+    name: 'getLatestProposalId',
+    outputs: [{ name: '', internalType: 'uint256', type: 'uint256' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
     inputs: [{ name: '_proposalId', internalType: 'uint256', type: 'uint256' }],
     name: 'getProposalCore',
     outputs: [
@@ -377,6 +611,19 @@ export const daoProposalsImplementationAbi = [
   {
     type: 'function',
     inputs: [],
+    name: 'paymentTracker',
+    outputs: [
+      {
+        name: '',
+        internalType: 'contract ISpacePaymentTracker',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [],
     name: 'proposalCounter',
     outputs: [{ name: '', internalType: 'uint256', type: 'uint256' }],
     stateMutability: 'view',
@@ -407,9 +654,25 @@ export const daoProposalsImplementationAbi = [
   },
   {
     type: 'function',
+    inputs: [
+      { name: '_paymentTracker', internalType: 'address', type: 'address' },
+    ],
+    name: 'setPaymentTracker',
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
     inputs: [{ name: '', internalType: 'uint256', type: 'uint256' }],
     name: 'spaceAddresses',
     outputs: [{ name: '', internalType: 'address', type: 'address' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [{ name: '', internalType: 'uint256', type: 'uint256' }],
+    name: 'spaceTrialActivated',
+    outputs: [{ name: '', internalType: 'bool', type: 'bool' }],
     stateMutability: 'view',
   },
   {

--- a/packages/core/src/generated.ts
+++ b/packages/core/src/generated.ts
@@ -208,14 +208,14 @@ export const agreementsImplementationAbi = [
     outputs: [],
     stateMutability: 'payable',
   },
-] as const
+] as const;
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0x83B5d4F555A68126bB302685e67767Bb7a2985F0)
  */
 export const agreementsImplementationAddress = {
   8453: '0x83B5d4F555A68126bB302685e67767Bb7a2985F0',
-} as const
+} as const;
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0x83B5d4F555A68126bB302685e67767Bb7a2985F0)
@@ -223,7 +223,7 @@ export const agreementsImplementationAddress = {
 export const agreementsImplementationConfig = {
   address: agreementsImplementationAddress,
   abi: agreementsImplementationAbi,
-} as const
+} as const;
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // DAOProposalsImplementation
@@ -702,14 +702,14 @@ export const daoProposalsImplementationAbi = [
     outputs: [],
     stateMutability: 'nonpayable',
   },
-] as const
+] as const;
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0x001bA7a00a259Fb12d7936455e292a60FC2bef14)
  */
 export const daoProposalsImplementationAddress = {
   8453: '0x001bA7a00a259Fb12d7936455e292a60FC2bef14',
-} as const
+} as const;
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0x001bA7a00a259Fb12d7936455e292a60FC2bef14)
@@ -717,7 +717,7 @@ export const daoProposalsImplementationAddress = {
 export const daoProposalsImplementationConfig = {
   address: daoProposalsImplementationAddress,
   abi: daoProposalsImplementationAbi,
-} as const
+} as const;
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // DAOSpaceFactoryImplementation
@@ -1189,14 +1189,14 @@ export const daoSpaceFactoryImplementationAbi = [
     outputs: [],
     stateMutability: 'payable',
   },
-] as const
+] as const;
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0xc8B8454D2F9192FeCAbc2C6F5d88F6434A2a9cd9)
  */
 export const daoSpaceFactoryImplementationAddress = {
   8453: '0xc8B8454D2F9192FeCAbc2C6F5d88F6434A2a9cd9',
-} as const
+} as const;
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0xc8B8454D2F9192FeCAbc2C6F5d88F6434A2a9cd9)
@@ -1204,4 +1204,4 @@ export const daoSpaceFactoryImplementationAddress = {
 export const daoSpaceFactoryImplementationConfig = {
   address: daoSpaceFactoryImplementationAddress,
   abi: daoSpaceFactoryImplementationAbi,
-} as const
+} as const;

--- a/packages/core/src/generated.ts
+++ b/packages/core/src/generated.ts
@@ -1,11 +1,11 @@
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-// AgreementsImplementation
+// DAOProposalsImplementation
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 /**
- * [__View Contract on Base Basescan__](https://basescan.org/address/0x83B5d4F555A68126bB302685e67767Bb7a2985F0)
+ * [__View Contract on Base Basescan__](https://basescan.org/address/0x001bA7a00a259Fb12d7936455e292a60FC2bef14)
  */
-export const agreementsImplementationAbi = [
+export const daoProposalsImplementationAbi = [
   { type: 'constructor', inputs: [], stateMutability: 'nonpayable' },
   {
     type: 'error',
@@ -50,19 +50,13 @@ export const agreementsImplementationAbi = [
         indexed: true,
       },
       {
-        name: 'proposalId',
-        internalType: 'uint256',
-        type: 'uint256',
-        indexed: true,
-      },
-      {
         name: 'executor',
         internalType: 'address',
         type: 'address',
         indexed: false,
       },
     ],
-    name: 'AgreementAccepted',
+    name: 'ExecutorSet',
   },
   {
     type: 'event',
@@ -101,6 +95,156 @@ export const agreementsImplementationAbi = [
     anonymous: false,
     inputs: [
       {
+        name: 'proposalId',
+        internalType: 'uint256',
+        type: 'uint256',
+        indexed: true,
+      },
+      {
+        name: 'spaceId',
+        internalType: 'uint256',
+        type: 'uint256',
+        indexed: true,
+      },
+      {
+        name: 'startTime',
+        internalType: 'uint256',
+        type: 'uint256',
+        indexed: false,
+      },
+      {
+        name: 'duration',
+        internalType: 'uint256',
+        type: 'uint256',
+        indexed: false,
+      },
+      {
+        name: 'creator',
+        internalType: 'address',
+        type: 'address',
+        indexed: false,
+      },
+      {
+        name: 'executionData',
+        internalType: 'bytes',
+        type: 'bytes',
+        indexed: false,
+      },
+    ],
+    name: 'ProposalCreated',
+  },
+  {
+    type: 'event',
+    anonymous: false,
+    inputs: [
+      {
+        name: 'proposalId',
+        internalType: 'uint256',
+        type: 'uint256',
+        indexed: true,
+      },
+      {
+        name: 'spaceId',
+        internalType: 'uint256',
+        type: 'uint256',
+        indexed: true,
+      },
+      {
+        name: 'newDuration',
+        internalType: 'uint256',
+        type: 'uint256',
+        indexed: false,
+      },
+      {
+        name: 'targetContract',
+        internalType: 'address',
+        type: 'address',
+        indexed: false,
+      },
+      {
+        name: 'executionData',
+        internalType: 'bytes',
+        type: 'bytes',
+        indexed: false,
+      },
+      {
+        name: 'value',
+        internalType: 'uint256',
+        type: 'uint256',
+        indexed: false,
+      },
+      {
+        name: 'editor',
+        internalType: 'address',
+        type: 'address',
+        indexed: false,
+      },
+    ],
+    name: 'ProposalEdited',
+  },
+  {
+    type: 'event',
+    anonymous: false,
+    inputs: [
+      {
+        name: 'proposalId',
+        internalType: 'uint256',
+        type: 'uint256',
+        indexed: true,
+      },
+      { name: 'passed', internalType: 'bool', type: 'bool', indexed: false },
+      {
+        name: 'yesVotes',
+        internalType: 'uint256',
+        type: 'uint256',
+        indexed: false,
+      },
+      {
+        name: 'noVotes',
+        internalType: 'uint256',
+        type: 'uint256',
+        indexed: false,
+      },
+    ],
+    name: 'ProposalExecuted',
+  },
+  {
+    type: 'event',
+    anonymous: false,
+    inputs: [
+      {
+        name: 'proposalId',
+        internalType: 'uint256',
+        type: 'uint256',
+        indexed: true,
+      },
+    ],
+    name: 'ProposalExpired',
+  },
+  {
+    type: 'event',
+    anonymous: false,
+    inputs: [
+      {
+        name: 'proposalId',
+        internalType: 'uint256',
+        type: 'uint256',
+        indexed: true,
+      },
+      {
+        name: 'value',
+        internalType: 'uint256',
+        type: 'uint256',
+        indexed: false,
+      },
+    ],
+    name: 'ProposalValueSet',
+  },
+  {
+    type: 'event',
+    anonymous: false,
+    inputs: [
+      {
         name: 'implementation',
         internalType: 'address',
         type: 'address',
@@ -108,6 +252,32 @@ export const agreementsImplementationAbi = [
       },
     ],
     name: 'Upgraded',
+  },
+  {
+    type: 'event',
+    anonymous: false,
+    inputs: [
+      {
+        name: 'proposalId',
+        internalType: 'uint256',
+        type: 'uint256',
+        indexed: true,
+      },
+      {
+        name: 'voter',
+        internalType: 'address',
+        type: 'address',
+        indexed: true,
+      },
+      { name: 'support', internalType: 'bool', type: 'bool', indexed: false },
+      {
+        name: 'votingPower',
+        internalType: 'uint256',
+        type: 'uint256',
+        indexed: false,
+      },
+    ],
+    name: 'VoteCast',
   },
   {
     type: 'function',
@@ -118,28 +288,73 @@ export const agreementsImplementationAbi = [
   },
   {
     type: 'function',
-    inputs: [
-      { name: '_spaceId', internalType: 'uint256', type: 'uint256' },
-      { name: '_proposalId', internalType: 'uint256', type: 'uint256' },
-    ],
-    name: 'acceptAgreement',
-    outputs: [],
+    inputs: [{ name: '_proposalId', internalType: 'uint256', type: 'uint256' }],
+    name: 'checkProposalExpiration',
+    outputs: [{ name: '', internalType: 'bool', type: 'bool' }],
     stateMutability: 'nonpayable',
   },
   {
     type: 'function',
-    inputs: [{ name: '_spaceId', internalType: 'uint256', type: 'uint256' }],
-    name: 'getSpaceProposals',
-    outputs: [{ name: '', internalType: 'uint256[]', type: 'uint256[]' }],
+    inputs: [
+      {
+        name: 'params',
+        internalType: 'struct IDAOProposals.ProposalParams',
+        type: 'tuple',
+        components: [
+          { name: 'spaceId', internalType: 'uint256', type: 'uint256' },
+          { name: 'duration', internalType: 'uint256', type: 'uint256' },
+          {
+            name: 'transactions',
+            internalType: 'struct IDAOProposals.Transaction[]',
+            type: 'tuple[]',
+            components: [
+              { name: 'target', internalType: 'address', type: 'address' },
+              { name: 'value', internalType: 'uint256', type: 'uint256' },
+              { name: 'data', internalType: 'bytes', type: 'bytes' },
+            ],
+          },
+        ],
+      },
+    ],
+    name: 'createProposal',
+    outputs: [{ name: '', internalType: 'uint256', type: 'uint256' }],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    inputs: [{ name: '_proposalId', internalType: 'uint256', type: 'uint256' }],
+    name: 'getProposalCore',
+    outputs: [
+      { name: 'spaceId', internalType: 'uint256', type: 'uint256' },
+      { name: 'startTime', internalType: 'uint256', type: 'uint256' },
+      { name: 'endTime', internalType: 'uint256', type: 'uint256' },
+      { name: 'executed', internalType: 'bool', type: 'bool' },
+      { name: 'expired', internalType: 'bool', type: 'bool' },
+      { name: 'yesVotes', internalType: 'uint256', type: 'uint256' },
+      { name: 'noVotes', internalType: 'uint256', type: 'uint256' },
+      {
+        name: 'totalVotingPowerAtSnapshot',
+        internalType: 'uint256',
+        type: 'uint256',
+      },
+      { name: 'creator', internalType: 'address', type: 'address' },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [{ name: '_proposalId', internalType: 'uint256', type: 'uint256' }],
+    name: 'getProposalEndTime',
+    outputs: [{ name: '', internalType: 'uint256', type: 'uint256' }],
     stateMutability: 'view',
   },
   {
     type: 'function',
     inputs: [
-      { name: '_spaceId', internalType: 'uint256', type: 'uint256' },
       { name: '_proposalId', internalType: 'uint256', type: 'uint256' },
+      { name: '_voter', internalType: 'address', type: 'address' },
     ],
-    name: 'hasProposal',
+    name: 'hasVoted',
     outputs: [{ name: '', internalType: 'bool', type: 'bool' }],
     stateMutability: 'view',
   },
@@ -162,6 +377,13 @@ export const agreementsImplementationAbi = [
   {
     type: 'function',
     inputs: [],
+    name: 'proposalCounter',
+    outputs: [{ name: '', internalType: 'uint256', type: 'uint256' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [],
     name: 'proxiableUUID',
     outputs: [{ name: '', internalType: 'bytes32', type: 'bytes32' }],
     stateMutability: 'view',
@@ -177,6 +399,7 @@ export const agreementsImplementationAbi = [
     type: 'function',
     inputs: [
       { name: '_spaceFactory', internalType: 'address', type: 'address' },
+      { name: '_directory', internalType: 'address', type: 'address' },
     ],
     name: 'setContracts',
     outputs: [],
@@ -184,11 +407,9 @@ export const agreementsImplementationAbi = [
   },
   {
     type: 'function',
-    inputs: [],
-    name: 'spaceFactory',
-    outputs: [
-      { name: '', internalType: 'contract IDAOSpaceFactory', type: 'address' },
-    ],
+    inputs: [{ name: '', internalType: 'uint256', type: 'uint256' }],
+    name: 'spaceAddresses',
+    outputs: [{ name: '', internalType: 'address', type: 'address' }],
     stateMutability: 'view',
   },
   {
@@ -208,21 +429,31 @@ export const agreementsImplementationAbi = [
     outputs: [],
     stateMutability: 'payable',
   },
+  {
+    type: 'function',
+    inputs: [
+      { name: '_proposalId', internalType: 'uint256', type: 'uint256' },
+      { name: '_support', internalType: 'bool', type: 'bool' },
+    ],
+    name: 'vote',
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
 ] as const
 
 /**
- * [__View Contract on Base Basescan__](https://basescan.org/address/0x83B5d4F555A68126bB302685e67767Bb7a2985F0)
+ * [__View Contract on Base Basescan__](https://basescan.org/address/0x001bA7a00a259Fb12d7936455e292a60FC2bef14)
  */
-export const agreementsImplementationAddress = {
-  8453: '0x83B5d4F555A68126bB302685e67767Bb7a2985F0',
+export const daoProposalsImplementationAddress = {
+  8453: '0x001bA7a00a259Fb12d7936455e292a60FC2bef14',
 } as const
 
 /**
- * [__View Contract on Base Basescan__](https://basescan.org/address/0x83B5d4F555A68126bB302685e67767Bb7a2985F0)
+ * [__View Contract on Base Basescan__](https://basescan.org/address/0x001bA7a00a259Fb12d7936455e292a60FC2bef14)
  */
-export const agreementsImplementationConfig = {
-  address: agreementsImplementationAddress,
-  abi: agreementsImplementationAbi,
+export const daoProposalsImplementationConfig = {
+  address: daoProposalsImplementationAddress,
+  abi: daoProposalsImplementationAbi,
 } as const
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/packages/core/src/generated.ts
+++ b/packages/core/src/generated.ts
@@ -1,4 +1,231 @@
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// AgreementsImplementation
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * [__View Contract on Base Basescan__](https://basescan.org/address/0x83B5d4F555A68126bB302685e67767Bb7a2985F0)
+ */
+export const agreementsImplementationAbi = [
+  { type: 'constructor', inputs: [], stateMutability: 'nonpayable' },
+  {
+    type: 'error',
+    inputs: [{ name: 'target', internalType: 'address', type: 'address' }],
+    name: 'AddressEmptyCode',
+  },
+  {
+    type: 'error',
+    inputs: [
+      { name: 'implementation', internalType: 'address', type: 'address' },
+    ],
+    name: 'ERC1967InvalidImplementation',
+  },
+  { type: 'error', inputs: [], name: 'ERC1967NonPayable' },
+  { type: 'error', inputs: [], name: 'FailedCall' },
+  { type: 'error', inputs: [], name: 'InvalidInitialization' },
+  { type: 'error', inputs: [], name: 'NotInitializing' },
+  {
+    type: 'error',
+    inputs: [{ name: 'owner', internalType: 'address', type: 'address' }],
+    name: 'OwnableInvalidOwner',
+  },
+  {
+    type: 'error',
+    inputs: [{ name: 'account', internalType: 'address', type: 'address' }],
+    name: 'OwnableUnauthorizedAccount',
+  },
+  { type: 'error', inputs: [], name: 'UUPSUnauthorizedCallContext' },
+  {
+    type: 'error',
+    inputs: [{ name: 'slot', internalType: 'bytes32', type: 'bytes32' }],
+    name: 'UUPSUnsupportedProxiableUUID',
+  },
+  {
+    type: 'event',
+    anonymous: false,
+    inputs: [
+      {
+        name: 'spaceId',
+        internalType: 'uint256',
+        type: 'uint256',
+        indexed: true,
+      },
+      {
+        name: 'proposalId',
+        internalType: 'uint256',
+        type: 'uint256',
+        indexed: true,
+      },
+      {
+        name: 'executor',
+        internalType: 'address',
+        type: 'address',
+        indexed: false,
+      },
+    ],
+    name: 'AgreementAccepted',
+  },
+  {
+    type: 'event',
+    anonymous: false,
+    inputs: [
+      {
+        name: 'version',
+        internalType: 'uint64',
+        type: 'uint64',
+        indexed: false,
+      },
+    ],
+    name: 'Initialized',
+  },
+  {
+    type: 'event',
+    anonymous: false,
+    inputs: [
+      {
+        name: 'previousOwner',
+        internalType: 'address',
+        type: 'address',
+        indexed: true,
+      },
+      {
+        name: 'newOwner',
+        internalType: 'address',
+        type: 'address',
+        indexed: true,
+      },
+    ],
+    name: 'OwnershipTransferred',
+  },
+  {
+    type: 'event',
+    anonymous: false,
+    inputs: [
+      {
+        name: 'implementation',
+        internalType: 'address',
+        type: 'address',
+        indexed: true,
+      },
+    ],
+    name: 'Upgraded',
+  },
+  {
+    type: 'function',
+    inputs: [],
+    name: 'UPGRADE_INTERFACE_VERSION',
+    outputs: [{ name: '', internalType: 'string', type: 'string' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [
+      { name: '_spaceId', internalType: 'uint256', type: 'uint256' },
+      { name: '_proposalId', internalType: 'uint256', type: 'uint256' },
+    ],
+    name: 'acceptAgreement',
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    inputs: [{ name: '_spaceId', internalType: 'uint256', type: 'uint256' }],
+    name: 'getSpaceProposals',
+    outputs: [{ name: '', internalType: 'uint256[]', type: 'uint256[]' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [
+      { name: '_spaceId', internalType: 'uint256', type: 'uint256' },
+      { name: '_proposalId', internalType: 'uint256', type: 'uint256' },
+    ],
+    name: 'hasProposal',
+    outputs: [{ name: '', internalType: 'bool', type: 'bool' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [
+      { name: 'initialOwner', internalType: 'address', type: 'address' },
+    ],
+    name: 'initialize',
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    inputs: [],
+    name: 'owner',
+    outputs: [{ name: '', internalType: 'address', type: 'address' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [],
+    name: 'proxiableUUID',
+    outputs: [{ name: '', internalType: 'bytes32', type: 'bytes32' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [],
+    name: 'renounceOwnership',
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    inputs: [
+      { name: '_spaceFactory', internalType: 'address', type: 'address' },
+    ],
+    name: 'setContracts',
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    inputs: [],
+    name: 'spaceFactory',
+    outputs: [
+      { name: '', internalType: 'contract IDAOSpaceFactory', type: 'address' },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [{ name: 'newOwner', internalType: 'address', type: 'address' }],
+    name: 'transferOwnership',
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    inputs: [
+      { name: 'newImplementation', internalType: 'address', type: 'address' },
+      { name: 'data', internalType: 'bytes', type: 'bytes' },
+    ],
+    name: 'upgradeToAndCall',
+    outputs: [],
+    stateMutability: 'payable',
+  },
+] as const
+
+/**
+ * [__View Contract on Base Basescan__](https://basescan.org/address/0x83B5d4F555A68126bB302685e67767Bb7a2985F0)
+ */
+export const agreementsImplementationAddress = {
+  8453: '0x83B5d4F555A68126bB302685e67767Bb7a2985F0',
+} as const
+
+/**
+ * [__View Contract on Base Basescan__](https://basescan.org/address/0x83B5d4F555A68126bB302685e67767Bb7a2985F0)
+ */
+export const agreementsImplementationConfig = {
+  address: agreementsImplementationAddress,
+  abi: agreementsImplementationAbi,
+} as const
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // DAOSpaceFactoryImplementation
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -44,32 +271,6 @@ export const daoSpaceFactoryImplementationAbi = [
     anonymous: false,
     inputs: [
       {
-        name: 'newAddress',
-        internalType: 'address',
-        type: 'address',
-        indexed: true,
-      },
-    ],
-    name: 'DirectoryContractUpdated',
-  },
-  {
-    type: 'event',
-    anonymous: false,
-    inputs: [
-      {
-        name: 'newAddress',
-        internalType: 'address',
-        type: 'address',
-        indexed: true,
-      },
-    ],
-    name: 'ExitMethodDirectoryContractUpdated',
-  },
-  {
-    type: 'event',
-    anonymous: false,
-    inputs: [
-      {
         name: 'version',
         internalType: 'uint64',
         type: 'uint64',
@@ -83,26 +284,13 @@ export const daoSpaceFactoryImplementationAbi = [
     anonymous: false,
     inputs: [
       {
-        name: 'newAddress',
-        internalType: 'address',
-        type: 'address',
-        indexed: true,
-      },
-    ],
-    name: 'JoinMethodDirectoryContractUpdated',
-  },
-  {
-    type: 'event',
-    anonymous: false,
-    inputs: [
-      {
         name: 'spaceId',
         internalType: 'uint256',
         type: 'uint256',
         indexed: true,
       },
       {
-        name: 'member',
+        name: 'memberAddress',
         internalType: 'address',
         type: 'address',
         indexed: true,
@@ -121,7 +309,7 @@ export const daoSpaceFactoryImplementationAbi = [
         indexed: true,
       },
       {
-        name: 'member',
+        name: 'memberAddress',
         internalType: 'address',
         type: 'address',
         indexed: true,
@@ -147,19 +335,6 @@ export const daoSpaceFactoryImplementationAbi = [
       },
     ],
     name: 'OwnershipTransferred',
-  },
-  {
-    type: 'event',
-    anonymous: false,
-    inputs: [
-      {
-        name: 'newAddress',
-        internalType: 'address',
-        type: 'address',
-        indexed: true,
-      },
-    ],
-    name: 'ProposalManagerUpdated',
   },
   {
     type: 'event',
@@ -211,23 +386,10 @@ export const daoSpaceFactoryImplementationAbi = [
         name: 'executor',
         internalType: 'address',
         type: 'address',
-        indexed: true,
+        indexed: false,
       },
     ],
     name: 'SpaceCreated',
-  },
-  {
-    type: 'event',
-    anonymous: false,
-    inputs: [
-      {
-        name: 'newAddress',
-        internalType: 'address',
-        type: 'address',
-        indexed: true,
-      },
-    ],
-    name: 'TokenFactoryContractUpdated',
   },
   {
     type: 'event',
@@ -253,9 +415,9 @@ export const daoSpaceFactoryImplementationAbi = [
     type: 'function',
     inputs: [
       { name: '_spaceId', internalType: 'uint256', type: 'uint256' },
-      { name: '_tokenAddress', internalType: 'address', type: 'address' },
+      { name: '_memberAddress', internalType: 'address', type: 'address' },
     ],
-    name: 'addTokenToSpace',
+    name: 'addMember',
     outputs: [],
     stateMutability: 'nonpayable',
   },
@@ -308,6 +470,15 @@ export const daoSpaceFactoryImplementationAbi = [
   },
   {
     type: 'function',
+    inputs: [
+      { name: '_memberAddress', internalType: 'address', type: 'address' },
+    ],
+    name: 'getMemberSpaces',
+    outputs: [{ name: '', internalType: 'uint256[]', type: 'uint256[]' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
     inputs: [{ name: '_spaceId', internalType: 'uint256', type: 'uint256' }],
     name: 'getSpaceDetails',
     outputs: [
@@ -343,8 +514,8 @@ export const daoSpaceFactoryImplementationAbi = [
   {
     type: 'function',
     inputs: [{ name: '_spaceId', internalType: 'uint256', type: 'uint256' }],
-    name: 'getSpaceMemberAddresses',
-    outputs: [{ name: '', internalType: 'address[]', type: 'address[]' }],
+    name: 'getSpaceMemberIds',
+    outputs: [{ name: '', internalType: 'uint256[]', type: 'uint256[]' }],
     stateMutability: 'view',
   },
   {
@@ -352,16 +523,6 @@ export const daoSpaceFactoryImplementationAbi = [
     inputs: [{ name: '_spaceId', internalType: 'uint256', type: 'uint256' }],
     name: 'getSpaceMembers',
     outputs: [{ name: '', internalType: 'address[]', type: 'address[]' }],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    inputs: [
-      { name: '_spaceId', internalType: 'uint256', type: 'uint256' },
-      { name: '_tokenAddress', internalType: 'address', type: 'address' },
-    ],
-    name: 'hasToken',
-    outputs: [{ name: '', internalType: 'bool', type: 'bool' }],
     stateMutability: 'view',
   },
   {
@@ -434,6 +595,15 @@ export const daoSpaceFactoryImplementationAbi = [
   {
     type: 'function',
     inputs: [],
+    name: 'proposalsContract',
+    outputs: [
+      { name: '', internalType: 'contract IDAOProposals', type: 'address' },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [],
     name: 'proxiableUUID',
     outputs: [{ name: '', internalType: 'bytes32', type: 'bytes32' }],
     stateMutability: 'view',
@@ -458,11 +628,6 @@ export const daoSpaceFactoryImplementationAbi = [
   {
     type: 'function',
     inputs: [
-      {
-        name: '_tokenFactoryAddress',
-        internalType: 'address',
-        type: 'address',
-      },
       {
         name: '_joinMethodDirectoryAddress',
         internalType: 'address',
@@ -530,14 +695,14 @@ export const daoSpaceFactoryImplementationAbi = [
     outputs: [],
     stateMutability: 'payable',
   },
-] as const;
+] as const
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0xc8B8454D2F9192FeCAbc2C6F5d88F6434A2a9cd9)
  */
 export const daoSpaceFactoryImplementationAddress = {
   8453: '0xc8B8454D2F9192FeCAbc2C6F5d88F6434A2a9cd9',
-} as const;
+} as const
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0xc8B8454D2F9192FeCAbc2C6F5d88F6434A2a9cd9)
@@ -545,4 +710,4 @@ export const daoSpaceFactoryImplementationAddress = {
 export const daoSpaceFactoryImplementationConfig = {
   address: daoSpaceFactoryImplementationAddress,
   abi: daoSpaceFactoryImplementationAbi,
-} as const;
+} as const

--- a/packages/core/src/governance/client/hooks/useAgreementMutations.web2.rsc.ts
+++ b/packages/core/src/governance/client/hooks/useAgreementMutations.web2.rsc.ts
@@ -6,6 +6,7 @@ import { CreateAgreementInput, UpdateAgreementBySlugInput } from '../../types';
 import {
   createAgreementAction,
   updateAgreementBySlugAction,
+  deleteAgreementBySlugAction,
 } from '@core/governance/server/actions';
 
 export const useAgreementMutationsWeb2Rsc = (authToken?: string | null) => {
@@ -33,6 +34,18 @@ export const useAgreementMutationsWeb2Rsc = (authToken?: string | null) => {
       updateAgreementBySlugAction(arg, { authToken }),
   );
 
+  const {
+    trigger: deleteAgreementBySlugMutation,
+    reset: resetDeleteAgreementBySlugMutation,
+    isMutating: isDeletingAgreement,
+    error: errorDeleteAgreementBySlugMutation,
+    data: deletedAgreement,
+  } = useSWRMutation(
+    authToken ? [authToken, 'deleteAgreement'] : null,
+    async ([authToken], { arg }: { arg: { slug: string } }) =>
+      deleteAgreementBySlugAction(arg, { authToken }),
+  );
+
   return {
     createAgreement: createAgreementMutation,
     resetCreateAgreementMutation,
@@ -45,5 +58,11 @@ export const useAgreementMutationsWeb2Rsc = (authToken?: string | null) => {
     isUpdatingAgreement,
     errorUpdateAgreementBySlugMutation,
     updatedAgreement,
+
+    deleteAgreementBySlug: deleteAgreementBySlugMutation,
+    resetDeleteAgreementBySlugMutation,
+    isDeletingAgreement,
+    errorDeleteAgreementBySlugMutation,
+    deletedAgreement,
   };
 };

--- a/packages/core/src/governance/client/hooks/useAgreementMutations.web3.rsc.ts
+++ b/packages/core/src/governance/client/hooks/useAgreementMutations.web3.rsc.ts
@@ -1,0 +1,83 @@
+'use client';
+
+import useSWRMutation from 'swr/mutation';
+import { Config, writeContract } from '@wagmi/core';
+import {
+  createProposal,
+  getProposalFromLogs,
+  mapToCreateProposalWeb3Input,
+} from '../web3';
+import { schemaCreateProposalWeb3 } from '@core/governance/validation';
+import useSWR from 'swr';
+import { publicClient } from '@core/common/web3/public-client';
+import { encodeFunctionData } from 'viem';
+import {
+  agreementsImplementationAbi,
+  agreementsImplementationAddress,
+  daoProposalsImplementationAbi,
+  daoProposalsImplementationAddress,
+} from '@core/generated';
+
+export const useAgreementMutationsWeb3Rpc = (config?: Config) => {
+  const {
+    trigger: createAgreementMutation,
+    reset: resetCreateAgreementMutation,
+    isMutating: isCreatingAgreement,
+    data: createAgreementHash,
+    error: errorCreateAgreement,
+  } = useSWRMutation(
+    config ? [config, 'createProposal'] : null,
+    async ([config], { arg }: { arg: { spaceId: number } }) => {
+      const proposalCounter = await publicClient.readContract({
+        address: daoProposalsImplementationAddress[8453],
+        abi: daoProposalsImplementationAbi,
+        functionName: 'proposalCounter',
+      });
+
+      const acceptAgreementTx = {
+        target: agreementsImplementationAddress[8453],
+        value: 0,
+        data: encodeFunctionData({
+          abi: agreementsImplementationAbi,
+          functionName: 'acceptAgreement',
+          args: [BigInt(arg.spaceId), proposalCounter + 1n],
+        }),
+      };
+
+      const input = {
+        spaceId: arg.spaceId,
+        duration: 86400,
+        transactions: [acceptAgreementTx],
+      };
+      console.log(input);
+      const parsedInput = schemaCreateProposalWeb3.parse(input);
+      const args = mapToCreateProposalWeb3Input(parsedInput);
+      return writeContract(config, createProposal(args));
+    },
+  );
+
+  const {
+    data: createdAgreement,
+    isLoading: isLoadingAgreementFromTransaction,
+    error: errorWaitAgreementFromTransaction,
+  } = useSWR(
+    createAgreementHash ? [createAgreementHash, 'waitFor'] : null,
+    async ([hash]) => {
+      const { logs } = await publicClient.waitForTransactionReceipt({
+        hash,
+      });
+      return getProposalFromLogs(logs);
+    },
+  );
+
+  return {
+    createAgreement: createAgreementMutation,
+    resetCreateAgreementMutation,
+    isCreatingAgreement,
+    isLoadingAgreementFromTransaction,
+    errorCreateAgreement,
+    errorWaitAgreementFromTransaction,
+    createAgreementHash,
+    createdAgreement,
+  };
+};

--- a/packages/core/src/governance/client/web3/create-proposal.ts
+++ b/packages/core/src/governance/client/web3/create-proposal.ts
@@ -1,0 +1,54 @@
+import {
+  daoProposalsImplementationAbi,
+  daoProposalsImplementationAddress,
+} from '@core/generated';
+import { schemaCreateProposalWeb3 } from '@core/governance/validation';
+import { base } from 'viem/chains';
+import { z } from 'zod';
+
+export type CreateProposalWeb3Input = {
+  spaceId: bigint;
+  duration: bigint;
+  transactions: readonly {
+    target: `0x${string}`;
+    value: bigint;
+    data: `0x${string}`;
+  }[];
+};
+
+export type CreateProposalWeb3Config = {
+  chain?: keyof typeof daoProposalsImplementationAddress;
+};
+
+export const mapToCreateProposalWeb3Input = (
+  d: z.infer<typeof schemaCreateProposalWeb3>,
+): CreateProposalWeb3Input => ({
+  spaceId: BigInt(d.spaceId),
+  duration: BigInt(d.duration),
+  transactions: d.transactions.map((tx) => ({
+    target: tx.target as `0x${string}`,
+    value: BigInt(tx.value),
+    data: tx.data ? (tx.data as `0x${string}`) : '0x',
+  })),
+});
+
+export const createProposal = (
+  { spaceId, duration, transactions }: CreateProposalWeb3Input,
+  { chain = base.id }: CreateProposalWeb3Config = {},
+) => {
+  const address = daoProposalsImplementationAddress[chain];
+
+  const callConfig = {
+    address,
+    abi: daoProposalsImplementationAbi,
+    functionName: 'createProposal' as const,
+    args: [
+      {
+        spaceId,
+        duration,
+        transactions,
+      },
+    ] as const,
+  };
+  return callConfig;
+};

--- a/packages/core/src/governance/client/web3/get-proposal-created-event.ts
+++ b/packages/core/src/governance/client/web3/get-proposal-created-event.ts
@@ -1,0 +1,34 @@
+import { parseEventLogs } from 'viem';
+import { daoProposalsImplementationAbi } from '@core/generated';
+
+/**
+ * Extract the ProposalCreated event from transaction logs
+ * @param logs - The transaction logs to parse
+ * @returns The ProposalCreated event if found, undefined otherwise
+ */
+export const getProposalCreatedEvent = (logs: any[]) => {
+  try {
+    // Parse logs for the specific event
+    const ProposalCreatedEvents = parseEventLogs({
+      abi: daoProposalsImplementationAbi,
+      logs,
+      eventName: 'ProposalCreated',
+    });
+
+    if (ProposalCreatedEvents.length > 0) {
+      return ProposalCreatedEvents[0];
+    }
+    return undefined;
+  } catch (error) {
+    console.error('Failed to parse ProposalCreated event:', error);
+    return undefined;
+  }
+};
+
+export const getProposalFromLogs = (logs: any[]) => {
+  const event = getProposalCreatedEvent(logs);
+  if (event) {
+    return event.args;
+  }
+  return undefined;
+};

--- a/packages/core/src/governance/client/web3/index.ts
+++ b/packages/core/src/governance/client/web3/index.ts
@@ -1,0 +1,2 @@
+export * from './create-proposal';
+export * from './get-proposal-created-event';

--- a/packages/core/src/governance/server/actions.ts
+++ b/packages/core/src/governance/server/actions.ts
@@ -2,7 +2,11 @@
 
 // TODO: #602 Define RLS Policies for Agreement Table
 // import { getDb } from '@core/common/server/get-db';
-import { createAgreement, updateAgreementBySlug } from './mutations';
+import {
+  createAgreement,
+  updateAgreementBySlug,
+  deleteAgreementBySlug,
+} from './mutations';
 import { CreateAgreementInput, UpdateAgreementBySlugInput } from '../types';
 // TODO: #602 Define RLS Policies for Agreement Table
 import { db } from '@hypha-platform/storage-postgres';
@@ -22,4 +26,13 @@ export async function updateAgreementBySlugAction(
   // TODO: #602 Define RLS Policies for Spaces Table
   // const db = getDb({ authToken });
   return updateAgreementBySlug(data, { db });
+}
+
+export async function deleteAgreementBySlugAction(
+  data: { slug: string },
+  { authToken }: { authToken?: string },
+) {
+  // TODO: #602 Define RLS Policies for Spaces Table
+  // const db = getDb({ authToken });
+  return deleteAgreementBySlug(data, { db });
 }

--- a/packages/core/src/governance/server/mutations.ts
+++ b/packages/core/src/governance/server/mutations.ts
@@ -46,3 +46,19 @@ export const updateAgreementBySlug = async (
 
   return updatedAgreement;
 };
+
+export const deleteAgreementBySlug = async (
+  { slug }: { slug: string },
+  { db }: { db: DatabaseInstance },
+) => {
+  const deleted = await db
+    .delete(documents)
+    .where(eq(documents.slug, slug))
+    .returning();
+
+  if (!deleted || deleted.length === 0) {
+    throw new Error('Failed to delete agreement');
+  }
+
+  return deleted[0];
+};

--- a/packages/core/src/governance/types.ts
+++ b/packages/core/src/governance/types.ts
@@ -10,6 +10,12 @@ export enum DocumentState {
   AGREEMENT = 'agreement',
 }
 
+interface Transaction {
+  target: string;
+  value: number;
+  data: string | Uint8Array;
+}
+
 export type Document = {
   id: number;
   creatorId: number;
@@ -22,6 +28,7 @@ export type Document = {
   creator?: Creator;
   leadImage?: string;
   attachments?: string[];
+  web3ProposalId?: number | null;
 };
 
 export interface CreateAgreementInput {
@@ -38,6 +45,7 @@ export interface UpdateAgreementInput {
   leadImage?: string;
   slug?: string;
   attachments?: string[];
+  web3ProposalId?: number | null;
 }
 
 export type UpdateAgreementBySlugInput = {

--- a/packages/core/wagmi.config.ts
+++ b/packages/core/wagmi.config.ts
@@ -10,11 +10,14 @@ export default defineConfig({
   plugins: [
     hardhat({
       project: '../storage-evm/',
-      include: ['DAOSpaceFactoryImplementation.sol/**'],
+      include: ['DAOSpaceFactoryImplementation.sol/**', 'AgreementsImplementation.sol/**'],
       deployments: {
         DAOSpaceFactoryImplementation: {
           [base.id]: '0xc8B8454D2F9192FeCAbc2C6F5d88F6434A2a9cd9',
         },
+        AgreementsImplementation: {
+          [base.id]: '0x83B5d4F555A68126bB302685e67767Bb7a2985F0'
+        }
       },
     }),
   ],

--- a/packages/core/wagmi.config.ts
+++ b/packages/core/wagmi.config.ts
@@ -10,13 +10,16 @@ export default defineConfig({
   plugins: [
     hardhat({
       project: '../storage-evm/',
-      include: ['DAOSpaceFactoryImplementation.sol/**', 'AgreementsImplementation.sol/**'],
+      include: ['DAOSpaceFactoryImplementation.sol/**', 'AgreementsImplementation.sol/**', 'DAOProposalsImplementation.sol/**'],
       deployments: {
         DAOSpaceFactoryImplementation: {
           [base.id]: '0xc8B8454D2F9192FeCAbc2C6F5d88F6434A2a9cd9',
         },
         AgreementsImplementation: {
           [base.id]: '0x83B5d4F555A68126bB302685e67767Bb7a2985F0'
+        },
+        DAOProposalsImplementation: {
+          [base.id]: '0x001bA7a00a259Fb12d7936455e292a60FC2bef14'
         }
       },
     }),

--- a/packages/core/wagmi.config.ts
+++ b/packages/core/wagmi.config.ts
@@ -10,17 +10,21 @@ export default defineConfig({
   plugins: [
     hardhat({
       project: '../storage-evm/',
-      include: ['DAOSpaceFactoryImplementation.sol/**', 'AgreementsImplementation.sol/**', 'DAOProposalsImplementation.sol/**'],
+      include: [
+        'DAOSpaceFactoryImplementation.sol/**',
+        'AgreementsImplementation.sol/**',
+        'DAOProposalsImplementation.sol/**',
+      ],
       deployments: {
         DAOSpaceFactoryImplementation: {
           [base.id]: '0xc8B8454D2F9192FeCAbc2C6F5d88F6434A2a9cd9',
         },
         AgreementsImplementation: {
-          [base.id]: '0x83B5d4F555A68126bB302685e67767Bb7a2985F0'
+          [base.id]: '0x83B5d4F555A68126bB302685e67767Bb7a2985F0',
         },
         DAOProposalsImplementation: {
-          [base.id]: '0x001bA7a00a259Fb12d7936455e292a60FC2bef14'
-        }
+          [base.id]: '0x001bA7a00a259Fb12d7936455e292a60FC2bef14',
+        },
       },
     }),
   ],

--- a/packages/epics/src/proposals/components/proposal-detail.tsx
+++ b/packages/epics/src/proposals/components/proposal-detail.tsx
@@ -2,10 +2,16 @@ import { addDays } from 'date-fns';
 import { formatISO } from 'date-fns';
 import { FormVoting } from './form-voting';
 import { ProposalHead, ProposalHeadProps } from './proposal-head';
-import { Button, Separator } from '@hypha-platform/ui';
+import {
+  Button,
+  Separator,
+  AttachmentList,
+  Skeleton,
+} from '@hypha-platform/ui';
 import { RxCross1 } from 'react-icons/rx';
 import { CommentsList } from '../../interactions/components/comments-list';
 import Link from 'next/link';
+import Image from 'next/image';
 
 type ProposalDetailProps = ProposalHeadProps & {
   onAccept: () => void;
@@ -13,6 +19,8 @@ type ProposalDetailProps = ProposalHeadProps & {
   onSetActiveFilter: (value: string) => void;
   content?: string;
   closeUrl: string;
+  leadImage?: string;
+  attachments?: string[];
 };
 
 export const ProposalDetail = ({
@@ -26,6 +34,8 @@ export const ProposalDetail = ({
   content,
   onSetActiveFilter,
   closeUrl,
+  leadImage,
+  attachments,
 }: ProposalDetailProps) => {
   return (
     <div className="flex flex-col gap-5">
@@ -45,8 +55,22 @@ export const ProposalDetail = ({
         </Link>
       </div>
       <Separator />
+      <Skeleton
+        width="100%"
+        height="150px"
+        loading={isLoading}
+        className="rounded-lg"
+      >
+        <Image
+          height={150}
+          width={554}
+          className="w-full object-cover rounded-lg max-h-[150px]"
+          src={leadImage ?? ''}
+          alt={title ?? ''}
+        />
+      </Skeleton>
       <div>{content}</div>
-      <Separator />
+      <AttachmentList attachments={attachments || []} />
       <FormVoting
         unity={50}
         quorum={25}

--- a/packages/storage-postgres/migrations/0023_milky_skreet.sql
+++ b/packages/storage-postgres/migrations/0023_milky_skreet.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "documents" ADD COLUMN "web3_proposal_id" integer;

--- a/packages/storage-postgres/migrations/0024_workable_morg.sql
+++ b/packages/storage-postgres/migrations/0024_workable_morg.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "documents" ALTER COLUMN "state" SET DEFAULT 'proposal';

--- a/packages/storage-postgres/migrations/meta/0023_snapshot.json
+++ b/packages/storage-postgres/migrations/meta/0023_snapshot.json
@@ -1,0 +1,505 @@
+{
+  "id": "7e534c8e-7142-415b-8191-0a0ae9c9b82a",
+  "prevId": "2d0cefff-04e7-4005-bdb7-5e2aa2e14a8b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.documents": {
+      "name": "documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "document_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'agreement'"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lead_image": {
+          "name": "lead_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "web3_proposal_id": {
+          "name": "web3_proposal_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "documents_creator_id_people_id_fk": {
+          "name": "documents_creator_id_people_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "people",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "documents_space_id_spaces_id_fk": {
+          "name": "documents_space_id_spaces_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memberships": {
+      "name": "memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "person_space_idx": {
+          "name": "person_space_idx",
+          "columns": [
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memberships_person_id_people_id_fk": {
+          "name": "memberships_person_id_people_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "people",
+          "columnsFrom": [
+            "person_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "memberships_space_id_spaces_id_fk": {
+          "name": "memberships_space_id_spaces_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.people": {
+      "name": "people",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sub": {
+          "name": "sub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "(auth.user_id())"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lead_image_url": {
+          "name": "lead_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "surname": {
+          "name": "surname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "people_sub_unique": {
+          "name": "people_sub_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sub"
+          ]
+        },
+        "people_slug_unique": {
+          "name": "people_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "people_email_unique": {
+          "name": "people_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {
+        "crud-authenticated-policy-select": {
+          "name": "crud-authenticated-policy-select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "crud-authenticated-policy-insert": {
+          "name": "crud-authenticated-policy-insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(select auth.user_id() = \"people\".\"sub\")"
+        },
+        "crud-authenticated-policy-update": {
+          "name": "crud-authenticated-policy-update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(select auth.user_id() = \"people\".\"sub\")",
+          "withCheck": "(select auth.user_id() = \"people\".\"sub\")"
+        },
+        "crud-authenticated-policy-delete": {
+          "name": "crud-authenticated-policy-delete",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(select auth.user_id() = \"people\".\"sub\")"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.spaces": {
+      "name": "spaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lead_image": {
+          "name": "lead_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "web3_space_id": {
+          "name": "web3_space_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "links": {
+          "name": "links",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "categories": {
+          "name": "categories",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "spaces_parent_id_spaces_id_fk": {
+          "name": "spaces_parent_id_spaces_id_fk",
+          "tableFrom": "spaces",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "spaces_slug_unique": {
+          "name": "spaces_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.document_state": {
+      "name": "document_state",
+      "schema": "public",
+      "values": [
+        "discussion",
+        "proposal",
+        "agreement"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/storage-postgres/migrations/meta/0024_snapshot.json
+++ b/packages/storage-postgres/migrations/meta/0024_snapshot.json
@@ -1,0 +1,505 @@
+{
+  "id": "af47ba93-aa83-4fc3-a92c-073abde7937d",
+  "prevId": "7e534c8e-7142-415b-8191-0a0ae9c9b82a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.documents": {
+      "name": "documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "document_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'proposal'"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lead_image": {
+          "name": "lead_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "web3_proposal_id": {
+          "name": "web3_proposal_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "documents_creator_id_people_id_fk": {
+          "name": "documents_creator_id_people_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "people",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "documents_space_id_spaces_id_fk": {
+          "name": "documents_space_id_spaces_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memberships": {
+      "name": "memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "person_space_idx": {
+          "name": "person_space_idx",
+          "columns": [
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memberships_person_id_people_id_fk": {
+          "name": "memberships_person_id_people_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "people",
+          "columnsFrom": [
+            "person_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "memberships_space_id_spaces_id_fk": {
+          "name": "memberships_space_id_spaces_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.people": {
+      "name": "people",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sub": {
+          "name": "sub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "(auth.user_id())"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lead_image_url": {
+          "name": "lead_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "surname": {
+          "name": "surname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "people_sub_unique": {
+          "name": "people_sub_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sub"
+          ]
+        },
+        "people_slug_unique": {
+          "name": "people_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "people_email_unique": {
+          "name": "people_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {
+        "crud-authenticated-policy-select": {
+          "name": "crud-authenticated-policy-select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "crud-authenticated-policy-insert": {
+          "name": "crud-authenticated-policy-insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(select auth.user_id() = \"people\".\"sub\")"
+        },
+        "crud-authenticated-policy-update": {
+          "name": "crud-authenticated-policy-update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(select auth.user_id() = \"people\".\"sub\")",
+          "withCheck": "(select auth.user_id() = \"people\".\"sub\")"
+        },
+        "crud-authenticated-policy-delete": {
+          "name": "crud-authenticated-policy-delete",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(select auth.user_id() = \"people\".\"sub\")"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.spaces": {
+      "name": "spaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lead_image": {
+          "name": "lead_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "web3_space_id": {
+          "name": "web3_space_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "links": {
+          "name": "links",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "categories": {
+          "name": "categories",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "spaces_parent_id_spaces_id_fk": {
+          "name": "spaces_parent_id_spaces_id_fk",
+          "tableFrom": "spaces",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "spaces_slug_unique": {
+          "name": "spaces_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.document_state": {
+      "name": "document_state",
+      "schema": "public",
+      "values": [
+        "discussion",
+        "proposal",
+        "agreement"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/storage-postgres/migrations/meta/_journal.json
+++ b/packages/storage-postgres/migrations/meta/_journal.json
@@ -162,6 +162,20 @@
       "when": 1745993822494,
       "tag": "0022_parched_morph",
       "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "7",
+      "when": 1746451390386,
+      "tag": "0023_milky_skreet",
+      "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "7",
+      "when": 1746531231999,
+      "tag": "0024_workable_morg",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/storage-postgres/src/schema/document.ts
+++ b/packages/storage-postgres/src/schema/document.ts
@@ -25,10 +25,11 @@ export const documents = pgTable('documents', {
   spaceId: integer('space_id').references(() => spaces.id),
   title: text('title'),
   description: text('description'),
-  state: documentStateEnum('state').default('agreement'),
+  state: documentStateEnum('state').default('proposal'),
   slug: varchar('slug', { length: 255 }),
   leadImage: text('lead_image'),
   attachments: jsonb('attachments').$type<string[]>().default([]),
+  web3ProposalId: integer('web3_proposal_id'),
   ...commonDateFields,
 });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for creating and linking agreements with Web3 proposals, enabling blockchain-based governance actions.
  - Enhanced agreement forms and orchestrators to handle both Web2 and Web3 agreement creation flows.
  - Introduced the ability to delete agreements directly from the interface.
  - Proposal details now display lead images and attachments for improved context.

- **Improvements**
  - Updated validation and data models to support Web3 proposal creation and transaction details.
  - Refined contract integrations and added new contract interfaces for governance actions.

- **Database**
  - Added a column for Web3 proposal IDs to agreements.
  - Changed the default state of new agreements to "proposal".

- **Bug Fixes**
  - Improved error handling and state management during agreement creation and linking processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->