### PR TITLE
feat(#871): fixed form voting "not finished" state when proposal has been executed

### DIFF
--- a/packages/epics/src/proposals/components/form-voting.tsx
+++ b/packages/epics/src/proposals/components/form-voting.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@hypha-platform/ui';
+import { Button, Skeleton } from '@hypha-platform/ui';
 import { ProgressLine } from './progress-line';
 import { intervalToDuration, isPast } from 'date-fns';
 
@@ -28,39 +28,64 @@ export const FormVoting = ({
   unity,
   quorum,
   endTime,
+  executed,
+  isLoading,
   onAccept,
   onReject,
 }: {
   unity: number;
   quorum: number;
   endTime: string;
+  executed?: boolean;
+  isLoading?: boolean;
   onAccept: () => void;
   onReject: () => void;
 }) => {
   return (
     <div className="flex flex-col gap-5 text-neutral-11">
       <div className="flex flex-col gap-4">
-        <ProgressLine
-          label="Unity"
-          value={unity}
-          indicatorColor="bg-accent-9"
-        />
-        <ProgressLine
-          label="Quorum"
-          value={quorum}
-          indicatorColor="bg-accent-12"
-        />
+        <Skeleton
+          width="100%"
+          height="28px"
+          loading={isLoading}
+          className="rounded-lg"
+        >
+          <ProgressLine
+            label="Unity"
+            value={unity}
+            indicatorColor="bg-accent-9"
+          />
+        </Skeleton>
+        <Skeleton
+          width="100%"
+          height="28px"
+          loading={isLoading}
+          className="rounded-lg"
+        >
+          <ProgressLine
+            label="Quorum"
+            value={quorum}
+            indicatorColor="bg-accent-12"
+          />
+        </Skeleton>
       </div>
       <div className="flex items-center justify-between">
-        <div className="text-1">{formatTimeRemaining(endTime)}</div>
-        {isPast(new Date(endTime)) ? null : (
-          <div className="flex gap-2">
-            <Button variant="outline" onClick={onReject}>
-              Vote no
-            </Button>
-            <Button onClick={onAccept}>Vote yes</Button>
-          </div>
-        )}
+        <Skeleton
+          width="100%"
+          height="28px"
+          loading={isLoading}
+          className="rounded-lg"
+        >
+          <div className="text-1">{formatTimeRemaining(endTime)}</div>
+          {isPast(new Date(endTime)) || executed ? null : (
+            <div className="flex gap-2">
+              <Button variant="outline" onClick={onReject}>
+                Vote no
+              </Button>
+              <Button onClick={onAccept}>Vote yes</Button>
+            </div>
+          )}
+        </Skeleton>
       </div>
     </div>
   );

--- a/packages/epics/src/proposals/components/proposal-detail.tsx
+++ b/packages/epics/src/proposals/components/proposal-detail.tsx
@@ -130,8 +130,10 @@ export const ProposalDetail = ({
         unity={proposalDetails?.yesVotePercentage || 0}
         quorum={proposalDetails?.quorumPercentage || 0}
         endTime={formatISO(new Date(proposalDetails?.endTime || new Date()))}
+        executed={proposalDetails?.executed}
         onAccept={handleOnAccept}
         onReject={handleOnReject}
+        isLoading={isLoading}
       />
       <Separator />
       <CommentsList


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added loading indicators to the voting section for improved user feedback during data fetching.
  - Voting controls are now disabled and hidden after a proposal has been executed.

- **Enhancements**
  - Improved clarity by displaying loading placeholders for voting progress and time remaining when data is loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->