### PR TITLE
fix(ui-utils): resolve CodeQL ReDoS in parseLocaleDecimal

### DIFF
--- a/packages/ui-utils/src/localeDecimal.ts
+++ b/packages/ui-utils/src/localeDecimal.ts
@@ -15,6 +15,24 @@ export function getLocaleNumberSeparators(locale: string): {
   return { group, decimal };
 }
 
+/** Linear-time shape check: optional digits, optional single '.', optional digits. */
+function isDecimalDigitString(s: string): boolean {
+  let i = 0;
+  while (i < s.length && s[i] >= '0' && s[i] <= '9') i += 1;
+  if (i < s.length && s[i] === '.') {
+    i += 1;
+    while (i < s.length && s[i] >= '0' && s[i] <= '9') i += 1;
+  }
+  return i === s.length;
+}
+
+function hasAsciiDigit(s: string): boolean {
+  for (let i = 0; i < s.length; i += 1) {
+    if (s[i] >= '0' && s[i] <= '9') return true;
+  }
+  return false;
+}
+
 /**
  * Parse user input that uses the locale's decimal and grouping separators
  * into a finite number. Returns undefined for empty input or unparseable values.
@@ -34,7 +52,7 @@ export function parseLocaleDecimal(
     s = decParts.join('.');
   }
 
-  if (!/^\d*\.?\d*$/.test(s) || s === '.' || !/\d/.test(s)) {
+  if (!isDecimalDigitString(s) || s === '.' || !hasAsciiDigit(s)) {
     return undefined;
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

CodeQL failed on PR #2078 with a **high** finding: polynomial regular expression on uncontrolled data in `packages/ui-utils/src/localeDecimal.ts` (the `/^\d*\.?\d*$/` validation).

## Changes

- Replace that regex with a **linear-time** character scan (`isDecimalDigitString`) and a small ASCII digit check (`hasAsciiDigit`).
- Behavior matches the previous acceptance rules: only digits and at most one `.`, with at least one digit, and `.` alone rejected.

## Verification

- `pnpm --filter @hypha-platform/ui-utils lint`

Target merge: `litzi/feat/1444-space-token-purchase-proposal` (same base as the failing PR).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-454cf59d-bcc3-4c9f-a884-9dcf3ddad8e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-454cf59d-bcc3-4c9f-a884-9dcf3ddad8e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

