### PR TITLE
feat(#681): added logic for getting recipients list in pay-for-expenses form

### DIFF
--- a/apps/web/src/app/[lang]/dho/[id]/@aside/governance/create/pay-for-expenses/page.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@aside/governance/create/pay-for-expenses/page.tsx
@@ -17,7 +17,7 @@ export default async function CreatePayForExpensesPage({ params }: PageProps) {
   const spaceFromDb = await spaceService.getBySlug({ slug: id });
 
   if (!spaceFromDb) notFound();
-  const { id: spaceId, web3SpaceId } = spaceFromDb;
+  const { id: spaceId, web3SpaceId, slug: spaceSlug } = spaceFromDb;
 
   return (
     <SidePanel>
@@ -25,7 +25,7 @@ export default async function CreatePayForExpensesPage({ params }: PageProps) {
         successfulUrl={getDhoPathGovernance(lang as Locale, id)}
         spaceId={spaceId}
         web3SpaceId={web3SpaceId}
-        plugin={<Plugin name="pay-for-expenses" />}
+        plugin={<Plugin name="pay-for-expenses" spaceSlug={spaceSlug} />}
       />
     </SidePanel>
   );

--- a/apps/web/src/app/[lang]/dho/[id]/@aside/governance/create/plugins.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@aside/governance/create/plugins.tsx
@@ -8,7 +8,13 @@ export const PLUGINS = {
   'deploy-funds': DeployFundsPlugin,
 };
 
-export const Plugin = ({ name }: { name: keyof typeof PLUGINS }) => {
+type PluginProps = {
+  name: keyof typeof PLUGINS;
+  spaceSlug?: string;
+};
+
+export const Plugin = ({ name, spaceSlug }: PluginProps) => {
   const PluginCmp = PLUGINS[name];
-  return <PluginCmp />;
+
+  return <PluginCmp spaceSlug={spaceSlug || ''} />;
 };

--- a/apps/web/src/app/[lang]/dho/[id]/@aside/governance/create/plugins.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@aside/governance/create/plugins.tsx
@@ -1,6 +1,9 @@
+'use client';
+
 import { ProposeContributionPlugin } from '@hypha-platform/epics';
 import { PayForExpensesPlugin } from '@hypha-platform/epics';
 import { DeployFundsPlugin } from '@hypha-platform/epics';
+import { useMembers } from '@web/hooks/use-members';
 
 export const PLUGINS = {
   'propose-contribution': ProposeContributionPlugin,
@@ -14,7 +17,9 @@ type PluginProps = {
 };
 
 export const Plugin = ({ name, spaceSlug }: PluginProps) => {
+  const { members } = useMembers({ spaceSlug });
+
   const PluginCmp = PLUGINS[name];
 
-  return <PluginCmp spaceSlug={spaceSlug || ''} />;
+  return <PluginCmp spaceSlug={spaceSlug || ''} members={members} />;
 };

--- a/packages/epics/src/agreements/plugins/components/common/recipient-field.tsx
+++ b/packages/epics/src/agreements/plugins/components/common/recipient-field.tsx
@@ -7,7 +7,7 @@ import {
   FormMessage,
 } from '@hypha-platform/ui';
 
-export function RecipientField() {
+export function RecipientField({ recipients }: { recipients: any[] }) {
   const { control } = useFormContext();
   return (
     <FormField
@@ -20,7 +20,7 @@ export function RecipientField() {
               onChange={(recipient) => {
                 field.onChange(recipient.address);
               }}
-              recipients={[]}
+              recipients={recipients}
             />
           </FormControl>
           <FormMessage />

--- a/packages/epics/src/agreements/plugins/deploy-funds/plugin.tsx
+++ b/packages/epics/src/agreements/plugins/deploy-funds/plugin.tsx
@@ -1,14 +1,18 @@
 'use client';
 
-import { useMembers } from '@web/hooks/use-members';
 import { RecipientField } from '../components/common/recipient-field';
 import { TokenPayoutFieldArray } from '../components/common/token-payout-field-array';
 import { Separator } from '@hypha-platform/ui';
 import { tokens } from '../pay-for-expenses/tokens';
+import { Person } from '@core/people';
 
-export const DeployFundsPlugin = ({ spaceSlug }: { spaceSlug: string }) => {
-  const { members } = useMembers({ spaceSlug });
-
+export const DeployFundsPlugin = ({
+  spaceSlug,
+  members,
+}: {
+  spaceSlug: string;
+  members: Person[];
+}) => {
   return (
     <div className="flex flex-col gap-4">
       <RecipientField recipients={members} />

--- a/packages/epics/src/agreements/plugins/deploy-funds/plugin.tsx
+++ b/packages/epics/src/agreements/plugins/deploy-funds/plugin.tsx
@@ -1,15 +1,19 @@
 'use client';
 
+import { useMembers } from '@web/hooks/use-members';
 import { RecipientField } from '../components/common/recipient-field';
 import { TokenPayoutFieldArray } from '../components/common/token-payout-field-array';
 import { Separator } from '@hypha-platform/ui';
+import { tokens } from '../pay-for-expenses/tokens';
 
-export const DeployFundsPlugin = () => {
+export const DeployFundsPlugin = ({ spaceSlug }: { spaceSlug: string }) => {
+  const { members } = useMembers({ spaceSlug });
+
   return (
     <div className="flex flex-col gap-4">
-      <RecipientField />
+      <RecipientField recipients={members} />
       <Separator />
-      <TokenPayoutFieldArray tokens={[]} name="payouts" />
+      <TokenPayoutFieldArray tokens={tokens} name="payouts" />
     </div>
   );
 };

--- a/packages/epics/src/agreements/plugins/pay-for-expenses/plugin.tsx
+++ b/packages/epics/src/agreements/plugins/pay-for-expenses/plugin.tsx
@@ -1,14 +1,17 @@
 'use client';
 
+import { useMembers } from '@web/hooks/use-members';
 import { RecipientField } from '../components/common/recipient-field';
 import { TokenPayoutFieldArray } from '../components/common/token-payout-field-array';
 import { Separator } from '@hypha-platform/ui';
 import { tokens } from './tokens';
 
-export const PayForExpensesPlugin = () => {
+export const PayForExpensesPlugin = ({ spaceSlug }: { spaceSlug: string }) => {
+  const { members } = useMembers({ spaceSlug });
+
   return (
     <div className="flex flex-col gap-4">
-      <RecipientField />
+      <RecipientField recipients={members} />
       <Separator />
       <TokenPayoutFieldArray tokens={tokens} name="payouts" />
     </div>

--- a/packages/epics/src/agreements/plugins/pay-for-expenses/plugin.tsx
+++ b/packages/epics/src/agreements/plugins/pay-for-expenses/plugin.tsx
@@ -1,14 +1,18 @@
 'use client';
 
-import { useMembers } from '@web/hooks/use-members';
 import { RecipientField } from '../components/common/recipient-field';
 import { TokenPayoutFieldArray } from '../components/common/token-payout-field-array';
 import { Separator } from '@hypha-platform/ui';
 import { tokens } from './tokens';
+import { Person } from '@core/people';
 
-export const PayForExpensesPlugin = ({ spaceSlug }: { spaceSlug: string }) => {
-  const { members } = useMembers({ spaceSlug });
-
+export const PayForExpensesPlugin = ({
+  spaceSlug,
+  members,
+}: {
+  spaceSlug: string;
+  members: Person[];
+}) => {
   return (
     <div className="flex flex-col gap-4">
       <RecipientField recipients={members} />

--- a/packages/epics/src/agreements/plugins/propose-contribution/plugin.tsx
+++ b/packages/epics/src/agreements/plugins/propose-contribution/plugin.tsx
@@ -4,16 +4,16 @@ import { RecipientField } from '../components/common/recipient-field';
 import { TokenPayoutFieldArray } from '../components/common/token-payout-field-array';
 import { PaymentSchedule } from './components/payment-schedule';
 import { Separator } from '@hypha-platform/ui';
-import { useMembers } from '@web/hooks/use-members';
 import { tokens } from '../pay-for-expenses/tokens';
+import { Person } from '@core/people';
 
 export const ProposeContributionPlugin = ({
   spaceSlug,
+  members,
 }: {
   spaceSlug: string;
+  members: Person[];
 }) => {
-  const { members } = useMembers({ spaceSlug });
-
   return (
     <div className="flex flex-col gap-4">
       <RecipientField recipients={members} />

--- a/packages/epics/src/agreements/plugins/propose-contribution/plugin.tsx
+++ b/packages/epics/src/agreements/plugins/propose-contribution/plugin.tsx
@@ -4,14 +4,22 @@ import { RecipientField } from '../components/common/recipient-field';
 import { TokenPayoutFieldArray } from '../components/common/token-payout-field-array';
 import { PaymentSchedule } from './components/payment-schedule';
 import { Separator } from '@hypha-platform/ui';
+import { useMembers } from '@web/hooks/use-members';
+import { tokens } from '../pay-for-expenses/tokens';
 
-export const ProposeContributionPlugin = () => {
+export const ProposeContributionPlugin = ({
+  spaceSlug,
+}: {
+  spaceSlug: string;
+}) => {
+  const { members } = useMembers({ spaceSlug });
+
   return (
     <div className="flex flex-col gap-4">
-      <RecipientField />
+      <RecipientField recipients={members} />
       <Separator />
       <PaymentSchedule />
-      <TokenPayoutFieldArray tokens={[]} name="payouts" />
+      <TokenPayoutFieldArray tokens={tokens} name="payouts" />
     </div>
   );
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Dynamic member lists are now available in plugin forms, allowing selection of recipients based on the current space.
  - Token options in relevant plugins are now populated with actual data instead of being empty.
  - Plugin components now receive and utilize space-specific identifiers to tailor displayed information.

- **Improvements**
  - Plugin forms now adapt to the specific space context, ensuring accurate member and token information is displayed during expense and contribution workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->