### PR TITLE
feat(#771): add memberCount to list query

### DIFF
--- a/apps/web/src/app/[lang]/my-spaces/page.tsx
+++ b/apps/web/src/app/[lang]/my-spaces/page.tsx
@@ -83,10 +83,9 @@ export default async function Index(props: PageProps) {
                     leadImage={
                       space.leadImage || '/placeholder/space-lead-image.png'
                     }
-                    members={0}
-                    agreements={0}
+                    members={space.memberCount}
+                    agreements={space.documentCount}
                     activeAgreements={1}
-                    openDiscussions={1}
                     title={space.title as string}
                   />
                 </Link>

--- a/apps/web/src/app/[lang]/network/page.tsx
+++ b/apps/web/src/app/[lang]/network/page.tsx
@@ -35,6 +35,7 @@ export default async function Index(props: PageProps) {
 
   const spaces = await createSpaceService().getAll();
   const uniqueCategories = extractUniqueCategories(spaces);
+  console.debug('spaces', JSON.stringify(spaces, null, 2));
 
   return (
     <Container>

--- a/packages/core/src/space/server/queries.ts
+++ b/packages/core/src/space/server/queries.ts
@@ -1,9 +1,41 @@
-import { asc, eq } from 'drizzle-orm';
+import { asc, eq, sql } from 'drizzle-orm';
 import { memberships, Space, spaces } from '@hypha-platform/storage-postgres';
 import { DbConfig } from '@core/common/server';
 
 export const findAllSpaces = async ({ db }: DbConfig) => {
-  const results = await db.select().from(spaces).orderBy(asc(spaces.title));
+  const results = await db
+    .select({
+      id: spaces.id,
+      logoUrl: spaces.logoUrl,
+      leadImage: spaces.leadImage,
+      title: spaces.title,
+      description: spaces.description,
+      slug: spaces.slug,
+      web3SpaceId: spaces.web3SpaceId,
+      links: spaces.links,
+      categories: spaces.categories,
+      parentId: spaces.parentId,
+      createdAt: spaces.createdAt,
+      updatedAt: spaces.updatedAt,
+      memberCount: sql<number>`count(${memberships.personId})`.mapWith(Number),
+    })
+    .from(spaces)
+    .leftJoin(memberships, eq(memberships.spaceId, spaces.id))
+    .groupBy(
+      spaces.id,
+      spaces.logoUrl,
+      spaces.leadImage,
+      spaces.title,
+      spaces.description,
+      spaces.slug,
+      spaces.web3SpaceId,
+      spaces.links,
+      spaces.categories,
+      spaces.parentId,
+      spaces.createdAt,
+      spaces.updatedAt,
+    )
+    .orderBy(asc(spaces.title));
   return results;
 };
 export const findSpaceById = async (

--- a/packages/core/src/space/server/queries.ts
+++ b/packages/core/src/space/server/queries.ts
@@ -1,5 +1,10 @@
 import { asc, eq, sql } from 'drizzle-orm';
-import { memberships, Space, spaces } from '@hypha-platform/storage-postgres';
+import {
+  memberships,
+  Space,
+  spaces,
+  documents,
+} from '@hypha-platform/storage-postgres';
 import { DbConfig } from '@core/common/server';
 
 export const findAllSpaces = async ({ db }: DbConfig) => {
@@ -17,10 +22,16 @@ export const findAllSpaces = async ({ db }: DbConfig) => {
       parentId: spaces.parentId,
       createdAt: spaces.createdAt,
       updatedAt: spaces.updatedAt,
-      memberCount: sql<number>`count(${memberships.personId})`.mapWith(Number),
+      memberCount: sql<number>`count(distinct ${memberships.personId})`.mapWith(
+        Number,
+      ),
+      documentCount: sql<number>`count(distinct ${documents.id})`.mapWith(
+        Number,
+      ),
     })
     .from(spaces)
     .leftJoin(memberships, eq(memberships.spaceId, spaces.id))
+    .leftJoin(documents, eq(documents.spaceId, spaces.id))
     .groupBy(
       spaces.id,
       spaces.logoUrl,

--- a/packages/core/src/space/types.ts
+++ b/packages/core/src/space/types.ts
@@ -15,6 +15,7 @@ export interface Space {
   categories?: Category[] | null;
   subspaces?: Space[];
   members?: Person[];
+  memberCount?: number;
   documents?: Document[];
 }
 

--- a/packages/core/src/space/types.ts
+++ b/packages/core/src/space/types.ts
@@ -16,6 +16,7 @@ export interface Space {
   subspaces?: Space[];
   members?: Person[];
   memberCount?: number;
+  documentCount?: number;
   documents?: Document[];
 }
 

--- a/packages/epics/src/spaces/components/space-card.tsx
+++ b/packages/epics/src/spaces/components/space-card.tsx
@@ -17,7 +17,6 @@ type SpaceCardProps = {
   agreements?: number;
   title: string;
   activeAgreements?: number;
-  openDiscussions?: number;
   isLoading?: boolean;
   leadImage?: string;
 };
@@ -39,7 +38,6 @@ export const SpaceCard: React.FC<SpaceCardProps> = ({
   members,
   agreements,
   activeAgreements,
-  openDiscussions,
   isLoading = false,
   title,
   leadImage,
@@ -81,17 +79,6 @@ export const SpaceCard: React.FC<SpaceCardProps> = ({
                   colorVariant="success"
                 >
                   {activeAgreements} Active Agreements
-                </Badge>
-              ) : null}
-            </div>
-            <div className="ml-2">
-              {openDiscussions ? (
-                <Badge
-                  isLoading={isLoading}
-                  variant="surface"
-                  colorVariant="warn"
-                >
-                  {openDiscussions} Open Discussions
                 </Badge>
               ) : null}
             </div>

--- a/packages/epics/src/spaces/components/space-group-slider.tsx
+++ b/packages/epics/src/spaces/components/space-group-slider.tsx
@@ -50,7 +50,7 @@ export const SpaceGroupSlider = ({
                   title={space.title as string}
                   isLoading={isLoading}
                   members={space.memberCount}
-                  agreements={0}
+                  agreements={space.documentCount}
                 />
               </Link>
             </CarouselItem>

--- a/packages/epics/src/spaces/components/space-group-slider.tsx
+++ b/packages/epics/src/spaces/components/space-group-slider.tsx
@@ -49,7 +49,7 @@ export const SpaceGroupSlider = ({
                   }
                   title={space.title as string}
                   isLoading={isLoading}
-                  members={0}
+                  members={space.memberCount}
                   agreements={0}
                 />
               </Link>


### PR DESCRIPTION
#771

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Each space now displays the actual number of members and documents, providing more accurate information in space listings.

- **Enhancements**
	- The member and document counts shown for each space are now dynamically updated, replacing previous static values.
	- The "Open Discussions" badge has been removed from space cards for a cleaner interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->