### PR TITLE
Fix/1731 Buttons do not show when I'm only a delegate in the space

### DIFF
--- a/packages/epics/src/governance/components/vote-proposal-button.tsx
+++ b/packages/epics/src/governance/components/vote-proposal-button.tsx
@@ -84,6 +84,6 @@ export const VoteProposalButton = ({
           </Button>
         );
     }
-  }, [proposalStatus, myVote, proposalDetails, isMember]);
+  }, [proposalStatus, myVote, proposalDetails, isMember, isDelegate]);
   return output;
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Delegates in governance spaces can now vote on proposals alongside members. Voting controls, buttons and proposal availability will reflect delegate status so eligible delegates see and can interact with voting options where applicable, ensuring delegates are presented with the same voting experience and access as members where permissions allow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->