### PR TITLE
Fixing error handling in webhook

### DIFF
--- a/packages/core/src/common/server/webhooks/alchemy/handler.ts
+++ b/packages/core/src/common/server/webhooks/alchemy/handler.ts
@@ -52,7 +52,7 @@ export function newHandler<A extends Abi, E extends ContractEventName<A>>(
       callbacks.map((callback) => callback(events)),
     );
     const rejected = callbacksResult.filter((res) => res.status === 'rejected');
-    rejected.forEach((reason) =>
+    rejected.forEach(({ reason }) =>
       console.error('Webhook callback failed with error:', reason),
     );
 

--- a/packages/core/src/common/server/webhooks/alchemy/handler.ts
+++ b/packages/core/src/common/server/webhooks/alchemy/handler.ts
@@ -19,7 +19,7 @@ export function newHandler<A extends Abi, E extends ContractEventName<A>>(
   return newHandlerWithMiddleware(middleware, async (request: NextRequest) => {
     const payload = await (async () => {
       try {
-        return request.json();
+        return await request.json();
       } catch (error) {
         console.error('Failed to get request body:', error);
       }
@@ -34,7 +34,7 @@ export function newHandler<A extends Abi, E extends ContractEventName<A>>(
       return NextResponse.json({ error: 'Invalid body' }, { status: 400 });
     }
 
-    const events = await (async () => {
+    const events = (() => {
       try {
         return parseEventLogs({
           abi: abi,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Malformed webhook payloads now return a 400 instead of causing unhandled errors.
  * Event parsing uses consistent synchronous error handling to reduce intermittent failures.
  * Webhook callback error reporting improved for clearer, more actionable logs and increased webhook stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->