### PR TITLE
fix(#1612): added token name comparison

### DIFF
--- a/packages/core/src/common/server/web3-rpc/get-token-meta.ts
+++ b/packages/core/src/common/server/web3-rpc/get-token-meta.ts
@@ -71,7 +71,7 @@ export async function getTokenMeta(
     const name = nameResult || 'MISSING NAME';
 
     const dbToken = dbTokens?.find(
-      (t) => t.symbol.toUpperCase() === symbol.toUpperCase(),
+      (t) => t.symbol.toUpperCase() === symbol.toUpperCase() && t.name === name,
     );
     const icon = dbToken?.iconUrl ?? '/placeholder/token-icon.svg';
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token metadata accuracy by tightening matching criteria: when available, both token symbol and name must align. This reduces mismatches from tokens sharing the same symbol.
  * Users should see more reliable token details across the app (names, icons, decimals), with fewer incorrect or ambiguous results in balances, transactions, and portfolios.
  * Enhances consistency of token resolution across networks, minimizing edge-case errors and unexpected token substitutions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->