### PR TITLE
fix(#1293): fixed getVotingMethodLabel method

### DIFF
--- a/packages/epics/src/governance/components/proposal-voting-info.tsx
+++ b/packages/epics/src/governance/components/proposal-voting-info.tsx
@@ -9,11 +9,11 @@ interface ProposalVotingInfoProps {
 const getVotingMethodLabel = (source: bigint): string => {
   switch (source) {
     case 1n:
-      return '1 Voice 1 Vote';
+      return '1 Token 1 Vote';
     case 2n:
       return '1 Member 1 Vote';
     case 3n:
-      return '1 Token 1 Vote';
+      return '1 Voice 1 Vote';
     default:
       return 'Unknown';
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected voting method labels in proposal voting details. “1 Token 1 Vote” and “1 Voice 1 Vote” are now displayed for the correct methods, and “1 Member 1 Vote” remains unchanged. This fixes previously swapped text between “Token” and “Voice” options. No functional behavior changed—only the displayed labels were updated for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->