### PR TITLE
Feat/1350 Network: Show ALL Spaces

### DIFF
--- a/apps/web/src/app/[lang]/network/page.tsx
+++ b/apps/web/src/app/[lang]/network/page.tsx
@@ -49,7 +49,7 @@ export default async function Index(props: PageProps) {
 
   const { lang } = params;
 
-  const spaces = await getAllSpaces({ search: query });
+  const spaces = await getAllSpaces({ search: query, parentOnly: false });
 
   const uniqueCategories = extractUniqueCategories(spaces);
 

--- a/apps/web/src/app/[lang]/network/page.tsx
+++ b/apps/web/src/app/[lang]/network/page.tsx
@@ -49,7 +49,10 @@ export default async function Index(props: PageProps) {
 
   const { lang } = params;
 
-  const spaces = await getAllSpaces({ search: query, parentOnly: false });
+  const spaces = await getAllSpaces({
+    search: query?.trim() || undefined,
+    parentOnly: false,
+  });
 
   const uniqueCategories = extractUniqueCategories(spaces);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Network page results now include both parent and non-parent spaces, providing broader search and browsing matches.
  * Search input is trimmed so queries ignore leading/trailing whitespace for more accurate results.
  * No changes to navigation, controls, or category extraction; only the visible set of returned spaces has been broadened.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->