### PR TITLE
Add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ Turborepo + pnpm monorepo for the Hypha DAO platform (Web3/Base L2).
 | Service | Path | Dev command | Port | Notes |
 |---------|------|-------------|------|-------|
 | **Web** (Next.js 15) | `apps/web` | `pnpm dev` (from root) or `cd apps/web && pnpm dev` | 3000 | Requires `DEFAULT_DB_URL` for pages that touch DB |
-| **API** (Fastify 5) | `apps/api` | `cd apps/api && pnpm dev` | 3001 | Health at `GET /health` (not under `/api/v1`). Swagger at `/api/v1/docs` when DB is configured |
+| **API** (Fastify 5) | `apps/api` | `cd apps/api && pnpm dev` | 3001 | Health at `GET /health` (not under `/api/v1`). Swagger at `/v1/docs` (note: **not** `/api/v1/docs`) |
 
 ### Key commands (from repo root)
 
@@ -27,3 +27,14 @@ Turborepo + pnpm monorepo for the Hypha DAO platform (Web3/Base L2).
 - `pnpm build` (production) will fail at the "Collecting page data" step if `DEFAULT_DB_URL` is not set, even though TypeScript compilation succeeds.
 - Unit tests use `vitest` at the workspace root level. There is no `vitest.config` file; run with `npx vitest run --globals` to enable global test APIs (`describe`, `it`, `expect`).
 - Hardhat tests in `packages/storage-evm` require a separate `npx hardhat test` invocation inside that package.
+- The Swagger docs route is at `/v1/docs` (the `routePrefix` in `swagger.ts` uses `/${API_VERSION}/docs` which resolves to `/v1/docs`, separate from the `/api/v1` prefix used by other routes).
+- When restarting dev servers, ensure lingering `next-server` processes are killed first — the child processes spawned by `pnpm dev` may survive the parent being killed. Use `netstat -tlnp | grep <port>` to find them.
+- The `.env` files injected with secrets from the environment must include `DEFAULT_DB_URL` for the web app and all three DB URLs (`DEFAULT_DB_URL`, `DEFAULT_DB_AUTHENTICATED_URL`, `DEFAULT_DB_ANONYMOUS_URL`) for the API. These are provided as Cursor Cloud secrets.
+
+### Required secrets
+
+| Secret | Used by | Purpose |
+|--------|---------|---------|
+| `DEFAULT_DB_URL` | Web + API | Primary Neon Postgres connection string |
+| `DEFAULT_DB_AUTHENTICATED_URL` | API | Neon authenticated role connection |
+| `DEFAULT_DB_ANONYMOUS_URL` | API | Neon anonymous role connection |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a root-level `AGENTS.md` with Cursor Cloud specific instructions for future cloud agents working in this codebase.

### What's included

- Services overview (Web on port 3000, API on port 3001) with dev commands
- Key commands reference (install, lint, dev, build, unit tests)
- Required secrets table (`DEFAULT_DB_URL`, `DEFAULT_DB_AUTHENTICATED_URL`, `DEFAULT_DB_ANONYMOUS_URL`)
- Important gotchas discovered during setup:
  - `.env.template` auto-copy behavior on `postinstall`
  - Database connection string requirements for web pages and production builds
  - Vitest configuration (no config file, needs `--globals` flag)
  - Swagger docs route is at `/v1/docs` (not `/api/v1/docs`)
  - Lingering Next.js child processes after killing parent dev server
  - Hardhat test setup for `storage-evm` package

### Environment setup validated

- `pnpm install` — dependencies install successfully
- `pnpm lint` — passes (warnings only, no errors)
- `pnpm build` — TypeScript compilation succeeds; page data collection requires DB
- `pnpm dev` — Both Next.js web app (port 3000) and Fastify API (port 3001) start successfully
- `npx vitest run --globals` — Unit tests pass
- Full hello-world demo: browsed network page (61 DAO spaces), clicked into Hypha space, viewed API Swagger docs

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8bba618a-61be-4aa5-9693-4f925c0070f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8bba618a-61be-4aa5-9693-4f925c0070f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive instructions documentation covering monorepo setup, environment configuration, development commands, deployment procedures, and operational guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->