### PR TITLE
feat(#1066): sales banner ui improvements

### DIFF
--- a/packages/epics/src/spaces/components/subscription-badge.tsx
+++ b/packages/epics/src/spaces/components/subscription-badge.tsx
@@ -60,8 +60,13 @@ export function SubscriptionBadge({
     });
   };
 
-  let status: 'active' | 'activeFreeTrial' | 'activate' | 'expired' | null =
-    null;
+  let status:
+    | 'active'
+    | 'activeFreeTrial'
+    | 'activate'
+    | 'expired'
+    | 'activeFreeTrialExpiring'
+    | null = null;
   let label: string = '';
 
   if (isLoading || !payments) {
@@ -69,11 +74,11 @@ export function SubscriptionBadge({
   }
 
   if (!hasSpacePaid && freeTrialUsed && daysLeft > 0) {
-    status = 'activeFreeTrial';
+    status = daysLeft <= 14 ? 'activeFreeTrialExpiring' : 'activeFreeTrial';
     label = `Active on free trial until ${formatDate(expiryTime)}`;
   } else if (hasSpacePaid && daysLeft > 0 && daysLeft <= 14) {
     status = 'activate';
-    label = `Activate before ${formatDate(expiryTime)}`;
+    label = `Renew before ${formatDate(expiryTime)}`;
   } else if (hasSpacePaid && daysLeft > 0) {
     status = 'active';
     label = `Active until ${formatDate(expiryTime)}`;
@@ -92,6 +97,7 @@ export function SubscriptionBadge({
   > = {
     active: { colorVariant: 'success' },
     activeFreeTrial: { colorVariant: 'success' },
+    activeFreeTrialExpiring: { colorVariant: 'warn' },
     activate: { colorVariant: 'warn' },
     expired: { colorVariant: 'error' },
   };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Subscription badges now show an “expiring” state for free trials with 14 days or less remaining, using a warning color.
  * Badges display “Expired since …” when a subscription has lapsed.
  * Labels updated for paid spaces nearing renewal (≤14 days): “Renew before …” replaces “Activate before …”.
  * Improved lifecycle clarity with distinct states for active, expiring, and expired, enhancing visibility and urgency cues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->