### PR TITLE
fix(epics): bundle emoji-mart i18n so picker works offline

### DIFF
--- a/packages/epics/src/common/human-chat-panel/emoji-mart-i18n.ts
+++ b/packages/epics/src/common/human-chat-panel/emoji-mart-i18n.ts
@@ -1,0 +1,18 @@
+import en from '@emoji-mart/data/i18n/en.json';
+import es from '@emoji-mart/data/i18n/es.json';
+import fr from '@emoji-mart/data/i18n/fr.json';
+import de from '@emoji-mart/data/i18n/de.json';
+import pt from '@emoji-mart/data/i18n/pt.json';
+
+/** Bundled i18n so emoji-mart does not fetch from CDN (blocked/offline → empty picker). */
+const byLocale: Record<string, typeof en> = {
+  en,
+  es,
+  fr,
+  de,
+  pt,
+};
+
+export function getEmojiMartI18n(locale: string): typeof en {
+  return byLocale[locale] ?? en;
+}

--- a/packages/epics/src/common/human-chat-panel/human-chat-panel-emoji-picker.tsx
+++ b/packages/epics/src/common/human-chat-panel/human-chat-panel-emoji-picker.tsx
@@ -8,6 +8,8 @@ import data from '@emoji-mart/data';
 import { Popover, PopoverContent, PopoverTrigger } from '@hypha-platform/ui';
 import { cn } from '@hypha-platform/ui-utils';
 
+import { getEmojiMartI18n } from './emoji-mart-i18n';
+
 type HumanChatPanelEmojiPickerProps = {
   children: React.ReactNode;
   /** Called when user selects an emoji (native string). */
@@ -60,6 +62,7 @@ export function HumanChatPanelEmojiPicker({
           <div className="max-h-[min(420px,70vh)] w-[min(100vw-2rem,352px)] min-h-[230px] overflow-hidden">
             <Picker
               data={data}
+              i18n={getEmojiMartI18n(pickerLocale)}
               onEmojiSelect={(emoji: { native: string }) => {
                 onEmojiSelect(emoji.native);
                 onOpenChange(false);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The human chat emoji picker used `emoji-mart` with `locale` set from `next-intl`. For any locale other than English, `emoji-mart` loads category/search strings from jsDelivr (`@emoji-mart/data@latest/i18n/{locale}.json`). When that CDN request fails (CSP, offline, or blocked network), the picker rendered an empty frame while English still worked.

## Changes

- Import the matching `@emoji-mart/data/i18n/*.json` files for app locales (`en`, `es`, `fr`, `de`, `pt`) and pass them via the `i18n` prop on the `Picker`, so translations are bundled with the app and no runtime fetch is required.

## Testing

- `pnpm exec tsc --noEmit -p packages/epics`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-67cce379-af4c-419a-97a9-5278d3375e3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-67cce379-af4c-419a-97a9-5278d3375e3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-language support to the emoji picker with localized interface text in English, Spanish, French, German, and Portuguese, with automatic fallback to English for unsupported locales.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->