### PR TITLE
feat(#849): disabled join button for sub-space card

### DIFF
--- a/packages/epics/src/spaces/components/inner-space-card.tsx
+++ b/packages/epics/src/spaces/components/inner-space-card.tsx
@@ -96,7 +96,7 @@ export const InnerSpaceCard: React.FC<InnerSpaceCardProps> = ({
           </Skeleton>
         </div>
 
-        <Skeleton width="200px" height="32px" loading={isLoading}>
+        {/* <Skeleton width="200px" height="32px" loading={isLoading}>
           <div>
             {isMember ? (
               <Button className="rounded-lg w-full" variant="outline">
@@ -115,7 +115,7 @@ export const InnerSpaceCard: React.FC<InnerSpaceCardProps> = ({
               </Button>
             )}
           </div>
-        </Skeleton>
+        </Skeleton> */}
       </CardContent>
     </Card>
   );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed the display of "Join" and "Joined" buttons from space cards. These buttons are no longer visible in the user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->