### PR TITLE
fix: proposal title/description max length copy (#1862)

### DIFF
--- a/packages/core/src/governance/validation.ts
+++ b/packages/core/src/governance/validation.ts
@@ -112,12 +112,16 @@ const createAgreementWeb2Props = {
     .string()
     .trim()
     .min(1, { message: 'Please add a title for your proposal' })
-    .max(50),
+    .max(50, {
+      message: 'Title cannot exceed 50 characters (including spaces)',
+    }),
   description: z
     .string()
     .trim()
     .min(1, { message: 'Please add content to your proposal' })
-    .max(4000),
+    .max(4000, {
+      message: 'Description cannot exceed 4000 characters (including spaces)',
+    }),
   slug: z
     .string()
     .min(1)
@@ -483,12 +487,16 @@ export const schemaCreateProposalChangeVotingMethod = z
       .string()
       .trim()
       .min(1, { message: 'Please add a title for your proposal' })
-      .max(50),
+      .max(50, {
+        message: 'Title cannot exceed 50 characters (including spaces)',
+      }),
     description: z
       .string()
       .trim()
       .min(1, { message: 'Please add content to your proposal' })
-      .max(4000),
+      .max(4000, {
+        message: 'Description cannot exceed 4000 characters (including spaces)',
+      }),
     slug: z
       .string()
       .min(1)

--- a/packages/epics/src/agreements/utils/proposal-error-translations.ts
+++ b/packages/epics/src/agreements/utils/proposal-error-translations.ts
@@ -8,6 +8,10 @@ const PROPOSAL_ERROR_KEY_MAP: Record<string, string> = {
     'issueNewTokenForm.errors.titleRequired',
   'Please add content to your proposal':
     'issueNewTokenForm.errors.descriptionRequired',
+  'Title cannot exceed 50 characters (including spaces)':
+    'issueNewTokenForm.errors.titleMaxLength',
+  'Description cannot exceed 4000 characters (including spaces)':
+    'issueNewTokenForm.errors.descriptionMaxLength',
   'Slug must contain only lowercase letters, numbers, and hyphens':
     'issueNewTokenForm.errors.slugFormat',
   'Please upload a valid file': 'issueNewTokenForm.errors.uploadValidFile',

--- a/packages/epics/src/governance/components/issue-new-token-form.tsx
+++ b/packages/epics/src/governance/components/issue-new-token-form.tsx
@@ -30,6 +30,10 @@ const ISSUE_NEW_TOKEN_ERROR_KEYS: Record<string, string> = {
     'issueNewTokenForm.errors.titleRequired',
   'Please add content to your proposal':
     'issueNewTokenForm.errors.descriptionRequired',
+  'Title cannot exceed 50 characters (including spaces)':
+    'issueNewTokenForm.errors.titleMaxLength',
+  'Description cannot exceed 4000 characters (including spaces)':
+    'issueNewTokenForm.errors.descriptionMaxLength',
   'Slug must contain only lowercase letters, numbers, and hyphens':
     'issueNewTokenForm.errors.slugFormat',
   'Please upload a valid file': 'issueNewTokenForm.errors.uploadValidFile',

--- a/packages/i18n/src/messages/de.json
+++ b/packages/i18n/src/messages/de.json
@@ -699,6 +699,8 @@
       "errors": {
         "titleRequired": "Bitte fügen Sie einen Titel für Ihren Vorschlag hinzu",
         "descriptionRequired": "Bitte fügen Sie Inhalt zu Ihrem Vorschlag hinzu",
+        "titleMaxLength": "Der Titel darf höchstens 50 Zeichen einschließlich Leerzeichen umfassen",
+        "descriptionMaxLength": "Die Beschreibung darf höchstens 4000 Zeichen einschließlich Leerzeichen umfassen",
         "slugFormat": "Der Slug darf nur Kleinbuchstaben, Zahlen und Bindestriche enthalten",
         "uploadValidFile": "Bitte laden Sie eine gültige Datei hoch",
         "fileTooLarge": "Ihre Datei ist zu groß und überschreitet das 4MB-Limit. Bitte laden Sie eine kleinere Datei hoch.",

--- a/packages/i18n/src/messages/en.json
+++ b/packages/i18n/src/messages/en.json
@@ -699,6 +699,8 @@
       "errors": {
         "titleRequired": "Please add a title for your proposal",
         "descriptionRequired": "Please add content to your proposal",
+        "titleMaxLength": "Title cannot exceed 50 characters (including spaces)",
+        "descriptionMaxLength": "Description cannot exceed 4000 characters (including spaces)",
         "slugFormat": "Slug must contain only lowercase letters, numbers, and hyphens",
         "uploadValidFile": "Please upload a valid file",
         "fileTooLarge": "Your file is too large and exceeds the 4MB limit. Please upload a smaller file.",

--- a/packages/i18n/src/messages/es.json
+++ b/packages/i18n/src/messages/es.json
@@ -474,6 +474,8 @@
       "errors": {
         "titleRequired": "Por favor agregue un título para su propuesta",
         "descriptionRequired": "Por favor agregue contenido a su propuesta",
+        "titleMaxLength": "El título no puede superar 50 caracteres (incluidos los espacios)",
+        "descriptionMaxLength": "La descripción no puede superar 4000 caracteres (incluidos los espacios)",
         "slugFormat": "Slug debe contener solo letras minúsculas, números y guiones.",
         "uploadValidFile": "Por favor sube un archivo válido",
         "fileTooLarge": "Su archivo es demasiado grande y excede el límite de 4 MB. Sube un archivo más pequeño.",

--- a/packages/i18n/src/messages/fr.json
+++ b/packages/i18n/src/messages/fr.json
@@ -699,6 +699,8 @@
       "errors": {
         "titleRequired": "Veuillez ajouter un titre à votre proposition",
         "descriptionRequired": "Veuillez ajouter du contenu à votre proposition",
+        "titleMaxLength": "Le titre ne peut pas dépasser 50 caractères (espaces inclus)",
+        "descriptionMaxLength": "La description ne peut pas dépasser 4000 caractères (espaces inclus)",
         "slugFormat": "Le slug ne doit contenir que des lettres minuscules, des chiffres et des tirets",
         "uploadValidFile": "Veuillez téléverser un fichier valide",
         "fileTooLarge": "Votre fichier est trop volumineux et dépasse la limite de 4 Mo. Veuillez téléverser un fichier plus petit.",

--- a/packages/i18n/src/messages/pt.json
+++ b/packages/i18n/src/messages/pt.json
@@ -474,6 +474,8 @@
       "errors": {
         "titleRequired": "Adicione um título para sua proposta",
         "descriptionRequired": "Adicione conteúdo à sua proposta",
+        "titleMaxLength": "O título não pode exceder 50 caracteres (incluindo espaços)",
+        "descriptionMaxLength": "A descrição não pode exceder 4000 caracteres (incluindo espaços)",
         "slugFormat": "Slug deve conter apenas letras minúsculas, números e hifens",
         "uploadValidFile": "Por favor carregue um arquivo válido",
         "fileTooLarge": "Seu arquivo é muito grande e excede o limite de 4 MB. Faça upload de um arquivo menor.",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates proposal validation so title and description length errors match the copy requested in the issue:

- **Title:** "Title cannot exceed 50 characters (including spaces)"
- **Description:** "Description cannot exceed 4000 characters (including spaces)"

## Changes

- Set explicit `max()` messages on shared agreement proposal fields in `packages/core/src/governance/validation.ts` (including the change-voting-method schema).
- Map those English strings to `AgreementFlow.issueNewTokenForm.errors.titleMaxLength` and `descriptionMaxLength` in `proposal-error-translations.ts` and the issue-new-token error key map so localized forms show the right text.
- Added the new keys to all locale message files (en, de, fr, es, pt).

Closes #1862
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e870c48a-4733-47c4-b8e8-3f3163e1aa5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e870c48a-4733-47c4-b8e8-3f3163e1aa5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced validation error messages for proposal and token creation forms with explicit character limits for titles (50 characters) and descriptions (4000 characters), including spaces in the count.
  * Added multilingual support for validation messages across English, German, Spanish, French, and Portuguese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->