### PR TITLE
chore: only load references when required

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -2,7 +2,6 @@
 
 When the user has not specified a role, select the best-matching one based on the task.
 
-
 ## Roles
 
 | Role | File | Use when |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified agent activation step: instructions now state to "follow and load linked references (references, skills) WHEN REQUIRED for the given task," adding the conditional "WHEN REQUIRED" and the action "load" to better define when and how references should be used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->