### PR TITLE
fix(api): clarify duplicate email error on profile (closes #1840)

### DIFF
--- a/apps/web/src/app/api/v1/people/create-profile/route.ts
+++ b/apps/web/src/app/api/v1/people/create-profile/route.ts
@@ -38,7 +38,8 @@ export async function POST(request: NextRequest) {
         errorMessage =
           'Profile with this nickname already exists. Please choose a different one.';
       } else if (error.message.includes('people_email_unique')) {
-        errorMessage = 'Profile with this email already exists.';
+        errorMessage =
+          'An account with this email already exists. Try signing in or use a different email.';
       }
     }
 

--- a/apps/web/src/app/api/v1/people/edit-profile/route.ts
+++ b/apps/web/src/app/api/v1/people/edit-profile/route.ts
@@ -37,7 +37,8 @@ export async function POST(request: NextRequest) {
         errorMessage =
           'Profile with this nickname already exists. Please choose a different one.';
       } else if (error.message.includes('people_email_unique')) {
-        errorMessage = 'Profile with this email already exists.';
+        errorMessage =
+          'An account with this email already exists. Try signing in or use a different email.';
       }
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the API error returned when a user hits the unique email constraint during profile create or edit, matching the copy requested in [#1840](https://github.com/hypha-dao/hypha-web/issues/1840).

**New message:** An account with this email already exists. Try signing in or use a different email.

## Changes

- `apps/web/src/app/api/v1/people/create-profile/route.ts` — duplicate email branch
- `apps/web/src/app/api/v1/people/edit-profile/route.ts` — duplicate email branch

Fixes #1840
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5318d817-bf20-469e-a903-01398b076881"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5318d817-bf20-469e-a903-01398b076881"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging when an email address is already in use during profile creation or editing. Users now receive clearer guidance to either sign in with the existing account or use a different email address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->