### PR TITLE
fix: apply CodeRabbit auto-fixes for gh-cli and autofix skills

### DIFF
--- a/.agents/skills/autofix/SKILL.md
+++ b/.agents/skills/autofix/SKILL.md
@@ -184,11 +184,12 @@ If all deferred (no commit): Skip this step.
 
 ### Step 11: Post Summary
 
-**REQUIRED after all issues reviewed:**
+**If fixes were applied, post a fixes summary. If none were applied, post a neutral review-status summary:**
 
 ```bash
+# When fixes were applied:
 gh pr comment <pr-number> --body "$(cat <<'EOF'
-## Fixes Applied Successfully
+## Autofix Review Completed
 
 Fixed <file-count> file(s) based on <issue-count> unresolved review comment(s).
 
@@ -202,6 +203,11 @@ The latest autofix changes are on the `<branch-name>` branch.
 
 EOF
 )"
+
+# When no fixes were applied (all deferred or none required):
+gh pr comment <pr-number> --body "## Autofix Review Completed
+
+No fixes applied — all issues deferred or none required."
 ```
 
 See [github.md § 3](./github.md#3-post-summary-comment) for details.

--- a/.agents/skills/autofix/github.md
+++ b/.agents/skills/autofix/github.md
@@ -101,8 +101,8 @@ gh pr create --title '<title>' --body '<body>'
 - Exit skill
 
 **API failures:**
-- Log error and continue
-- Don't abort for comment posting failures
+- Fail fast for core data-fetching steps (PR lookup, unresolved thread retrieval)
+- Continue only for non-critical post actions (for example, summary comment posting)
 
 **Getting repo info:**
 ```bash

--- a/.agents/skills/gh-cli/references/best-practices.md
+++ b/.agents/skills/gh-cli/references/best-practices.md
@@ -18,13 +18,13 @@
    gh pr list --json number,title --jq '.[] | select(.title | contains("fix"))'
    ```
 
-4. **Pagination**: Use --paginate for large result sets
+4. **Limiting Results**: Use --limit for gh issue list (--paginate applies only to gh api)
 
    ```bash
-   gh issue list --state all --paginate
+   gh issue list --state all --limit 200
    ```
 
-5. **Large responses**: Use --paginate for API endpoints that return many items
+5. **Large responses**: Use --paginate for gh api endpoints that return many items
 
    ```bash
    gh api /user/repos --paginate

--- a/.agents/skills/gh-cli/references/comment-on-pull-request.md
+++ b/.agents/skills/gh-cli/references/comment-on-pull-request.md
@@ -4,8 +4,10 @@
 # Add comment
 gh pr comment 123 --body "Looks good!"
 
-# Comment on specific line
+# Comment with repository specified (--repo selects the target repository)
 gh pr comment 123 --body "Fix this" --repo owner/repo
+
+# For line-specific review comments, use gh pr review instead.
 
 # Edit last comment
 gh pr comment 123 --edit-last --body "Updated"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Resolves 4 unresolved CodeRabbit review comments from PR #2013 (feat/github-cli-skill).

## Fixes Applied

1. **comment-on-pull-request.md** – Clarify that "Comment on specific line" was misleading; `gh pr comment` creates PR-level comments. Updated to "Comment with repository specified" and added note that `gh pr review` is used for line-specific review comments.

2. **github.md** – Differentiate fatal vs non-fatal API failures: fail fast for core steps (PR lookup, thread fetch); continue only for non-critical post actions (e.g. summary comment posting).

3. **SKILL.md** – Conditional summary wording: post "Autofix Review Completed" with files/commit when fixes were applied; post neutral "No fixes applied" message when all deferred or none required.

4. **best-practices.md** – Fix invalid `gh issue list --paginate` usage: `gh issue list` does not support `--paginate`; use `--limit` instead. Added note that `--paginate` applies only to `gh api`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7ab215d6-b92c-4c57-a6b1-73df818eea30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7ab215d6-b92c-4c57-a6b1-73df818eea30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

