### PR TITLE
Feat/1418 Space Configuration bug

### DIFF
--- a/packages/epics/src/spaces/components/create-space-form.tsx
+++ b/packages/epics/src/spaces/components/create-space-form.tsx
@@ -82,6 +82,10 @@ export const SpaceForm = ({
   });
 
   React.useEffect(() => {
+    form?.reset(defaultValues);
+  }, [form, defaultValues]);
+
+  React.useEffect(() => {
     if (parentSpaceId) {
       form.setValue('parentId', parentSpaceId);
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The Create Space form now automatically refreshes its fields when default values change (e.g., selecting a different parent space or reopening the form), preventing stale or mismatched inputs.
  * Ensures the parent selection and related fields stay in sync during edits and navigation, improving consistency and reliability.
  * No user actions required; behavior is seamless and does not alter any existing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->