### PR TITLE
fix(epics): highlight quorum/unity template when values match preset (#1819)

### DIFF
--- a/packages/epics/src/agreements/plugins/components/common/quorum-and-unity-change-field.tsx
+++ b/packages/epics/src/agreements/plugins/components/common/quorum-and-unity-change-field.tsx
@@ -26,10 +26,9 @@ export function QuorumAndUnityChangerField({
   const { theme } = useTheme();
   const isDark = theme === 'dark';
 
-  const matchedPresetTitle =
-    VOTING_METHOD_TEMPLATES.find(
-      (p) => p.quorum === fieldValue.quorum && p.unity === fieldValue.unity,
-    )?.title ?? null;
+  const matchedPreset = VOTING_METHOD_TEMPLATES.find(
+    (p) => p.quorum === fieldValue.quorum && p.unity === fieldValue.unity,
+  );
 
   const handleChange = (values: { quorum: number; unity: number }) => {
     setValue(name, values, { shouldValidate: true });
@@ -66,7 +65,7 @@ export function QuorumAndUnityChangerField({
         <FormItem>
           <div className="grid sm:grid-cols-2 md:grid-cols-3 gap-4 mb-2">
             {VOTING_METHOD_TEMPLATES.map((preset) => {
-              const isSelected = matchedPresetTitle === preset.title;
+              const isSelected = matchedPreset === preset;
               return (
                 <Button
                   key={preset.title}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [hypha-dao/hypha-web#1819](https://github.com/hypha-dao/hypha-web/issues/1819).

The quorum/unity **preset cards** above the sliders (`QuorumAndUnityChangerField`) only showed the selected border after a direct click. If `quorumAndUnity` already matched a `VOTING_METHOD_TEMPLATES` entry (defaults, prefilled form, or slider changes), no card appeared selected.

## Changes

- Derive the highlighted preset by matching current `quorum` / `unity` from the form against `VOTING_METHOD_TEMPLATES` (same equality as before).
- Remove `useState` for `selectedPreset`; preset clicks still `setValue` and the border updates from watched values.

## Verification

- `pnpm run format:fix`
- `pnpm --filter @hypha-platform/epics run lint` (0 errors; existing warnings in package)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5706aa45-5503-44cf-994b-cc7948ecb740"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5706aa45-5503-44cf-994b-cc7948ecb740"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Quorum and unity selection now derives directly from current form values rather than component-local state.
  * Preset buttons are highlighted only when form values exactly match a preset; selecting a preset updates the form values.
  * Change handling simplified to remove extra local side effects, making selection and validation behavior more predictable and reliable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->