### PR TITLE
Feat/1322 The fields in proposal are too small to contain the text

### DIFF
--- a/packages/epics/src/agreements/plugins/components/common/token-payout-field-array.tsx
+++ b/packages/epics/src/agreements/plugins/components/common/token-payout-field-array.tsx
@@ -53,11 +53,11 @@ export const TokenPayoutFieldArray = ({
 
   return (
     <div className="flex flex-col gap-2 w-full">
-      <div className="flex flex-col gap-4 md:gap-8 md:flex-row md:items-start w-full">
+      <div className="flex flex-col gap-4 md:flex-row md:items-start w-full">
         <label className="text-2 text-neutral-11 whitespace-nowrap md:min-w-max items-center md:pt-1">
           Payment Request
         </label>
-        <div className="flex flex-col gap-2">
+        <div className="flex flex-col gap-2 grow">
           {fields.map((field, index) => (
             <div key={field.id} className="flex md:justify-end gap-2">
               <div className="">

--- a/packages/epics/src/agreements/plugins/components/common/token-payout-field-array.tsx
+++ b/packages/epics/src/agreements/plugins/components/common/token-payout-field-array.tsx
@@ -57,7 +57,7 @@ export const TokenPayoutFieldArray = ({
         <label className="text-2 text-neutral-11 whitespace-nowrap md:min-w-max items-center md:pt-1">
           Payment Request
         </label>
-        <div className="flex flex-col gap-2 grow">
+        <div className="flex flex-col gap-2 grow min-w-0">
           {fields.map((field, index) => (
             <div key={field.id} className="flex md:justify-end gap-2">
               <div className="">

--- a/packages/epics/src/agreements/plugins/components/common/token-payout-field.tsx
+++ b/packages/epics/src/agreements/plugins/components/common/token-payout-field.tsx
@@ -79,7 +79,9 @@ export const TokenPayoutField = ({
                       alt={selectedToken.symbol}
                       className="mr-2 object-cover rounded-full w-5 h-5"
                     />
-                    <span className="text-2 truncate">{selectedToken.symbol}</span>
+                    <span className="text-2 truncate">
+                      {selectedToken.symbol}
+                    </span>
                   </>
                 ) : (
                   <span className="text-2 text-nowrap">Select a token</span>

--- a/packages/epics/src/agreements/plugins/components/common/token-payout-field.tsx
+++ b/packages/epics/src/agreements/plugins/components/common/token-payout-field.tsx
@@ -50,58 +50,62 @@ export const TokenPayoutField = ({
   };
 
   return (
-    <div className="flex flex-row md:justify-end gap-4 items-end">
-      <Input
-        value={value.amount}
-        type="number"
-        placeholder="Type an amount"
-        onChange={(e) => handleAmountChange(e.target.value)}
-      />
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button
-            variant="outline"
-            colorVariant="neutral"
-            role="combobox"
-            className="w-full flex-1 text-2 md:w-72 justify-between py-2 font-normal"
-          >
-            <div className="flex items-center gap-2 w-24">
-              {selectedToken ? (
-                <>
-                  <Image
-                    src={selectedToken.icon}
-                    width={20}
-                    height={20}
-                    alt={selectedToken.symbol}
-                    className="mr-2 object-cover rounded-full w-5 h-5"
-                  />
-                  <span className="text-2">{selectedToken.symbol}</span>
-                </>
-              ) : (
-                <span className="text-2 text-nowrap">Select a token</span>
-              )}
-            </div>
-            <ChevronDownIcon className="size-2" />
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent>
-          {tokens.map((token) => (
-            <DropdownMenuItem
-              key={`${token.address}_${token.symbol}`}
-              onSelect={() => handleTokenChange(token)}
+    <div className="flex flex-row gap-2 md:justify-end sm:gap-4 items-end">
+      <span className="flex top-0 w-25 m-0 p-0">
+        <Input
+          value={value.amount}
+          type="number"
+          placeholder="Amount"
+          onChange={(e) => handleAmountChange(e.target.value)}
+        />
+      </span>
+      <span className="flex top-0 w-60 m-0 p-0">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="outline"
+              colorVariant="neutral"
+              role="combobox"
+              className="w-full flex-1 text-2 justify-between py-2 font-normal"
             >
-              <Image
-                src={token.icon}
-                width={24}
-                height={24}
-                alt={token.symbol}
-                className="mr-2 object-cover rounded-full w-5 h-5"
-              />
-              <span className="text-2 text-neutral-11">{token.symbol}</span>
-            </DropdownMenuItem>
-          ))}
-        </DropdownMenuContent>
-      </DropdownMenu>
+              <div className="flex items-center gap-2 w-24">
+                {selectedToken ? (
+                  <>
+                    <Image
+                      src={selectedToken.icon}
+                      width={20}
+                      height={20}
+                      alt={selectedToken.symbol}
+                      className="mr-2 object-cover rounded-full w-5 h-5"
+                    />
+                    <span className="text-2">{selectedToken.symbol}</span>
+                  </>
+                ) : (
+                  <span className="text-2 text-nowrap">Select a token</span>
+                )}
+              </div>
+              <ChevronDownIcon className="size-2" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent>
+            {tokens.map((token) => (
+              <DropdownMenuItem
+                key={`${token.address}_${token.symbol}`}
+                onSelect={() => handleTokenChange(token)}
+              >
+                <Image
+                  src={token.icon}
+                  width={24}
+                  height={24}
+                  alt={token.symbol}
+                  className="mr-2 object-cover rounded-full w-5 h-5"
+                />
+                <span className="text-2 text-neutral-11">{token.symbol}</span>
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </span>
     </div>
   );
 };

--- a/packages/epics/src/agreements/plugins/components/common/token-payout-field.tsx
+++ b/packages/epics/src/agreements/plugins/components/common/token-payout-field.tsx
@@ -50,16 +50,17 @@ export const TokenPayoutField = ({
   };
 
   return (
-    <div className="flex flex-row gap-2 md:justify-end sm:gap-4 items-end">
-      <span className="flex top-0 w-25 m-0 p-0">
+    <div className="flex flex-col sm:flex-row gap-2 sm:gap-4 md:justify-end items-end">
+      <div className="flex top-0 m-0 p-0 flex-1 min-w-0">
         <Input
           value={value.amount}
           type="number"
+          step="any"
           placeholder="Amount"
           onChange={(e) => handleAmountChange(e.target.value)}
         />
-      </span>
-      <span className="flex top-0 w-60 m-0 p-0">
+      </div>
+      <div className="flex top-0 w-full sm:w-60 shrink-0 min-w-0 m-0 p-0">
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button
@@ -105,7 +106,7 @@ export const TokenPayoutField = ({
             ))}
           </DropdownMenuContent>
         </DropdownMenu>
-      </span>
+      </div>
     </div>
   );
 };

--- a/packages/epics/src/agreements/plugins/components/common/token-payout-field.tsx
+++ b/packages/epics/src/agreements/plugins/components/common/token-payout-field.tsx
@@ -69,7 +69,7 @@ export const TokenPayoutField = ({
               role="combobox"
               className="w-full flex-1 text-2 justify-between py-2 font-normal"
             >
-              <div className="flex items-center gap-2 w-24">
+              <div className="flex items-center gap-2 min-w-0 flex-1">
                 {selectedToken ? (
                   <>
                     <Image
@@ -79,7 +79,7 @@ export const TokenPayoutField = ({
                       alt={selectedToken.symbol}
                       className="mr-2 object-cover rounded-full w-5 h-5"
                     />
-                    <span className="text-2">{selectedToken.symbol}</span>
+                    <span className="text-2 truncate">{selectedToken.symbol}</span>
                   </>
                 ) : (
                   <span className="text-2 text-nowrap">Select a token</span>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Redesigned token payout controls into a responsive two-area layout for improved alignment and sizing.
  * Reduced medium-screen horizontal gaps; improved small-screen spacing; fields now grow/shrink to use available space and avoid overflow.
  * Amount input placeholder standardized to “Amount” and accepts any numeric step.
  * Token selector now shows icon and truncated symbol or “Select a token”; dropdown sizing and alignment refined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->