### PR TITLE
fix: Thread bar shows correct origin (Network, Profile, My Spaces)

### DIFF
--- a/apps/web/src/app/[lang]/dho/[id]/_components/breadcrumb-space-item.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/breadcrumb-space-item.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { SpaceBreadcrumbItem } from '@hypha-platform/epics';
+import { useBreadcrumbFrom } from './breadcrumbs-root-selector';
+
+export function BreadcrumbSpaceItem({
+  breadcrumb,
+  lang,
+}: {
+  breadcrumb: { slug: string; title: string };
+  lang: string;
+}) {
+  const fromQuery = useBreadcrumbFrom();
+  return (
+    <SpaceBreadcrumbItem
+      breadcrumb={breadcrumb}
+      lang={lang}
+      fromQuery={fromQuery}
+    />
+  );
+}

--- a/apps/web/src/app/[lang]/dho/[id]/_components/breadcrumbs-root-selector.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/breadcrumbs-root-selector.tsx
@@ -1,0 +1,165 @@
+'use client';
+
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+} from '@hypha-platform/ui';
+import { useSearchParams, useParams } from 'next/navigation';
+import { useTranslations } from 'next-intl';
+import { createContext, useContext, useEffect, useMemo } from 'react';
+
+const BREADCRUMB_ORIGIN_COOKIE = 'breadcrumb_origin';
+const COOKIE_MAX_AGE_DAYS = 1;
+
+type BreadcrumbOrigin = 'network' | 'profile' | 'my-spaces';
+
+function getBreadcrumbOriginFromCookie(): {
+  from: BreadcrumbOrigin;
+  profileSlug?: string;
+} | null {
+  if (typeof document === 'undefined') return null;
+  const match = document.cookie.match(
+    new RegExp(`(?:^|; )${BREADCRUMB_ORIGIN_COOKIE}=([^;]*)`),
+  );
+  if (!match?.[1]) return null;
+  try {
+    return JSON.parse(decodeURIComponent(match[1])) as {
+      from: BreadcrumbOrigin;
+      profileSlug?: string;
+    };
+  } catch {
+    return null;
+  }
+}
+
+function setBreadcrumbOriginCookie(from: BreadcrumbOrigin, profileSlug?: string) {
+  if (typeof document === 'undefined') return;
+  const value = JSON.stringify(
+    profileSlug ? { from, profileSlug } : { from },
+  );
+  document.cookie = `${BREADCRUMB_ORIGIN_COOKIE}=${encodeURIComponent(value)}; path=/; max-age=${60 * 60 * 24 * COOKIE_MAX_AGE_DAYS}; SameSite=Lax`;
+}
+
+function getFromQuery(from: BreadcrumbOrigin, profileSlug?: string): string {
+  if (from === 'profile' && profileSlug) {
+    return `from=profile&profileSlug=${encodeURIComponent(profileSlug)}`;
+  }
+  return `from=${from}`;
+}
+
+const BreadcrumbFromContext = createContext<string | undefined>(undefined);
+
+export function useBreadcrumbFrom() {
+  return useContext(BreadcrumbFromContext);
+}
+
+/** Returns the from query string for preserving breadcrumb origin in links */
+export function useBreadcrumbFromQuery(): string | undefined {
+  const searchParams = useSearchParams();
+  const from = searchParams.get('from') as BreadcrumbOrigin | null;
+  const profileSlug = searchParams.get('profileSlug');
+
+  return useMemo(() => {
+    let resolvedFrom = from;
+    let resolvedProfileSlug = profileSlug;
+
+    if (!resolvedFrom) {
+      const cookie = getBreadcrumbOriginFromCookie();
+      if (cookie) {
+        resolvedFrom = cookie.from;
+        resolvedProfileSlug = cookie.profileSlug ?? null;
+      } else {
+        return undefined;
+      }
+    }
+
+    return getFromQuery(
+      resolvedFrom,
+      resolvedProfileSlug ?? undefined,
+    );
+  }, [from, profileSlug]);
+}
+
+export function BreadcrumbsRootSelector({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const searchParams = useSearchParams();
+  const params = useParams<{ lang: string }>();
+  const lang = params?.lang ?? 'en';
+  const tNavigation = useTranslations('Navigation');
+
+  const from = searchParams.get('from') as BreadcrumbOrigin | null;
+  const profileSlug = searchParams.get('profileSlug');
+
+  const { rootHref, rootLabel, fromQuery } = useMemo(() => {
+    let resolvedFrom = from;
+    let resolvedProfileSlug = profileSlug;
+
+    if (!resolvedFrom) {
+      const cookie = getBreadcrumbOriginFromCookie();
+      if (cookie) {
+        resolvedFrom = cookie.from;
+        resolvedProfileSlug = cookie.profileSlug ?? null;
+      } else {
+        resolvedFrom = 'my-spaces';
+      }
+    } else {
+      setBreadcrumbOriginCookie(
+        resolvedFrom,
+        resolvedProfileSlug ?? undefined,
+      );
+    }
+
+    let href: string;
+    let label: string;
+
+    switch (resolvedFrom) {
+      case 'network':
+        href = `/${lang}/network`;
+        label = tNavigation('network');
+        break;
+      case 'profile':
+        href = resolvedProfileSlug
+          ? `/${lang}/profile/${resolvedProfileSlug}`
+          : `/${lang}/profile`;
+        label = tNavigation('profile');
+        break;
+      case 'my-spaces':
+      default:
+        href = `/${lang}/my-spaces`;
+        label = tNavigation('mySpaces');
+        break;
+    }
+
+    const query = getFromQuery(resolvedFrom, resolvedProfileSlug ?? undefined);
+
+    return { rootHref: href, rootLabel: label, fromQuery: query };
+  }, [from, profileSlug, lang, tNavigation]);
+
+  useEffect(() => {
+    if (from) {
+      setBreadcrumbOriginCookie(from, profileSlug ?? undefined);
+    }
+  }, [from, profileSlug]);
+
+  const contextValue = useMemo(() => fromQuery, [fromQuery]);
+
+  return (
+    <BreadcrumbFromContext.Provider value={contextValue}>
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink href={rootHref} className="flex items-center">
+              {rootLabel}
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+          {children}
+        </BreadcrumbList>
+      </Breadcrumb>
+    </BreadcrumbFromContext.Provider>
+  );
+}

--- a/apps/web/src/app/[lang]/dho/[id]/_components/breadcrumbs.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/breadcrumbs.tsx
@@ -1,9 +1,9 @@
 import { findParentSpaceById } from '@hypha-platform/core/server';
-import { SpaceBreadcrumb, SpaceBreadcrumbItem } from '@hypha-platform/epics';
 import { db } from '@hypha-platform/storage-postgres';
 import { Locale } from '@hypha-platform/i18n';
-import { getTranslations } from 'next-intl/server';
 import { Fragment } from 'react';
+import { BreadcrumbsRootSelector } from './breadcrumbs-root-selector';
+import { BreadcrumbSpaceItem } from './breadcrumb-space-item';
 
 async function RecursiveBreadcrumbItem({
   spaceId,
@@ -16,7 +16,6 @@ async function RecursiveBreadcrumbItem({
   depth?: number;
   maxDepth?: number;
 }) {
-  console.debug('RecursiveBreadcrumbItem', { spaceId, depth, maxDepth });
   const space = await findParentSpaceById({ id: spaceId }, { db });
   if (!space || depth > maxDepth) return null;
 
@@ -30,7 +29,7 @@ async function RecursiveBreadcrumbItem({
           maxDepth={maxDepth}
         />
       )}
-      <SpaceBreadcrumbItem
+      <BreadcrumbSpaceItem
         lang={lang}
         breadcrumb={{ slug: space.slug, title: space.title }}
       />
@@ -45,14 +44,9 @@ export async function Breadcrumbs({
   spaceId: number;
   lang: Locale;
 }) {
-  const tNavigation = await getTranslations('Navigation');
-
   return (
-    <SpaceBreadcrumb
-      rootHref={`/${lang}/my-spaces`}
-      rootLabel={tNavigation('mySpaces')}
-    >
+    <BreadcrumbsRootSelector>
       <RecursiveBreadcrumbItem spaceId={spaceId} lang={lang} />
-    </SpaceBreadcrumb>
+    </BreadcrumbsRootSelector>
   );
 }

--- a/apps/web/src/app/[lang]/dho/[id]/_components/spaces-carousel-with-from.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/spaces-carousel-with-from.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import {
+  SpaceCard,
+  getDhoPathAgreements,
+} from '@hypha-platform/epics';
+import {
+  isSpaceArchived,
+  DEFAULT_SPACE_LEAD_IMAGE,
+  type Space,
+} from '@hypha-platform/core/client';
+import { Carousel, CarouselContent, CarouselItem } from '@hypha-platform/ui';
+import Link from 'next/link';
+import { Locale } from '@hypha-platform/i18n';
+import { useBreadcrumbFromQuery } from './breadcrumbs-root-selector';
+
+export function SpacesCarouselWithFrom({
+  spaces,
+  lang,
+}: {
+  spaces: Space[];
+  lang: Locale;
+}) {
+  const fromQuery = useBreadcrumbFromQuery();
+
+  return (
+    <Carousel className="my-6 mt-6">
+      <CarouselContent className="pb-5" showScrollbar>
+        {spaces.map((space) => {
+          const baseHref = getDhoPathAgreements(lang, space.slug as string);
+          const href = fromQuery ? `${baseHref}?${fromQuery}` : baseHref;
+          return (
+            <CarouselItem
+              key={space.id}
+              className="w-full sm:w-[454px] max-w-[454px] flex-shrink-0"
+            >
+              <Link className="flex flex-col flex-1" href={href}>
+                <SpaceCard
+                  description={space.description as string}
+                  icon={space.logoUrl || ''}
+                  leadImage={space.leadImage || DEFAULT_SPACE_LEAD_IMAGE}
+                  members={space.memberCount}
+                  agreements={space.documentCount}
+                  title={space.title as string}
+                  isSandbox={space.flags?.includes('sandbox') ?? false}
+                  isDemo={space.flags?.includes('demo') ?? false}
+                  isArchived={isSpaceArchived(space)}
+                  web3SpaceId={space.web3SpaceId as number}
+                  configPath={`${baseHref}/space-configuration`}
+                  createdAt={space.createdAt}
+                />
+              </Link>
+            </CarouselItem>
+          );
+        })}
+      </CarouselContent>
+    </Carousel>
+  );
+}

--- a/apps/web/src/app/[lang]/dho/[id]/layout.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/layout.tsx
@@ -1,7 +1,6 @@
 import {
   JoinSpace,
   SalesBanner,
-  SpaceCard,
   SpaceModeLabel,
   WebLinks,
   SubscriptionBadge,
@@ -16,8 +15,6 @@ import {
 } from '@hypha-platform/ui';
 import { Text } from '@radix-ui/themes';
 import Image from 'next/image';
-import { Carousel, CarouselContent, CarouselItem } from '@hypha-platform/ui';
-import Link from 'next/link';
 import { getAllSpaces, findSpaceBySlug } from '@hypha-platform/core/server';
 import { getDhoPathAgreements } from './@tab/agreements/constants';
 import { ActionButtons } from './_components/action-buttons';
@@ -27,11 +24,11 @@ import {
   DEFAULT_SPACE_LEAD_IMAGE,
   fetchSpaceDetails,
   fetchSpaceProposalsIds,
-  isSpaceArchived,
 } from '@hypha-platform/core/client';
 import { notFound } from 'next/navigation';
 import { db } from '@hypha-platform/storage-postgres';
 import { Breadcrumbs } from './_components/breadcrumbs';
+import { SpacesCarouselWithFrom } from './_components/spaces-carousel-with-from';
 import { canConvertToBigInt, formatDate } from '@hypha-platform/ui-utils';
 import { getTranslations } from 'next-intl/server';
 
@@ -193,39 +190,7 @@ export default async function DhoLayout({
             <Text className="text-4 font-medium pb-4 pt-4">
               {tSpaces('spacesYouMightLike')}
             </Text>
-            <Carousel className="my-6 mt-6">
-              <CarouselContent className="pb-5" showScrollbar>
-                {spaces.map((space) => (
-                  <CarouselItem
-                    key={space.id}
-                    className="w-full sm:w-[454px] max-w-[454px] flex-shrink-0"
-                  >
-                    <Link
-                      className="flex flex-col flex-1"
-                      href={getDhoPathAgreements(lang, space.slug as string)}
-                    >
-                      <SpaceCard
-                        description={space.description as string}
-                        icon={space.logoUrl || ''}
-                        leadImage={space.leadImage || DEFAULT_SPACE_LEAD_IMAGE}
-                        members={space.memberCount}
-                        agreements={space.documentCount}
-                        title={space.title as string}
-                        isSandbox={space.flags?.includes('sandbox') ?? false}
-                        isDemo={space.flags?.includes('demo') ?? false}
-                        isArchived={isSpaceArchived(space)}
-                        web3SpaceId={space.web3SpaceId as number}
-                        configPath={`${getDhoPathAgreements(
-                          lang,
-                          space.slug,
-                        )}/space-configuration`}
-                        createdAt={space.createdAt}
-                      />
-                    </Link>
-                  </CarouselItem>
-                ))}
-              </CarouselContent>
-            </Carousel>
+            <SpacesCarouselWithFrom spaces={spaces} lang={lang} />
           </div>
         </div>
       </Container>

--- a/apps/web/src/app/[lang]/my-spaces/page.tsx
+++ b/apps/web/src/app/[lang]/my-spaces/page.tsx
@@ -16,7 +16,10 @@ import {
 import { Heading } from '@hypha-platform/ui';
 import { Text } from '@radix-ui/themes';
 import { getAllSpaces } from '@hypha-platform/core/server';
-import { getDhoPathAgreements } from '../dho/[id]/@tab/agreements/constants';
+import {
+  addFromParam,
+  getDhoPathAgreements,
+} from '@hypha-platform/epics';
 import { PlusIcon } from '@radix-ui/react-icons';
 import { DEFAULT_SPACE_LEAD_IMAGE } from '@hypha-platform/core/client';
 import { getTranslations } from 'next-intl/server';
@@ -83,7 +86,10 @@ export default async function Index(props: PageProps) {
                 >
                   <Link
                     className="flex flex-col flex-1"
-                    href={getDhoPathAgreements(lang, space.slug as string)}
+                    href={addFromParam(
+                      getDhoPathAgreements(lang, space.slug as string),
+                      'my-spaces',
+                    )}
                   >
                     <SpaceCard
                       description={space.description as string}

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,11 +1,14 @@
 import { NextResponse, type NextRequest } from 'next/server';
 import { middleware as i18nMiddleware } from '@hypha-platform/i18n';
 
+const BREADCRUMB_ORIGIN_COOKIE = 'breadcrumb_origin';
+const COOKIE_MAX_AGE_DAYS = 1;
+
 const IMAGE_HOSTS = process.env.NEXT_PUBLIC_IMAGE_HOSTS?.split(', ') ?? [];
 const CONNECT_SOURCES =
   process.env.NEXT_PUBLIC_CONNECT_SOURCES?.split(', ') ?? [];
 
-function applyCsp(response: NextResponse, request: NextRequest): NextResponse {
+function applyCsp(response: NextResponse): NextResponse {
   if (
     process.env.NODE_ENV === 'development' &&
     process.env.ENABLE_LOCALHOST_CSP !== 'true'
@@ -46,6 +49,29 @@ function applyCsp(response: NextResponse, request: NextRequest): NextResponse {
   return response;
 }
 
+function setBreadcrumbOriginCookie(
+  response: NextResponse,
+  req: NextRequest,
+): void {
+  const url = req.nextUrl;
+  if (!url.pathname.match(/\/[a-z]{2}\/dho\/[^/]+/)) {
+    return;
+  }
+  const from = url.searchParams.get('from');
+  if (!from || !['network', 'profile', 'my-spaces'].includes(from)) {
+    return;
+  }
+  const profileSlug = url.searchParams.get('profileSlug');
+  const value = JSON.stringify(
+    profileSlug ? { from, profileSlug } : { from },
+  );
+  response.cookies.set(BREADCRUMB_ORIGIN_COOKIE, value, {
+    path: '/',
+    maxAge: 60 * 60 * 24 * COOKIE_MAX_AGE_DAYS,
+    sameSite: 'lax',
+  });
+}
+
 export function middleware(request: NextRequest) {
   // Run i18n middleware first — it returns a NextResponse with the
   // X-NEXT-INTL-LOCALE request header embedded. We must use this response
@@ -58,8 +84,10 @@ export function middleware(request: NextRequest) {
     return response;
   }
 
+  setBreadcrumbOriginCookie(response, request);
+
   // Apply CSP headers on top of the i18n response
-  return applyCsp(response, request);
+  return applyCsp(response);
 }
 
 export const config = {

--- a/packages/epics/src/common/get-path-function.ts
+++ b/packages/epics/src/common/get-path-function.ts
@@ -2,9 +2,38 @@
 
 import { Locale } from '@hypha-platform/i18n';
 
+export type BreadcrumbOrigin = 'network' | 'profile' | 'my-spaces';
+
 export const getDhoPathAgreements = (lang: Locale, id: string) => {
   return `/${lang}/dho/${id}/agreements`;
 };
+
+/**
+ * Builds the from query string for breadcrumb origin tracking.
+ * Used when linking to spaces from Network, Profile, or My Spaces.
+ */
+export function getFromQueryString(
+  origin: BreadcrumbOrigin,
+  profileSlug?: string,
+): string {
+  if (origin === 'profile' && profileSlug) {
+    return `from=profile&profileSlug=${encodeURIComponent(profileSlug)}`;
+  }
+  return `from=${origin}`;
+}
+
+/**
+ * Appends the from param to a URL for breadcrumb origin tracking.
+ */
+export function addFromParam(
+  url: string,
+  origin: BreadcrumbOrigin,
+  profileSlug?: string,
+): string {
+  const fromQuery = getFromQueryString(origin, profileSlug);
+  const separator = url.includes('?') ? '&' : '?';
+  return `${url}${separator}${fromQuery}`;
+}
 
 export const getDhoUrlAgreements = (lang: Locale, id: string) => {
   const protocol = window.location.protocol;

--- a/packages/epics/src/people/components/profile-member-spaces.tsx
+++ b/packages/epics/src/people/components/profile-member-spaces.tsx
@@ -2,7 +2,11 @@
 
 import { Skeleton, Image, Button } from '@hypha-platform/ui';
 import { Person, Space, useMe } from '@hypha-platform/core/client';
-import { ExitSpace, getDhoPathAgreements } from '@hypha-platform/epics';
+import {
+  ExitSpace,
+  addFromParam,
+  getDhoPathAgreements,
+} from '@hypha-platform/epics';
 import React from 'react';
 import Link from 'next/link';
 import { Locale } from '@hypha-platform/i18n';
@@ -100,7 +104,11 @@ export const ProfileMemberSpaces = ({
               {spaces?.map((space, index) => (
                 <Link
                   key={space.id || index}
-                  href={getDhoPathAgreements(lang as Locale, space.slug ?? '')}
+                  href={addFromParam(
+                    getDhoPathAgreements(lang as Locale, space.slug ?? ''),
+                    'profile',
+                    person.slug ?? undefined,
+                  )}
                 >
                   <div className="group relative" title={space.title}>
                     <div

--- a/packages/epics/src/spaces/components/breadcrumbs.tsx
+++ b/packages/epics/src/spaces/components/breadcrumbs.tsx
@@ -39,20 +39,22 @@ export function SpaceBreadcrumb({
 export const SpaceBreadcrumbItem = ({
   breadcrumb,
   lang,
+  fromQuery,
 }: {
   breadcrumb: SpaceBreadcrumb;
   lang?: string;
+  /** Query string to append for breadcrumb origin (e.g. "from=network") */
+  fromQuery?: string;
 }) => {
+  const baseHref = `${lang ? `/${lang}` : ''}/dho/${breadcrumb.slug}/agreements`;
+  const href = fromQuery ? `${baseHref}?${fromQuery}` : baseHref;
   return (
     <Fragment key={breadcrumb.slug}>
       <BreadcrumbSeparator>
         <ChevronRightIcon width={16} height={16} />
       </BreadcrumbSeparator>
       <BreadcrumbItem>
-        <BreadcrumbLink
-          href={`${lang ? `/${lang}` : ''}/dho/${breadcrumb.slug}/agreements`}
-          className="flex items-center"
-        >
+        <BreadcrumbLink href={href} className="flex items-center">
           {breadcrumb.title}
         </BreadcrumbLink>
       </BreadcrumbItem>

--- a/packages/epics/src/spaces/components/explore-spaces.tsx
+++ b/packages/epics/src/spaces/components/explore-spaces.tsx
@@ -357,7 +357,12 @@ export function ExploreSpaces({
         </Link>
       </div>
       <div className="space-y-6 flex mt-4 mb-7">
-        <SpaceCardList lang={lang} spaces={sortedSpaces} pageSize={15} />
+        <SpaceCardList
+          lang={lang}
+          spaces={sortedSpaces}
+          pageSize={15}
+          fromParam="from=network"
+        />
       </div>
       <Separator className="mt-1 mb-1" />
       <div className="flex justify-around flex-row columns-3 space-x-3 mt-6 -mb-15">

--- a/packages/epics/src/spaces/components/my-filtered-spaces.tsx
+++ b/packages/epics/src/spaces/components/my-filtered-spaces.tsx
@@ -84,6 +84,7 @@ export function MyFilteredSpaces({
         spaces={displayedSpaces}
         showLoadMore={showLoadMore}
         showExitButton={true}
+        fromParam="from=my-spaces"
       />
     </div>
   );

--- a/packages/epics/src/spaces/components/space-card-list.tsx
+++ b/packages/epics/src/spaces/components/space-card-list.tsx
@@ -18,6 +18,8 @@ type SpaceCardListProps = {
   pageSize?: number;
   showLoadMore?: boolean;
   showExitButton?: boolean;
+  /** Query string for breadcrumb origin (e.g. "from=network" or "from=profile&profileSlug=xxx") */
+  fromParam?: string;
 };
 
 export function SpaceCardList({
@@ -26,6 +28,7 @@ export function SpaceCardList({
   pageSize = 3,
   showLoadMore = true,
   showExitButton = false,
+  fromParam,
 }: SpaceCardListProps) {
   const { pages, loadMore, pagination } = useSpaceCardList({
     spaces,
@@ -51,6 +54,7 @@ export function SpaceCardList({
                     spaces={pageSpaces}
                     lang={lang}
                     showExitButton={showExitButton}
+                    fromParam={fromParam}
                   />
                 );
               })
@@ -60,6 +64,7 @@ export function SpaceCardList({
                 spaces={spaces}
                 lang={lang}
                 showExitButton={showExitButton}
+                fromParam={fromParam}
               />
             )}
           </div>

--- a/packages/epics/src/spaces/components/space-card.container.tsx
+++ b/packages/epics/src/spaces/components/space-card.container.tsx
@@ -9,14 +9,20 @@ type SpaceCardContainerProps = {
   lang: Locale;
   spaces: Space[];
   showExitButton?: boolean;
+  /** Query string for breadcrumb origin (e.g. "from=network" or "from=profile&profileSlug=xxx") */
+  fromParam?: string;
 };
 
 export const SpaceCardContainer = ({
   lang,
   spaces,
   showExitButton,
+  fromParam,
 }: SpaceCardContainerProps) => {
-  const getHref = (slug: string) => getDhoPathAgreements(lang, slug);
+  const getHref = (slug: string) => {
+    const baseUrl = getDhoPathAgreements(lang, slug);
+    return fromParam ? `${baseUrl}?${fromParam}` : baseUrl;
+  };
 
   return (
     <div

--- a/packages/i18n/src/messages/de.json
+++ b/packages/i18n/src/messages/de.json
@@ -22,6 +22,7 @@
   "Navigation": {
     "network": "Netzwerk",
     "mySpaces": "Meine Spaces",
+    "profile": "Profil",
     "openMenu": "Menü öffnen",
     "closeMenu": "Menü schließen",
     "selectLanguage": "Sprache auswählen",

--- a/packages/i18n/src/messages/en.json
+++ b/packages/i18n/src/messages/en.json
@@ -22,6 +22,7 @@
   "Navigation": {
     "network": "Network",
     "mySpaces": "My Spaces",
+    "profile": "Profile",
     "openMenu": "Open menu",
     "closeMenu": "Close menu",
     "selectLanguage": "Select language",

--- a/packages/i18n/src/messages/fr.json
+++ b/packages/i18n/src/messages/fr.json
@@ -22,6 +22,7 @@
   "Navigation": {
     "network": "Réseau",
     "mySpaces": "Mes espaces",
+    "profile": "Profil",
     "openMenu": "Ouvrir le menu",
     "closeMenu": "Fermer le menu",
     "selectLanguage": "Choisir la langue",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #1614 - Navigation issue: thread bar

The breadcrumb/thread bar on space and profile pages was always showing "My Spaces" as the parent. It now correctly shows the origin based on where the user navigated from: **Network**, **Profile**, or **My Space**.

## Changes

- **Breadcrumb root**: Now reflects the correct origin (Network, Profile, or My Spaces) based on the `from` query parameter or persisted cookie
- **Space links**: Added `from` param when linking to spaces from:
  - Network page (`?from=network`)
  - Profile page (`?from=profile&profileSlug=xxx`)
  - My Spaces page (`?from=my-spaces`)
- **Persistence**: Origin is stored in a cookie when visiting a space with the `from` param, so it persists when navigating between spaces (e.g. via carousel or breadcrumb)
- **DHO carousel**: "Spaces you might like" carousel preserves the `from` param when linking to other spaces
- **Breadcrumb items**: Parent space links in the breadcrumb preserve the `from` param
- **i18n**: Added "Profile" to Navigation translations (en, fr, de)

## How it works

1. When a user clicks a space from Network, Profile, or My Spaces, the link includes `?from=network`, `?from=profile&profileSlug=xxx`, or `?from=my-spaces`
2. Middleware sets a cookie when it detects the `from` param on DHO pages
3. The breadcrumb client component reads the `from` param from the URL (or cookie as fallback) and displays the appropriate root link
4. All internal links (carousel, breadcrumb items) preserve the `from` param so the origin stays consistent during the session
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f26f5a00-2ac4-4963-974b-de65c09ea159"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f26f5a00-2ac4-4963-974b-de65c09ea159"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Breadcrumbs now preserve navigation origin (Network, Profile, My Spaces) across pages, improving back-navigation and context.
  * Root breadcrumb is auto-selected and remembered, with seamless sync between URL and cookies.
  * Spaces carousels and lists include origin in links, keeping context when exploring or opening a space.
  * Profile and My Spaces links now carry origin parameters for consistent navigation.
  * Some links now use full URLs, improving sharing.
  * Added “Profile” translations in English, German, and French.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->