### PR TITLE
fix(epics): correct AI panel speech transcript accumulation

### DIFF
--- a/packages/epics/src/common/ai-panel/ai-panel-chat-bar.tsx
+++ b/packages/epics/src/common/ai-panel/ai-panel-chat-bar.tsx
@@ -107,6 +107,7 @@ export function AiPanelChatBar({
   const fileInputRef = useRef<HTMLInputElement>(null);
   const imageInputRef = useRef<HTMLInputElement>(null);
   const recognitionRef = useRef<SpeechRecognitionInstance | null>(null);
+  const dictationBaseRef = useRef('');
   const [isListening, setIsListening] = useState(false);
 
   useEffect(() => {
@@ -179,6 +180,8 @@ export function AiPanelChatBar({
       return;
     }
 
+    dictationBaseRef.current = value;
+
     const recognition = new SpeechRecognitionCtor();
     recognitionRef.current = recognition;
     recognition.continuous = true;
@@ -187,11 +190,17 @@ export function AiPanelChatBar({
 
     recognition.onresult = (e: SpeechRecognitionResultEvent) => {
       const results = Array.from(e.results) as SpeechRecognitionResult[];
-      const transcript = results.map((r) => r[0]?.transcript ?? '').join('');
-      if (transcript) {
-        onChange(value + (value ? ' ' : '') + transcript);
-        autoResize();
-      }
+      const dictated = results.map((r) => r[0]?.transcript ?? '').join('');
+      if (!dictated) return;
+
+      const base = dictationBaseRef.current;
+      const needsSpace =
+        base.length > 0 &&
+        dictated.length > 0 &&
+        !base.endsWith(' ') &&
+        !dictated.startsWith(' ');
+      onChange(base + (needsSpace ? ' ' : '') + dictated);
+      autoResize();
     };
 
     recognition.onend = () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes voice input in the Hypha AI chat bar so dictated text no longer repeats on every interim Web Speech result.

## Problem

With `continuous` and `interimResults`, each `onresult` event includes the **full** `SpeechRecognitionResultList` built so far. The previous handler appended the joined transcript to the current textarea value, so the same prefixes were re-appended on every update.

## Change

- Capture the textarea value in a ref when dictation starts.
- On each result, set input to `base + (optional space) + fullTranscriptFromAllResults`.

## Notes

- The agent transcript JSONL path referenced in the task was not present in this workspace; the fix aligns with the branch name and the existing `ai-panel-chat-bar` speech handling.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9b6a5437-5860-4647-81d5-1e7fa311f4c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9b6a5437-5860-4647-81d5-1e7fa311f4c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

