### PR TITLE
Feat/1384 Hypha services link has exired, change to this new link

### DIFF
--- a/packages/ui/src/organisms/footer.tsx
+++ b/packages/ui/src/organisms/footer.tsx
@@ -34,7 +34,7 @@ export const Footer = () => {
                 rel="noopener noreferrer"
                 style={customLinkStyles}
                 target="_blank"
-                href="https://discord.gg/cvTgbymA"
+                href="https://discord.gg/Um9vASx8a8"
               >
                 Hypha Services
               </Link>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Discord invite in the footer to the new Hypha Services URL so users land on the correct community server.
  * Prevents navigation to an outdated or broken invite, improving reliability of the contact/social section.
  * No changes to layout, other links, or overall footer behavior; existing footer functionality remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->