### PR TITLE
feat(#1392): added initial allocation section for 1t1v voting method

### DIFF
--- a/apps/web/src/app/[lang]/dho/[id]/@aside/governance/proposal/[documentSlug]/page.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@aside/governance/proposal/[documentSlug]/page.tsx
@@ -60,10 +60,14 @@ export default function Agreements() {
       setProgress(70);
       setVoteMessage('Getting updated data...');
       await votersMutate();
+      setProgress(100);
+      setVoteMessage('Vote processed!');
     } catch (err) {
-      console.debug(err);
+      console.error('Error during vote process:', err);
       setProgress(0);
-      setVoteMessage('Processing vote...');
+      setVoteMessage('An error occurred while processing your vote.');
+    } finally {
+      setIsVoting(false);
     }
   };
 

--- a/packages/core/src/governance/client/hooks/useChangeVotingMethodMutations.web3.rsc.ts
+++ b/packages/core/src/governance/client/hooks/useChangeVotingMethodMutations.web3.rsc.ts
@@ -83,6 +83,17 @@ export const useChangeVotingMethodMutationsWeb3Rpc = ({
       });
 
       if (arg.votingMethod === '1t1v') {
+        for (const { member, number } of arg.members) {
+          transactions.push({
+            target: arg.token as `0x${string}`,
+            value: 0,
+            data: encodeFunctionData({
+              abi: decayingSpaceTokenAbi,
+              functionName: 'mint',
+              args: [member as `0x${string}`, BigInt(number) * 10n ** 18n],
+            }),
+          });
+        }
         if (!arg.token || !/^0x[a-fA-F0-9]{40}$/.test(arg.token)) {
           throw new Error('Invalid or missing token address for 1t1v');
         }

--- a/packages/epics/src/agreements/plugins/change-voting-method/plugin.tsx
+++ b/packages/epics/src/agreements/plugins/change-voting-method/plugin.tsx
@@ -88,6 +88,7 @@ export const ChangeVotingMethodPlugin = ({
       {votingMethod === '1t1v' && (
         <Skeleton loading={isLoading} width={'100%'} height={24}>
           <TokenSelectorField name="token" tokens={filteredTokensFor1t1v} />
+          <MemberWithNumberFieldFieldArray name="members" members={members} />
         </Skeleton>
       )}
       <QuorumAndUnityChangerField name="quorumAndUnity" />

--- a/packages/epics/src/agreements/plugins/components/common/member-with-number-field-array.tsx
+++ b/packages/epics/src/agreements/plugins/components/common/member-with-number-field-array.tsx
@@ -46,7 +46,7 @@ export const MemberWithNumberFieldFieldArray = ({
     <div className="flex flex-col gap-4">
       <div className="flex flex-col md:flex-row gap-4">
         <Text className="pt-1 text-2 text-neutral-11 text-nowrap">
-          Initial voice allocation
+          Initial allocation
         </Text>
         <div className="flex flex-col gap-2">
           {fields.map((field, index) => (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Add per-member initial allocation input for the 1t1v voting method.
  - Automatically mint tokens to members based on their initial allocations when changing to 1t1v.

- Bug Fixes
  - Voting flow now reliably resets after completion or failure.
  - Clearer success (“Vote processed!”) and error messaging, with improved error logging.

- Style
  - Renamed label from “Initial voice allocation” to “Initial allocation” for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->