### PR TITLE
fix(governance): unblock publish after issue-token Web2 parse failure (#1647)

### DIFF
--- a/packages/core/src/governance/client/hooks/useIssueNewTokenOrchestrator.ts
+++ b/packages/core/src/governance/client/hooks/useIssueNewTokenOrchestrator.ts
@@ -201,8 +201,11 @@ export const useCreateIssueTokenOrchestrator = ({
   const { trigger: createIssueToken } = useSWRMutation(
     'createIssueTokenOrchestration',
     async (_: string, { arg }: { arg: CreateIssueTokenArg }) => {
-      startTask('CREATE_WEB2_AGREEMENT');
+      // Validate before marking CREATE_WEB2_AGREEMENT pending; otherwise a parse
+      // failure leaves a stuck task, progress stays < 100, and the loading
+      // overlay blocks the publish button (see hypha-web#1647).
       const inputWeb2 = schemaCreateAgreementWeb2.parse(arg);
+      startTask('CREATE_WEB2_AGREEMENT');
       const createdAgreement = await web2.createAgreement(inputWeb2);
       completeTask('CREATE_WEB2_AGREEMENT');
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [hypha-web#1647](https://github.com/hypha-dao/hypha-web/issues/1647) (submit proposal / publish unresponsive after validation error on issue new token flow).

## Root cause

In `useCreateIssueTokenOrchestrator`, `startTask('CREATE_WEB2_AGREEMENT')` ran **before** `schemaCreateAgreementWeb2.parse(arg)`. If parsing threw (e.g. empty description after trim), the task stayed in `IS_PENDING`, `computeProgress` stayed between 0–100, `isPending` stayed `true`, and `LoadingBackdrop` kept a full-height overlay over the form—so **Publish appeared to do nothing** after fixing the field.

## Change

Parse `inputWeb2` first, then call `startTask` only when work actually begins.

## Testing

- `pnpm turbo run lint --filter=@hypha-platform/core` (passes; existing warnings only)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d4a8dbaf-4433-463f-94ab-44244ed533fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4a8dbaf-4433-463f-94ab-44244ed533fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the token orchestrator could become stuck during completion if input validation failed. Validation now occurs before marking tasks as pending, preventing workflow deadlocks and ensuring proper completion progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->