### PR TITLE
fix(#1325): fixed transition to /network/create from outside

### DIFF
--- a/apps/web/src/app/[lang]/my-spaces/@aside/create/page.tsx
+++ b/apps/web/src/app/[lang]/my-spaces/@aside/create/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { SpaceForm, SidePanel } from '@hypha-platform/epics';
-import { useParams, useRouter } from 'next/navigation';
+import { useParams, useRouter, usePathname } from 'next/navigation';
 import React from 'react';
 import { Locale } from '@hypha-platform/i18n';
 import { LoadingBackdrop } from '@hypha-platform/ui/server';
@@ -20,6 +20,7 @@ export default function AsideCreateSpacePage() {
   const config = useConfig();
   const { person } = useMe();
   const { jwt, isLoadingJwt } = useJwt();
+  const pathname = usePathname();
   const {
     createSpace,
     reset,
@@ -36,7 +37,7 @@ export default function AsideCreateSpacePage() {
     }
   }, [progress, spaceSlug]);
 
-  const mySpacesUrl = `/${lang}/my-spaces/`;
+  const closeUrl = pathname.split('/').slice(0, -1).join('/') || '/';
 
   return progress !== 100 ? (
     <SidePanel>
@@ -60,8 +61,8 @@ export default function AsideCreateSpacePage() {
             name: person?.name,
             surname: person?.surname,
           }}
-          closeUrl={mySpacesUrl}
-          backUrl={mySpacesUrl}
+          closeUrl={closeUrl}
+          backUrl={closeUrl}
           backLabel="Back"
           onSubmit={createSpace}
           isLoading={isLoadingJwt}

--- a/apps/web/src/app/[lang]/network/@aside/create/page.tsx
+++ b/apps/web/src/app/[lang]/network/@aside/create/page.tsx
@@ -1,3 +1,5 @@
-import AsideCreateSpacePage from '../../../my-spaces/@aside/create/page';
+import AsideCreateSpacePage from '@web/app/[lang]/my-spaces/@aside/create/page';
 
-export default AsideCreateSpacePage;
+export default function NetworkCreateSpacePage() {
+  return <AsideCreateSpacePage />;
+}

--- a/apps/web/src/app/[lang]/network/default.tsx
+++ b/apps/web/src/app/[lang]/network/default.tsx
@@ -1,0 +1,2 @@
+import Page from './page';
+export default Page;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Consistent “Create Space” experience in the Network section, aligning behavior with My Spaces.

- Bug Fixes
  - Close/Back actions in the “Create Space” sidebar now return to the correct previous page based on your current location.
  - Improved navigation reliability in the Network area to ensure expected page loading and redirects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->