### PR TITLE
feat(#1232): added paginationDisabled props and logic in useMembers hook

### DIFF
--- a/apps/web/src/app/[lang]/dho/[id]/@aside/governance/create/plugins.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@aside/governance/create/plugins.tsx
@@ -33,7 +33,7 @@ export const Plugin = ({
   web3SpaceId,
   spaces,
 }: PluginProps) => {
-  const { members } = useMembers({ spaceSlug });
+  const { members } = useMembers({ spaceSlug, paginationDisabled: true });
 
   const PluginCmp = PLUGINS[name];
 

--- a/apps/web/src/app/api/v1/spaces/[spaceSlug]/members/route.ts
+++ b/apps/web/src/app/api/v1/spaces/[spaceSlug]/members/route.ts
@@ -51,13 +51,23 @@ export async function GET(
     const [, , , , members] = spaceDetails;
 
     const url = new URL(request.url);
-    const page = parseInt(url.searchParams.get('page') || '1', 10);
-    const pageSize = parseInt(url.searchParams.get('pageSize') || '4', 10);
+    const page = url.searchParams.get('page');
+    const pageSize = url.searchParams.get('pageSize');
     const searchTerm = url.searchParams.get('searchTerm') || undefined;
+
+    const paginationOptions =
+      page && pageSize
+        ? {
+            pagination: {
+              page: parseInt(page, 10),
+              pageSize: parseInt(pageSize, 10),
+            },
+          }
+        : {};
 
     const result = await findPersonByAddresses(
       members as `0x${string}`[],
-      { pagination: { page, pageSize }, searchTerm },
+      { ...paginationOptions, searchTerm },
       { db },
     );
 

--- a/apps/web/src/app/api/v1/spaces/[spaceSlug]/members/route.ts
+++ b/apps/web/src/app/api/v1/spaces/[spaceSlug]/members/route.ts
@@ -51,19 +51,21 @@ export async function GET(
     const [, , , , members] = spaceDetails;
 
     const url = new URL(request.url);
-    const page = url.searchParams.get('page');
-    const pageSize = url.searchParams.get('pageSize');
+    const pageRaw = url.searchParams.get('page');
+    const pageSizeRaw = url.searchParams.get('pageSize');
     const searchTerm = url.searchParams.get('searchTerm') || undefined;
 
-    const paginationOptions =
-      page && pageSize
-        ? {
-            pagination: {
-              page: parseInt(page, 10),
-              pageSize: parseInt(pageSize, 10),
-            },
-          }
-        : {};
+    const page = pageRaw != null ? Number.parseInt(pageRaw, 10) : undefined;
+    const pageSize =
+      pageSizeRaw != null ? Number.parseInt(pageSizeRaw, 10) : undefined;
+    const hasValidPagination =
+      Number.isInteger(page) &&
+      page! > 0 &&
+      Number.isInteger(pageSize) &&
+      pageSize! > 0;
+    const paginationOptions = hasValidPagination
+      ? { pagination: { page: page!, pageSize: pageSize! } }
+      : {};
 
     const result = await findPersonByAddresses(
       members as `0x${string}`[],

--- a/apps/web/src/hooks/use-members.ts
+++ b/apps/web/src/hooks/use-members.ts
@@ -26,6 +26,7 @@ export const useMembers: UseMembers = ({
   spaceSlug,
   searchTerm,
   refreshInterval,
+  paginationDisabled = false,
 }: {
   page?: number;
   pageSize?: number;
@@ -33,17 +34,16 @@ export const useMembers: UseMembers = ({
   spaceSlug?: string;
   searchTerm?: string;
   refreshInterval?: number;
+  paginationDisabled?: boolean;
 }): UseMembersReturn => {
   const { jwt } = useJwt();
 
   const queryParams = React.useMemo(() => {
-    const effectiveFilter = {
-      page,
-      pageSize,
-      ...(searchTerm ? { searchTerm } : {}),
-    };
+    const effectiveFilter = paginationDisabled
+      ? { ...(searchTerm ? { searchTerm } : {}) }
+      : { page, pageSize, ...(searchTerm ? { searchTerm } : {}) };
     return `?${queryString.stringify(effectiveFilter)}`;
-  }, [page, pageSize, searchTerm]);
+  }, [page, pageSize, searchTerm, paginationDisabled]);
 
   console.debug('useMembers', { queryParams });
 

--- a/packages/epics/src/spaces/hooks/types.ts
+++ b/packages/epics/src/spaces/hooks/types.ts
@@ -17,6 +17,7 @@ export type UseMembersProps = {
   spaceSlug?: string;
   searchTerm?: string;
   refreshInterval?: number;
+  paginationDisabled?: boolean;
 };
 
 export type UseMembers = (props: UseMembersProps) => UseMembersReturn;

--- a/packages/epics/src/spaces/hooks/types.ts
+++ b/packages/epics/src/spaces/hooks/types.ts
@@ -13,6 +13,7 @@ export type UseMembersReturn = {
 
 export type UseMembersProps = {
   page?: number;
+  pageSize?: number;
   filter?: FilterParams<Person>;
   spaceSlug?: string;
   searchTerm?: string;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to disable pagination when viewing members, allowing all members to be fetched at once when desired.

* **Bug Fixes**
  * Improved member fetching so that pagination is now optional and only applied when both page and page size parameters are provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->