### PR TITLE
fix(governance): prevent redeem proposal execution failures with whitelist vaults

### DIFF
--- a/packages/core/src/governance/client/hooks/useRedeemTokensMutations.web3.rpc.test.ts
+++ b/packages/core/src/governance/client/hooks/useRedeemTokensMutations.web3.rpc.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test, vi } from 'vitest';
+import { decodeFunctionData } from 'viem';
+
+import {
+  tokenBackingVaultImplementationAbi,
+  tokenBackingVaultImplementationAddress,
+} from '@hypha-platform/core/generated';
+
+vi.mock('@hypha-platform/core/client', async () => {
+  return {
+    getTokenDecimals: vi.fn(async () => 18),
+    percentageStringToBigInt: vi.fn((value: string) =>
+      BigInt(Math.round(Number.parseFloat(value) * 100)),
+    ),
+    getSpaceMinProposalDuration: vi.fn(() => ({})),
+    getSpaceDetails: vi.fn(() => ({})),
+    publicClient: {
+      readContract: vi.fn(),
+    },
+  };
+});
+
+describe('prepareRedeemProposalParams', () => {
+  test('adds addToWhitelist before redeem when vault whitelist is enabled and executor is not whitelisted', async () => {
+    const { publicClient } = await import('@hypha-platform/core/client');
+    const { prepareRedeemProposalParams } = await import(
+      './useRedeemTokensMutations.web3.rpc'
+    );
+    const readContractMock = vi.mocked(publicClient.readContract);
+    readContractMock
+      .mockResolvedValueOnce(3600n) // getSpaceMinProposalDuration
+      .mockResolvedValueOnce(true) // vaultExists
+      .mockResolvedValueOnce([
+        '0x00000000000000000000000000000000000000b1',
+      ] as `0x${string}`[]) // getBackingTokens
+      .mockResolvedValueOnce({
+        redeemEnabled: true,
+        membersOnly: false,
+        whitelistEnabled: true,
+        minimumBackingBps: 0n,
+        redemptionStartDate: 0n,
+      }) // getVaultConfig
+      .mockResolvedValueOnce([
+        0n,
+        0n,
+        0n,
+        [],
+        [],
+        0n,
+        0n,
+        0n,
+        '0x00000000000000000000000000000000000000a1',
+        '0x00000000000000000000000000000000000000e1',
+      ]) // getSpaceDetails
+      .mockResolvedValueOnce(false); // isWhitelisted
+
+    const result = await prepareRedeemProposalParams({
+      redemption: {
+        web3SpaceId: 123,
+        amount: '10',
+        token: '0x00000000000000000000000000000000000000c1',
+      },
+      conversions: [
+        {
+          asset: '0x00000000000000000000000000000000000000b1',
+          percentage: '100.00',
+        },
+      ],
+    });
+
+    expect(result.transactions).toHaveLength(2);
+
+    const addToWhitelistTx = result.transactions[0];
+    const redeemTx = result.transactions[1];
+
+    expect(addToWhitelistTx?.target).toBe(
+      tokenBackingVaultImplementationAddress[8453],
+    );
+    expect(redeemTx?.target).toBe(tokenBackingVaultImplementationAddress[8453]);
+
+    const addToWhitelistDecoded = decodeFunctionData({
+      abi: tokenBackingVaultImplementationAbi,
+      data: addToWhitelistTx!.data,
+    });
+    expect(addToWhitelistDecoded.functionName).toBe('addToWhitelist');
+
+    const redeemDecoded = decodeFunctionData({
+      abi: tokenBackingVaultImplementationAbi,
+      data: redeemTx!.data,
+    });
+    expect(redeemDecoded.functionName).toBe('redeem');
+  });
+});

--- a/packages/core/src/governance/client/hooks/useRedeemTokensMutations.web3.rpc.ts
+++ b/packages/core/src/governance/client/hooks/useRedeemTokensMutations.web3.rpc.ts
@@ -14,13 +14,14 @@ import {
 } from '@hypha-platform/core/generated';
 import {
   getTokenDecimals,
+  getSpaceDetails,
   getSpaceMinProposalDuration,
   publicClient,
   percentageStringToBigInt,
 } from '@hypha-platform/core/client';
 import { getDuration } from '@hypha-platform/ui-utils';
 
