### PR TITLE
Fix/1483 lead image resizer bug

### DIFF
--- a/packages/epics/src/agreements/components/create-agreement-base-fields.tsx
+++ b/packages/epics/src/agreements/components/create-agreement-base-fields.tsx
@@ -121,6 +121,7 @@ export function CreateAgreementBaseFields({
               <UploadLeadImage
                 onChange={field.onChange}
                 maxFileSize={ALLOWED_IMAGE_FILE_SIZE}
+                enableImageResizer={true}
               />
             </FormControl>
             <FormMessage />

--- a/packages/epics/src/people/components/edit-person-section.tsx
+++ b/packages/epics/src/people/components/edit-person-section.tsx
@@ -200,6 +200,7 @@ export const EditPersonSection = ({
                           : undefined
                       }
                       onChange={field.onChange}
+                      enableImageResizer={true}
                     />
                   </FormControl>
                   <FormMessage />

--- a/packages/epics/src/people/components/signup-panel.tsx
+++ b/packages/epics/src/people/components/signup-panel.tsx
@@ -184,7 +184,10 @@ export const SignupPanel = ({
             render={({ field }) => (
               <FormItem>
                 <FormControl>
-                  <UploadLeadImage onChange={field.onChange} />
+                  <UploadLeadImage
+                    onChange={field.onChange}
+                    enableImageResizer={true}
+                  />
                 </FormControl>
                 <FormMessage />
               </FormItem>

--- a/packages/ui-utils/src/get-cropped-img.ts
+++ b/packages/ui-utils/src/get-cropped-img.ts
@@ -33,10 +33,5 @@ export async function getCroppedImg(
     crop.height,
   );
 
-  return new Promise((resolve) => {
-    canvas.toBlob((blob) => {
-      if (!blob) return;
-      resolve(URL.createObjectURL(blob));
-    }, 'image/jpeg');
-  });
+  return canvas.toDataURL('image/jpeg');
 }

--- a/packages/ui/src/upload/lead-image.tsx
+++ b/packages/ui/src/upload/lead-image.tsx
@@ -18,6 +18,19 @@ export type UploadLeadImageProps = {
   enableImageResizer?: boolean;
 };
 
+function dataURLtoFile(dataUrl: string, filename: string) {
+  if (!dataUrl) throw new Error('dataUrl is undefined');
+  const arr = dataUrl.split(',');
+  const mime = arr[0]?.match(/:(.*?);/)?.[1] || 'image/jpeg';
+  const bstr = atob(arr[1] || '');
+  let n = bstr.length;
+  const u8arr = new Uint8Array(n);
+  while (n--) {
+    u8arr[n] = bstr.charCodeAt(n);
+  }
+  return new File([u8arr], filename, { type: mime });
+}
+
 export const UploadLeadImage = ({
   onChange,
   defaultImage,
@@ -69,9 +82,7 @@ export const UploadLeadImage = ({
     const croppedImageUrl = await getCroppedImg(imageSrc, croppedAreaPixels);
     setPreview(croppedImageUrl);
 
-    const res = await fetch(croppedImageUrl);
-    const blob = await res.blob();
-    const file = new File([blob], 'cropped.jpg', { type: 'image/jpeg' });
+    const file = dataURLtoFile(croppedImageUrl, 'cropped.jpg');
     onChange(file);
 
     setImageSrc(null);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Enable image resizing for lead image uploads in agreement creation, person editing, and signup flows.

- Performance
  - In-memory image processing replaces network-based cropping, reducing upload latency and eliminating temporary network fetches.

- UX Improvements
  - Smoother, more reliable cropping and confirmation experience for lead images across forms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->