### PR TITLE
feat(#1440): added disabled condition for treasury actions button

### DIFF
--- a/apps/web/src/app/[lang]/profile/[personSlug]/_components/profile-tabs.tsx
+++ b/apps/web/src/app/[lang]/profile/[personSlug]/_components/profile-tabs.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Person } from '@hypha-platform/core/client';
+import { Person, useMe } from '@hypha-platform/core/client';
 import {
   UserAssetsSection,
   UserTransactionsSection,
@@ -16,6 +16,10 @@ export const ProfileTabs = ({
   lang: string;
 }) => {
   const [activeTab, setActiveTab] = React.useState('treasury');
+  const { person: authenticatedPerson } = useMe();
+  const isMyProfile =
+    person?.address?.toLowerCase() ===
+    authenticatedPerson?.address?.toLowerCase();
 
   return (
     <Tabs value={activeTab} className="w-full flex flex-col gap-4">
@@ -31,6 +35,7 @@ export const ProfileTabs = ({
       </TabsList>
       <TabsContent value="treasury" className="flex flex-col gap-4">
         <UserAssetsSection
+          isMyProfile={isMyProfile}
           personSlug={person?.slug || ''}
           basePath={`/${lang}/profile/${person?.slug}`}
         />

--- a/packages/epics/src/treasury/components/assets/user-assets-section.tsx
+++ b/packages/epics/src/treasury/components/assets/user-assets-section.tsx
@@ -12,11 +12,13 @@ import { Input } from '@hypha-platform/ui';
 type UserAssetsSectionProps = {
   personSlug: string;
   basePath?: string;
+  isMyProfile?: boolean;
 };
 
 export const UserAssetsSection: FC<UserAssetsSectionProps> = ({
   personSlug,
   basePath,
+  isMyProfile,
 }) => {
   const {
     visibleAssets,
@@ -49,11 +51,9 @@ export const UserAssetsSection: FC<UserAssetsSectionProps> = ({
         </label>
       </SectionFilter>
       <div className="flex gap-2 justify-end">
-        <Button asChild>
-          <Link href={`${basePath}/actions`} scroll={false}>
-            Actions
-          </Link>
-        </Button>
+        <Link href={isMyProfile ? `${basePath}/actions` : {}} scroll={false}>
+          <Button disabled={!isMyProfile}>Actions</Button>
+        </Link>
       </div>
     </div>
   );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Profile pages now detect when you’re viewing your own profile.
  * Asset actions are enabled with a direct link to manage your assets when it’s your profile.
  * When viewing someone else’s profile, the asset action button is disabled to prevent unauthorized actions.
* **Improvements**
  * Clearer navigation by routing asset actions appropriately based on profile ownership.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->