### PR TITLE
Fix profile side-panel close behavior for activate and purchase flows

### DIFF
--- a/packages/epics/src/people/components/activate-spaces-form.tsx
+++ b/packages/epics/src/people/components/activate-spaces-form.tsx
@@ -203,7 +203,7 @@ export const ActivateSpacesForm = ({ spaces }: ActivateSpacesFormProps) => {
         clearTimeout(closePanelTimeoutRef.current);
       }
       closePanelTimeoutRef.current = setTimeout(() => {
-        router.replace(closePanelUrl);
+        router.replace(closePanelUrl, { scroll: false });
       }, 3000);
       form.reset();
     } catch (error) {

--- a/packages/epics/src/people/components/people-purchase-hypha-tokens.tsx
+++ b/packages/epics/src/people/components/people-purchase-hypha-tokens.tsx
@@ -222,7 +222,7 @@ export const PeoplePurchaseHyphaTokens = ({
         clearTimeout(closePanelTimeoutRef.current);
       }
       closePanelTimeoutRef.current = setTimeout(() => {
-        router.replace(closePanelUrl);
+        router.replace(closePanelUrl, { scroll: false });
       }, 3000);
       form.reset();
     } catch (error) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- auto-closes profile side panels after success in both Activate Spaces and Purchase Hypha Tokens flows
- uses `router.replace(...)` for delayed panel close navigation so browser Back does not reopen completed forms
- preserves scroll position during delayed panel close via `router.replace(..., { scroll: false })`
- isolates post-purchase `manualUpdate()` refresh errors from purchase transaction errors to avoid showing false purchase failures
- applies Prettier formatting to pass CI `format:check`
- resolves merge conflicts with latest `main` while preserving both:
  - upstream translation/localized validation resolver updates
  - branch-specific side-panel auto-close and review-driven fixes

## Commits addressing review comments
1. `da3e288f5` — `fix(profile): replace history entry after activate spaces success`
2. `978255b9e` — `fix(profile): isolate post-purchase asset refresh errors`
3. `4a390dd76` — `fix(profile): replace history entry after token purchase success`
4. `7deb23035` — `style(profile): apply prettier formatting for CI`
5. `2ba6131b5` — `merge: resolve main branch conflicts in profile activation/purchase flows`
6. `428116476` — `fix(profile): preserve scroll when auto-closing side panels`

## Validation
- `pnpm run format:check` ✅

## Issues
- Closes #1938
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b2a9c772-77cd-4175-ac3d-97722b2ed3d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b2a9c772-77cd-4175-ac3d-97722b2ed3d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Success messages now appear immediately after activating spaces or purchasing tokens and remain visible while the user is automatically redirected to their profile after 3 seconds.
  * Post-purchase backend sync occurs without delaying the visible success flow.

* **Bug Fixes**
  * Pending scheduled redirects are cleared when leaving forms to prevent unexpected or duplicate navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->