### PR TITLE
feat(agents): add agentic engineering team template

### DIFF
--- a/.agents/teams.yaml
+++ b/.agents/teams.yaml
@@ -8,38 +8,38 @@ teams:
       meta-cognition, and Cursor IDE configuration.
     agents:
       - name: fullstack-nextjs
-        role: roles/Senior-Lead-Fullstack-Nextjs-Engineer.md
+        role: roles/senior-lead-fullstack-nextjs-engineer.base.md
         model: anthropic/claude-sonnet-4
       - name: neon-db
-        role: roles/Senior-Neon-DB-Engineer.md
+        role: roles/senior-neon-db-engineer.base.md
         model: anthropic/claude-sonnet-4
       - name: app-security
-        role: roles/Senior-Application-Security-Engineer.md
+        role: roles/senior-application-security-engineer.base.md
         model: anthropic/claude-sonnet-4
       - name: qa-test
-        role: roles/Senior-QA-Test-Engineer.md
+        role: roles/senior-qa-test-engineer.base.md
         model: anthropic/claude-sonnet-4
       - name: ui-ux-design
-        role: roles/Senior-UI-UX-Design-Engineer.md
+        role: roles/senior-ui-ux-design-engineer.base.md
         model: anthropic/claude-sonnet-4
       - name: product-owner
-        role: roles/Senior-Product-Owner.md
+        role: roles/senior-product-owner.base.md
         model: anthropic/claude-sonnet-4
       - name: requirements-eng
-        role: roles/Senior-Requirements-Engineer.md
+        role: roles/senior-requirements-engineer.base.md
         model: anthropic/claude-sonnet-4
       - name: prompt-eng
-        role: roles/Senior-Prompt-Engineer.md
+        role: roles/senior-prompt-engineer.base.md
         model: anthropic/claude-sonnet-4
       - name: user-researcher
-        role: roles/Senior-User-Researcher.md
+        role: roles/senior-user-researcher.base.md
         model: anthropic/claude-sonnet-4
       - name: cursor-engineer
-        role: roles/Elite-Senior-Lead-Cursor-Engineer.md
+        role: roles/elite-senior-lead-cursor-engineer.base.md
         model: anthropic/claude-sonnet-4
       - name: i18n-eng
-        role: roles/I18n-Engineer.md
+        role: roles/i18n-engineer.md
         model: anthropic/claude-sonnet-4
       - name: meta-cognition
-        role: roles/Meta-Cognition-Bounding-Expert.md
+        role: roles/meta-cognitive-reasoning-expert.base.md
         model: anthropic/claude-sonnet-4


### PR DESCRIPTION
## Summary

Adds a reusable team template at `.agents/teams.yaml` that defines the **agentic-engineering** team — a 12-agent specialized coding team for the hypha-web DAO platform.

## Team Roster

| Agent | Specialization |
|-------|---------------|
| `fullstack-nextjs` | Next.js 15 App Router, React, fullstack TypeScript |
| `neon-db` | Neon PostgreSQL, schema, migrations, performance |
| `app-security` | OWASP, threat modeling, secure code review |
| `qa-test` | Playwright E2E, Vitest, CI/CD testing |
| `ui-ux-design` | Design systems, shadcn/ui, accessibility |
| `product-owner` | Product strategy, backlog, stakeholders |
| `requirements-eng` | Requirements elicitation, specs, validation |
| `prompt-eng` | LLM prompts, evaluation, output quality |
| `user-researcher` | User research, usability, personas |
| `cursor-engineer` | Cursor IDE, rules, skills, MCP, agent roles |
| `i18n-eng` | Internationalization, next-intl, locales |
| `meta-cognition` | Structured problem-solving, confidence calibration |

## Changes

- **New file:** `.agents/teams.yaml` — team template config referencing existing role definitions in `.agents/roles/`

## How to use

Start the team from pi:
```
create_predefined_team(team_name="agentic-engineering", predefined_team="agentic-engineering", cwd=".")
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new team configuration with multiple preconfigured agents to support collaborative workflows.
  * Agents include role assignments and a shared AI model setting for consistent behavior across the team.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->