### PR TITLE
feat(#1636): added person data in contribution proposal

### DIFF
--- a/packages/epics/src/governance/components/proposal-transaction-item.tsx
+++ b/packages/epics/src/governance/components/proposal-transaction-item.tsx
@@ -21,6 +21,8 @@ export const ProposalTransactionItem = ({
   tokenAddress,
   spaceSlug,
 }: ProposalTransactionItemProps) => {
+  if (!recipient) return null;
+  const { person } = usePersonByWeb3Address(recipient as `0x${string}`);
   const { tokens } = useTokens({ spaceSlug });
   const token = tokens.find(
     (t: Token) => t.address.toLowerCase() === tokenAddress?.toLowerCase(),
@@ -39,8 +41,6 @@ export const ProposalTransactionItem = ({
 
   const parsedAmount = Number(amount) / 10 ** decimals;
   const formattedAmount = parsedAmount.toFixed(decimals);
-
-  const { person } = usePersonByWeb3Address(recipient as `0x${string}`);
 
   return (
     <div className="w-full flex items-center justify-between gap-4">
@@ -68,7 +68,7 @@ export const ProposalTransactionItem = ({
               height={24}
               alt={`${person?.nickname} avatar`}
             />
-            <span>
+            <span className="text-nowrap">
               {person?.name} {person?.surname}
             </span>
           </span>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Proposal transaction items now show a compact, right-aligned person profile (avatar, given name and surname) when a matching user is found, improving recognizability.
  * If no profile is available, the item falls back to displaying the wallet address as before. No other behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->