### PR TITLE
Notifications about proposal creation for creators

### DIFF
--- a/apps/web/src/app/api/webhooks/proposal/created/route.ts
+++ b/apps/web/src/app/api/webhooks/proposal/created/route.ts
@@ -1,5 +1,18 @@
-import { Alchemy } from '@hypha-platform/core/server';
+import {
+  Alchemy,
+  findPersonByWeb3Address,
+  findSpaceByWeb3Id,
+} from '@hypha-platform/core/server';
 import { daoProposalsImplementationAbi } from '@hypha-platform/core/generated';
+import { db } from '@hypha-platform/storage-postgres';
+import {
+  sendEmailByAlias,
+  sendPushByAlias,
+} from '@hypha-platform/notifications/server';
+import {
+  emailProposalCreationForCreator,
+  pushProposalCreationForCreator,
+} from '@hypha-platform/notifications/template';
 
 export const POST = Alchemy.newHandler(
   {
@@ -12,5 +25,81 @@ export const POST = Alchemy.newHandler(
     abi: daoProposalsImplementationAbi,
     event: 'ProposalCreated',
   },
-  async () => {},
+  async (events) => {
+    const eventsData = events.map(({ args }) => ({
+      spaceWeb3Id: args.spaceId,
+      creatorWeb3Address: args.creator,
+      proposalWeb3Id: args.proposalId,
+    }));
+
+    const fetchingDbData = eventsData.map(
+      async ({ spaceWeb3Id, creatorWeb3Address, proposalWeb3Id }) => {
+        const person = findPersonByWeb3Address(
+          { address: creatorWeb3Address },
+          { db },
+        );
+        const space = findSpaceByWeb3Id({ id: Number(spaceWeb3Id) }, { db });
+
+        return { proposalWeb3Id, person: await person, space: await space };
+      },
+    );
+    const resultFetchingDbData = await Promise.allSettled(fetchingDbData);
+    resultFetchingDbData
+      .filter((failure) => failure.status === 'rejected')
+      .forEach(({ reason }) =>
+        console.error('Failed to fetch person and space from DB:', reason),
+      );
+
+    const dbData = resultFetchingDbData
+      .filter((res) => res.status === 'fulfilled')
+      .map(({ value }) => value);
+    if (dbData.length === 0) {
+      console.warn(
+        'Zero creators and spaces found in the DB for the "ProposalCreation" event.',
+        'Proposal IDs:',
+        events.map(({ args }) => args.proposalId),
+      );
+
+      return;
+    }
+
+    const notificationParams = dbData.map((data) => ({
+      proposalCreatorSlug: data.person?.slug,
+      creatorName: data.person?.name,
+      spaceTitle: data.space?.title,
+      spaceSlug: data.space?.slug,
+    }));
+    const sendingEmails = notificationParams.map(async (params) => {
+      const { body, subject } = emailProposalCreationForCreator(params);
+
+      return await sendEmailByAlias({
+        app_id: process.env.NEXT_PUBLIC_ONESIGNAL_APP_ID ?? '',
+        alias: {
+          include_aliases: { external_id: [params.proposalCreatorSlug!] },
+        },
+        content: { email_body: body, email_subject: subject },
+      });
+    });
+    const sendingPushes = notificationParams.map(async (params) => {
+      const { contents, headings } = pushProposalCreationForCreator(params);
+
+      return await sendPushByAlias({
+        app_id: process.env.NEXT_PUBLIC_ONESIGNAL_APP_ID ?? '',
+        alias: {
+          include_aliases: { external_id: [params.proposalCreatorSlug!] },
+        },
+        content: { contents, headings },
+      });
+    });
+
+    const notifying = Promise.allSettled(sendingEmails.concat(sendingPushes));
+    (await notifying)
+      .filter((res) => res.status === 'rejected')
+      .forEach(({ reason }) =>
+        console.error(
+          'Failed to notify creators about proposal creation:',
+          reason,
+        ),
+      );
+  },
 );

--- a/apps/web/src/app/api/webhooks/proposal/created/route.ts
+++ b/apps/web/src/app/api/webhooks/proposal/created/route.ts
@@ -3,7 +3,12 @@ import { daoProposalsImplementationAbi } from '@hypha-platform/core/generated';
 
 export const POST = Alchemy.newHandler(
   {
-    signingKey: process.env.WH_PROPOSAL_CREATED_SIGN_KEY ?? '',
+    signingKey: (() => {
+      const key = process.env.WH_PROPOSAL_CREATED_SIGN_KEY;
+      if (!key) throw new Error('Missing key for proposal creation webhook');
+
+      return key;
+    })(),
     abi: daoProposalsImplementationAbi,
     event: 'ProposalCreated',
   },

--- a/packages/notifications/src/template/common/types.ts
+++ b/packages/notifications/src/template/common/types.ts
@@ -5,3 +5,12 @@ export interface ProposalSettlementProps {
   proposalTitle?: string;
   spaceTitle?: string;
 }
+
+export interface ProposalCreationProps {
+  creatorName?: string;
+  proposalLabel?: string;
+  proposalState?: string;
+  proposalTitle?: string;
+  spaceTitle?: string;
+  spaceSlug?: string;
+}

--- a/packages/notifications/src/template/email/index.ts
+++ b/packages/notifications/src/template/email/index.ts
@@ -1,4 +1,5 @@
 export * from './proposal-execution-for-creator';
 export * from './proposal-rejection-for-creator';
+export * from './proposal-creation-for-creator';
 
 export type * from './types';

--- a/packages/notifications/src/template/email/proposal-creation-for-creator.ts
+++ b/packages/notifications/src/template/email/proposal-creation-for-creator.ts
@@ -1,0 +1,30 @@
+import type { Email } from './types';
+import type { ProposalCreationProps } from '../common';
+
+export function emailProposalCreationForCreator({
+  creatorName,
+  proposalLabel,
+  proposalState = 'proposal',
+  proposalTitle,
+  spaceTitle,
+}: ProposalCreationProps): Email {
+  const beginning = creatorName
+    ? `Dear ${creatorName}, great news,`
+    : 'Great news,';
+  const space = spaceTitle ? `the space "${spaceTitle}"` : 'a space';
+  const proposal = proposalTitle ? `"${proposalTitle}"` : proposalState;
+
+  switch (proposalLabel) {
+    case 'Invite':
+      return {
+        subject: 'Your invite to join a space has been created',
+        body: `${beginning} your invite to join ${space} has been created.`,
+      };
+
+    default:
+      return {
+        subject: `Your ${proposalState} has been created`,
+        body: `${beginning} your ${proposal} has been created in ${space}.`,
+      };
+  }
+}

--- a/packages/notifications/src/template/push/index.ts
+++ b/packages/notifications/src/template/push/index.ts
@@ -1,5 +1,6 @@
 export * from './proposal-execution-for-creator';
 export * from './proposal-rejection-for-creator';
 export * from './space-creation-for-creator';
+export * from './proposal-creation-for-creator';
 
 export * from './types';

--- a/packages/notifications/src/template/push/proposal-creation-for-creator.ts
+++ b/packages/notifications/src/template/push/proposal-creation-for-creator.ts
@@ -1,0 +1,26 @@
+import type { Push } from './types';
+import type { ProposalCreationProps } from '../common';
+
+export function pushProposalCreationForCreator({
+  proposalState = 'proposal',
+  proposalLabel,
+  proposalTitle,
+  spaceTitle,
+}: ProposalCreationProps): Push {
+  const space = spaceTitle ? `the space "${spaceTitle}"` : 'a space';
+  const proposal = proposalTitle ? `"${proposalTitle}"` : proposalState;
+
+  switch (proposalLabel) {
+    case 'Invite':
+      return {
+        headings: { en: 'You successfully created a join request' },
+        contents: { en: `Your request to join ${space} was created.` },
+      };
+
+    default:
+      return {
+        headings: { en: `You successfully created a ${proposalState}` },
+        contents: { en: `Your ${proposal} was created in ${space}.` },
+      };
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Proposal creation now triggers creator notifications via new email and push templates with personalized content and invite-specific wording.
  * Added a typed payload shape for proposal notification templates.

* **Improvements**
  * Webhook processing now validates configuration more strictly, performs lookups to enrich notifications, and handles partial failures with aggregated logging to improve reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->