### PR TITLE
feat(#1137): fixed token number on proposal details

### DIFF
--- a/packages/epics/src/governance/components/proposal-mint-item.tsx
+++ b/packages/epics/src/governance/components/proposal-mint-item.tsx
@@ -11,7 +11,7 @@ export const ProposalMintItem = ({ member, number }: ProposalMintItemProps) => {
     <div className="flex flex-col gap-5">
       <div className="flex justify-between items-center">
         <div className="text-1 w-full">{member}</div>
-        <div className="text-1">{originalNumber}</div>
+        <div className="text-1">{Number(originalNumber).toFixed(2)}</div>
       </div>
     </div>
   );

--- a/packages/epics/src/governance/components/proposal-token-items.tsx
+++ b/packages/epics/src/governance/components/proposal-token-items.tsx
@@ -24,7 +24,7 @@ export const ProposalTokenItem = ({
       </div>
       <div className="flex justify-between items-center">
         <div className="text-1 text-neutral-11 w-full">Token Max.Supply</div>
-        <div className="text-1">{originalSupply}</div>
+        <div className="text-1">{Number(originalSupply).toFixed(2)}</div>
       </div>
     </div>
   );

--- a/packages/epics/src/governance/components/proposal-transaction-item.tsx
+++ b/packages/epics/src/governance/components/proposal-transaction-item.tsx
@@ -49,7 +49,7 @@ export const ProposalTransactionItem = ({
           className="rounded-full"
         />
         <div className="text-sm font-medium text-neutral-9">
-          {formattedAmount} {token.symbol}
+          {Number(formattedAmount).toFixed(2)} {token.symbol}
         </div>
       </div>
       <div className="w-[140px]">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated numeric values in proposal-related components to consistently display with two decimal places for improved readability. This affects mint amounts, token supply, and transaction amounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->