### PR TITLE
Feat/1564 Hide email address from the profile for others

### DIFF
--- a/packages/epics/src/people/components/person-head.tsx
+++ b/packages/epics/src/people/components/person-head.tsx
@@ -137,7 +137,7 @@ export const PersonHead = ({
           <div className="flex flex-col gap-4">
             <WebLinks links={links} />
             <div className="flex gap-5 text-1">
-              {email ? (
+              {email && isMe(personSlug as string) ? (
                 <span className="flex gap-3">
                   <MailIcon width={16} height={16} />
                   {email}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved profile privacy: email addresses are now shown only when you view your own profile. Emails are hidden on other users’ profiles to match access controls and expected behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->