### PR TITLE
Fixing error handling in webhook handlers

### DIFF
--- a/packages/core/src/common/server/webhooks/alchemy/handler.ts
+++ b/packages/core/src/common/server/webhooks/alchemy/handler.ts
@@ -49,17 +49,12 @@ export function newHandler<A extends Abi, E extends ContractEventName<A>>(
       return NextResponse.json({ error: 'Invalid body' }, { status: 400 });
 
     const callbacksResult = await Promise.allSettled(
-      callbacks.map((callback) => callback(events)),
+      callbacks.map(async (callback) => await callback(events)),
     );
-    const rejected = callbacksResult.filter((res) => res.status === 'rejected');
-    rejected.forEach(({ reason }) =>
-      console.error('Webhook callback failed with error:', reason),
-    );
-
-    if (rejected.length > 0)
-      return NextResponse.json(
-        { error: 'Internal server error' },
-        { status: 500 },
+    callbacksResult
+      .filter((res) => res.status === 'rejected')
+      .forEach(({ reason }) =>
+        console.error('Webhook callback failed with error:', reason),
       );
 
     return NextResponse.json(null, { status: 200 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Webhook endpoint no longer returns 500 when some internal handlers fail; it now responds with 200 OK when payload parsing succeeds.
  * Errors from individual handlers are logged but do not change the HTTP response, preventing cascading failures.
  * Reduces unnecessary retries and false alarms from providers by decoupling partial processing failures from the final status.
  * Improves reliability and stability of webhook integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->