### PR TITLE
fix(#1288): added dynamic address setting to the form

### DIFF
--- a/packages/epics/src/people/components/signup-panel.tsx
+++ b/packages/epics/src/people/components/signup-panel.tsx
@@ -27,6 +27,7 @@ import Link from 'next/link';
 import { Loader2 } from 'lucide-react';
 import { Links } from '../../common';
 import { useAuthentication } from '@hypha-platform/authentication';
+import { useEffect } from 'react';
 
 const schemaSignupPersonForm = schemaSignupPerson.extend(editPersonFiles.shape);
 
@@ -58,11 +59,20 @@ export const SignupPanel = ({
       leadImageUrl: undefined,
       description: '',
       location: undefined,
-      email: user?.email?.trim() || undefined,
-      address: user?.wallet?.address || '',
+      email: undefined,
+      address: '',
       links: [],
     },
   });
+
+  useEffect(() => {
+    if (user?.email) {
+      form.setValue('email', user.email.trim());
+    }
+    if (user?.wallet?.address) {
+      form.setValue('address', user.wallet.address);
+    }
+  }, [user, form]);
 
   return (
     <Form {...form}>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Signup form now reliably auto-fills your email and wallet address once your account data loads, avoiding empty or stale values on initial render.
  * Reduces form flicker and unnecessary manual re-entry when information loads asynchronously.
  * Trims whitespace from your email before populating the field for cleaner input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->