### PR TITLE
fix: persist token backing vault draft and redemption sync on navigation

### DIFF
--- a/apps/web/src/app/[lang]/dho/[id]/@aside/agreements/create/space-token-purchase/page.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@aside/agreements/create/space-token-purchase/page.tsx
@@ -1,0 +1,77 @@
+import {
+  SidePanel,
+  CreateProposalTokenBackingVaultForm,
+} from '@hypha-platform/epics';
+import { Locale } from '@hypha-platform/i18n';
+import { notFound } from 'next/navigation';
+import { PATH_SELECT_CREATE_ACTION } from '@web/app/constants';
+import { getDhoPathAgreements } from '../../../../@tab/agreements/constants';
+import { findSpaceBySlug } from '@hypha-platform/core/server';
+import { db } from '@hypha-platform/storage-postgres';
+import { getAllSpaces } from '@hypha-platform/core/server';
+import { findAllPeopleWithoutPagination } from '@hypha-platform/core/server';
+import { Person, Space } from '@hypha-platform/core/client';
+import { Plugin } from '../../../../_components/plugins';
+
+type PageProps = {
+  params: Promise<{ lang: Locale; id: string }>;
+};
+
+/**
+ * Token purchase / backing vault proposal (same flow as Settings → Token backing vault).
+ * Route alias for deep links such as …/agreements/create/space-token-purchase.
+ */
+export default async function SpaceTokenPurchaseAgreementPage({
+  params,
+}: PageProps) {
+  const { lang, id } = await params;
+
+  const spaceFromDb = await findSpaceBySlug({ slug: id }, { db });
+
+  if (!spaceFromDb) notFound();
+
+  const { id: spaceId, web3SpaceId, slug } = spaceFromDb;
+
+  const successfulUrl = getDhoPathAgreements(lang, id);
+  const backUrl = `${successfulUrl}${PATH_SELECT_CREATE_ACTION}`;
+
+  let spaces: Space[] = [];
+  const people: Person[] = await findAllPeopleWithoutPagination({ db });
+  const filteredPeople = people.filter(
+    (person) => person.address && person.address.trim() !== '',
+  );
+
+  try {
+    spaces = await getAllSpaces({
+      parentOnly: false,
+      omitSandbox: false,
+    });
+  } catch (err) {
+    console.error('Failed to fetch spaces:', err);
+  }
+
+  const filteredSpaces = spaces?.filter(
+    (space) =>
+      space?.address && space.address.trim() !== '' && space.id !== spaceId,
+  );
+
+  return (
+    <SidePanel>
+      <CreateProposalTokenBackingVaultForm
+        spaceId={spaceId}
+        web3SpaceId={web3SpaceId}
+        successfulUrl={successfulUrl}
+        backUrl={backUrl}
+        closeUrl={successfulUrl}
+        plugin={
+          <Plugin
+            name="token-backing-vault"
+            spaceSlug={slug}
+            spaces={filteredSpaces}
+            members={filteredPeople}
+          />
+        }
+      />
+    </SidePanel>
+  );
+}

--- a/packages/epics/src/governance/components/create-proposal-token-backing-vault-form.tsx
+++ b/packages/epics/src/governance/components/create-proposal-token-backing-vault-form.tsx
@@ -14,7 +14,12 @@ import { Button, Form, Separator } from '@hypha-platform/ui';
 import React from 'react';
 import { LoadingBackdrop } from '@hypha-platform/ui/server';
 import { useConfig } from 'wagmi';
-import { useScrollToErrors, useResubmitProposalData } from '../../hooks';
+import {
+  useScrollToErrors,
+  useResubmitProposalData,
+  useTokenBackingVaultFormDraft,
+  clearTokenBackingVaultFormDraft,
+} from '../../hooks';
 import { CreateAgreementBaseFields } from '../../agreements';
 import { useTranslations } from 'next-intl';
 import { useLocalizedProposalResolver } from '../hooks/use-localized-proposal-resolver';
