### PR TITLE
Adding attachments uploader

### DIFF
--- a/apps/web/src/hooks/use-people-file-uploads.tsx
+++ b/apps/web/src/hooks/use-people-file-uploads.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useFileUpload, editPersonFiles } from '@hypha-platform/core/client';
+import { useImageUpload, editPersonFiles } from '@hypha-platform/core/client';
 import { useCallback, useState } from 'react';
 import { z } from 'zod';
 
@@ -15,7 +15,7 @@ export const usePeopleFileUploads = ({
 }: UsePeopleFileUploadsParams) => {
   const [isUploading, setIsUploading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const { upload: uploadFile } = useFileUpload({
+  const { upload: uploadImage } = useImageUpload({
     headers: {
       Authorization: `Bearer ${authToken || ''}`,
     },
@@ -34,7 +34,7 @@ export const usePeopleFileUploads = ({
             if (!file) return;
 
             if (file instanceof File) {
-              const result = await uploadFile([file]);
+              const result = await uploadImage([file]);
               if (result?.[0]?.ufsUrl) {
                 uploadedFiles[key as keyof PersonFiles] = result[0].ufsUrl;
               }
@@ -54,7 +54,7 @@ export const usePeopleFileUploads = ({
         setIsUploading(false);
       }
     },
-    [uploadFile],
+    [uploadImage],
   );
 
   return {

--- a/apps/web/src/hooks/use-people-file-uploads.tsx
+++ b/apps/web/src/hooks/use-people-file-uploads.tsx
@@ -16,9 +16,7 @@ export const usePeopleFileUploads = ({
   const [isUploading, setIsUploading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const { upload: uploadImage } = useImageUpload({
-    headers: {
-      Authorization: `Bearer ${authToken || ''}`,
-    },
+    authorizationToken: authToken ?? undefined,
   });
 
   const upload = useCallback(

--- a/packages/core/src/assets/client/index.ts
+++ b/packages/core/src/assets/client/index.ts
@@ -1,2 +1,4 @@
-export * from './use-file-uploads';
+export * from './use-image-upload';
+
 export * from '../constant';
+export * from './types';

--- a/packages/core/src/assets/client/index.ts
+++ b/packages/core/src/assets/client/index.ts
@@ -1,3 +1,4 @@
+export * from './use-attachment-upload';
 export * from './use-image-upload';
 
 export * from '../constant';

--- a/packages/core/src/assets/client/types.ts
+++ b/packages/core/src/assets/client/types.ts
@@ -1,0 +1,5 @@
+export type UseFileUploadProps = {
+  headers: {
+    Authorization: `Bearer ${string}`;
+  };
+};

--- a/packages/core/src/assets/client/types.ts
+++ b/packages/core/src/assets/client/types.ts
@@ -1,5 +1,3 @@
-export type UseFileUploadProps = {
-  headers: {
-    Authorization: `Bearer ${string}`;
-  };
-};
+export interface FileUploadProps {
+  authorizationToken?: string;
+}

--- a/packages/core/src/assets/client/use-attachment-upload.ts
+++ b/packages/core/src/assets/client/use-attachment-upload.ts
@@ -1,10 +1,16 @@
 'use client';
 
 import { generateReactHelpers } from '@uploadthing/react';
-import type { UseFileUploadProps } from './types';
+import type { FileUploadProps } from './types';
 import type { CoreFileRouter } from '../server';
 
-export const useAttachmentUpload = ({ headers }: UseFileUploadProps) => {
+export const useAttachmentUpload = ({
+  authorizationToken,
+}: FileUploadProps) => {
+  const headers = authorizationToken
+    ? new Headers({ Authorization: `Bearer ${authorizationToken}` })
+    : new Headers();
+
   const { useUploadThing } = generateReactHelpers<CoreFileRouter>();
 
   const { startUpload, isUploading } = useUploadThing('attachmentUploader', {

--- a/packages/core/src/assets/client/use-attachment-upload.ts
+++ b/packages/core/src/assets/client/use-attachment-upload.ts
@@ -1,0 +1,18 @@
+'use client';
+
+import { generateReactHelpers } from '@uploadthing/react';
+import type { UseFileUploadProps } from './types';
+import type { CoreFileRouter } from '../server';
+
+export const useAttachmentUpload = ({ headers }: UseFileUploadProps) => {
+  const { useUploadThing } = generateReactHelpers<CoreFileRouter>();
+
+  const { startUpload, isUploading } = useUploadThing('attachmentUploader', {
+    headers,
+  });
+
+  return {
+    upload: startUpload,
+    isUploading,
+  };
+};

--- a/packages/core/src/assets/client/use-image-upload.ts
+++ b/packages/core/src/assets/client/use-image-upload.ts
@@ -1,12 +1,10 @@
+'use client';
+
 import { generateReactHelpers } from '@uploadthing/react';
+import type { UseFileUploadProps } from './types';
 import type { CoreFileRouter } from '../server';
 
-export type UseFileUploadProps = {
-  headers: {
-    Authorization: `Bearer ${string}`;
-  };
-};
-export const useFileUpload = ({ headers }: UseFileUploadProps) => {
+export const useImageUpload = ({ headers }: UseFileUploadProps) => {
   const { useUploadThing } = generateReactHelpers<CoreFileRouter>();
 
   const { startUpload, isUploading } = useUploadThing('imageUploader', {

--- a/packages/core/src/assets/client/use-image-upload.ts
+++ b/packages/core/src/assets/client/use-image-upload.ts
@@ -1,10 +1,14 @@
 'use client';
 
 import { generateReactHelpers } from '@uploadthing/react';
-import type { UseFileUploadProps } from './types';
+import type { FileUploadProps } from './types';
 import type { CoreFileRouter } from '../server';
 
-export const useImageUpload = ({ headers }: UseFileUploadProps) => {
+export const useImageUpload = ({ authorizationToken }: FileUploadProps) => {
+  const headers = authorizationToken
+    ? new Headers({ Authorization: `Bearer ${authorizationToken}` })
+    : new Headers();
+
   const { useUploadThing } = generateReactHelpers<CoreFileRouter>();
 
   const { startUpload, isUploading } = useUploadThing('imageUploader', {

--- a/packages/core/src/assets/server/file-router.ts
+++ b/packages/core/src/assets/server/file-router.ts
@@ -14,6 +14,31 @@ const getAuthenticatedUser = async (req: NextRequest) => {
 };
 
 export const fileRouter: FileRouter = {
+  attachmentUploader: f({
+    pdf: {
+      maxFileSize: '4MB',
+      maxFileCount: 3,
+      contentDisposition: 'attachment',
+    },
+    image: {
+      maxFileSize: '4MB',
+      maxFileCount: 3,
+      contentDisposition: 'attachment',
+    },
+  })
+    .middleware(async ({ req }) => {
+      const isValidAuthToken = await getAuthenticatedUser(req);
+
+      if (!isValidAuthToken) {
+        throw new UploadThingError('Unauthorized');
+      }
+
+      return { isAuthenticated: true };
+    })
+    .onUploadError((error) => console.error('Attachment upload failed:', error))
+    .onUploadComplete(({ file }) =>
+      console.debug(`Attachment "${file.key}" was successfully uploaded`),
+    ),
   imageUploader: f({
     image: {
       maxFileSize: '4MB',

--- a/packages/core/src/governance/client/hooks/useAgreementFileUploads.ts
+++ b/packages/core/src/governance/client/hooks/useAgreementFileUploads.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import {
-  useFileUpload,
+  useImageUpload,
   schemaCreateAgreementFiles,
 } from '@hypha-platform/core/client';
 import React from 'react';
@@ -32,7 +32,7 @@ export const useAgreementFileUploads = (
     leadImage?: string;
     attachments?: string[];
   } | null>(null);
-  const { upload, isUploading } = useFileUpload({
+  const { upload, isUploading } = useImageUpload({
     headers: { Authorization: `Bearer ${authToken}` },
   });
 

--- a/packages/core/src/governance/client/hooks/useAgreementFileUploads.ts
+++ b/packages/core/src/governance/client/hooks/useAgreementFileUploads.ts
@@ -4,7 +4,6 @@ import {
   useImageUpload,
   useAttachmentUpload,
   schemaCreateAgreementFiles,
-  type UseFileUploadProps,
 } from '@hypha-platform/core/client';
 import React from 'react';
 import { z } from 'zod';
@@ -35,13 +34,11 @@ export const useAgreementFileUploads = (
     attachments?: string[];
   } | null>(null);
 
-  const uploadProps: UseFileUploadProps = {
-    headers: { Authorization: `Bearer ${authToken}` },
-  };
-  const { upload: uploadImage, isUploading: isUploadingImage } =
-    useImageUpload(uploadProps);
+  const { upload: uploadImage, isUploading: isUploadingImage } = useImageUpload(
+    { authorizationToken: authToken ?? undefined },
+  );
   const { upload: uploadAttachment, isUploading: isUploadingAttachment } =
-    useAttachmentUpload(uploadProps);
+    useAttachmentUpload({ authorizationToken: authToken ?? undefined });
 
   const handleUpload = React.useCallback(
     async (fileInput: Files, slug: string | null | undefined) => {

--- a/packages/core/src/governance/client/hooks/useAgreementFileUploads.ts
+++ b/packages/core/src/governance/client/hooks/useAgreementFileUploads.ts
@@ -2,7 +2,9 @@
 
 import {
   useImageUpload,
+  useAttachmentUpload,
   schemaCreateAgreementFiles,
+  type UseFileUploadProps,
 } from '@hypha-platform/core/client';
 import React from 'react';
 import { z } from 'zod';
@@ -32,9 +34,14 @@ export const useAgreementFileUploads = (
     leadImage?: string;
     attachments?: string[];
   } | null>(null);
-  const { upload, isUploading } = useImageUpload({
+
+  const uploadProps: UseFileUploadProps = {
     headers: { Authorization: `Bearer ${authToken}` },
-  });
+  };
+  const { upload: uploadImage, isUploading: isUploadingImage } =
+    useImageUpload(uploadProps);
+  const { upload: uploadAttachment, isUploading: isUploadingAttachment } =
+    useAttachmentUpload(uploadProps);
 
   const handleUpload = React.useCallback(
     async (fileInput: Files, slug: string | null | undefined) => {
@@ -49,12 +56,12 @@ export const useAgreementFileUploads = (
 
           try {
             if (key === 'leadImage' && fileOrFiles instanceof File) {
-              const result = await upload([fileOrFiles]);
+              const result = await uploadImage([fileOrFiles]);
               if (result?.[0]?.ufsUrl) {
                 uploadedFiles.leadImage = result[0].ufsUrl;
               }
             } else if (key === 'attachments' && Array.isArray(fileOrFiles)) {
-              const result = await upload(fileOrFiles);
+              const result = await uploadAttachment(fileOrFiles);
               if (result?.every((item) => item.ufsUrl)) {
                 uploadedFiles.attachments = result.map((item) => item.ufsUrl);
               }
@@ -70,11 +77,11 @@ export const useAgreementFileUploads = (
       setFiles(uploadedFiles);
       onSuccess?.(uploadedFiles, slug);
     },
-    [upload, onSuccess],
+    [uploadImage, uploadAttachment, onSuccess],
   );
 
   return {
-    isLoading: isUploading,
+    isLoading: isUploadingImage || isUploadingAttachment,
     files,
     upload: handleUpload,
   };

--- a/packages/core/src/governance/client/hooks/useTokenFileUploads.ts
+++ b/packages/core/src/governance/client/hooks/useTokenFileUploads.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useFileUpload } from '@hypha-platform/core/client';
+import { useImageUpload } from '@hypha-platform/core/client';
 import React from 'react';
 import { z } from 'zod';
 
@@ -33,7 +33,7 @@ export const useTokenFileUploads = (
   authToken?: string | null,
 ): UseTokenFileUploadsReturn => {
   const [file, setFile] = React.useState<{ iconUrl?: string } | null>(null);
-  const { upload, isUploading } = useFileUpload({
+  const { upload, isUploading } = useImageUpload({
     headers: { Authorization: `Bearer ${authToken}` },
   });
 

--- a/packages/core/src/governance/client/hooks/useTokenFileUploads.ts
+++ b/packages/core/src/governance/client/hooks/useTokenFileUploads.ts
@@ -34,7 +34,7 @@ export const useTokenFileUploads = (
 ): UseTokenFileUploadsReturn => {
   const [file, setFile] = React.useState<{ iconUrl?: string } | null>(null);
   const { upload, isUploading } = useImageUpload({
-    headers: { Authorization: `Bearer ${authToken}` },
+    authorizationToken: authToken ?? undefined,
   });
 
   const handleUpload = React.useCallback(

--- a/packages/core/src/people/client/hooks/usePersonFileUploads.ts
+++ b/packages/core/src/people/client/hooks/usePersonFileUploads.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useFileUpload, editPersonFiles } from '@hypha-platform/core/client';
+import { useImageUpload, editPersonFiles } from '@hypha-platform/core/client';
 import React from 'react';
 import { z } from 'zod';
 
@@ -22,7 +22,7 @@ export const usePersonFileUploads = (
   const [files, setFiles] = React.useState<{ [K in keyof Files]: string }>(
     {} as { [K in keyof Files]: string },
   );
-  const { upload, isUploading } = useFileUpload({
+  const { upload, isUploading } = useImageUpload({
     headers: { Authorization: `Bearer ${authToken}` },
   });
 

--- a/packages/core/src/people/client/hooks/usePersonFileUploads.ts
+++ b/packages/core/src/people/client/hooks/usePersonFileUploads.ts
@@ -23,7 +23,7 @@ export const usePersonFileUploads = (
     {} as { [K in keyof Files]: string },
   );
   const { upload, isUploading } = useImageUpload({
-    headers: { Authorization: `Bearer ${authToken}` },
+    authorizationToken: authToken ?? undefined,
   });
 
   const handleUpload = React.useCallback(

--- a/packages/core/src/space/client/hooks/useSpaceFileUploads.ts
+++ b/packages/core/src/space/client/hooks/useSpaceFileUploads.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useFileUpload } from '@hypha-platform/core/client';
+import { useImageUpload } from '@hypha-platform/core/client';
 import { schemaCreateSpaceFiles } from '@hypha-platform/core/client';
 import React from 'react';
 import { z } from 'zod';
@@ -26,7 +26,7 @@ export const useSpaceFileUploads = (
     { [K in keyof Files]?: string } | null
   >(null);
   const [error, setError] = React.useState<string | null>(null);
-  const { upload, isUploading } = useFileUpload({
+  const { upload, isUploading } = useImageUpload({
     headers: { Authorization: `Bearer ${authToken}` },
   });
 

--- a/packages/core/src/space/client/hooks/useSpaceFileUploads.ts
+++ b/packages/core/src/space/client/hooks/useSpaceFileUploads.ts
@@ -27,7 +27,7 @@ export const useSpaceFileUploads = (
   >(null);
   const [error, setError] = React.useState<string | null>(null);
   const { upload, isUploading } = useImageUpload({
-    headers: { Authorization: `Bearer ${authToken}` },
+    authorizationToken: authToken ?? undefined,
   });
 
   const handleUpload = React.useCallback(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added support for uploading attachments (PDFs and images), up to 3 files and 4MB each; attachment uploads require authentication and include clearer logging for failures and completion.

- Refactor
  - Split upload flows into dedicated image and attachment paths; upload indicators now reflect image or attachment activity across the app.
  - Upload hooks now accept a token-based authorization option; public APIs and call sites remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->