### PR TITLE
feat(#1410): nickname field made editable

### DIFF
--- a/packages/core/src/people/server/mutations.ts
+++ b/packages/core/src/people/server/mutations.ts
@@ -28,9 +28,11 @@ export const updatePerson = async (
   person: Person,
   { db }: CreatePersonConfig,
 ) => {
+  const slug = person.nickname?.toLowerCase().replace(/\s+/g, '-') || '';
   const updateData = {
     ...person,
     email: person.email || null,
+    slug,
   };
   const [dbPerson] = await db
     .update(people)

--- a/packages/epics/src/people/components/edit-person-section.tsx
+++ b/packages/epics/src/people/components/edit-person-section.tsx
@@ -152,7 +152,7 @@ export const EditPersonSection = ({
                       render={({ field }) => (
                         <FormItem>
                           <FormControl>
-                            <Input disabled placeholder="Nickname" {...field} />
+                            <Input placeholder="Nickname" {...field} />
                           </FormControl>
                           <FormMessage />
                         </FormItem>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Person profiles now auto-generate and persist a URL-friendly slug from the nickname when updating, keeping links consistent after edits.

- Bug Fixes
  - The nickname field in the Edit Person form is now editable (previously always disabled), allowing users to update nicknames as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->