### PR TITLE
Feat/1287 review default duration of proposals

### DIFF
--- a/apps/web/src/app/[lang]/dho/[id]/_components/select-create-action.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/select-create-action.tsx
@@ -11,7 +11,7 @@ import {
 
 export const CREATE_ACTIONS = [
   {
-    //NOTE duration: 3 days
+    defaultDurationDays: 3,
     title: 'Make a Collective Agreement',
     description:
       'Define and formalize a mutual understanding, policy, or decision among members of the space.',
@@ -19,7 +19,7 @@ export const CREATE_ACTIONS = [
     icon: <FileIcon />,
   },
   {
-    //NOTE duration: 4 days
+    defaultDurationDays: 4,
     title: 'Propose a Contribution',
     description:
       'Propose a new contribution, such as work, knowledge, capital, or resources, for the space to consider.',
@@ -27,7 +27,7 @@ export const CREATE_ACTIONS = [
     icon: <RocketIcon />,
   },
   {
-    //NOTE duration: 7 days
+    defaultDurationDays: 7,
     title: 'Pay for Products or Services',
     description:
       'Make payments for products and services by transferring funds from your Space treasury to another space, entity, or individual wallet.',
@@ -35,7 +35,7 @@ export const CREATE_ACTIONS = [
     icon: <ArrowUpIcon />,
   },
   {
-    //NOTE duration: 7 days
+    defaultDurationDays: 7,
     title: 'Accept Investment (Coming Soon)',
     description:
       'Receive capital from investors, members, or aligned spaces in exchange for native space tokens.',
@@ -44,7 +44,7 @@ export const CREATE_ACTIONS = [
     disabled: true,
   },
   {
-    //NOTE duration: 7 days
+    defaultDurationDays: 7,
     title: 'Exchange Ownership (Coming Soon)',
     description:
       'Swap ownership between members or spaces, whether selling a stake or exchanging assets.',
@@ -53,7 +53,7 @@ export const CREATE_ACTIONS = [
     disabled: true,
   },
   {
-    //NOTE duration: 7 days
+    defaultDurationDays: 7,
     title: 'Deploy Funds',
     description:
       'Allocate treasury funds for investments to other spaces or distributing resources among sub-spaces.',

--- a/apps/web/src/app/[lang]/dho/[id]/_components/select-create-action.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/select-create-action.tsx
@@ -11,28 +11,28 @@ import {
 
 export const CREATE_ACTIONS = [
   {
-    title: 'Make a Collective Agreement',
+    title: 'Make a Collective Agreement', // duration: 3 days
     description:
       'Define and formalize a mutual understanding, policy, or decision among members of the space.',
     href: 'governance/create',
     icon: <FileIcon />,
   },
   {
-    title: 'Propose a Contribution',
+    title: 'Propose a Contribution', // duration: 4 days
     description:
       'Propose a new contribution, such as work, knowledge, capital, or resources, for the space to consider.',
     href: 'governance/create/propose-contribution',
     icon: <RocketIcon />,
   },
   {
-    title: 'Pay for Products or Services',
+    title: 'Pay for Products or Services', // duration: 7 days
     description:
       'Make payments for products and services by transferring funds from your Space treasury to another space, entity, or individual wallet.',
     href: 'governance/create/pay-for-expenses',
     icon: <ArrowUpIcon />,
   },
   {
-    title: 'Accept Investment (Coming Soon)',
+    title: 'Accept Investment (Coming Soon)', // duration: 7 days
     description:
       'Receive capital from investors, members, or aligned spaces in exchange for native space tokens.',
     href: '#',
@@ -40,7 +40,7 @@ export const CREATE_ACTIONS = [
     disabled: true,
   },
   {
-    title: 'Exchange Ownership (Coming Soon)',
+    title: 'Exchange Ownership (Coming Soon)', // duration: 7 days
     description:
       'Swap ownership between members or spaces, whether selling a stake or exchanging assets.',
     href: '#',
@@ -48,7 +48,7 @@ export const CREATE_ACTIONS = [
     disabled: true,
   },
   {
-    title: 'Deploy Funds',
+    title: 'Deploy Funds', // duration: 7 days
     description:
       'Allocate treasury funds for investments to other spaces or distributing resources among sub-spaces.',
     href: 'governance/create/deploy-funds',

--- a/apps/web/src/app/[lang]/dho/[id]/_components/select-create-action.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/select-create-action.tsx
@@ -10,45 +10,45 @@ import {
 } from '@radix-ui/react-icons';
 
 export const CREATE_ACTIONS = [
-  {
-    title: 'Make a Collective Agreement', // duration: 3 days
+  { //NOTE duration: 3 days
+    title: 'Make a Collective Agreement',
     description:
       'Define and formalize a mutual understanding, policy, or decision among members of the space.',
     href: 'governance/create',
     icon: <FileIcon />,
   },
-  {
-    title: 'Propose a Contribution', // duration: 4 days
+  { //NOTE duration: 4 days
+    title: 'Propose a Contribution',
     description:
       'Propose a new contribution, such as work, knowledge, capital, or resources, for the space to consider.',
     href: 'governance/create/propose-contribution',
     icon: <RocketIcon />,
   },
-  {
-    title: 'Pay for Products or Services', // duration: 7 days
+  { //NOTE duration: 7 days
+    title: 'Pay for Products or Services',
     description:
       'Make payments for products and services by transferring funds from your Space treasury to another space, entity, or individual wallet.',
     href: 'governance/create/pay-for-expenses',
     icon: <ArrowUpIcon />,
   },
-  {
-    title: 'Accept Investment (Coming Soon)', // duration: 7 days
+  { //NOTE duration: 7 days
+    title: 'Accept Investment (Coming Soon)',
     description:
       'Receive capital from investors, members, or aligned spaces in exchange for native space tokens.',
     href: '#',
     icon: <PlusCircledIcon />,
     disabled: true,
   },
-  {
-    title: 'Exchange Ownership (Coming Soon)', // duration: 7 days
+  { //NOTE duration: 7 days
+    title: 'Exchange Ownership (Coming Soon)',
     description:
       'Swap ownership between members or spaces, whether selling a stake or exchanging assets.',
     href: '#',
     icon: <PlusCircledIcon />,
     disabled: true,
   },
-  {
-    title: 'Deploy Funds', // duration: 7 days
+  { //NOTE duration: 7 days
+    title: 'Deploy Funds',
     description:
       'Allocate treasury funds for investments to other spaces or distributing resources among sub-spaces.',
     href: 'governance/create/deploy-funds',

--- a/apps/web/src/app/[lang]/dho/[id]/_components/select-create-action.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/select-create-action.tsx
@@ -10,28 +10,32 @@ import {
 } from '@radix-ui/react-icons';
 
 export const CREATE_ACTIONS = [
-  { //NOTE duration: 3 days
+  {
+    //NOTE duration: 3 days
     title: 'Make a Collective Agreement',
     description:
       'Define and formalize a mutual understanding, policy, or decision among members of the space.',
     href: 'governance/create',
     icon: <FileIcon />,
   },
-  { //NOTE duration: 4 days
+  {
+    //NOTE duration: 4 days
     title: 'Propose a Contribution',
     description:
       'Propose a new contribution, such as work, knowledge, capital, or resources, for the space to consider.',
     href: 'governance/create/propose-contribution',
     icon: <RocketIcon />,
   },
-  { //NOTE duration: 7 days
+  {
+    //NOTE duration: 7 days
     title: 'Pay for Products or Services',
     description:
       'Make payments for products and services by transferring funds from your Space treasury to another space, entity, or individual wallet.',
     href: 'governance/create/pay-for-expenses',
     icon: <ArrowUpIcon />,
   },
-  { //NOTE duration: 7 days
+  {
+    //NOTE duration: 7 days
     title: 'Accept Investment (Coming Soon)',
     description:
       'Receive capital from investors, members, or aligned spaces in exchange for native space tokens.',
@@ -39,7 +43,8 @@ export const CREATE_ACTIONS = [
     icon: <PlusCircledIcon />,
     disabled: true,
   },
-  { //NOTE duration: 7 days
+  {
+    //NOTE duration: 7 days
     title: 'Exchange Ownership (Coming Soon)',
     description:
       'Swap ownership between members or spaces, whether selling a stake or exchanging assets.',
@@ -47,7 +52,8 @@ export const CREATE_ACTIONS = [
     icon: <PlusCircledIcon />,
     disabled: true,
   },
-  { //NOTE duration: 7 days
+  {
+    //NOTE duration: 7 days
     title: 'Deploy Funds',
     description:
       'Allocate treasury funds for investments to other spaces or distributing resources among sub-spaces.',

--- a/apps/web/src/app/[lang]/dho/[id]/_components/select-settings-action.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/select-settings-action.tsx
@@ -44,7 +44,7 @@ export const SETTINGS_ACTIONS = [
     disabled: true,
   },
   {
-    //NOTE duration: 4 days
+    defaultDurationDays: 4,
     group: 'Governance',
     title: 'Voting Method',
     description:
@@ -54,7 +54,7 @@ export const SETTINGS_ACTIONS = [
     baseTab: 'governance',
   },
   {
-    //NOTE duration: 4 days
+    defaultDurationDays: 4,
     group: 'Membership',
     title: 'Entry Method',
     description:
@@ -82,7 +82,7 @@ export const SETTINGS_ACTIONS = [
     disabled: true,
   },
   {
-    //NOTE duration: 4 days
+    defaultDurationDays: 4,
     group: 'Treasury',
     title: 'Issue New Token',
     description:

--- a/apps/web/src/app/[lang]/dho/[id]/_components/select-settings-action.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/select-settings-action.tsx
@@ -45,7 +45,7 @@ export const SETTINGS_ACTIONS = [
   },
   {
     group: 'Governance',
-    title: 'Voting Method',
+    title: 'Voting Method', // duration: 4 days
     description:
       'Select and configure the voting method for decision-making within your space.',
     href: 'create/change-voting-method',
@@ -54,7 +54,7 @@ export const SETTINGS_ACTIONS = [
   },
   {
     group: 'Membership',
-    title: 'Entry Method',
+    title: 'Entry Method', // duration: 4 days
     description:
       'Select and configure the process by which new members join your space.',
     href: 'create/change-entry-method',
@@ -81,7 +81,7 @@ export const SETTINGS_ACTIONS = [
   },
   {
     group: 'Treasury',
-    title: 'Issue New Token',
+    title: 'Issue New Token', // duration: 4 days
     description:
       'Create a new token for utility, cash credit, or ownership within your space.',
     href: 'create/issue-new-token',

--- a/apps/web/src/app/[lang]/dho/[id]/_components/select-settings-action.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/select-settings-action.tsx
@@ -43,7 +43,8 @@ export const SETTINGS_ACTIONS = [
     baseTab: 'membership',
     disabled: true,
   },
-  { //NOTE duration: 4 days
+  {
+    //NOTE duration: 4 days
     group: 'Governance',
     title: 'Voting Method',
     description:
@@ -52,7 +53,8 @@ export const SETTINGS_ACTIONS = [
     icon: <MixerVerticalIcon />,
     baseTab: 'governance',
   },
-  { //NOTE duration: 4 days
+  {
+    //NOTE duration: 4 days
     group: 'Membership',
     title: 'Entry Method',
     description:
@@ -79,7 +81,8 @@ export const SETTINGS_ACTIONS = [
     icon: <CrossCircledIcon />,
     disabled: true,
   },
-  { //NOTE duration: 4 days
+  {
+    //NOTE duration: 4 days
     group: 'Treasury',
     title: 'Issue New Token',
     description:

--- a/apps/web/src/app/[lang]/dho/[id]/_components/select-settings-action.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/select-settings-action.tsx
@@ -43,18 +43,18 @@ export const SETTINGS_ACTIONS = [
     baseTab: 'membership',
     disabled: true,
   },
-  {
+  { //NOTE duration: 4 days
     group: 'Governance',
-    title: 'Voting Method', // duration: 4 days
+    title: 'Voting Method',
     description:
       'Select and configure the voting method for decision-making within your space.',
     href: 'create/change-voting-method',
     icon: <MixerVerticalIcon />,
     baseTab: 'governance',
   },
-  {
+  { //NOTE duration: 4 days
     group: 'Membership',
-    title: 'Entry Method', // duration: 4 days
+    title: 'Entry Method',
     description:
       'Select and configure the process by which new members join your space.',
     href: 'create/change-entry-method',
@@ -79,9 +79,9 @@ export const SETTINGS_ACTIONS = [
     icon: <CrossCircledIcon />,
     disabled: true,
   },
-  {
+  { //NOTE duration: 4 days
     group: 'Treasury',
-    title: 'Issue New Token', // duration: 4 days
+    title: 'Issue New Token',
     description:
       'Create a new token for utility, cash credit, or ownership within your space.',
     href: 'create/issue-new-token',

--- a/packages/core/src/governance/client/hooks/useAgreementMutations.web3.rsc.ts
+++ b/packages/core/src/governance/client/hooks/useAgreementMutations.web3.rsc.ts
@@ -59,7 +59,7 @@ export const useAgreementMutationsWeb3Rpc = ({
       };
 
       const input = {
-        spaceId: arg.spaceId,
+        spaceId: BigInt(arg.spaceId),
         duration: getDuration(3),
         transactions: [acceptAgreementTx],
       };

--- a/packages/core/src/governance/client/hooks/useAgreementMutations.web3.rsc.ts
+++ b/packages/core/src/governance/client/hooks/useAgreementMutations.web3.rsc.ts
@@ -20,6 +20,7 @@ import {
   daoProposalsImplementationAbi,
   daoProposalsImplementationAddress,
 } from '@hypha-platform/core/generated';
+import { getDuration } from '@hypha-platform/ui-utils';
 
 export const useAgreementMutationsWeb3Rpc = ({
   proposalSlug,
@@ -59,7 +60,7 @@ export const useAgreementMutationsWeb3Rpc = ({
 
       const input = {
         spaceId: arg.spaceId,
-        duration: 86400,
+        duration: getDuration(3),
         transactions: [acceptAgreementTx],
       };
 

--- a/packages/core/src/governance/client/hooks/useChangeEntryMethodMutations.web3.rpc.ts
+++ b/packages/core/src/governance/client/hooks/useChangeEntryMethodMutations.web3.rpc.ts
@@ -22,6 +22,7 @@ import {
 
 import { Address, EntryMethodType, TokenBase } from '../../types';
 import { schemaCreateProposalWeb3, transactionSchema } from '../../validation';
+import { getDuration } from '@hypha-platform/ui-utils';
 
 type TxData = z.infer<typeof transactionSchema>;
 
@@ -104,7 +105,7 @@ export const useChangeEntryMethodMutationsWeb3Rpc = ({
 
       const input = {
         spaceId: arg.spaceId,
-        duration: 86400,
+        duration: getDuration(4),
         transactions,
       };
 

--- a/packages/core/src/governance/client/hooks/useChangeEntryMethodMutations.web3.rpc.ts
+++ b/packages/core/src/governance/client/hooks/useChangeEntryMethodMutations.web3.rpc.ts
@@ -104,7 +104,7 @@ export const useChangeEntryMethodMutationsWeb3Rpc = ({
       }
 
       const input = {
-        spaceId: arg.spaceId,
+        spaceId: BigInt(arg.spaceId),
         duration: getDuration(4),
         transactions,
       };

--- a/packages/core/src/governance/client/hooks/useChangeVotingMethodMutations.web3.rsc.ts
+++ b/packages/core/src/governance/client/hooks/useChangeVotingMethodMutations.web3.rsc.ts
@@ -24,6 +24,7 @@ import {
 
 import { transactionSchema } from '@hypha-platform/core/client';
 import { VotingMethodType } from '@hypha-platform/core/client';
+import { getDuration } from '@hypha-platform/ui-utils';
 
 const chainId = 8453;
 type TxData = z.infer<typeof transactionSchema>;
@@ -106,7 +107,7 @@ export const useChangeVotingMethodMutationsWeb3Rpc = ({
 
       const input = {
         spaceId: arg.spaceId,
-        duration: 604800,
+        duration: getDuration(4),
         transactions,
       };
 

--- a/packages/core/src/governance/client/hooks/useChangeVotingMethodMutations.web3.rsc.ts
+++ b/packages/core/src/governance/client/hooks/useChangeVotingMethodMutations.web3.rsc.ts
@@ -106,7 +106,7 @@ export const useChangeVotingMethodMutationsWeb3Rpc = ({
       }
 
       const input = {
-        spaceId: arg.spaceId,
+        spaceId: BigInt(arg.spaceId),
         duration: getDuration(4),
         transactions,
       };

--- a/packages/core/src/governance/client/hooks/useDeployFundsMutations.web3.rpc.ts
+++ b/packages/core/src/governance/client/hooks/useDeployFundsMutations.web3.rpc.ts
@@ -12,6 +12,7 @@ import {
   daoProposalsImplementationAddress,
 } from '@hypha-platform/core/generated';
 import { getTokenDecimals } from '@hypha-platform/core/client';
+import { getDuration } from '@hypha-platform/ui-utils';
 
 interface CreateDeployFundsInput {
   spaceId: number;
@@ -63,7 +64,7 @@ export const useDeployFundsMutationsWeb3Rpc = ({
 
       const proposalParams = {
         spaceId: BigInt(arg.spaceId),
-        duration: BigInt(86400),
+        duration: getDuration(7),
         transactions,
       };
 

--- a/packages/core/src/governance/client/hooks/useIssueNewTokenMutations.web3.rsc.ts
+++ b/packages/core/src/governance/client/hooks/useIssueNewTokenMutations.web3.rsc.ts
@@ -130,7 +130,7 @@ export const useIssueTokenMutationsWeb3Rpc = ({
       }
 
       const parsedProposal = schemaCreateProposalWeb3.parse({
-        spaceId: arg.spaceId,
+        spaceId: BigInt(arg.spaceId),
         duration: getDuration(4),
         transactions: txData,
       });

--- a/packages/core/src/governance/client/hooks/useIssueNewTokenMutations.web3.rsc.ts
+++ b/packages/core/src/governance/client/hooks/useIssueNewTokenMutations.web3.rsc.ts
@@ -20,6 +20,7 @@ import {
   decayingTokenFactoryAbi,
   decayingTokenFactoryAddress,
 } from '@hypha-platform/core/generated';
+import { getDuration } from '@hypha-platform/ui-utils';
 
 interface CreateTokenArgs {
   spaceId: number;
@@ -130,7 +131,7 @@ export const useIssueTokenMutationsWeb3Rpc = ({
 
       const parsedProposal = schemaCreateProposalWeb3.parse({
         spaceId: arg.spaceId,
-        duration: 604800,
+        duration: getDuration(4),
         transactions: txData,
       });
 

--- a/packages/core/src/governance/client/hooks/usePayForExpensesMutations.web3.rpc.ts
+++ b/packages/core/src/governance/client/hooks/usePayForExpensesMutations.web3.rpc.ts
@@ -12,6 +12,7 @@ import {
   daoProposalsImplementationAddress,
 } from '@hypha-platform/core/generated';
 import { getTokenDecimals } from '@hypha-platform/core/client';
+import { getDuration } from '@hypha-platform/ui-utils';
 
 interface CreatePayForExpensesInput {
   spaceId: number;
@@ -63,7 +64,7 @@ export const usePayForExpensesMutationsWeb3Rpc = ({
 
       const proposalParams = {
         spaceId: BigInt(arg.spaceId),
-        duration: BigInt(86400),
+        duration: getDuration(7),
         transactions,
       };
 

--- a/packages/core/src/governance/client/hooks/useProposeAContributionMutations.web3.rsc.ts
+++ b/packages/core/src/governance/client/hooks/useProposeAContributionMutations.web3.rsc.ts
@@ -12,6 +12,7 @@ import {
   daoProposalsImplementationAddress,
 } from '@hypha-platform/core/generated';
 import { getTokenDecimals } from '@hypha-platform/core/client';
+import { getDuration } from '@hypha-platform/ui-utils';
 
 interface CreateProposeAContributionInput {
   spaceId: number;
@@ -63,7 +64,7 @@ export const useProposeAContributionMutationsWeb3Rpc = ({
 
       const proposalParams = {
         spaceId: BigInt(arg.spaceId),
-        duration: BigInt(86400),
+        duration: getDuration(4),
         transactions,
       };
 

--- a/packages/core/src/governance/validation.ts
+++ b/packages/core/src/governance/validation.ts
@@ -319,8 +319,10 @@ export const schemaCreateAgreementForm = z.object({
 });
 
 export const schemaCreateProposalWeb3 = z.object({
-  spaceId: z.number().min(1, { message: 'Space ID must be a positive number' }),
-  duration: z.number().min(1, { message: 'Duration must be greater than 0' }),
+  spaceId: z
+    .bigint()
+    .min(1n, { message: 'Space ID must be a positive number' }),
+  duration: z.bigint().min(1n, { message: 'Duration must be greater than 0' }),
   transactions: z
     .array(transactionSchema)
     .min(1, { message: 'At least one transaction is required' })

--- a/packages/epics/src/common/select-action.tsx
+++ b/packages/epics/src/common/select-action.tsx
@@ -14,6 +14,7 @@ type ActionProps = {
   icon: React.ReactNode;
   disabled?: boolean;
   target?: string;
+  defaultDurationDays?: number;
 };
 
 type SelectActionProps = {

--- a/packages/ui-utils/src/get-duration.ts
+++ b/packages/ui-utils/src/get-duration.ts
@@ -1,3 +1,8 @@
+const DAY_DURATION_IN_SECS: bigint = 86_400n;
+
 export const getDuration = (days: number): bigint => {
-  return BigInt(days * 86400);
+  if (!Number.isInteger(days) || days < 0) {
+    throw new Error('getDuration expects a non-negative integer number of days');
+  }
+  return BigInt(days) * DAY_DURATION_IN_SECS;
 };

--- a/packages/ui-utils/src/get-duration.ts
+++ b/packages/ui-utils/src/get-duration.ts
@@ -1,0 +1,3 @@
+export const getDuration = (days: number): bigint => {
+  return BigInt(days * 86400);
+};

--- a/packages/ui-utils/src/get-duration.ts
+++ b/packages/ui-utils/src/get-duration.ts
@@ -2,7 +2,9 @@ const DAY_DURATION_IN_SECS: bigint = 86_400n;
 
 export const getDuration = (days: number): bigint => {
   if (!Number.isInteger(days) || days < 0) {
-    throw new Error('getDuration expects a non-negative integer number of days');
+    throw new Error(
+      'getDuration expects a non-negative integer number of days',
+    );
   }
   return BigInt(days) * DAY_DURATION_IN_SECS;
 };

--- a/packages/ui-utils/src/index.ts
+++ b/packages/ui-utils/src/index.ts
@@ -5,3 +5,4 @@ export * from './strip-markdown';
 export * from './formatCurrencyValue';
 export * from './formatDate';
 export * from './set-number-value';
+export * from './get-duration';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Actions and settings now show default proposal durations when initiated (visible to users when creating proposals).

* **Refactor**
  * Standardized proposal durations across actions for predictability: Make a Collective Agreement (3 days); Propose a Contribution, Change Voting/Entry Method, Issue New Token (4 days); Pay for Products/Services, Accept Investment, Exchange Ownership, Deploy Funds (7 days).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->