### PR TITLE
Resolving inappropriate imports

### DIFF
--- a/packages/core/src/categories/types.ts
+++ b/packages/core/src/categories/types.ts
@@ -1,3 +1,6 @@
+/**
+ * @todo fix duplication. Origin at `packages/storage-postgres/src/schema/categories.ts`
+ */
 export const CATEGORIES = [
   // outdated
   'art',
@@ -43,5 +46,8 @@ export const SPACE_ORDERS = [
 ] as const;
 export type SpaceOrder = (typeof SPACE_ORDERS)[number];
 
+/**
+ * @todo fix duplication. Origin at `packages/storage-postgres/src/schema/flags.ts`
+ */
 export const SPACE_FLAGS = ['sandbox', 'demo'] as const;
 export type SpaceFlags = (typeof SPACE_FLAGS)[number];

--- a/packages/storage-postgres/src/schema/categories.ts
+++ b/packages/storage-postgres/src/schema/categories.ts
@@ -1,4 +1,39 @@
 import { pgEnum } from 'drizzle-orm/pg-core';
-import { CATEGORIES } from '../../../core/src/categories';
 
+export const CATEGORIES = [
+  // outdated
+  'art',
+  'events',
+  // actual
+  'arts',
+  'biodiversity',
+  'bioregions',
+  'cities',
+  'culture',
+  'education',
+  'emergency',
+  'energy',
+  'finance',
+  'food',
+  'gaming',
+  'governance',
+  'health',
+  'housing',
+  'innovation',
+  'knowledge',
+  'land',
+  'media',
+  'mobility',
+  'networks',
+  'ocean',
+  'distribution',
+  'goods',
+  'services',
+  'sport',
+  'tech',
+  'tourism',
+  'villages',
+  'water',
+  'wellbeing',
+] as const;
 export const categories = pgEnum('categories', CATEGORIES);

--- a/packages/storage-postgres/src/schema/flags.ts
+++ b/packages/storage-postgres/src/schema/flags.ts
@@ -1,4 +1,4 @@
 import { pgEnum } from 'drizzle-orm/pg-core';
-import { SPACE_FLAGS } from '../../../core/src/categories';
 
+export const SPACE_FLAGS = ['sandbox', 'demo'] as const;
 export const spaceFlags = pgEnum('space_flags', SPACE_FLAGS);

--- a/packages/storage-postgres/src/schema/index.ts
+++ b/packages/storage-postgres/src/schema/index.ts
@@ -8,6 +8,9 @@ import { peopleRelations } from './people.relations';
 import { documentRelation } from './document.relations';
 import { tokenRelations, tokens } from './tokens';
 
+export { SPACE_FLAGS } from './flags';
+export { CATEGORIES } from './categories';
+
 export * from './document';
 export * from './membership';
 export * from './people';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal category and environment-flag definitions were localized within the storage layer to reduce cross-module coupling; behavior is unchanged.
* **Chores**
  * Those lists are now surfaced by the storage schema as part of its public interface, slightly expanding the exposed configuration surface without altering functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->