### PR TITLE
Updating default number of treasury rows

### DIFF
--- a/packages/epics/src/treasury/hooks/use-assets-section.ts
+++ b/packages/epics/src/treasury/hooks/use-assets-section.ts
@@ -12,7 +12,7 @@ export interface UseAssetsSectionProps {
 }
 
 export const useAssetsSection = ({
-  pageSize = 3,
+  pageSize = 9,
   filterOptions = FILTER_OPTIONS_ASSETS,
 }: UseAssetsSectionProps = {}) => {
   const [activeFilter, setActiveFilter] = React.useState('all');

--- a/packages/epics/src/treasury/hooks/use-assets-section.ts
+++ b/packages/epics/src/treasury/hooks/use-assets-section.ts
@@ -3,24 +3,32 @@ import { useAssets } from './use-assets';
 import { FILTER_OPTIONS_ASSETS } from '../../common/constants';
 import { formatCurrencyValue } from '@hypha-platform/ui-utils';
 
-const filterOptions = FILTER_OPTIONS_ASSETS;
-const PAGE_SIZE = 3;
+export interface UseAssetsSectionProps {
+  pageSize?: number;
+  filterOptions?: {
+    label: string;
+    value: string;
+  }[];
+}
 
-export const useAssetsSection = () => {
+export const useAssetsSection = ({
+  pageSize = 3,
+  filterOptions = FILTER_OPTIONS_ASSETS,
+}: UseAssetsSectionProps = {}) => {
   const [activeFilter, setActiveFilter] = React.useState('all');
-  const [visibleCount, setVisibleCount] = React.useState(PAGE_SIZE);
+  const [visibleCount, setVisibleCount] = React.useState(pageSize);
 
   const { isLoading, balance, assets } = useAssets({
     ...(activeFilter !== 'all' && { filter: { type: activeFilter } }),
   });
 
   React.useEffect(() => {
-    setVisibleCount(PAGE_SIZE);
-  }, [activeFilter, assets]);
+    setVisibleCount(pageSize);
+  }, [activeFilter, assets.length, pageSize]);
 
   const loadMore = React.useCallback(() => {
-    setVisibleCount((prev) => prev + PAGE_SIZE);
-  }, []);
+    setVisibleCount((prev) => prev + pageSize);
+  }, [pageSize]);
 
   const totalBalance = `$ ${formatCurrencyValue(balance)}`;
   const visibleAssets = assets.slice(0, visibleCount);

--- a/packages/epics/src/treasury/hooks/use-user-assets-section.ts
+++ b/packages/epics/src/treasury/hooks/use-user-assets-section.ts
@@ -16,7 +16,7 @@ export interface UseUserAssetsSectionProps {
 
 export const useUserAssetsSection = ({
   personSlug,
-  pageSize = 3,
+  pageSize = 9,
   filterOptions = FILTER_OPTIONS_ASSETS,
 }: UseUserAssetsSectionProps = {}) => {
   const [activeFilter, setActiveFilter] = React.useState('all');

--- a/packages/epics/src/treasury/hooks/use-user-assets-section.ts
+++ b/packages/epics/src/treasury/hooks/use-user-assets-section.ts
@@ -5,13 +5,22 @@ import { formatCurrencyValue } from '@hypha-platform/ui-utils';
 import { FILTER_OPTIONS_ASSETS } from '../../common/constants';
 import { useUserAssets } from './use-user-assets';
 
+export interface UseUserAssetsSectionProps {
+  personSlug?: string;
+  pageSize?: number;
+  filterOptions?: {
+    label: string;
+    value: string;
+  }[];
+}
+
 export const useUserAssetsSection = ({
   personSlug,
-}: {
-  personSlug?: string;
-}) => {
+  pageSize = 3,
+  filterOptions = FILTER_OPTIONS_ASSETS,
+}: UseUserAssetsSectionProps = {}) => {
   const [activeFilter, setActiveFilter] = React.useState('all');
-  const [visibleCount, setVisibleCount] = React.useState(3);
+  const [visibleCount, setVisibleCount] = React.useState(pageSize);
 
   const { isLoading, balance, assets } = useUserAssets({
     ...(activeFilter !== 'all' && { filter: { type: activeFilter } }),
@@ -19,12 +28,12 @@ export const useUserAssetsSection = ({
   });
 
   React.useEffect(() => {
-    setVisibleCount(3);
-  }, [activeFilter, assets]);
+    setVisibleCount(pageSize);
+  }, [activeFilter, assets.length, pageSize]);
 
   const loadMore = React.useCallback(() => {
-    setVisibleCount((prev) => prev + 3);
-  }, []);
+    setVisibleCount((prev) => prev + pageSize);
+  }, [pageSize]);
 
   const totalBalance = `$ ${formatCurrencyValue(balance)}`;
   const visibleAssets = assets.slice(0, visibleCount);
@@ -37,7 +46,7 @@ export const useUserAssetsSection = ({
     hasMore,
     activeFilter,
     setActiveFilter,
-    filterOptions: FILTER_OPTIONS_ASSETS,
+    filterOptions,
     totalBalance,
   };
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Assets and user-assets sections now accept configurable pageSize and custom filter options.
  * "Load more" increments by the configured page size and a hasMore flag indicates lazy-load availability; filter options are returned from props.

* **Refactor**
  * Sections are data-driven via props, controlling initial visible items and filtering for improved lazy-loading and adaptability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->