### PR TITLE
feat(#1432): fixed display of the button for creating a space on the my spaces page

### DIFF
--- a/apps/web/src/app/[lang]/dho/[id]/_components/authenticated-link-button.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/authenticated-link-button.tsx
@@ -8,19 +8,25 @@ import { ReactNode } from 'react';
 type AuthLinkButtonProps = {
   href: string;
   children: ReactNode;
+  hideInsteadDisabled?: boolean;
 };
 
 export function AuthenticatedLinkButton({
   href,
   children,
+  hideInsteadDisabled = false,
 }: AuthLinkButtonProps) {
   const { isAuthenticated } = useAuthentication();
+
+  if (hideInsteadDisabled && !isAuthenticated) {
+    return null;
+  }
 
   return (
     <Link href={isAuthenticated ? href : '#'} scroll={false}>
       <Button
         title={!isAuthenticated ? 'Please sign in to use this feature.' : ''}
-        disabled={!isAuthenticated}
+        disabled={!isAuthenticated && !hideInsteadDisabled}
         className="ml-2"
       >
         {children}

--- a/apps/web/src/app/[lang]/my-spaces/page.tsx
+++ b/apps/web/src/app/[lang]/my-spaces/page.tsx
@@ -45,10 +45,15 @@ export default async function Index(props: PageProps) {
         </Heading>
         <div className="flex justify-center">
           <SpaceSearch />
-          <AuthenticatedLinkButton href={`/${lang}/my-spaces/create`}>
-            <PlusIcon />
-            Create Space
-          </AuthenticatedLinkButton>
+          {spaces?.length > 0 ? (
+            <AuthenticatedLinkButton
+              hideInsteadDisabled
+              href={`/${lang}/my-spaces/create`}
+            >
+              <PlusIcon />
+              Create Space
+            </AuthenticatedLinkButton>
+          ) : null}
         </div>
         <FilteredSpaces lang={lang} spaces={spaces} showLoadMore={false} />
         <div


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Action buttons that require sign-in can now be hidden instead of shown as disabled, improving clarity for unauthenticated users.
  - Updated button behavior: when visible and sign-in is required, buttons remain disabled until authenticated.
  - The “Create Space” button now shows only when you already have at least one space; otherwise it’s hidden to reduce clutter.
  - Link destinations remain unchanged: full navigation when authenticated, placeholder when not.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->