### PR TITLE
fix: fixed formatTimeRemaining helper

### DIFF
--- a/packages/epics/src/proposals/components/form-voting.tsx
+++ b/packages/epics/src/proposals/components/form-voting.tsx
@@ -2,10 +2,10 @@ import { Button, Skeleton } from '@hypha-platform/ui';
 import { ProgressLine } from './progress-line';
 import { intervalToDuration, isPast } from 'date-fns';
 
-function formatTimeRemaining(endTime: string): string {
+function formatTimeRemaining(endTime: string, executed?: boolean): string {
   const end = new Date(endTime);
 
-  if (isPast(end)) {
+  if (isPast(end) || executed) {
     return 'Vote closed';
   }
 
@@ -76,7 +76,7 @@ export const FormVoting = ({
           loading={isLoading}
           className="rounded-lg"
         >
-          <div className="text-1">{formatTimeRemaining(endTime)}</div>
+          <div className="text-1">{formatTimeRemaining(endTime, executed)}</div>
           {isPast(new Date(endTime)) || executed ? null : (
             <div className="flex gap-2">
               <Button variant="outline" onClick={onReject}>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The time remaining display for votes now correctly shows "Vote closed" if the vote has been executed, improving accuracy in the voting interface.
  - Voting buttons are conditionally shown or hidden based on both the vote's end time and execution status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->