### PR TITLE
Feat/767 proposal vote integration

### DIFF
--- a/apps/web/src/app/[lang]/dho/[id]/@aside/governance/proposal/[documentSlug]/page.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@aside/governance/proposal/[documentSlug]/page.tsx
@@ -12,7 +12,6 @@ export default function Agreements() {
   const { id, lang } = useParams();
   const documentSlug = useDocumentSlug();
   const { document, isLoading } = useDocumentBySlug(documentSlug);
-  console.log(document);
   const { handleAccept, handleReject } = useVote({
     proposalId: document?.web3ProposalId,
   });

--- a/apps/web/src/app/[lang]/dho/[id]/@aside/governance/proposal/[documentSlug]/page.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@aside/governance/proposal/[documentSlug]/page.tsx
@@ -6,18 +6,23 @@ import { Locale } from '@hypha-platform/i18n';
 import { useDocumentSlug } from '@web/hooks/use-document-slug';
 import { useDocumentBySlug } from '@web/hooks/use-document-by-slug';
 import { getDhoPathGovernance } from '../../../../@tab/governance/constants';
+import { useVote } from '@core/governance';
 
 export default function Agreements() {
   const { id, lang } = useParams();
   const documentSlug = useDocumentSlug();
   const { document, isLoading } = useDocumentBySlug(documentSlug);
+  console.log(document);
+  const { handleAccept, handleReject } = useVote({
+    proposalId: document?.web3ProposalId,
+  });
 
   return (
     <SidePanel>
       <ProposalDetail
         closeUrl={getDhoPathGovernance(lang as Locale, id as string)}
-        onAccept={() => console.log('accept')}
-        onReject={() => console.log('reject')}
+        onAccept={handleAccept}
+        onReject={handleReject}
         content={document?.description}
         creator={{
           avatar: document?.creator?.avatarUrl || '',

--- a/packages/core/src/governance/client/hooks/index.ts
+++ b/packages/core/src/governance/client/hooks/index.ts
@@ -1,3 +1,4 @@
 export * from './useAgreementFileUploads';
 export * from './useAgreementMutations.web2.rsc';
 export * from './useCreateAgreementOrchestrator';
+export * from './useVote';

--- a/packages/core/src/governance/client/hooks/useVote.ts
+++ b/packages/core/src/governance/client/hooks/useVote.ts
@@ -1,0 +1,58 @@
+'use client';
+
+import { useCallback } from 'react';
+import { useAccount, useWriteContract } from 'wagmi';
+import { daoProposalsImplementationConfig } from '@core/generated';
+
+export const useVote = ({ proposalId }: { proposalId?: number | null }) => {
+  const { address } = useAccount();
+  const { writeContractAsync } = useWriteContract();
+
+  const vote = useCallback(
+    async (proposalId: number, support: boolean) => {
+      if (!address) {
+        throw new Error('Wallet not connected');
+      }
+      if (proposalId === undefined || proposalId === null) {
+        throw new Error('Proposal ID is required');
+      }
+
+      try {
+        const txHash = await writeContractAsync({
+          address: daoProposalsImplementationConfig.address[8453],
+          abi: daoProposalsImplementationConfig.abi,
+          functionName: 'vote',
+          args: [BigInt(proposalId), support],
+        });
+
+        return txHash;
+      } catch (error) {
+        console.error('Voting failed:', error);
+        throw error;
+      }
+    },
+    [address, writeContractAsync],
+  );
+
+  const handleAccept = async () => {
+    try {
+      if (proposalId !== undefined && proposalId !== null) {
+        await vote(proposalId, true);
+      }
+    } catch (error) {
+      console.error('Failed to vote yes:', error);
+    }
+  };
+
+  const handleReject = async () => {
+    try {
+      if (proposalId !== undefined && proposalId !== null) {
+        await vote(proposalId, false);
+      }
+    } catch (error) {
+      console.error('Failed to vote no:', error);
+    }
+  };
+
+  return { handleAccept, handleReject };
+};

--- a/packages/core/src/governance/server/queries.ts
+++ b/packages/core/src/governance/server/queries.ts
@@ -28,6 +28,7 @@ export const mapToDocument = (
     attachments: dbDocument.attachments || [],
     createdAt: dbDocument.createdAt,
     updatedAt: dbDocument.updatedAt,
+    web3ProposalId: dbDocument.web3ProposalId,
     creator: {
       avatarUrl: creator?.avatarUrl || '',
       name: creator?.name || '',


### PR DESCRIPTION
Implemented voting functionality for governance proposals by connecting the UI to the blockchain contract.

### What changed?

- Created a new `useVote` hook in the core governance package that handles voting on proposals
- Connected the proposal detail page to the voting functionality
- Replaced placeholder console.log statements with actual voting handlers
- Added web3ProposalId to the document mapping to enable voting on the correct proposal
