### PR TITLE
Feat/984 voice decay ux issues

### DIFF
--- a/packages/epics/src/governance/components/issue-new-token-form.tsx
+++ b/packages/epics/src/governance/components/issue-new-token-form.tsx
@@ -69,7 +69,7 @@ export const IssueNewTokenForm = ({
       maxSupply: 0,
       // tokenDescription: '',
       decaySettings: {
-        decayInterval: 604800,
+        decayInterval: 2592000,
         decayPercentage: 1,
       },
       label: 'Issue New Token',

--- a/packages/epics/src/treasury/components/common/decay-settings.tsx
+++ b/packages/epics/src/treasury/components/common/decay-settings.tsx
@@ -10,20 +10,12 @@ import {
 import { PercentIcon } from 'lucide-react';
 import { useFormContext, useWatch } from 'react-hook-form';
 
-type TimeFormat = 'Minutes' | 'Hours' | 'Days' | 'Weeks' | 'Months';
+type TimeFormat = 'Weeks' | 'Months' | 'Years';
 
 const TIME_FORMAT_TO_SECONDS: Record<TimeFormat, number> = {
-  Minutes: 60,
-  Hours: 3600,
-  Days: 86400,
   Weeks: 604800,
   Months: 2592000,
-};
-
-type DecaySettingsInternal = {
-  decayPeriod: number | '';
-  timeFormat: TimeFormat;
-  decayPercent: number | '';
+  Years: 31536000,
 };
 
 type DecaySettingsOutput = {
@@ -96,7 +88,7 @@ export const DecaySettings = ({ value, onChange }: DecaySettingsProps) => {
     <>
       <div className="flex justify-between items-center gap-3">
         <div className="text-2 text-neutral-11 font-medium">
-          Voice Decay Period
+          Voice Decay Frequency
         </div>
 
         <div className="flex justify-between flex-row flex-1 gap-3 max-w-[50%]">
@@ -116,11 +108,9 @@ export const DecaySettings = ({ value, onChange }: DecaySettingsProps) => {
                 <SelectValue placeholder="Select time format" />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="Minutes">Minutes</SelectItem>
-                <SelectItem value="Hours">Hours</SelectItem>
-                <SelectItem value="Days">Days</SelectItem>
                 <SelectItem value="Weeks">Weeks</SelectItem>
                 <SelectItem value="Months">Months</SelectItem>
+                <SelectItem value="Years">Years</SelectItem>
               </SelectContent>
             </Select>
           </div>

--- a/packages/epics/src/treasury/plugins/issue-new-token/plugin.tsx
+++ b/packages/epics/src/treasury/plugins/issue-new-token/plugin.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Separator } from '@hypha-platform/ui';
+import { Separator, Switch } from '@hypha-platform/ui';
 import {
   TokenNameField,
   TokenSymbolField,
@@ -19,6 +19,7 @@ export const IssueNewTokenPlugin = () => {
   const { getValues, setValue } = useFormContext();
   const values = getValues();
   const [tokenType, setTokenType] = useState<string>(values['type']);
+  const [showDecaySettings, setShowDecaySettings] = useState<boolean>(true);
 
   useEffect(() => {
     if (tokenType === 'voice') {
@@ -41,8 +42,25 @@ export const IssueNewTokenPlugin = () => {
       <TokenMaxSupplyField />
       {tokenType === 'voice' && (
         <>
-          <Separator />
-          <DecaySettingsField name="decaySettings" />
+          <div className="flex items-center gap-3 justify-between">
+            <label
+              htmlFor="decay-settings-toggle"
+              className="text-2 text-neutral-11 font-medium"
+            >
+              Enable Decay Settings
+            </label>
+            <Switch
+              id="decay-settings-toggle"
+              checked={showDecaySettings}
+              onCheckedChange={setShowDecaySettings}
+            />
+          </div>
+          {showDecaySettings && (
+            <>
+              <Separator />
+              <DecaySettingsField name="decaySettings" />
+            </>
+          )}
         </>
       )}
       {tokenType !== 'voice' && <IsVotingTokenField />}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a toggle switch to enable or disable the display of decay settings when issuing a new token.

* **Improvements**
  * Updated decay period options to include 'Weeks', 'Months', and 'Years', and removed 'Minutes', 'Hours', and 'Days'.
  * Changed the label from "Voice Decay Period" to "Voice Decay Frequency" for clearer terminology.
  * Adjusted the default decay interval to 30 days for new tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->