### PR TITLE
feat(#816): made logoUrl and leadImageUrl as mandatory

### DIFF
--- a/packages/core/src/space/validation.ts
+++ b/packages/core/src/space/validation.ts
@@ -46,8 +46,8 @@ const createSpaceWeb2Props = {
 export const schemaCreateSpaceWeb2 = z.object(createSpaceWeb2Props);
 
 export const createSpaceWeb2FileUrls = {
-  logoUrl: z.string().url('Logo URL must be a valid URL').optional(),
-  leadImage: z.string().url('Lead Image URL must be a valid URL').optional(),
+  logoUrl: z.string().url('Logo URL must be a valid URL'),
+  leadImage: z.string().url('Lead Image URL must be a valid URL'),
 };
 
 export const schemaCreateSpaceWeb2FileUrls = z.object(createSpaceWeb2FileUrls);
@@ -62,36 +62,32 @@ const createSpaceWeb3Props = {
 export const schemaCreateSpaceWeb3 = z.object(createSpaceWeb3Props);
 
 export const createSpaceFiles = {
-  logoUrl: z
-    .union([
-      z.string().url('logoUrl URL must be a valid URL'),
-      z
-        .instanceof(File)
-        .refine(
-          (file) => file.size <= ALLOWED_IMAGE_FILE_SIZE,
-          'File size must be less than 5MB',
-        )
-        .refine(
-          (file) => DEFAULT_IMAGE_ACCEPT.includes(file.type),
-          'File must be an image (JPEG, PNG, GIF, WEBP)',
-        ),
-    ])
-    .optional(),
-  leadImage: z
-    .union([
-      z.string().url('Lead Image URL must be a valid URL'),
-      z
-        .instanceof(File)
-        .refine(
-          (file) => file.size <= ALLOWED_IMAGE_FILE_SIZE,
-          'File size must be less than 5MB',
-        )
-        .refine(
-          (file) => DEFAULT_IMAGE_ACCEPT.includes(file.type),
-          'File must be an image (JPEG, PNG, GIF, WEBP)',
-        ),
-    ])
-    .optional(),
+  logoUrl: z.union([
+    z.string().url('logoUrl URL must be a valid URL'),
+    z
+      .instanceof(File)
+      .refine(
+        (file) => file.size <= ALLOWED_IMAGE_FILE_SIZE,
+        'File size must be less than 5MB',
+      )
+      .refine(
+        (file) => DEFAULT_IMAGE_ACCEPT.includes(file.type),
+        'File must be an image (JPEG, PNG, GIF, WEBP)',
+      ),
+  ]),
+  leadImage: z.union([
+    z.string().url('Lead Image URL must be a valid URL'),
+    z
+      .instanceof(File)
+      .refine(
+        (file) => file.size <= ALLOWED_IMAGE_FILE_SIZE,
+        'File size must be less than 5MB',
+      )
+      .refine(
+        (file) => DEFAULT_IMAGE_ACCEPT.includes(file.type),
+        'File must be an image (JPEG, PNG, GIF, WEBP)',
+      ),
+  ]),
 };
 
 export const schemaCreateSpaceFiles = z.object(createSpaceFiles);

--- a/packages/epics/src/spaces/components/create-space-form.tsx
+++ b/packages/epics/src/spaces/components/create-space-form.tsx
@@ -50,8 +50,8 @@ export type CreateSpaceFormProps = {
 const DEFAULT_VALUES = {
   title: '',
   description: '',
-  logoUrl: undefined,
-  leadImage: undefined,
+  logoUrl: '',
+  leadImage: '',
   categories: [],
   links: [],
   parentId: null,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Made the logo and lead image fields required when creating a new space.
  - Updated form defaults so that logo and lead image fields now start as empty strings instead of undefined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->