### PR TITLE
fix: bold entry method label on entry method proposal (closes #1800)

### DIFF
--- a/packages/epics/src/governance/components/proposal-entry-info.tsx
+++ b/packages/epics/src/governance/components/proposal-entry-info.tsx
@@ -24,7 +24,7 @@ export const ProposalEntryInfo = ({ joinMethod }: ProposalEntryInfoProps) => {
   return (
     <div className="flex flex-col gap-5">
       <div className="flex justify-between items-center">
-        <div className="text-1 text-neutral-11 w-full">
+        <div className="text-1 text-neutral-11 w-full font-bold">
           {tProposalDetails('labels.entryMethod')}
         </div>
         <div className="text-1 text-nowrap">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The "Entry Method" label on the proposal detail view for change-entry-method proposals was rendered with the same weight as body text. This adds `font-bold` to the label in `ProposalEntryInfo`, matching the emphasis used for other section titles in proposal detail (e.g. whitelist subsection headings).

## Testing

- Visual: open a proposal that includes entry method data and confirm the "Entry Method" label appears bold.

Closes #1800
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f5f4d30c-09bb-4d70-a0c2-93d75409b10a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5f4d30c-09bb-4d70-a0c2-93d75409b10a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced the visual prominence of the proposal entry method label by applying bold text styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->