### PR TITLE
feat(#836): Implementing balance display for treasury screen

### DIFF
--- a/apps/web/src/app/api/v1/spaces/[spaceSlug]/assets/_asset-provider/erc20-provider.ts
+++ b/apps/web/src/app/api/v1/spaces/[spaceSlug]/assets/_asset-provider/erc20-provider.ts
@@ -1,0 +1,89 @@
+import { AssetProvider, ProviderOpts } from './interface';
+import { erc20Abi, PublicClient, Hex, formatUnits } from 'viem';
+import { AssetItem } from '@hypha-platform/graphql/rsc';
+
+export type TokenType = (
+  | 'voice'
+  | 'ownership'
+  | 'utility'
+  | 'credits'
+) & string;
+
+export type Erc20ProviderOpts = ProviderOpts & {
+  token: Hex,
+  status?: TokenType,
+  name?: string,
+};
+
+export class Erc20Provider implements AssetProvider {
+  private readonly client: PublicClient;
+  private readonly token: Hex;
+  private readonly name: string;
+  private readonly icon: string;
+  private readonly status: TokenType;
+  private readonly closeUrl: string;
+  private readonly slug: string;
+  private readonly usdEquivalent: (amount: number) => Promise<number>;
+
+  constructor(
+    opts: Erc20ProviderOpts,
+  ) {
+    this.client = opts.client;
+    this.token = opts.token;
+    this.name = opts.name || '';
+    this.icon = opts.icon || '';
+    this.status = opts.status || 'utility';
+    this.closeUrl = opts.closeUrl || '';
+    this.slug = opts.slug;
+    this.usdEquivalent = opts.usdEquivalent || function() {
+      return new Promise((resolve, _) => resolve(0));
+    }
+  }
+
+  async formItem(address: Hex): Promise<AssetItem> {
+    const contract = {
+      address: this.token,
+      abi: erc20Abi,
+    } as const;
+
+    const balance = await this.client.multicall({
+      contracts: [
+        {
+          ...contract,
+          functionName: 'balanceOf',
+          args: [address],
+        },
+        {
+          ...contract,
+          functionName: 'symbol',
+        },
+        {
+          ...contract,
+          functionName: 'decimals',
+        }
+      ]
+    })
+
+    const failure = balance.find(res => res.status === "failure");
+    if (failure) {
+      throw failure.error;
+    }
+
+    const [amount, symbol, decimals] = balance.map(obj => obj.result);
+    const value = +formatUnits((amount as bigint), (decimals as number));
+    return {
+      icon: this.icon,
+      name: this.name,
+      symbol: String(symbol),
+      value: value,
+      usdEqual: await this.usdEquivalent(value),
+      status: this.status,
+      // TODO: get chart data
+      chartData: [],
+      // TODO: get transactions
+      transactions: [],
+      closeUrl: this.closeUrl,
+      slug: this.slug,
+    }
+  }
+}

--- a/apps/web/src/app/api/v1/spaces/[spaceSlug]/assets/_asset-provider/erc20-provider.ts
+++ b/apps/web/src/app/api/v1/spaces/[spaceSlug]/assets/_asset-provider/erc20-provider.ts
@@ -2,17 +2,13 @@ import { AssetProvider, ProviderOpts, Balance } from './interface';
 import { Hex, formatUnits } from 'viem';
 import { AssetItem } from '@hypha-platform/graphql/rsc';
 
-export type TokenType = (
-  | 'voice'
-  | 'ownership'
-  | 'utility'
-  | 'credits'
-) & string;
+export type TokenType = ('voice' | 'ownership' | 'utility' | 'credits') &
+  string;
 
 export type Erc20ProviderOpts = ProviderOpts & {
-  token: Hex,
-  status?: TokenType,
-  name?: string,
+  token: Hex;
+  status?: TokenType;
+  name?: string;
 };
 
 export class Erc20Provider implements AssetProvider {
@@ -25,9 +21,7 @@ export class Erc20Provider implements AssetProvider {
   private readonly getBalance: (address: Hex) => Promise<Balance>;
   private readonly usdEquivalent: (amount: number) => Promise<number>;
 
-  constructor(
-    opts: Erc20ProviderOpts,
-  ) {
+  constructor(opts: Erc20ProviderOpts) {
     this.token = opts.token;
     this.name = opts.name || '';
     this.icon = opts.icon || '';
@@ -35,14 +29,16 @@ export class Erc20Provider implements AssetProvider {
     this.closeUrl = opts.closeUrl || '';
     this.slug = opts.slug;
     this.getBalance = opts.getBalance;
-    this.usdEquivalent = opts.usdEquivalent || function() {
-      return new Promise((resolve, _) => resolve(0));
-    }
+    this.usdEquivalent =
+      opts.usdEquivalent ||
+      function () {
+        return new Promise((resolve, _) => resolve(0));
+      };
   }
 
   async formItem(address: Hex): Promise<AssetItem> {
     const { amount, symbol, decimals } = await this.getBalance(address);
-    const value = +formatUnits((amount as bigint), (decimals as number));
+    const value = +formatUnits(amount as bigint, decimals as number);
 
     return {
       icon: this.icon,
@@ -57,6 +53,6 @@ export class Erc20Provider implements AssetProvider {
       transactions: [],
       closeUrl: this.closeUrl,
       slug: this.slug,
-    }
+    };
   }
 }

--- a/apps/web/src/app/api/v1/spaces/[spaceSlug]/assets/_asset-provider/ethereum-provider.ts
+++ b/apps/web/src/app/api/v1/spaces/[spaceSlug]/assets/_asset-provider/ethereum-provider.ts
@@ -1,0 +1,50 @@
+import { AssetProvider, ProviderOpts } from './interface';
+import { PublicClient, Hex, formatUnits } from 'viem';
+import { AssetItem } from '@hypha-platform/graphql/rsc';
+
+export class EthereumProvider implements AssetProvider {
+  private readonly client: PublicClient;
+  private readonly icon: string;
+  private readonly status = 'liquid';
+  private readonly name = 'Ethereum';
+  private readonly symbol = 'ETH';
+  private readonly decimals = 18;
+  private readonly slug: string;
+  private readonly closeUrl: string;
+  private readonly usdEquivalent: (amount: number) => Promise<number>;
+
+  constructor(
+    opts: ProviderOpts,
+  ) {
+    this.client = opts.client;
+    this.icon = opts.icon || '/placeholder/eth.png';
+    this.slug = opts.slug;
+    this.closeUrl = opts.closeUrl || '';
+    this.usdEquivalent = opts.usdEquivalent || function() {
+      return new Promise((resolve, _) => resolve(0));
+    }
+  }
+
+  async formItem(address: Hex): Promise<AssetItem> {
+    const balance = await this.client.getBalance({
+      blockTag: 'safe',
+      address,
+    });
+    const amount = +formatUnits(balance, this.decimals);
+
+    return {
+      icon: this.icon,
+      name: this.name,
+      symbol: this.symbol,
+      value: amount,
+      usdEqual: await this.usdEquivalent(amount),
+      status: this.status,
+      // TODO: get chart data
+      chartData: [],
+      // TODO: get transactions
+      transactions: [],
+      closeUrl: this.closeUrl,
+      slug: this.slug,
+    }
+  }
+}

--- a/apps/web/src/app/api/v1/spaces/[spaceSlug]/assets/_asset-provider/ethereum-provider.ts
+++ b/apps/web/src/app/api/v1/spaces/[spaceSlug]/assets/_asset-provider/ethereum-provider.ts
@@ -11,21 +11,21 @@ export class EthereumProvider implements AssetProvider {
   private readonly getBalance: (address: Hex) => Promise<Balance>;
   private readonly usdEquivalent: (amount: number) => Promise<number>;
 
-  constructor(
-    opts: ProviderOpts,
-  ) {
+  constructor(opts: ProviderOpts) {
     this.icon = opts.icon || '/placeholder/eth.png';
     this.slug = opts.slug;
     this.closeUrl = opts.closeUrl || '';
     this.getBalance = opts.getBalance;
-    this.usdEquivalent = opts.usdEquivalent || function() {
-      return new Promise((resolve, _) => resolve(0));
-    }
+    this.usdEquivalent =
+      opts.usdEquivalent ||
+      function () {
+        return new Promise((resolve, _) => resolve(0));
+      };
   }
 
   async formItem(address: Hex): Promise<AssetItem> {
     const { amount, symbol, decimals } = await this.getBalance(address);
-    const value = +formatUnits((amount as bigint), (decimals as number));
+    const value = +formatUnits(amount as bigint, decimals as number);
 
     return {
       icon: this.icon,
@@ -40,6 +40,6 @@ export class EthereumProvider implements AssetProvider {
       transactions: [],
       closeUrl: this.closeUrl,
       slug: this.slug,
-    }
+    };
   }
 }

--- a/apps/web/src/app/api/v1/spaces/[spaceSlug]/assets/_asset-provider/ethereum-provider.ts
+++ b/apps/web/src/app/api/v1/spaces/[spaceSlug]/assets/_asset-provider/ethereum-provider.ts
@@ -1,43 +1,38 @@
-import { AssetProvider, ProviderOpts } from './interface';
-import { PublicClient, Hex, formatUnits } from 'viem';
+import { AssetProvider, ProviderOpts, Balance } from './interface';
+import { Hex, formatUnits } from 'viem';
 import { AssetItem } from '@hypha-platform/graphql/rsc';
 
 export class EthereumProvider implements AssetProvider {
-  private readonly client: PublicClient;
   private readonly icon: string;
   private readonly status = 'liquid';
   private readonly name = 'Ethereum';
-  private readonly symbol = 'ETH';
-  private readonly decimals = 18;
   private readonly slug: string;
   private readonly closeUrl: string;
+  private readonly getBalance: (address: Hex) => Promise<Balance>;
   private readonly usdEquivalent: (amount: number) => Promise<number>;
 
   constructor(
     opts: ProviderOpts,
   ) {
-    this.client = opts.client;
     this.icon = opts.icon || '/placeholder/eth.png';
     this.slug = opts.slug;
     this.closeUrl = opts.closeUrl || '';
+    this.getBalance = opts.getBalance;
     this.usdEquivalent = opts.usdEquivalent || function() {
       return new Promise((resolve, _) => resolve(0));
     }
   }
 
   async formItem(address: Hex): Promise<AssetItem> {
-    const balance = await this.client.getBalance({
-      blockTag: 'safe',
-      address,
-    });
-    const amount = +formatUnits(balance, this.decimals);
+    const { amount, symbol, decimals } = await this.getBalance(address);
+    const value = +formatUnits((amount as bigint), (decimals as number));
 
     return {
       icon: this.icon,
       name: this.name,
-      symbol: this.symbol,
-      value: amount,
-      usdEqual: await this.usdEquivalent(amount),
+      symbol: symbol,
+      value: value,
+      usdEqual: await this.usdEquivalent(value),
       status: this.status,
       // TODO: get chart data
       chartData: [],

--- a/apps/web/src/app/api/v1/spaces/[spaceSlug]/assets/_asset-provider/index.ts
+++ b/apps/web/src/app/api/v1/spaces/[spaceSlug]/assets/_asset-provider/index.ts
@@ -1,0 +1,3 @@
+export * from './interface';
+export * from './erc20-provider';
+export * from './ethereum-provider';

--- a/apps/web/src/app/api/v1/spaces/[spaceSlug]/assets/_asset-provider/interface.ts
+++ b/apps/web/src/app/api/v1/spaces/[spaceSlug]/assets/_asset-provider/interface.ts
@@ -1,0 +1,18 @@
+import { AssetItem } from '@hypha-platform/graphql/rsc';
+import { Hex, PublicClient } from 'viem';
+
+export type ProviderOpts = {
+  client: PublicClient;
+  slug: string;
+  icon?: string;
+  closeUrl?: string;
+
+  // Method to convert amount of provided token to its USD equivalent
+  usdEquivalent?: (amount: number) => Promise<number>;
+}
+
+export interface AssetProvider {
+  // Should provide all necessary info about the asset with a balance for the
+  // "address"
+  formItem(address: Hex): Promise<AssetItem>;
+};

--- a/apps/web/src/app/api/v1/spaces/[spaceSlug]/assets/_asset-provider/interface.ts
+++ b/apps/web/src/app/api/v1/spaces/[spaceSlug]/assets/_asset-provider/interface.ts
@@ -5,7 +5,7 @@ export type Balance = {
   amount: bigint;
   symbol: string;
   decimals: number;
-}
+};
 
 export type ProviderOpts = {
   slug: string;
@@ -17,10 +17,10 @@ export type ProviderOpts = {
 
   // Method to convert amount of provided token to its USD equivalent
   usdEquivalent?: (amount: number) => Promise<number>;
-}
+};
 
 export interface AssetProvider {
   // Should provide all necessary info about the asset with a balance for the
   // "address"
   formItem(address: Hex): Promise<AssetItem>;
-};
+}

--- a/apps/web/src/app/api/v1/spaces/[spaceSlug]/assets/_asset-provider/interface.ts
+++ b/apps/web/src/app/api/v1/spaces/[spaceSlug]/assets/_asset-provider/interface.ts
@@ -1,11 +1,19 @@
 import { AssetItem } from '@hypha-platform/graphql/rsc';
-import { Hex, PublicClient } from 'viem';
+import { Hex } from 'viem';
+
+export type Balance = {
+  amount: bigint;
+  symbol: string;
+  decimals: number;
+}
 
 export type ProviderOpts = {
-  client: PublicClient;
   slug: string;
   icon?: string;
   closeUrl?: string;
+
+  // Method to get the balance of the address
+  getBalance: (address: Hex) => Promise<Balance>;
 
   // Method to convert amount of provided token to its USD equivalent
   usdEquivalent?: (amount: number) => Promise<number>;

--- a/apps/web/src/app/api/v1/spaces/[spaceSlug]/assets/_paginator.ts
+++ b/apps/web/src/app/api/v1/spaces/[spaceSlug]/assets/_paginator.ts
@@ -1,0 +1,38 @@
+import {
+  PaginationMetadata,
+  PaginationParams,
+} from '@hypha-platform/graphql/rsc';
+
+export function paginate<T>(
+  data: T[],
+  {
+    page = 1,
+    pageSize = 2,
+    filter = {},
+  }: PaginationParams<T>,
+): {
+  paginatedData: T[],
+  pagination: PaginationMetadata
+} {
+  const filtered = data.filter(obj => {
+    return Object.entries(filter).every(([key, value]) => {
+      return value === undefined || obj[key as keyof T] === value;
+    })
+  });
+
+  const totalPages = Math.ceil(filtered.length / pageSize)
+  const meta = {
+    total: filtered.length,
+    page,
+    pageSize,
+    totalPages,
+    hasNextPage: page < totalPages,
+    hasPreviousPage: page > 1,
+  }
+
+  const start = (page - 1) * pageSize;
+  return {
+    paginatedData: filtered.slice(start, start + pageSize),
+    pagination: meta,
+  }
+}

--- a/apps/web/src/app/api/v1/spaces/[spaceSlug]/assets/_paginator.ts
+++ b/apps/web/src/app/api/v1/spaces/[spaceSlug]/assets/_paginator.ts
@@ -5,22 +5,18 @@ import {
 
 export function paginate<T>(
   data: T[],
-  {
-    page = 1,
-    pageSize = 2,
-    filter = {},
-  }: PaginationParams<T>,
+  { page = 1, pageSize = 2, filter = {} }: PaginationParams<T>,
 ): {
-  paginatedData: T[],
-  pagination: PaginationMetadata
+  paginatedData: T[];
+  pagination: PaginationMetadata;
 } {
-  const filtered = data.filter(obj => {
+  const filtered = data.filter((obj) => {
     return Object.entries(filter).every(([key, value]) => {
       return value === undefined || obj[key as keyof T] === value;
-    })
+    });
   });
 
-  const totalPages = Math.ceil(filtered.length / pageSize)
+  const totalPages = Math.ceil(filtered.length / pageSize);
   const meta = {
     total: filtered.length,
     page,
@@ -28,11 +24,11 @@ export function paginate<T>(
     totalPages,
     hasNextPage: page < totalPages,
     hasPreviousPage: page > 1,
-  }
+  };
 
   const start = (page - 1) * pageSize;
   return {
     paginatedData: filtered.slice(start, start + pageSize),
     pagination: meta,
-  }
+  };
 }

--- a/apps/web/src/app/api/v1/spaces/[spaceSlug]/assets/_tokens.ts
+++ b/apps/web/src/app/api/v1/spaces/[spaceSlug]/assets/_tokens.ts
@@ -1,0 +1,30 @@
+import { AssetProvider, Erc20Provider, EthereumProvider } from './_asset-provider';
+import { publicClient } from '@core/common';
+
+export const TOKENS: AssetProvider[] = [
+  new EthereumProvider({
+    client: publicClient,
+    slug: 'ETH',
+  }),
+  new Erc20Provider({
+    client: publicClient,
+    token: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
+    slug: 'USDC',
+    name: 'USD Coin',
+    icon: '/placeholder/usdc-icon.png',
+  }),
+  new Erc20Provider({
+    client: publicClient,
+    token: '0x60a3e35cc302bfa44cb288bc5a4f316fdb1adb42',
+    slug: 'EURC',
+    name: 'EUR Coin',
+    icon: '/placeholder/eurc-icon.png',
+  }),
+  new Erc20Provider({
+    client: publicClient,
+    token: '0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf',
+    slug: 'cbBTC',
+    name: 'Conibase Wrapped BTC',
+    icon: '/placeholder/cbBTC-icon.png'
+  }),
+]

--- a/apps/web/src/app/api/v1/spaces/[spaceSlug]/assets/_tokens.ts
+++ b/apps/web/src/app/api/v1/spaces/[spaceSlug]/assets/_tokens.ts
@@ -1,4 +1,8 @@
-import { AssetProvider, Erc20Provider, EthereumProvider } from './_asset-provider';
+import {
+  AssetProvider,
+  Erc20Provider,
+  EthereumProvider,
+} from './_asset-provider';
 import { publicClient } from '@core/common';
 import { Hex, erc20Abi } from 'viem';
 
@@ -24,23 +28,23 @@ export const formGetBalance = (token: Hex) => {
         {
           ...contract,
           functionName: 'decimals',
-        }
-      ]
-    })
+        },
+      ],
+    });
 
-    const failure = balance.find(res => res.status === "failure");
+    const failure = balance.find((res) => res.status === 'failure');
     if (failure) {
       throw failure.error;
     }
 
-    const [amount, symbol, decimals] = balance.map(obj => obj.result);
+    const [amount, symbol, decimals] = balance.map((obj) => obj.result);
     return {
       amount: amount as bigint,
       symbol: symbol as string,
       decimals: decimals as number,
     };
-  }
-}
+  };
+};
 
 export const TOKENS: AssetProvider[] = [
   new EthereumProvider({
@@ -52,10 +56,10 @@ export const TOKENS: AssetProvider[] = [
       const amount = await publicClient.getBalance({
         blockTag: 'safe',
         address,
-      })
+      });
 
       return { amount, decimals, symbol };
-    }
+    },
   }),
   new Erc20Provider({
     token: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
@@ -76,6 +80,6 @@ export const TOKENS: AssetProvider[] = [
     getBalance: formGetBalance('0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf'),
     slug: 'cbBTC',
     name: 'Conibase Wrapped BTC',
-    icon: '/placeholder/cbBTC-icon.png'
+    icon: '/placeholder/cbBTC-icon.png',
   }),
-]
+];