-interface CreateRedeemTokensInput {
+export interface CreateRedeemTokensInput {
   redemption: {
     web3SpaceId: number;
     amount: string;
@@ -33,6 +34,134 @@ interface CreateRedeemTokensInput {
 }
 
 const chainId = 8453;
+
+export type RedeemProposalTransaction = {
+  target: `0x${string}`;
+  value: bigint;
+  data: `0x${string}`;
+};
+
+export async function prepareRedeemProposalParams(
+  arg: CreateRedeemTokensInput,
+  chain: keyof typeof tokenBackingVaultImplementationAddress = chainId,
+): Promise<{
+  spaceId: bigint;
+  duration: bigint;
+  transactions: RedeemProposalTransaction[];
+}> {
+  const spaceId = BigInt(arg.redemption.web3SpaceId);
+  const spaceToken = arg.redemption.token as `0x${string}`;
+  const vaultAddress = tokenBackingVaultImplementationAddress[chain];
+
+  const duration = await publicClient.readContract(
+    getSpaceMinProposalDuration({
+      spaceId,
+    }),
+  );
+
+  const backingTokens: `0x${string}`[] = [];
+  const proportions: bigint[] = [];
+
+  for (const conversion of arg.conversions) {
+    if (!conversion.asset || !conversion.percentage) {
+      continue;
+    }
+    backingTokens.push(conversion.asset as `0x${string}`);
+    const percentage = percentageStringToBigInt(conversion.percentage);
+    proportions.push(percentage);
+  }
+
+  if (backingTokens.length === 0) {
+    throw new Error(
+      'At least one valid conversion with asset and percentage is required',
+    );
+  }
+
+  const vaultExists = await publicClient.readContract({
+    address: vaultAddress,
+    abi: tokenBackingVaultImplementationAbi,
+    functionName: 'vaultExists',
+    args: [spaceId, spaceToken],
+  });
+  if (!vaultExists) {
+    throw new Error(
+      'The selected redemption token does not have an active backing vault.',
+    );
+  }
+
+  const configuredBackingTokens = await publicClient.readContract({
+    address: vaultAddress,
+    abi: tokenBackingVaultImplementationAbi,
+    functionName: 'getBackingTokens',
+    args: [spaceId, spaceToken],
+  });
+  const configuredBackingSet = new Set(
+    configuredBackingTokens.map((token) => token.toLowerCase()),
+  );
+  const invalidBackingTokens = backingTokens.filter(
+    (token) => !configuredBackingSet.has(token.toLowerCase()),
+  );
+  if (invalidBackingTokens.length > 0) {
+    throw new Error(
+      'One or more selected conversion assets are not configured as backing tokens for this vault token.',
+    );
+  }
+
+  const decimals = await getTokenDecimals(arg.redemption.token);
+  const amount = parseUnits(arg.redemption.amount, decimals);
+
+  const redeemCallData = encodeFunctionData({
+    abi: tokenBackingVaultImplementationAbi,
+    functionName: 'redeem',
+    args: [spaceId, spaceToken, amount, backingTokens, proportions],
+  });
+
+  const transactions: RedeemProposalTransaction[] = [];
+
+  const vaultConfig = await publicClient.readContract({
+    address: vaultAddress,
+    abi: tokenBackingVaultImplementationAbi,
+    functionName: 'getVaultConfig',
+    args: [spaceId, spaceToken],
+  });
+  if (vaultConfig.whitelistEnabled) {
+    const spaceDetails = await publicClient.readContract(
+      getSpaceDetails({ spaceId }),
+    );
+    const executor = spaceDetails[9] as `0x${string}`;
+    const isExecutorWhitelisted = await publicClient.readContract({
+      address: vaultAddress,
+      abi: tokenBackingVaultImplementationAbi,
+      functionName: 'isWhitelisted',
+      args: [spaceId, spaceToken, executor],
+    });
+
+    if (!isExecutorWhitelisted) {
+      // Proposals execute via space executor, so whitelist it first.
+      transactions.push({
+        target: vaultAddress,
+        value: 0n,
+        data: encodeFunctionData({
+          abi: tokenBackingVaultImplementationAbi,
+          functionName: 'addToWhitelist',
+          args: [spaceId, spaceToken, [executor]],
+        }),
+      });
+    }
+  }
+
+  transactions.push({
+    target: vaultAddress,
+    value: BigInt(0),
+    data: redeemCallData,
+  });
+
+  return {
+    spaceId,
+    duration: duration && duration > 0 ? duration : getDuration(7),
+    transactions,
+  };
+}
 
 export const useRedeemTokensMutationsWeb3Rpc = ({
   proposalSlug,
@@ -53,57 +182,12 @@ export const useRedeemTokensMutationsWeb3Rpc = ({
       if (!client) {
         throw new Error('Smart wallet client not available');
       }
-
-      const duration = await publicClient.readContract(
-        getSpaceMinProposalDuration({
-          spaceId: BigInt(arg.redemption.web3SpaceId),
-        }),
-      );
-
-      const backingTokens: `0x${string}`[] = [];
-      const proportions: bigint[] = [];
-
-      for (const conversion of arg.conversions) {
-        if (!conversion.asset || !conversion.percentage) {
-          continue;
-        }
-        backingTokens.push(conversion.asset as `0x${string}`);
-        const percentage = percentageStringToBigInt(conversion.percentage);
-        proportions.push(percentage);
-      }
-
-      if (backingTokens.length === 0) {
-        throw new Error(
-          'At least one valid conversion with asset and percentage is required',
-        );
-      }
-
-      const decimals = await getTokenDecimals(arg.redemption.token);
-      const amount = parseUnits(arg.redemption.amount, decimals);
-
-      const data = encodeFunctionData({
-        abi: tokenBackingVaultImplementationAbi,
-        functionName: 'redeem',
-        args: [
-          BigInt(arg.redemption.web3SpaceId),
-          arg.redemption.token as `0x${string}`,
-          amount,
-          backingTokens,
-          proportions,
-        ],
-      });
-
-      const transactions = [
-        {
-          target: tokenBackingVaultImplementationAddress[chainId],
-          value: BigInt(0),
-          data,
-        } as const,
-      ];
+      const { spaceId, duration, transactions } =
+        await prepareRedeemProposalParams(arg, chainId);
 
       const proposalParams = {
-        spaceId: BigInt(arg.redemption.web3SpaceId),
-        duration: duration && duration > 0 ? duration : getDuration(7),
+        spaceId,
+        duration,
         transactions,
       };
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a redeem proposal preflight builder (`prepareRedeemProposalParams`) to centralize and validate redeem proposal transaction construction
- validate that the selected redemption token has an active vault and that all selected conversion assets are configured backing tokens for that vault
- when vault whitelist is enabled, automatically prepend `addToWhitelist(executor)` before `redeem` if the space executor is not already whitelisted, so execution via proposal executor no longer reverts with generic transaction errors
- add targeted unit coverage asserting transaction order and payload (`addToWhitelist` then `redeem`)

## Validation
- `pnpm exec vitest run packages/core/src/governance/client/hooks/useRedeemTokensMutations.web3.rpc.test.ts` (pass)
- on-chain simulation evidence captured for failing proposal path showing root cause revert (`Not authorized to redeem`)

## Artifacts
- [redeem_executor_simulation.log](https://cursor.com/agents/bc-df188789-680d-43a3-ad5f-a1b364f2736f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fredeem_executor_simulation.log)
- [redeem_proposal_fix_validation.log](https://cursor.com/agents/bc-df188789-680d-43a3-ad5f-a1b364f2736f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fredeem_proposal_fix_validation.log)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-df188789-680d-43a3-ad5f-a1b364f2736f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-df188789-680d-43a3-ad5f-a1b364f2736f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

