### PR TITLE
Feat/1403 Purpose title missing on light mode

### DIFF
--- a/packages/epics/src/spaces/components/create-space-form.tsx
+++ b/packages/epics/src/spaces/components/create-space-form.tsx
@@ -180,7 +180,7 @@ export const SpaceForm = ({
           name="description"
           render={({ field }) => (
             <FormItem>
-              <FormLabel className="text-white">Purpose</FormLabel>
+              <FormLabel className="text-foreground">Purpose</FormLabel>
               <FormControl>
                 <Textarea
                   disabled={isLoading}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the description field label styling in the Create Space form to use the app’s foreground color, improving readability and visual consistency across themes.
  - Ensures better contrast in light/dark modes without altering form behavior, validation, or submission flows.
  - No functional changes; purely a UI polish for a more cohesive look and feel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->