--- a/apps/web/src/app/api/v1/spaces/[spaceSlug]/assets/_tokens.ts
+++ b/apps/web/src/app/api/v1/spaces/[spaceSlug]/assets/_tokens.ts
@@ -1,28 +1,79 @@
 import { AssetProvider, Erc20Provider, EthereumProvider } from './_asset-provider';
 import { publicClient } from '@core/common';
+import { Hex, erc20Abi } from 'viem';
+
+export const formGetBalance = (token: Hex) => {
+  return async (address: Hex) => {
+    const contract = {
+      address: token,
+      abi: erc20Abi,
+    } as const;
+
+    const balance = await publicClient.multicall({
+      blockTag: 'safe',
+      contracts: [
+        {
+          ...contract,
+          functionName: 'balanceOf',
+          args: [address],
+        },
+        {
+          ...contract,
+          functionName: 'symbol',
+        },
+        {
+          ...contract,
+          functionName: 'decimals',
+        }
+      ]
+    })
+
+    const failure = balance.find(res => res.status === "failure");
+    if (failure) {
+      throw failure.error;
+    }
+
+    const [amount, symbol, decimals] = balance.map(obj => obj.result);
+    return {
+      amount: amount as bigint,
+      symbol: symbol as string,
+      decimals: decimals as number,
+    };
+  }
+}
 
 export const TOKENS: AssetProvider[] = [
   new EthereumProvider({
-    client: publicClient,
     slug: 'ETH',
+    getBalance: async (address: Hex) => {
+      const decimals = 18;
+      const symbol = 'ETH';
+
+      const amount = await publicClient.getBalance({
+        blockTag: 'safe',
+        address,
+      })
+
+      return { amount, decimals, symbol };
+    }
   }),
   new Erc20Provider({
-    client: publicClient,
     token: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
+    getBalance: formGetBalance('0x833589fcd6edb6e08f4c7c32d4f71b54bda02913'),
     slug: 'USDC',
     name: 'USD Coin',
     icon: '/placeholder/usdc-icon.png',
   }),
   new Erc20Provider({
-    client: publicClient,
     token: '0x60a3e35cc302bfa44cb288bc5a4f316fdb1adb42',
+    getBalance: formGetBalance('0x60a3e35cc302bfa44cb288bc5a4f316fdb1adb42'),
     slug: 'EURC',
     name: 'EUR Coin',
     icon: '/placeholder/eurc-icon.png',
   }),
   new Erc20Provider({
-    client: publicClient,
     token: '0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf',
+    getBalance: formGetBalance('0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf'),
     slug: 'cbBTC',
     name: 'Conibase Wrapped BTC',
     icon: '/placeholder/cbBTC-icon.png'

--- a/apps/web/src/app/api/v1/spaces/[spaceSlug]/assets/route.ts
+++ b/apps/web/src/app/api/v1/spaces/[spaceSlug]/assets/route.ts
@@ -1,0 +1,123 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createSpaceService } from '@hypha-platform/core/server';
+import { getSpaceDetails } from '@core/space';
+import { publicClient } from '@core/common';
+import { TOKENS } from './_tokens';
+import { Erc20Provider, AssetProvider } from './_asset-provider';
+import { paginate } from './_paginator';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ spaceSlug: string }> },
+) {
+  const { spaceSlug } = await params;
+
+  try {
+    const spaceService = createSpaceService();
+
+    const space = await spaceService.getBySlug({ slug: spaceSlug });
+    if (!space) {
+      return NextResponse.json({ error: 'Space not found' }, { status: 404 });
+    }
+
+    let spaceDetails;
+    try {
+      spaceDetails = await publicClient.readContract(
+        getSpaceDetails({ spaceId: BigInt(space.web3SpaceId as number) }),
+      );
+    } catch (err: any) {
+      const errorMessage =
+        err?.message || err?.shortMessage || JSON.stringify(err);
+      if (errorMessage.includes('rate limit') || errorMessage.includes('429')) {
+        console.warn(
+          'Rate limit exceeded when calling readContract:',
+          errorMessage,
+        );
+        return NextResponse.json(
+          {
+            error: 'External API rate limit exceeded. Please try again later.',
+          },
+          { status: 503 },
+        );
+      }
+
+      console.error('Error while calling readContract:', err);
+      return NextResponse.json(
+        { error: 'Failed to fetch contract data.' },
+        { status: 500 },
+      );
+    }
+
+    const [
+      /*unity*/,
+      /*quorum*/,
+      /*votingPowerSource*/,
+      tokenAdresses,
+      /*members*/,
+      /*exitMethod*/,
+      /*joinMethod*/,
+      /*createdAt*/,
+      /*creator*/,
+      spaceAddress,
+    ] = spaceDetails;
+
+    const assets = await Promise.all(tokenAdresses
+      .map((token, index) => new Erc20Provider({
+        client: publicClient,
+        token: token,
+        slug: `${token}-${index}`,
+      }) as AssetProvider)
+      .concat(TOKENS)
+      .map(provider => provider.formItem(spaceAddress)));
+    const sorted = assets.sort((a, b) => a.usdEqual === b.usdEqual
+      ? b.value - a.value
+      : b.usdEqual - a.usdEqual);
+
+    const url = new URL(request.url)
+    const page = url.searchParams.get('page');
+    const pageSize = url.searchParams.get('pageSize');
+    const status = url.searchParams.get('status');
+
+    const parsedPage = page ? Number(page) : undefined;
+    const parsedPageSize = pageSize ? Number(pageSize) : undefined;
+    if (
+      parsedPage !== undefined &&
+      (!Number.isInteger(parsedPage) || parsedPage < 1)
+    ) {
+      return NextResponse.json(
+        { error: 'Invalid page parameter' },
+        { status: 400 }
+      );
+    }
+    if (
+      parsedPageSize !== undefined &&
+      (!Number.isInteger(parsedPageSize) || parsedPageSize < 1)
+    ) {
+      return NextResponse.json(
+        { error: 'Invalid pageSize parameter' },
+        { status: 400 }
+      );
+    }
+
+    const paginated = paginate(
+      sorted,
+      {
+        page: parsedPage,
+        pageSize: parsedPageSize,
+        filter: status ? { status } : {},
+      },
+    )
+
+    return NextResponse.json({
+      assets: paginated.paginatedData,
+      pagination: paginated.pagination,
+      balance: sorted.reduce((sum, asset) => sum + (asset.usdEqual), 0)
+    });
+  } catch (error) {
+    console.error('Failed to fetch assets:', error);
+    return NextResponse.json(
+      { error: 'Failed to fetch assets.' },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/src/app/api/v1/spaces/[spaceSlug]/assets/route.ts
+++ b/apps/web/src/app/api/v1/spaces/[spaceSlug]/assets/route.ts
@@ -48,32 +48,26 @@ export async function GET(
       );
     }
 
-    const [
-      /*unity*/,
-      /*quorum*/,
-      /*votingPowerSource*/,
-      tokenAdresses,
-      /*members*/,
-      /*exitMethod*/,
-      /*joinMethod*/,
-      /*createdAt*/,
-      /*creator*/,
-      spaceAddress,
-    ] = spaceDetails;
+    const [, , , tokenAdresses, , , , , , spaceAddress] = spaceDetails;
 
-    const assets = await Promise.all(tokenAdresses
-      .map((token, index) => new Erc20Provider({
-        getBalance: formGetBalance(token),
-        token: token,
-        slug: `${token}-${index}`,
-      }) as AssetProvider)
-      .concat(TOKENS)
-      .map(provider => provider.formItem(spaceAddress)));
-    const sorted = assets.sort((a, b) => a.usdEqual === b.usdEqual
-      ? b.value - a.value
-      : b.usdEqual - a.usdEqual);
+    const assets = await Promise.all(
+      tokenAdresses
+        .map(
+          (token, index) =>
+            new Erc20Provider({
+              getBalance: formGetBalance(token),
+              token: token,
+              slug: `${token}-${index}`,
+            }) as AssetProvider,
+        )
+        .concat(TOKENS)
+        .map((provider) => provider.formItem(spaceAddress)),
+    );
+    const sorted = assets.sort((a, b) =>
+      a.usdEqual === b.usdEqual ? b.value - a.value : b.usdEqual - a.usdEqual,
+    );
 
-    const url = new URL(request.url)
+    const url = new URL(request.url);
     const page = url.searchParams.get('page');
     const pageSize = url.searchParams.get('pageSize');
     const status = url.searchParams.get('status');
@@ -86,7 +80,7 @@ export async function GET(
     ) {
       return NextResponse.json(
         { error: 'Invalid page parameter' },
-        { status: 400 }
+        { status: 400 },
       );
     }
     if (
@@ -95,23 +89,20 @@ export async function GET(
     ) {
       return NextResponse.json(
         { error: 'Invalid pageSize parameter' },
-        { status: 400 }
+        { status: 400 },
       );
     }
 
-    const paginated = paginate(
-      sorted,
-      {
-        page: parsedPage,
-        pageSize: parsedPageSize,
-        filter: status ? { status } : {},
-      },
-    )
+    const paginated = paginate(sorted, {
+      page: parsedPage,
+      pageSize: parsedPageSize,
+      filter: status ? { status } : {},
+    });
 
     return NextResponse.json({
       assets: paginated.paginatedData,
       pagination: paginated.pagination,
-      balance: sorted.reduce((sum, asset) => sum + (asset.usdEqual), 0)
+      balance: sorted.reduce((sum, asset) => sum + asset.usdEqual, 0),
     });
   } catch (error) {
     console.error('Failed to fetch assets:', error);

--- a/apps/web/src/app/api/v1/spaces/[spaceSlug]/assets/route.ts
+++ b/apps/web/src/app/api/v1/spaces/[spaceSlug]/assets/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createSpaceService } from '@hypha-platform/core/server';
 import { getSpaceDetails } from '@core/space';
 import { publicClient } from '@core/common';
-import { TOKENS } from './_tokens';
+import { TOKENS, formGetBalance } from './_tokens';
 import { Erc20Provider, AssetProvider } from './_asset-provider';
 import { paginate } from './_paginator';
 
@@ -63,7 +63,7 @@ export async function GET(
 
     const assets = await Promise.all(tokenAdresses
       .map((token, index) => new Erc20Provider({
-        client: publicClient,
+        getBalance: formGetBalance(token),
         token: token,
         slug: `${token}-${index}`,
       }) as AssetProvider)

--- a/packages/epics/src/treasury/hooks/use-assets.ts
+++ b/packages/epics/src/treasury/hooks/use-assets.ts
@@ -1,12 +1,14 @@
 'use client';
 
+import React from 'react'
 import useSWR from 'swr';
+import queryString from 'query-string';
 import {
   AssetItem,
   PaginationMetadata,
   FilterParams,
-  fetchAssets,
 } from '@hypha-platform/graphql/rsc';
+import { useParams } from 'next/navigation';
 
 type UseAssetsReturn = {
   assets: AssetItem[];
@@ -17,19 +19,45 @@ type UseAssetsReturn = {
 
 export const useAssets = ({
   page = 1,
+  pageSize = 2,
   filter,
 }: {
   page?: number;
+  pageSize?: number;
   filter?: FilterParams<AssetItem>;
 }): UseAssetsReturn => {
-  const { data, isLoading } = useSWR(['assets', page, filter], () =>
-    fetchAssets({ page, filter }),
-  );
+  const { id } = useParams<{ id: string }>();
+  const queryParams = React.useMemo(() => {
+    const effectiveFilter = {
+      page,
+      pageSize,
+      ...filter,
+    };
+    return `?${queryString.stringify(effectiveFilter)}`;
+  }, [page, pageSize, filter]);
+
+  const endpoint = React.useMemo(() => {
+    return `/api/v1/spaces/${id}/assets${queryParams}`
+  }, [id, queryParams]);
+
+  const { data, isLoading } = useSWR(
+    [endpoint],
+    async ([endpoint]) => {
+      const res = await fetch(endpoint, {
+        headers: { 'Content-Type': 'application/json' },
+      });
+      return await res.json();
+    });
+
+  const typedData = data as UseAssetsReturn | undefined;
+  const hasValidData = typedData &&
+    Array.isArray(typedData.assets) &&
+    typeof typedData.balance === 'number';
 
   return {
-    assets: data?.assets || [],
-    pagination: data?.pagination,
+    assets: hasValidData ? typedData.assets : [],
+    pagination: hasValidData ? typedData.pagination : undefined,
     isLoading,
-    balance: data?.balance || 0,
+    balance: hasValidData ? typedData.balance : 0,
   };
 };

--- a/packages/epics/src/treasury/hooks/use-assets.ts
+++ b/packages/epics/src/treasury/hooks/use-assets.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react'
+import React from 'react';
 import useSWR from 'swr';
 import queryString from 'query-string';
 import {
@@ -37,20 +37,19 @@ export const useAssets = ({
   }, [page, pageSize, filter]);
 
   const endpoint = React.useMemo(() => {
-    return `/api/v1/spaces/${id}/assets${queryParams}`
+    return `/api/v1/spaces/${id}/assets${queryParams}`;
   }, [id, queryParams]);
 
-  const { data, isLoading } = useSWR(
-    [endpoint],
-    async ([endpoint]) => {
-      const res = await fetch(endpoint, {
-        headers: { 'Content-Type': 'application/json' },
-      });
-      return await res.json();
+  const { data, isLoading } = useSWR([endpoint], async ([endpoint]) => {
+    const res = await fetch(endpoint, {
+      headers: { 'Content-Type': 'application/json' },
     });
+    return await res.json();
+  });
 
   const typedData = data as UseAssetsReturn | undefined;
-  const hasValidData = typedData &&
+  const hasValidData =
+    typedData &&
     Array.isArray(typedData.assets) &&
     typeof typedData.balance === 'number';
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new API endpoint to retrieve and paginate asset information for a specified space, including filtering and error handling.
  - Added support for displaying Ethereum and ERC-20 token assets, including their balances and USD equivalents.
  - Asset data is now sorted by USD value and can be paginated and filtered by status.

- **Improvements**
  - Asset fetching in the app now uses a REST API with pagination and filtering, replacing the previous GraphQL approach.
  - Added a default page size option and improved validation for pagination parameters.

- **Bug Fixes**
  - Improved error responses for invalid input, missing space, or rate-limited blockchain queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->