### PR TITLE
Feat/1304 spacing on button

### DIFF
--- a/apps/web/src/app/[lang]/my-spaces/page.tsx
+++ b/apps/web/src/app/[lang]/my-spaces/page.tsx
@@ -40,7 +40,7 @@ export default async function Index(props: PageProps) {
           <SpaceSearch />
           <Link href={`/${lang}/my-spaces/create`} scroll={false}>
             <Button className="ml-2">
-              <PlusIcon className="mr-2" />
+              <PlusIcon />
               Create Space
             </Button>
           </Link>

--- a/packages/epics/src/spaces/components/network-all.tsx
+++ b/packages/epics/src/spaces/components/network-all.tsx
@@ -31,7 +31,7 @@ export function NetworkAll({
         <SpaceSearch />
         <Link href={`/${lang}/network/create`} scroll={false}>
           <Button className="ml-2">
-            <PlusIcon className="mr-2" />
+            <PlusIcon />
             Create Space
           </Button>
         </Link>

--- a/packages/epics/src/spaces/components/subspace-section.tsx
+++ b/packages/epics/src/spaces/components/subspace-section.tsx
@@ -26,7 +26,7 @@ export const SubspaceSection = ({
         <div className="flex items-center">
           <Link href={`membership/space/create`} scroll={false}>
             <Button className="ml-2">
-              <PlusIcon className="mr-2" />
+              <PlusIcon />
               Create Sub-Space
             </Button>
           </Link>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Tightened spacing between the plus icon and label in “Create Space” buttons across My Spaces and Network views for a more compact look.
  * Adjusted the “Create Sub-Space” button to match the updated icon-label spacing for visual consistency.
  * No functional changes; UI-only refinement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->