### PR TITLE
fix: fixed asset-card ui

### DIFF
--- a/packages/epics/src/treasury/components/assets/asset-card.tsx
+++ b/packages/epics/src/treasury/components/assets/asset-card.tsx
@@ -46,7 +46,7 @@ export const AssetCard: React.FC<AssetCardProps> = ({
             className="rounded-full"
           >
             <Image
-              className="rounded-full w-7 h-7"
+              className="rounded-full min-w-7 min-h-7"
               src={icon ? icon : ''}
               height={32}
               width={32}
@@ -82,7 +82,7 @@ export const AssetCard: React.FC<AssetCardProps> = ({
               {space?.title ? (
                 <Link
                   href={getDhoPathAgreements(lang as Locale, space.slug)}
-                  className="text-accent-11 text-1 text-ellipsis overflow-hidden text-nowrap hover:underline"
+                  className="text-accent-11 text-1 text-ellipsis overflow-hidden hover:underline"
                 >
                   from {space.title}
                 </Link>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Polished asset card visuals: asset icons now use minimum width/height to render more consistently across screen sizes and pixel densities.
  * Refined link text styling in asset cards: retains ellipsis truncation and hover underline while removing forced no-wrap, improving readability on narrow layouts.
  * No functional, API, or navigation changes—visual-only adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->