### PR TITLE
Feat/797 space member selection

### DIFF
--- a/apps/web/src/app/[lang]/dho/[id]/@aside/[tab]/space-configuration/page.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@aside/[tab]/space-configuration/page.tsx
@@ -81,6 +81,7 @@ export default function SpaceConfiguration() {
             links: space?.links || [],
             web3SpaceId: space?.web3SpaceId || undefined,
             parentId: space?.parentId || null,
+            address: space?.address || '',
           }}
         />
       </LoadingBackdrop>

--- a/apps/web/src/app/[lang]/dho/[id]/@aside/governance/create/deploy-funds/page.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@aside/governance/create/deploy-funds/page.tsx
@@ -22,6 +22,8 @@ export default async function CreateDeployFundsPage({ params }: PageProps) {
 
   const successfulUrl = getDhoPathGovernance(lang as Locale, id);
 
+  const subspaces = spaceFromDb.subspaces;
+
   return (
     <SidePanel>
       <CreateDeployFundsForm
@@ -29,7 +31,13 @@ export default async function CreateDeployFundsPage({ params }: PageProps) {
         backUrl={`${successfulUrl}${PATH_SELECT_CREATE_ACTION}`}
         spaceId={spaceId}
         web3SpaceId={web3SpaceId}
-        plugin={<Plugin name="deploy-funds" spaceSlug={spaceSlug} />}
+        plugin={
+          <Plugin
+            name="deploy-funds"
+            spaceSlug={spaceSlug}
+            subspaces={subspaces}
+          />
+        }
       />
     </SidePanel>
   );

--- a/apps/web/src/app/[lang]/dho/[id]/@aside/governance/create/pay-for-expenses/page.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@aside/governance/create/pay-for-expenses/page.tsx
@@ -23,6 +23,8 @@ export default async function CreatePayForExpensesPage({ params }: PageProps) {
 
   const successfulUrl = getDhoPathGovernance(lang as Locale, id);
 
+  const subspaces = spaceFromDb.subspaces;
+
   return (
     <SidePanel>
       <CreatePayForExpensesForm
@@ -30,7 +32,13 @@ export default async function CreatePayForExpensesPage({ params }: PageProps) {
         backUrl={`${successfulUrl}${PATH_SELECT_CREATE_ACTION}`}
         spaceId={spaceId}
         web3SpaceId={web3SpaceId}
-        plugin={<Plugin name="pay-for-expenses" spaceSlug={spaceSlug} />}
+        plugin={
+          <Plugin
+            name="pay-for-expenses"
+            spaceSlug={spaceSlug}
+            subspaces={subspaces}
+          />
+        }
       />
     </SidePanel>
   );

--- a/apps/web/src/app/[lang]/dho/[id]/@aside/governance/create/plugins.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@aside/governance/create/plugins.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { Space } from '@core/space';
 import {
   ProposeContributionPlugin,
   PayForExpensesPlugin,
@@ -10,6 +9,7 @@ import {
   IssueNewTokenPlugin,
 } from '@hypha-platform/epics';
 import { useMembers } from '@web/hooks/use-members';
+import { Space } from '@hypha-platform/core/client';
 
 export const PLUGINS = {
   'propose-contribution': ProposeContributionPlugin,

--- a/apps/web/src/app/[lang]/dho/[id]/@aside/governance/create/plugins.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@aside/governance/create/plugins.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Space } from '@core/space';
 import {
   ProposeContributionPlugin,
   PayForExpensesPlugin,
@@ -23,9 +24,15 @@ type PluginProps = {
   name: keyof typeof PLUGINS;
   spaceSlug?: string;
   web3SpaceId?: number | null;
+  subspaces?: Space[];
 };
 
-export const Plugin = ({ name, spaceSlug, web3SpaceId }: PluginProps) => {
+export const Plugin = ({
+  name,
+  spaceSlug,
+  web3SpaceId,
+  subspaces,
+}: PluginProps) => {
   const { members } = useMembers({ spaceSlug });
 
   const PluginCmp = PLUGINS[name];
@@ -35,6 +42,7 @@ export const Plugin = ({ name, spaceSlug, web3SpaceId }: PluginProps) => {
       spaceSlug={spaceSlug || ''}
       web3SpaceId={web3SpaceId}
       members={members}
+      subspaces={subspaces}
     />
   );
 };

--- a/apps/web/src/app/[lang]/dho/[id]/@aside/governance/create/propose-contribution/page.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@aside/governance/create/propose-contribution/page.tsx
@@ -26,6 +26,8 @@ export default async function CreateProposeAContributionPage({
   const { id: spaceId, web3SpaceId, slug: spaceSlug } = spaceFromDb;
   const successfulUrl = getDhoPathGovernance(lang as Locale, id);
 
+  const subspaces = spaceFromDb.subspaces;
+
   return (
     <SidePanel>
       <CreateProposeAContributionForm
@@ -33,7 +35,13 @@ export default async function CreateProposeAContributionPage({
         backUrl={`${successfulUrl}${PATH_SELECT_CREATE_ACTION}`}
         spaceId={spaceId}
         web3SpaceId={web3SpaceId}
-        plugin={<Plugin name="propose-contribution" spaceSlug={spaceSlug} />}
+        plugin={
+          <Plugin
+            name="propose-contribution"
+            spaceSlug={spaceSlug}
+            subspaces={subspaces}
+          />
+        }
       />
     </SidePanel>
   );

--- a/packages/core/src/space/client/hooks/useCreateSpaceOrchestrator.ts
+++ b/packages/core/src/space/client/hooks/useCreateSpaceOrchestrator.ts
@@ -193,15 +193,17 @@ export const useCreateSpaceOrchestrator = ({
       ? [
           web2.createdSpace.slug,
           web3.createdSpace?.spaceId,
+          web3.createdSpace?.executor,
           'linkingWeb2AndWeb3Space',
         ]
       : null,
-    async ([slug, web3SpaceId]) => {
+    async ([slug, web3SpaceId, address]) => {
       try {
         startTask('LINK_WEB2_AND_WEB3_SPACE');
         const result = await web2.updateSpaceBySlug({
           slug,
           web3SpaceId: Number(web3SpaceId),
+          address: address,
         });
         completeTask('LINK_WEB2_AND_WEB3_SPACE');
         return result;

--- a/packages/core/src/space/server/queries.ts
+++ b/packages/core/src/space/server/queries.ts
@@ -35,6 +35,7 @@ export const findAllSpaces = async (
       documentCount: sql<number>`count(distinct ${documents.id})`.mapWith(
         Number,
       ),
+      address: spaces.address,
     })
     .from(spaces)
     .leftJoin(memberships, eq(memberships.spaceId, spaces.id))
@@ -67,6 +68,7 @@ export const findAllSpaces = async (
       spaces.parentId,
       spaces.createdAt,
       spaces.updatedAt,
+      spaces.address,
     )
     .orderBy(asc(spaces.title));
   return results;

--- a/packages/core/src/space/types.ts
+++ b/packages/core/src/space/types.ts
@@ -18,7 +18,7 @@ export interface Space {
   memberCount?: number;
   documentCount?: number;
   documents?: Document[];
-  address?: string;
+  address?: string | null;
 }
 
 export interface CreateSpaceInput {

--- a/packages/core/src/space/types.ts
+++ b/packages/core/src/space/types.ts
@@ -18,6 +18,7 @@ export interface Space {
   memberCount?: number;
   documentCount?: number;
   documents?: Document[];
+  address?: string;
 }
 
 export interface CreateSpaceInput {
@@ -39,6 +40,7 @@ export interface UpdateSpaceInput {
   slug?: string;
   parentId?: number | null;
   web3SpaceId?: number;
+  address?: string;
 }
 
 export type UpdateSpaceBySlugInput = { slug: string } & UpdateSpaceInput;

--- a/packages/core/src/space/validation.ts
+++ b/packages/core/src/space/validation.ts
@@ -41,6 +41,7 @@ const createSpaceWeb2Props = {
     .array(z.string().url('Links must be a valid URL'))
     .max(3)
     .default([]),
+  address: z.string().optional(),
 };
 
 export const schemaCreateSpaceWeb2 = z.object(createSpaceWeb2Props);

--- a/packages/epics/src/agreements/plugins/components/common/recipient-field.tsx
+++ b/packages/epics/src/agreements/plugins/components/common/recipient-field.tsx
@@ -10,11 +10,18 @@ import {
 } from '@hypha-platform/ui';
 import { Space } from '@hypha-platform/core/client';
 
+type Recipient = {
+  name: string;
+  surname: string;
+  avatarUrl: string;
+  address: string;
+};
+
 export function RecipientField({
   members,
   subspaces,
 }: {
-  members: any[];
+  members: Recipient[];
   subspaces?: Space[];
 }) {
   const { control } = useFormContext();

--- a/packages/epics/src/agreements/plugins/components/common/recipient-field.tsx
+++ b/packages/epics/src/agreements/plugins/components/common/recipient-field.tsx
@@ -8,20 +8,13 @@ import {
   FormItem,
   FormMessage,
 } from '@hypha-platform/ui';
-import { Space } from '@hypha-platform/core/client';
-
-type Recipient = {
-  name: string;
-  surname: string;
-  avatarUrl: string;
-  address: string;
-};
+import { Space, Person } from '@hypha-platform/core/client';
 
 export function RecipientField({
   members,
   subspaces,
 }: {
-  members: Recipient[];
+  members: Person[];
   subspaces?: Space[];
 }) {
   const { control } = useFormContext();

--- a/packages/epics/src/agreements/plugins/components/common/recipient-field.tsx
+++ b/packages/epics/src/agreements/plugins/components/common/recipient-field.tsx
@@ -8,8 +8,15 @@ import {
   FormItem,
   FormMessage,
 } from '@hypha-platform/ui';
+import { Space } from '@core/space';
 
-export function RecipientField({ recipients }: { recipients: any[] }) {
+export function RecipientField({
+  members,
+  subspaces,
+}: {
+  members: any[];
+  subspaces?: Space[];
+}) {
   const { control } = useFormContext();
   return (
     <FormField
@@ -22,7 +29,8 @@ export function RecipientField({ recipients }: { recipients: any[] }) {
               onChange={(recipient) => {
                 field.onChange(recipient.address);
               }}
-              recipients={recipients}
+              members={members}
+              subspaces={subspaces}
             />
           </FormControl>
           <FormMessage />

--- a/packages/epics/src/agreements/plugins/components/common/recipient-field.tsx
+++ b/packages/epics/src/agreements/plugins/components/common/recipient-field.tsx
@@ -8,7 +8,7 @@ import {
   FormItem,
   FormMessage,
 } from '@hypha-platform/ui';
-import { Space } from '@core/space';
+import { Space } from '@hypha-platform/core/client';
 
 export function RecipientField({
   members,

--- a/packages/epics/src/agreements/plugins/components/common/recipient.tsx
+++ b/packages/epics/src/agreements/plugins/components/common/recipient.tsx
@@ -4,7 +4,7 @@ import { useState, useMemo, useCallback, useEffect } from 'react';
 import { Image, Combobox } from '@hypha-platform/ui';
 import { WalletAddress } from './wallet-address';
 import { Tabs, TabsList, TabsTrigger } from '@hypha-platform/ui/server';
-import { Space } from '@core/space';
+import { Space } from '@hypha-platform/core/client';
 
 type Recipient = {
   name: string;

--- a/packages/epics/src/agreements/plugins/components/common/recipient.tsx
+++ b/packages/epics/src/agreements/plugins/components/common/recipient.tsx
@@ -3,6 +3,8 @@
 import { useState, useMemo, useCallback, useEffect } from 'react';
 import { Image, Combobox } from '@hypha-platform/ui';
 import { WalletAddress } from './wallet-address';
+import { Tabs, TabsList, TabsTrigger } from '@hypha-platform/ui/server';
+import { Space } from '@core/space';
 
 type Recipient = {
   name: string;
@@ -12,117 +14,162 @@ type Recipient = {
 };
 
 type RecipientProps = {
-  recipients?: Recipient[];
+  subspaces?: Space[];
+  members?: Recipient[];
   value?: string;
-  onChange?: (selected: Recipient | { address: string }) => void;
+  onChange?: (selected: Recipient | Space | { address: string }) => void;
 };
 
 export const Recipient = ({
-  recipients = [],
+  members = [],
+  subspaces = [],
   onChange,
   value,
 }: RecipientProps) => {
+  const [recipientType, setRecipientType] = useState<'member' | 'space'>(
+    'member',
+  );
   const [selected, setSelected] = useState<
-    Recipient | { address: string } | null
+    Recipient | Space | { address: string } | null
   >(null);
   const [manualAddress, setManualAddress] = useState(value || '');
 
   useEffect(() => {
     if (value) {
-      const found = recipients.find((r) => r.address === value);
-      setSelected(found || { address: value });
+      const foundMember = members.find((r) => r.address === value);
+      const foundSpace = subspaces.find((s) => s.address === value);
+      setSelected(foundMember || foundSpace || { address: value });
       setManualAddress(value);
     }
-  }, [value, recipients]);
+  }, [value, members, subspaces]);
 
   const placeholder = 'Select recipient...';
 
-  const options = useMemo(
+  const memberOptions = useMemo(
     () =>
-      recipients.map((recipient) => ({
-        value: String(recipient.address),
-        label: `${recipient.name} ${recipient.surname}`,
-        avatarUrl: recipient.avatarUrl,
-        address: recipient.address,
+      members.map((member) => ({
+        value: String(member.address),
+        label: `${member.name} ${member.surname}`,
+        avatarUrl: member.avatarUrl,
+        address: member.address,
       })),
-    [recipients],
+    [members],
   );
+
+  const spaceOptions = useMemo(
+    () =>
+      subspaces.map((space) => ({
+        value: String(space.address),
+        label: space.title,
+        avatarUrl: space.logoUrl,
+        address: space.address,
+      })),
+    [subspaces],
+  );
+
+  const currentOptions =
+    recipientType === 'member' ? memberOptions : spaceOptions;
 
   const handleChange = useCallback(
     (value: string) => {
       const lowerValue = value.toLowerCase();
+      const source = recipientType === 'member' ? members : subspaces;
+
       const found =
-        recipients.find(
-          (r) =>
-            String(r.address).toLowerCase() === lowerValue ||
-            r.name.toLowerCase() === lowerValue ||
-            r.surname.toLowerCase() === lowerValue,
+        source.find(
+          (item) =>
+            String(item.address).toLowerCase() === lowerValue ||
+            ('name' in item && item.name.toLowerCase() === lowerValue) ||
+            ('surname' in item && item.surname.toLowerCase() === lowerValue) ||
+            ('title' in item && item.title.toLowerCase() === lowerValue),
         ) || null;
 
       setSelected(found);
       if (found) {
-        setManualAddress(found.address);
+        setManualAddress(found.address || '');
         onChange?.(found);
       }
     },
-    [recipients, onChange],
+    [members, subspaces, recipientType, onChange],
   );
 
   const handleAddressChange = useCallback(
     (address: string) => {
       setManualAddress(address);
-      const found = recipients.find((r) => r.address === address);
+      const foundMember = members.find((r) => r.address === address);
+      const foundSpace = subspaces.find((s) => s.address === address);
 
-      if (found) {
-        setSelected(found);
-        onChange?.(found);
+      if (foundMember || foundSpace) {
+        setSelected(foundMember || foundSpace || null);
+        onChange?.(foundMember || foundSpace!);
       } else {
         setSelected(null);
         onChange?.({ address });
       }
     },
-    [recipients, onChange],
+    [members, subspaces, onChange],
   );
 
   return (
     <div className="flex flex-col gap-4">
-      <div className="flex w-full justify-between items-center gap-2">
+      <div className="flex w-full justify-between items-center">
         <label className="text-sm text-neutral-11">Recipient</label>
-
-        <div className="flex items-center gap-2 min-w-[220px]">
-          <Combobox
-            options={options}
-            placeholder={placeholder}
-            onChange={handleChange}
-            renderOption={(option) => (
-              <>
-                <Image
-                  src={option.avatarUrl}
-                  alt={option.label}
-                  width={24}
-                  height={24}
-                  className="rounded-full"
-                />
-                <span>{option.label}</span>
-              </>
-            )}
-            renderValue={(option) =>
-              option ? (
-                <div className="flex items-center gap-2 truncate">
-                  <Image
-                    src={option.avatarUrl}
-                    alt={option.label}
-                    width={24}
-                    height={24}
-                    className="rounded-full"
-                  />
-                  <span className="truncate">{option.label}</span>
-                </div>
-              ) : (
-                placeholder
-              )
+        <div className="flex gap-2 items-center">
+          <Tabs
+            value={recipientType}
+            onValueChange={(value) =>
+              setRecipientType(value as 'member' | 'space')
             }
-          />
+            className="ml-4"
+          >
+            <TabsList>
+              <TabsTrigger value="member">Member</TabsTrigger>
+              <TabsTrigger value="space">Space</TabsTrigger>
+            </TabsList>
+          </Tabs>
+          <div className="flex items-center gap-2 min-w-[220px]">
+            <Combobox
+              options={currentOptions}
+              placeholder={placeholder}
+              onChange={handleChange}
+              renderOption={(option) => (
+                <>
+                  {option.avatarUrl && (
+                    <Image
+                      src={option.avatarUrl}
+                      alt={option.label}
+                      width={24}
+                      height={24}
+                      className="rounded-full min-h-[24px]"
+                    />
+                  )}
+                  <span className="text-ellipsis overflow-hidden text-nowrap">
+                    {option.label}
+                  </span>
+                </>
+              )}
+              renderValue={(option) =>
+                option ? (
+                  <div className="flex items-center gap-2 truncate">
+                    {option.avatarUrl && (
+                      <Image
+                        src={option.avatarUrl}
+                        alt={option.label}
+                        width={24}
+                        height={24}
+                        className="rounded-full min-h-[24px]"
+                      />
+                    )}
+                    <span className="truncate text-ellipsis overflow-hidden text-nowrap">
+                      {option.label}
+                    </span>
+                  </div>
+                ) : (
+                  placeholder
+                )
+              }
+            />
+          </div>
         </div>
       </div>
       <WalletAddress address={manualAddress} onChange={handleAddressChange} />

--- a/packages/epics/src/agreements/plugins/components/common/recipient.tsx
+++ b/packages/epics/src/agreements/plugins/components/common/recipient.tsx
@@ -140,7 +140,7 @@ export const Recipient = ({
                       alt={option.label}
                       width={24}
                       height={24}
-                      className="rounded-full min-h-[24px]"
+                      className="rounded-full min-h-5"
                     />
                   )}
                   <span className="text-ellipsis overflow-hidden text-nowrap">
@@ -157,7 +157,7 @@ export const Recipient = ({
                         alt={option.label}
                         width={24}
                         height={24}
-                        className="rounded-full min-h-[24px]"
+                        className="rounded-full min-h-5"
                       />
                     )}
                     <span className="truncate text-ellipsis overflow-hidden text-nowrap">

--- a/packages/epics/src/agreements/plugins/components/common/recipient.tsx
+++ b/packages/epics/src/agreements/plugins/components/common/recipient.tsx
@@ -4,20 +4,13 @@ import { useState, useMemo, useCallback, useEffect } from 'react';
 import { Image, Combobox } from '@hypha-platform/ui';
 import { WalletAddress } from './wallet-address';
 import { Tabs, TabsList, TabsTrigger } from '@hypha-platform/ui/server';
-import { Space } from '@hypha-platform/core/client';
-
-type Recipient = {
-  name: string;
-  surname: string;
-  avatarUrl: string;
-  address: string;
-};
+import { Space, Person } from '@hypha-platform/core/client';
 
 type RecipientProps = {
   subspaces?: Space[];
-  members?: Recipient[];
+  members?: Person[];
   value?: string;
-  onChange?: (selected: Recipient | Space | { address: string }) => void;
+  onChange?: (selected: Person | Space | { address: string }) => void;
 };
 
 export const Recipient = ({
@@ -30,7 +23,7 @@ export const Recipient = ({
     'member',
   );
   const [selected, setSelected] = useState<
-    Recipient | Space | { address: string } | null
+    Person | Space | { address: string } | null
   >(null);
   const [manualAddress, setManualAddress] = useState(value || '');
 
@@ -79,8 +72,9 @@ export const Recipient = ({
         source.find(
           (item) =>
             String(item.address).toLowerCase() === lowerValue ||
-            ('name' in item && item.name.toLowerCase() === lowerValue) ||
-            ('surname' in item && item.surname.toLowerCase() === lowerValue) ||
+            ('name' in item && item?.name?.toLowerCase() === lowerValue) ||
+            ('surname' in item &&
+              item?.surname?.toLowerCase() === lowerValue) ||
             ('title' in item && item.title.toLowerCase() === lowerValue),
         ) || null;
 

--- a/packages/epics/src/agreements/plugins/deploy-funds/plugin.tsx
+++ b/packages/epics/src/agreements/plugins/deploy-funds/plugin.tsx
@@ -3,20 +3,22 @@
 import { RecipientField } from '../components/common/recipient-field';
 import { TokenPayoutFieldArray } from '../components/common/token-payout-field-array';
 import { Separator, Skeleton } from '@hypha-platform/ui';
-import { useTokens } from '@hypha-platform/epics';
-import { Person } from '@hypha-platform/core/client';
+import { Person, Space } from '@hypha-platform/core/client';
+import { useTokens } from '../../../treasury';
 
 export const DeployFundsPlugin = ({
   spaceSlug,
   members,
+  subspaces,
 }: {
   spaceSlug: string;
   members: Person[];
+  subspaces?: Space[];
 }) => {
   const { tokens, isLoading } = useTokens({ spaceSlug });
   return (
     <div className="flex flex-col gap-4">
-      <RecipientField recipients={members} />
+      <RecipientField members={members} subspaces={subspaces} />
       <Separator />
       <Skeleton loading={isLoading} width={'100%'} height={90}>
         <TokenPayoutFieldArray tokens={tokens} name="payouts" />

--- a/packages/epics/src/agreements/plugins/pay-for-expenses/plugin.tsx
+++ b/packages/epics/src/agreements/plugins/pay-for-expenses/plugin.tsx
@@ -3,20 +3,22 @@
 import { RecipientField } from '../components/common/recipient-field';
 import { TokenPayoutFieldArray } from '../components/common/token-payout-field-array';
 import { Separator, Skeleton } from '@hypha-platform/ui';
-import { useTokens } from '@hypha-platform/epics';
-import { Person } from '@hypha-platform/core/client';
+import { Person, Space } from '@hypha-platform/core/client';
+import { useTokens } from '../../../treasury';
 
 export const PayForExpensesPlugin = ({
   spaceSlug,
   members,
+  subspaces,
 }: {
   spaceSlug: string;
   members: Person[];
+  subspaces?: Space[];
 }) => {
   const { tokens, isLoading } = useTokens({ spaceSlug });
   return (
     <div className="flex flex-col gap-4">
-      <RecipientField recipients={members} />
+      <RecipientField members={members} subspaces={subspaces} />
       <Separator />
       <Skeleton loading={isLoading} width={'100%'} height={90}>
         <TokenPayoutFieldArray tokens={tokens} name="payouts" />

--- a/packages/epics/src/agreements/plugins/propose-contribution/plugin.tsx
+++ b/packages/epics/src/agreements/plugins/propose-contribution/plugin.tsx
@@ -4,20 +4,22 @@ import { RecipientField } from '../components/common/recipient-field';
 import { TokenPayoutFieldArray } from '../components/common/token-payout-field-array';
 import { PaymentSchedule } from './components/payment-schedule';
 import { Separator, Skeleton } from '@hypha-platform/ui';
-import { useTokens } from '@hypha-platform/epics';
-import { Person } from '@hypha-platform/core/client';
+import { Person, Space } from '@hypha-platform/core/client';
+import { useTokens } from '../../../treasury';
 
 export const ProposeContributionPlugin = ({
   spaceSlug,
   members,
+  subspaces,
 }: {
   spaceSlug: string;
   members: Person[];
+  subspaces?: Space[];
 }) => {
   const { tokens, isLoading } = useTokens({ spaceSlug });
   return (
     <div className="flex flex-col gap-4">
-      <RecipientField recipients={members} />
+      <RecipientField members={members} subspaces={subspaces} />
       <Separator />
       <PaymentSchedule />
       <Skeleton loading={isLoading} width={'100%'} height={90}>

--- a/packages/epics/src/spaces/components/create-space-form.tsx
+++ b/packages/epics/src/spaces/components/create-space-form.tsx
@@ -59,6 +59,7 @@ const DEFAULT_VALUES = {
   categories: [],
   links: [],
   parentId: null,
+  address: '',
 };
 
 export const SpaceForm = ({

--- a/packages/storage-postgres/migrations/0030_windy_sprite.sql
+++ b/packages/storage-postgres/migrations/0030_windy_sprite.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "spaces" ADD COLUMN "web3_address" text;

--- a/packages/storage-postgres/migrations/meta/0030_snapshot.json
+++ b/packages/storage-postgres/migrations/meta/0030_snapshot.json
@@ -1,0 +1,563 @@
+{
+  "id": "6819977f-470b-4164-bae6-86ee3c453733",
+  "prevId": "dc5b5b4a-f09e-4699-98a2-a392576548ee",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.documents": {
+      "name": "documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "document_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'proposal'"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lead_image": {
+          "name": "lead_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "web3_proposal_id": {
+          "name": "web3_proposal_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "search_index_documents": {
+          "name": "search_index_documents",
+          "columns": [
+            {
+              "expression": "(\n          setweight(to_tsvector('english', \"title\"), 'A') ||\n          setweight(to_tsvector('english', \"description\"), 'B')\n      )",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "documents_creator_id_people_id_fk": {
+          "name": "documents_creator_id_people_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "people",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "documents_space_id_spaces_id_fk": {
+          "name": "documents_space_id_spaces_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memberships": {
+      "name": "memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "person_space_idx": {
+          "name": "person_space_idx",
+          "columns": [
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memberships_person_id_people_id_fk": {
+          "name": "memberships_person_id_people_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "people",
+          "columnsFrom": [
+            "person_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "memberships_space_id_spaces_id_fk": {
+          "name": "memberships_space_id_spaces_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.people": {
+      "name": "people",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sub": {
+          "name": "sub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "(auth.user_id())"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lead_image_url": {
+          "name": "lead_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "surname": {
+          "name": "surname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "web3_address": {
+          "name": "web3_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "links": {
+          "name": "links",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "people_sub_unique": {
+          "name": "people_sub_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sub"
+          ]
+        },
+        "people_slug_unique": {
+          "name": "people_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "people_email_unique": {
+          "name": "people_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {
+        "crud-authenticated-policy-select": {
+          "name": "crud-authenticated-policy-select",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        },
+        "crud-authenticated-policy-insert": {
+          "name": "crud-authenticated-policy-insert",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(select auth.user_id() = \"people\".\"sub\")"
+        },
+        "crud-authenticated-policy-update": {
+          "name": "crud-authenticated-policy-update",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(select auth.user_id() = \"people\".\"sub\")",
+          "withCheck": "(select auth.user_id() = \"people\".\"sub\")"
+        },
+        "crud-authenticated-policy-delete": {
+          "name": "crud-authenticated-policy-delete",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(select auth.user_id() = \"people\".\"sub\")"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.spaces": {
+      "name": "spaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lead_image": {
+          "name": "lead_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'SHOULD NOT BE EMPTY'"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "web3_space_id": {
+          "name": "web3_space_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "links": {
+          "name": "links",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "categories": {
+          "name": "categories",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "web3_address": {
+          "name": "web3_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "search_index_spaces": {
+          "name": "search_index_spaces",
+          "columns": [
+            {
+              "expression": "(\n          setweight(to_tsvector('english', \"title\"), 'A') ||\n          setweight(to_tsvector('english', \"description\"), 'B')\n      )",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "spaces_parent_id_spaces_id_fk": {
+          "name": "spaces_parent_id_spaces_id_fk",
+          "tableFrom": "spaces",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "spaces_slug_unique": {
+          "name": "spaces_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.document_state": {
+      "name": "document_state",
+      "schema": "public",
+      "values": [
+        "discussion",
+        "proposal",
+        "agreement"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/storage-postgres/migrations/meta/_journal.json
+++ b/packages/storage-postgres/migrations/meta/_journal.json
@@ -211,6 +211,13 @@
       "when": 1752135163283,
       "tag": "0029_noisy_mongu",
       "breakpoints": true
+    },
+    {
+      "idx": 30,
+      "version": "7",
+      "when": 1752480306338,
+      "tag": "0030_windy_sprite",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/storage-postgres/src/schema/space.ts
+++ b/packages/storage-postgres/src/schema/space.ts
@@ -32,6 +32,7 @@ export const spaces = pgTable(
       .notNull()
       .default([]),
     parentId: integer('parent_id').references((): AnyPgColumn => spaces.id),
+    address: text('web3_address'),
     ...commonDateFields,
   },
   (table) => [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for an optional "address" field in spaces, allowing spaces to store a Web3 address.
  * Enhanced recipient selection in agreement plugins with a tabbed interface to choose between members and subspaces.
  * Improved plugin forms to provide subspaces as recipient options when creating or deploying funds, paying for expenses, or proposing contributions.

* **Bug Fixes**
  * None.

* **Chores**
  * Updated database schema and migrations to include the new "web3_address" column for spaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->