### PR TITLE
Feat/1791 Remove link to constitution

### DIFF
--- a/packages/ui/src/organisms/footer.tsx
+++ b/packages/ui/src/organisms/footer.tsx
@@ -39,7 +39,9 @@ export const Footer = () => {
                 Hypha Services
               </Link>
             </Button>
-            <Button
+            {/* NOTE: Turned off until a new constitution is provided,
+                      which is still in development. */}
+            {/* <Button
               asChild
               variant="ghost"
               className="rounded-lg justify-start text-gray-400 px-0"
@@ -52,7 +54,7 @@ export const Footer = () => {
               >
                 Hypha Constitution
               </Link>
-            </Button>
+            </Button> */}
             <Button
               asChild
               variant="ghost"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled the Hypha Constitution link in the footer's Network section. The link is no longer accessible to users, while other network links remain available.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->