### PR TITLE
fix(#1591): submitting a repeat invite now depends on the time of submitting the previous one

### DIFF
--- a/packages/epics/src/spaces/components/join-space.tsx
+++ b/packages/epics/src/spaces/components/join-space.tsx
@@ -58,7 +58,7 @@ export const JoinSpace = ({ spaceId, web3SpaceId }: JoinSpaceProps) => {
     memberAddress: person?.address as `0x${string}`,
   });
 
-  const { hasActiveProposal, revalidateInviteStatus, isInviteLoading } =
+  const { revalidateInviteStatus, isInviteLoading, lastInviteTime } =
     useInviteStatus({
       spaceId: BigInt(web3SpaceId),
       address: person?.address as `0x${string}`,
@@ -138,18 +138,25 @@ export const JoinSpace = ({ spaceId, web3SpaceId }: JoinSpaceProps) => {
     revalidateInviteStatus,
   ]);
 
+  const FORTY_EIGHT_HOURS_MS = 48 * 60 * 60 * 1000;
+
+  const isInvitePending = useMemo(() => {
+    if (!isInviteOnly) return false;
+    if (inviteRequested) return true;
+    if (!lastInviteTime) return false;
+    return Date.now() - lastInviteTime < FORTY_EIGHT_HOURS_MS;
+  }, [isInviteOnly, inviteRequested, lastInviteTime]);
+
   const buttonTitle = useMemo(() => {
     if (isMember || justJoined) return 'Already member';
     if (isInviteOnly) {
-      if (hasActiveProposal || inviteRequested) return 'Invite pending';
+      if (isInvitePending) return 'Invite pending';
       return 'Request Invite';
     }
     return 'Become member';
-  }, [isMember, justJoined, isInviteOnly, hasActiveProposal, inviteRequested]);
+  }, [isMember, justJoined, isInviteOnly, isInvitePending]);
 
   const showLoader = isProcessing || isJoiningSpace || isCreating;
-  const isInvitePending =
-    isInviteOnly && (hasActiveProposal || inviteRequested);
   const isButtonDisabled =
     isMember ||
     justJoined ||


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Invite-only spaces now keep invites “pending” for 48 hours; the Join button reflects this state clearly.

* **Bug Fixes**
  * More accurate invite status and button titles for invite-only spaces.
  * Smoother experience with fewer unnecessary loading states.

* **Refactor**
  * Simplified internal logic for determining pending invites without changing public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->