@@ -96,6 +101,7 @@ export const CreateProposalTokenBackingVaultForm = ({
 
   useScrollToErrors(form, formRef);
   const { resubmitKey } = useResubmitProposalData(form, spaceId, person?.id);
+  useTokenBackingVaultFormDraft(form, spaceId);
 
   const handleCreate = async (data: FormValues) => {
     setFormError(null);
@@ -104,6 +110,9 @@ export const CreateProposalTokenBackingVaultForm = ({
       spaceId: spaceId as number,
       web3SpaceId: web3SpaceId as number,
     });
+    if (typeof spaceId === 'number') {
+      clearTokenBackingVaultFormDraft(spaceId);
+    }
   };
 
   return (

--- a/packages/epics/src/hooks/index.ts
+++ b/packages/epics/src/hooks/index.ts
@@ -2,3 +2,4 @@ export * from './use-db-tokens';
 export * from './use-scroll-to-errors';
 export * from './use-db-spaces';
 export * from './use-resubmit-proposal-data';
+export * from './use-token-backing-vault-form-draft';

--- a/packages/epics/src/hooks/use-token-backing-vault-form-draft.ts
+++ b/packages/epics/src/hooks/use-token-backing-vault-form-draft.ts
@@ -1,0 +1,140 @@
+'use client';
+
+import React from 'react';
+import { UseFormReturn, FieldValues } from 'react-hook-form';
+
+export const TOKEN_BACKING_VAULT_DRAFT_KEY = 'tokenBackingVaultProposalDraft';
+/** Set when defaults were applied for a token (no on-chain vault); avoids wiping drafts on remount. */
+export const TOKEN_BACKING_VAULT_PREFILL_TOKEN_KEY =
+  'tokenBackingVaultLastPrefilledToken';
+
+type DraftEnvelope<T extends FieldValues> = {
+  spaceId: number;
+  values: T;
+};
+
+function parseRedemptionDate(raw: unknown): Date | null | undefined {
+  if (raw === null || raw === undefined) return raw as null | undefined;
+  if (raw instanceof Date) {
+    return Number.isNaN(raw.getTime()) ? null : raw;
+  }
+  if (typeof raw === 'string') {
+    const d = new Date(raw);
+    return Number.isNaN(d.getTime()) ? null : d;
+  }
+  return null;
+}
+
+export function clearTokenBackingVaultFormDraft(spaceId: number) {
+  if (typeof window === 'undefined') return;
+  try {
+    const raw = sessionStorage.getItem(TOKEN_BACKING_VAULT_DRAFT_KEY);
+    if (!raw) return;
+    const parsed = JSON.parse(raw) as DraftEnvelope<FieldValues>;
+    if (parsed.spaceId === spaceId) {
+      sessionStorage.removeItem(TOKEN_BACKING_VAULT_DRAFT_KEY);
+      sessionStorage.removeItem(TOKEN_BACKING_VAULT_PREFILL_TOKEN_KEY);
+    }
+  } catch {
+    sessionStorage.removeItem(TOKEN_BACKING_VAULT_DRAFT_KEY);
+    sessionStorage.removeItem(TOKEN_BACKING_VAULT_PREFILL_TOKEN_KEY);
+  }
+}
+
+/**
+ * Persists token backing vault proposal form state in sessionStorage so navigating
+ * away and back restores title, plugin fields, and attachments metadata.
+ */
+export function useTokenBackingVaultFormDraft<
+  T extends FieldValues & {
+    tokenBackingVault?: {
+      redemptionStartDate?: Date | string | null;
+    };
+  },
+>(form: UseFormReturn<T>, spaceId: number | null | undefined) {
+  const restoredRef = React.useRef(false);
+  const saveTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  React.useEffect(() => {
+    if (typeof window === 'undefined' || spaceId == null) {
+      restoredRef.current = true;
+      return;
+    }
+
+    try {
+      const raw = sessionStorage.getItem(TOKEN_BACKING_VAULT_DRAFT_KEY);
+      if (!raw) {
+        restoredRef.current = true;
+        return;
+      }
+      const parsed = JSON.parse(raw) as DraftEnvelope<T>;
+      if (parsed.spaceId !== spaceId || !parsed.values) {
+        restoredRef.current = true;
+        return;
+      }
+
+      const v = { ...parsed.values } as T;
+      const tbv = v.tokenBackingVault as T['tokenBackingVault'] | undefined;
+      if (tbv && typeof tbv === 'object') {
+        (v as Record<string, unknown>).tokenBackingVault = {
+          ...tbv,
+          redemptionStartDate: parseRedemptionDate(
+            (tbv as { redemptionStartDate?: unknown }).redemptionStartDate,
+          ),
+        };
+      }
+
+      form.reset(v, { keepDefaultValues: false });
+    } catch {
+      sessionStorage.removeItem(TOKEN_BACKING_VAULT_DRAFT_KEY);
+    } finally {
+      restoredRef.current = true;
+    }
+  }, [form, spaceId]);
+
+  const watched = form.watch();
+
+  React.useEffect(() => {
+    if (!restoredRef.current || spaceId == null) return;
+    if (typeof window === 'undefined') return;
+    if (!form.formState.isDirty) return;
+
+    if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+    saveTimerRef.current = setTimeout(() => {
+      try {
+        const current = form.getValues();
+        const tbv = current.tokenBackingVault as
+          | {
+              redemptionStartDate?: Date | null;
+            }
+          | undefined;
+        const serialized: T = {
+          ...current,
+          tokenBackingVault: tbv
+            ? {
+                ...tbv,
+                redemptionStartDate:
+                  tbv.redemptionStartDate instanceof Date
+                    ? tbv.redemptionStartDate.toISOString()
+                    : tbv.redemptionStartDate,
+              }
+            : current.tokenBackingVault,
+        } as T;
+
+        sessionStorage.setItem(
+          TOKEN_BACKING_VAULT_DRAFT_KEY,
+          JSON.stringify({
+            spaceId,
+            values: serialized,
+          } satisfies DraftEnvelope<T>),
+        );
+      } catch {
+        /* ignore quota / serialization errors */
+      }
+    }, 400);
+
+    return () => {
+      if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+    };
+  }, [watched, form, spaceId]);
+}

--- a/packages/epics/src/treasury/plugins/token-backing-vault/plugin.tsx
+++ b/packages/epics/src/treasury/plugins/token-backing-vault/plugin.tsx
@@ -34,6 +34,7 @@ import { MinimumBackingPercentField } from './minimum-backing-percent-field';
 import { MaxRedemptionField } from './max-redemption-field';
 import { RedemptionStartDateField } from './redemption-start-date-field';
 import { EnableAdvancedRedemptionControlsField } from './enable-advanced-redemption-controls-field';
+import { TOKEN_BACKING_VAULT_PREFILL_TOKEN_KEY } from '../../../hooks/use-token-backing-vault-form-draft';
 
 interface ExtendedToken extends Token {
   space?: {
@@ -134,6 +135,20 @@ export const TokenBackingVaultPlugin = ({
     if (prefilledTokenRef.current === normalizedToken) return;
 
     if (!currentVault) {
+      if (typeof window !== 'undefined') {
+        try {
+          const lastPrefilled = sessionStorage
+            .getItem(TOKEN_BACKING_VAULT_PREFILL_TOKEN_KEY)
+            ?.toLowerCase();
+          if (lastPrefilled === normalizedToken) {
+            prefilledTokenRef.current = normalizedToken;
+            return;
+          }
+        } catch {
+          /* ignore */
+        }
+      }
+
       setValue('tokenBackingVault.addCollaterals', [], { shouldDirty: false });
       setValue('tokenBackingVault.removeCollaterals', [], {
         shouldDirty: false,
@@ -168,6 +183,16 @@ export const TokenBackingVaultPlugin = ({
       setValue('tokenBackingVault.redemptionWhitelist', [], {
         shouldDirty: false,
       });
+      if (typeof window !== 'undefined') {
+        try {
+          sessionStorage.setItem(
+            TOKEN_BACKING_VAULT_PREFILL_TOKEN_KEY,
+            normalizedToken,
+          );
+        } catch {
+          /* ignore */
+        }
+      }
       prefilledTokenRef.current = normalizedToken;
       return;
     }
@@ -230,6 +255,16 @@ export const TokenBackingVaultPlugin = ({
     setValue('tokenBackingVault.redemptionWhitelist', [], {
       shouldDirty: false,
     });
+    if (typeof window !== 'undefined') {
+      try {
+        sessionStorage.setItem(
+          TOKEN_BACKING_VAULT_PREFILL_TOKEN_KEY,
+          normalizedToken,
+        );
+      } catch {
+        /* ignore */
+      }
+    }
     prefilledTokenRef.current = normalizedToken;
   }, [spaceToken, currentVault, isLoadingVaults, setValue]);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Draft persistence:** Token backing vault proposal forms now save in-progress state to `sessionStorage` (title, description, plugin fields including redemption toggle and related values) and restore it when the user returns to the flow in the same browser tab/session.
- **Redemption / smart contract sync:** The token backing vault plugin no longer wipes redemption fields when there is no on-chain vault yet but the user navigates away and back with the same token selected (previously the "no vault" branch reset `enableRedemption` and related fields on every mount). When a vault exists, behavior is unchanged: fields are still filled from vault API data (on-chain via `/api/v1/spaces/.../vaults`).
- **Route:** Added `agreements/create/space-token-purchase` as an alias page that uses the same `CreateProposalTokenBackingVaultForm` + `token-backing-vault` plugin (deep link support for URLs like `en/dho/.../agreements/create/space-token-purchase`).

## Notes

- Successful publish clears the draft for that space.
- The default reference currency in code remains USD (`CURRENCY_FEED_OPTIONS[0]`); if users still see EUR, it likely reflects saved form or on-chain feed selection rather than this default.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-abde9b3b-68ba-4c26-848b-c90ee52b8ebf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-abde9b3b-68ba-4c26-848b-c90ee52b8ebf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

