### PR TITLE
feat: add BridgeInitialValues pre-fill support for quest submissions

### DIFF
--- a/packages/epics/src/agreements/components/create-agreement-base-fields.tsx
+++ b/packages/epics/src/agreements/components/create-agreement-base-fields.tsx
@@ -78,9 +78,14 @@ export type CreateAgreementFormProps = {
   bridgeKey?: string;
 };
 
+interface ResubmitFormData {
+  leadImage?: string;
+  attachments?: (string | { name: string; url: string })[];
+  applied?: boolean;
+}
+
 type Callback = () => Promise<void>;
 type CallbackList = Array<Callback>;
-
 export function CreateAgreementBaseFields({
   creator,
   isLoading = false,
@@ -128,16 +133,11 @@ export function CreateAgreementBaseFields({
     );
   }
 
-  const [resubmitFormData, setResubmitFormData] = React.useState<{
-    leadImage?: string;
-    attachments?: (string | { name: string; url: string })[];
-  } | null>(null);
+  const [resubmitFormData, setResubmitFormData] = React.useState<ResubmitFormData | null>(null);
   const [existingAttachments, setExistingAttachments] = React.useState<
     (string | { name: string; url: string })[]
   >([]);
 
-  // Apply title and description from bridge initialValues on first render.
-  // These come cross-origin via URL searchParams and are not in sessionStorage.
   React.useEffect(() => {
     if (!initialValues) return;
     if (initialValues.title) {
@@ -151,8 +151,6 @@ export function CreateAgreementBaseFields({
   React.useEffect(() => {
     if (typeof window === 'undefined') return;
 
-    // Pre-fill attachments from bridge initialValues (takes priority over
-    // sessionStorage since it comes from a trusted cross-origin source).
     if (initialValues?.attachments?.length) {
       const mapped = initialValues.attachments.map(
         ({ url, filename }) => ({ url, name: filename }),
@@ -164,12 +162,7 @@ export function CreateAgreementBaseFields({
       const data = sessionStorage.getItem('resubmitFormData');
       if (!data) return;
 
-      const parsed = JSON.parse(data) as {
-        leadImage?: string;
-        attachments?: (string | { name: string; url: string })[];
-        applied?: boolean;
-        [key: string]: any;
-      };
+      const parsed = JSON.parse(data) as ResubmitFormData;
 
       if (parsed.applied) {
         sessionStorage.removeItem('resubmitFormData');
@@ -178,8 +171,6 @@ export function CreateAgreementBaseFields({
 
       setResubmitFormData(parsed);
       if (parsed.attachments && parsed.attachments.length > 0) {
-        // Only set from sessionStorage if bridge initialValues didn't already
-        // provide attachments.
         if (!initialValues?.attachments?.length) {
           setExistingAttachments(parsed.attachments);
         }
@@ -197,7 +188,6 @@ export function CreateAgreementBaseFields({
       sessionStorage.removeItem('resubmitFormData');
     }
   }, []);
-
   const { space } = useSpaceBySlug(spaceSlug as string);
 
   const spaceIdBigInt = space?.web3SpaceId ? BigInt(space.web3SpaceId) : null;
@@ -279,7 +269,6 @@ export function CreateAgreementBaseFields({
         if (progressRef.current < 100) {
           setDelayedCallbacks((prev) => {
             if (prev.length > 0) {
-              // Normally should be called at most once
               return prev;
             }
             return [
@@ -315,7 +304,6 @@ export function CreateAgreementBaseFields({
     authToken,
     postProposalCreated,
   });
-
   return (
     <>
       <div className="flex flex-col-reverse md:flex-row justify-between gap-4 md:gap-2">
@@ -381,6 +369,7 @@ export function CreateAgreementBaseFields({
                     {creator?.name} {creator?.surname}
                   </Text>
                 </div>
+                </div>
                 {Number(duration) === 0 ? (
                   <div className="flex gap-2 h-fit items-center pr-3">
                     <Image
@@ -445,7 +434,12 @@ export function CreateAgreementBaseFields({
       <FormField
         control={form.control}
         name="leadImage"
-        render={({ field }) => (
+        render={({ field }) => {
+          const resolvedDefaultImage =
+            initialValues?.leadImage ||
+            (typeof field.value === 'string' ? field.value : undefined) ||
+            resubmitFormData?.leadImage;
+          return (
           <FormItem>
             <FormControl>
               <UploadLeadImage
@@ -460,19 +454,13 @@ export function CreateAgreementBaseFields({
                     ),
                   },
                 )}
-                defaultImage={
-                  initialValues?.leadImage ||
-                  (resubmitFormData?.leadImage || field.value
-                    ? typeof field.value === 'string'
-                      ? field.value
-                      : resubmitFormData?.leadImage
-                    : undefined)
-                }
+                defaultImage={resolvedDefaultImage}
               />
             </FormControl>
             <FormMessage />
           </FormItem>
-        )}
+          );
+        }}
       />
       <FormField
         control={form.control}

--- a/packages/epics/src/agreements/components/create-agreement-base-fields.tsx
+++ b/packages/epics/src/agreements/components/create-agreement-base-fields.tsx
@@ -50,6 +50,19 @@ const schemaCreateAgreementForm =
 
 export type CreateAgreementFormData = z.infer<typeof schemaCreateAgreementForm>;
 
+/**
+ * Pre-fill values passed in from an external bridge (e.g. ReGen Civics quest
+ * submission). These arrive via URL searchParams, not sessionStorage, so they
+ * need their own code path alongside the existing resubmit flow.
+ */
+export interface BridgeInitialValues {
+  title?: string;
+  description?: string;
+  leadImage?: string;
+  attachments?: Array<{ url: string; filename: string }>;
+  payouts?: Array<{ amount: string; token: string }>;
+}
+
 export type CreateAgreementFormProps = {
   creator?: Creator;
   isLoading?: boolean;
@@ -59,6 +72,10 @@ export type CreateAgreementFormProps = {
   backLabel?: string;
   label?: string;
   progress: number;
+  /** Pre-fill values from an external bridge (e.g. ReGen Civics). */
+  initialValues?: BridgeInitialValues;
+  /** Bridge key embedded in the proposal title marker (e.g. "rc:abc12345"). */
+  bridgeKey?: string;
 };
 
 type Callback = () => Promise<void>;
@@ -73,6 +90,8 @@ export function CreateAgreementBaseFields({
   backLabel,
   label,
   progress,
+  initialValues,
+  bridgeKey,
 }: CreateAgreementFormProps) {
   const tAgreementFlow = useTranslations('AgreementFlow');
   const translateEditor = React.useCallback(
@@ -117,8 +136,29 @@ export function CreateAgreementBaseFields({
     (string | { name: string; url: string })[]
   >([]);
 
+  // Apply title and description from bridge initialValues on first render.
+  // These come cross-origin via URL searchParams and are not in sessionStorage.
+  React.useEffect(() => {
+    if (!initialValues) return;
+    if (initialValues.title) {
+      form.setValue('title', initialValues.title);
+    }
+    if (initialValues.description) {
+      form.setValue('description', initialValues.description);
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
   React.useEffect(() => {
     if (typeof window === 'undefined') return;
+
+    // Pre-fill attachments from bridge initialValues (takes priority over
+    // sessionStorage since it comes from a trusted cross-origin source).
+    if (initialValues?.attachments?.length) {
+      const mapped = initialValues.attachments.map(
+        ({ url, filename }) => ({ url, name: filename }),
+      );
+      setExistingAttachments(mapped);
+    }
 
     try {
       const data = sessionStorage.getItem('resubmitFormData');
@@ -138,7 +178,11 @@ export function CreateAgreementBaseFields({
 
       setResubmitFormData(parsed);
       if (parsed.attachments && parsed.attachments.length > 0) {
-        setExistingAttachments(parsed.attachments);
+        // Only set from sessionStorage if bridge initialValues didn't already
+        // provide attachments.
+        if (!initialValues?.attachments?.length) {
+          setExistingAttachments(parsed.attachments);
+        }
       }
 
       sessionStorage.setItem(
@@ -417,11 +461,12 @@ export function CreateAgreementBaseFields({
                   },
                 )}
                 defaultImage={
-                  resubmitFormData?.leadImage || field.value
+                  initialValues?.leadImage ||
+                  (resubmitFormData?.leadImage || field.value
                     ? typeof field.value === 'string'
                       ? field.value
                       : resubmitFormData?.leadImage
-                    : undefined
+                    : undefined)
                 }
               />
             </FormControl>

--- a/packages/epics/src/governance/components/create-propose-a-contribution-form.tsx
+++ b/packages/epics/src/governance/components/create-propose-a-contribution-form.tsx
@@ -1,156 +1,200 @@
 'use client';
 
 import { useForm } from 'react-hook-form';
+
 import {
   schemaCreateAgreementForm,
-  createAgreementFiles,
-  useJwt,
-  useMe,
-  useCreateProposeAContributionOrchestrator,
-} from '@hypha-platform/core/client';
-import { z } from 'zod';
-import { Button, Form, Separator } from '@hypha-platform/ui';
-import React from 'react';
-import { useRouter } from 'next/navigation';
-import { LoadingBackdrop } from '@hypha-platform/ui/server';
-import { useConfig } from 'wagmi';
-import { useScrollToErrors, useResubmitProposalData } from '../../hooks';
-import { CreateAgreementBaseFields } from '../../agreements';
-import { useTranslations } from 'next-intl';
-import { useLocalizedProposalResolver } from '../hooks/use-localized-proposal-resolver';
-
-type FormValues = z.infer<typeof schemaCreateAgreementForm>;
-
-const fullSchemaCreateProposeAContributionForm =
-  schemaCreateAgreementForm.extend(createAgreementFiles);
-
-interface CreateProposeAContributionFormProps {
-  spaceId: number | undefined | null;
-  web3SpaceId: number | undefined | null;
-  successfulUrl: string;
-  backUrl?: string;
-  plugin: React.ReactNode;
-}
-
-export const CreateProposeAContributionForm = ({
-  successfulUrl,
-  backUrl,
-  spaceId,
-  web3SpaceId,
-  plugin,
-}: CreateProposeAContributionFormProps) => {
-  const tSpaces = useTranslations('Spaces');
-  const tAgreementFlow = useTranslations('AgreementFlow');
-  const router = useRouter();
-  const { person } = useMe();
-  const { jwt } = useJwt();
-  const config = useConfig();
-  const {
-    createProposeAContribution,
-    reset,
-    currentAction,
-    isError,
-    isPending,
-    progress,
-  } = useCreateProposeAContributionOrchestrator({ authToken: jwt, config });
-  const resolver = useLocalizedProposalResolver(
-    fullSchemaCreateProposeAContributionForm,
-    tAgreementFlow,
-  );
-
-  const formRef = React.useRef<HTMLFormElement>(null);
-  const form = useForm<FormValues>({
-    resolver,
-    defaultValues: {
-      title: '',
-      description: '',
-      leadImage: undefined,
-      attachments: undefined,
-      spaceId: spaceId ?? undefined,
-      creatorId: person?.id,
-      recipient: '',
-      payouts: [
-        {
-          amount: undefined,
-          token: undefined,
-        },
-      ],
-      label: 'Contribution',
-    },
-  });
-
-  useScrollToErrors(form, formRef);
-  const { resubmitKey } = useResubmitProposalData(form, spaceId, person?.id);
-
-  React.useEffect(() => {
-    if (progress === 100 && successfulUrl) {
-      router.push(successfulUrl);
-    }
-  }, [progress, successfulUrl, router]);
-
-  const handleCreate = async (data: FormValues) => {
-    if (!data.recipient || !data.payouts || data.payouts.length === 0) {
-      console.error('Recipient or payouts are missing');
-      return;
-    }
-
-    await createProposeAContribution({
-      ...data,
-      spaceId: spaceId as number,
-      web3SpaceId: typeof web3SpaceId === 'number' ? web3SpaceId : undefined,
-      recipient: data.recipient,
-      payouts: data.payouts.map(({ amount, token }) => ({
-        amount: String(amount ?? '0'),
-        token: token ?? '',
-      })),
-    });
-  };
-
-  return (
-    <LoadingBackdrop
-      showKeepWindowOpenMessage={true}
-      keepWindowOpenMessage={tAgreementFlow('loadingBackdrop.keepWindowOpen')}
-      fullHeight={true}
-      progress={progress}
-      isLoading={isPending}
-      message={
-        isError ? (
-          <div className="flex flex-col">
-            <div>{tSpaces('errorOhSnap')}</div>
-            <Button onClick={reset}>{tSpaces('reset')}</Button>
-          </div>
-        ) : (
-          <div>{currentAction}</div>
-        )
-      }
-    >
-      <Form {...form}>
-        <form
-          ref={formRef}
-          onSubmit={form.handleSubmit(handleCreate)}
-          className="flex flex-col gap-5"
-        >
-          <CreateAgreementBaseFields
-            key={resubmitKey}
-            creator={{
-              avatar: person?.avatarUrl || '',
-              name: person?.name || '',
-              surname: person?.surname || '',
-            }}
-            successfulUrl={successfulUrl}
-            closeUrl={successfulUrl}
-            backUrl={backUrl}
-            isLoading={false}
-            label={tAgreementFlow('labels.contribution')}
-            progress={progress}
-          />
-          {plugin}
-          <Separator />
-          <div className="flex justify-end w-full">
-            <Button type="submit">{tAgreementFlow('buttons.publish')}</Button>
-          </div>
-        </form>
-      </Form>
-    </LoadingBackdrop>
-  );
-};
+    createAgreementFiles,
+      useJwt,
+        useMe,
+          useCreateProposeAContributionOrchestrator,
+          } from '@hypha-platform/core/client';
+          
+          import { z } from 'zod';
+          
+          import { Button, Form, Separator } from '@hypha-platform/ui';
+          
+          import React from 'react';
+          
+          import { useRouter } from 'next/navigation';
+          
+          import { LoadingBackdrop } from '@hypha-platform/ui/server';
+          
+          import { useConfig } from 'wagmi';
+          
+          import { useScrollToErrors, useResubmitProposalData } from '../../hooks';
+          
+          import { CreateAgreementBaseFields } from '../../agreements';
+          
+          import { useTranslations } from 'next-intl';
+          
+          import { useLocalizedProposalResolver } from '../hooks/use-localized-proposal-resolver';
+          
+          type FormValues = z.infer<typeof schemaCreateAgreementForm>;
+          
+          const fullSchemaCreateProposeAContributionForm =
+            schemaCreateAgreementForm.extend(createAgreementFiles);
+            
+            /** Pre-fill values passed in via URL searchParams from an external bridge (e.g. ReGen Civics). */
+            export interface BridgeInitialValues {
+              title?: string;
+                description?: string;
+                  leadImage?: string;
+                    attachments?: Array<{ url: string; filename: string }>;
+                      payouts?: Array<{ amount: string; token: string }>;
+                      }
+                      
+                      interface CreateProposeAContributionFormProps {
+                        spaceId: number | undefined | null;
+                          web3SpaceId: number | undefined | null;
+                            successfulUrl: string;
+                              backUrl?: string;
+                                plugin: React.ReactNode;
+                                  /** Optional pre-fill values passed in via URL searchParams from an external bridge. */
+                                    initialValues?: BridgeInitialValues;
+                                      /** Bridge key for back-channel status tracking (embedded in the proposal title marker). */
+                                        bridgeKey?: string;
+                                        }
+                                        
+                                        export const CreateProposeAContributionForm = ({
+                                          successfulUrl,
+                                            backUrl,
+                                              spaceId,
+                                                web3SpaceId,
+                                                  plugin,
+                                                    initialValues,
+                                                      bridgeKey,
+                                                      }: CreateProposeAContributionFormProps) => {
+                                                        const tSpaces = useTranslations('Spaces');
+                                                          const tAgreementFlow = useTranslations('AgreementFlow');
+                                                            const router = useRouter();
+                                                              const { person } = useMe();
+                                                                const { jwt } = useJwt();
+                                                                  const config = useConfig();
+                                                                  
+                                                                    const {
+                                                                        createProposeAContribution,
+                                                                            reset,
+                                                                                currentAction,
+                                                                                    isError,
+                                                                                        isPending,
+                                                                                            progress,
+                                                                                              } = useCreateProposeAContributionOrchestrator({ authToken: jwt, config });
+                                                                                              
+                                                                                                const resolver = useLocalizedProposalResolver(
+                                                                                                    fullSchemaCreateProposeAContributionForm,
+                                                                                                        tAgreementFlow,
+                                                                                                          );
+                                                                                                          
+                                                                                                            const formRef = React.useRef<HTMLFormElement>(null);
+                                                                                                            
+                                                                                                              const form = useForm<FormValues>({
+                                                                                                                  resolver,
+                                                                                                                      defaultValues: {
+                                                                                                                            title: initialValues?.title ?? '',
+                                                                                                                                  description: initialValues?.description ?? '',
+                                                                                                                                        leadImage: initialValues?.leadImage ?? undefined,
+                                                                                                                                              attachments: undefined,
+                                                                                                                                                    spaceId: spaceId ?? undefined,
+                                                                                                                                                          creatorId: person?.id,
+                                                                                                                                                                recipient: '',
+                                                                                                                                                                      payouts: [
+                                                                                                                                                                              {
+                                                                                                                                                                                        amount: undefined,
+                                                                                                                                                                                                  token: undefined,
+                                                                                                                                                                                                          },
+                                                                                                                                                                                                                ],
+                                                                                                                                                                                                                      label: 'Contribution',
+                                                                                                                                                                                                                          },
+                                                                                                                                                                                                                            });
+                                                                                                                                                                                                                            
+                                                                                                                                                                                                                              useScrollToErrors(form, formRef);
+                                                                                                                                                                                                                                const { resubmitKey } = useResubmitProposalData(form, spaceId, person?.id);
+                                                                                                                                                                                                                                
+                                                                                                                                                                                                                                  // Apply payout pre-fills from the bridge after form mount.
+                                                                                                                                                                                                                                    // Done in an effect rather than defaultValues to avoid schema coercion issues.
+                                                                                                                                                                                                                                      React.useEffect(() => {
+                                                                                                                                                                                                                                          if (!initialValues?.payouts?.length) return;
+                                                                                                                                                                                                                                              form.setValue(
+                                                                                                                                                                                                                                                    'payouts',
+                                                                                                                                                                                                                                                          initialValues.payouts.map(({ amount, token }) => ({
+                                                                                                                                                                                                                                                                  amount: amount as unknown as undefined,
+                                                                                                                                                                                                                                                                          token: token as unknown as undefined,
+                                                                                                                                                                                                                                                                                })),
+                                                                                                                                                                                                                                                                                    );
+                                                                                                                                                                                                                                                                                      }, []); // eslint-disable-line react-hooks/exhaustive-deps
+                                                                                                                                                                                                                                                                                      
+                                                                                                                                                                                                                                                                                        React.useEffect(() => {
+                                                                                                                                                                                                                                                                                            if (progress === 100 && successfulUrl) {
+                                                                                                                                                                                                                                                                                                  router.push(successfulUrl);
+                                                                                                                                                                                                                                                                                                      }
+                                                                                                                                                                                                                                                                                                        }, [progress, successfulUrl, router]);
+                                                                                                                                                                                                                                                                                                        
+                                                                                                                                                                                                                                                                                                          const handleCreate = async (data: FormValues) => {
+                                                                                                                                                                                                                                                                                                              if (!data.recipient || !data.payouts || data.payouts.length === 0) {
+                                                                                                                                                                                                                                                                                                                    console.error('Recipient or payouts are missing');
+                                                                                                                                                                                                                                                                                                                          return;
+                                                                                                                                                                                                                                                                                                                              }
+                                                                                                                                                                                                                                                                                                                              
+                                                                                                                                                                                                                                                                                                                                  await createProposeAContribution({
+                                                                                                                                                                                                                                                                                                                                        ...data,
+                                                                                                                                                                                                                                                                                                                                              spaceId: spaceId as number,
+                                                                                                                                                                                                                                                                                                                                                    web3SpaceId: typeof web3SpaceId === 'number' ? web3SpaceId : undefined,
+                                                                                                                                                                                                                                                                                                                                                          recipient: data.recipient,
+                                                                                                                                                                                                                                                                                                                                                                payouts: data.payouts.map(({ amount, token }) => ({
+                                                                                                                                                                                                                                                                                                                                                                        amount: String(amount ?? '0'),
+                                                                                                                                                                                                                                                                                                                                                                                token: token ?? '',
+                                                                                                                                                                                                                                                                                                                                                                                      })),
+                                                                                                                                                                                                                                                                                                                                                                                          });
+                                                                                                                                                                                                                                                                                                                                                                                            };
+                                                                                                                                                                                                                                                                                                                                                                                            
+                                                                                                                                                                                                                                                                                                                                                                                              return (
+                                                                                                                                                                                                                                                                                                                                                                                                  <LoadingBackdrop
+                                                                                                                                                                                                                                                                                                                                                                                                        showKeepWindowOpenMessage={true}
+                                                                                                                                                                                                                                                                                                                                                                                                              keepWindowOpenMessage={tAgreementFlow('loadingBackdrop.keepWindowOpen')}
+                                                                                                                                                                                                                                                                                                                                                                                                                    fullHeight={true}
+                                                                                                                                                                                                                                                                                                                                                                                                                          progress={progress}
+                                                                                                                                                                                                                                                                                                                                                                                                                                isLoading={isPending}
+                                                                                                                                                                                                                                                                                                                                                                                                                                      message={
+                                                                                                                                                                                                                                                                                                                                                                                                                                              isError ? (
+                                                                                                                                                                                                                                                                                                                                                                                                                                                        <div className="flex flex-col">
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                    <div>{tSpaces('errorOhSnap')}</div>
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                <Button onClick={reset}>{tSpaces('reset')}</Button>
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          </div>
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  ) : (
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            <div>{currentAction}</div>
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    )
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          }
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              >
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    <Form {...form}>
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            <form
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      ref={formRef}
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                onSubmit={form.handleSubmit(handleCreate)}
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          className="flex flex-col gap-5"
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  >
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            <CreateAgreementBaseFields
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        key={resubmitKey}
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    creator={{
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  avatar: person?.avatarUrl || '',
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                name: person?.name || '',
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              surname: person?.surname || '',
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          }}
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      successfulUrl={successfulUrl}
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  closeUrl={successfulUrl}
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              backUrl={backUrl}
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          isLoading={false}
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      label={tAgreementFlow('labels.contribution')}
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  progress={progress}
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              initialValues={initialValues}
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          bridgeKey={bridgeKey}
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    />
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              {plugin}
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        <Separator />
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  <div className="flex justify-end w-full">
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              <Button type="submit">{tAgreementFlow('buttons.publish')}</Button>
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        </div>
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                </form>
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      </Form>
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          </LoadingBackdrop>
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            );
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            };'

--- a/packages/epics/src/governance/components/create-propose-a-contribution-form.tsx
+++ b/packages/epics/src/governance/components/create-propose-a-contribution-form.tsx
@@ -1,200 +1,171 @@
 'use client';
 
 import { useForm } from 'react-hook-form';
-
 import {
   schemaCreateAgreementForm,
-    createAgreementFiles,
-      useJwt,
-        useMe,
-          useCreateProposeAContributionOrchestrator,
-          } from '@hypha-platform/core/client';
-          
-          import { z } from 'zod';
-          
-          import { Button, Form, Separator } from '@hypha-platform/ui';
-          
-          import React from 'react';
-          
-          import { useRouter } from 'next/navigation';
-          
-          import { LoadingBackdrop } from '@hypha-platform/ui/server';
-          
-          import { useConfig } from 'wagmi';
-          
-          import { useScrollToErrors, useResubmitProposalData } from '../../hooks';
-          
-          import { CreateAgreementBaseFields } from '../../agreements';
-          
-          import { useTranslations } from 'next-intl';
-          
-          import { useLocalizedProposalResolver } from '../hooks/use-localized-proposal-resolver';
-          
-          type FormValues = z.infer<typeof schemaCreateAgreementForm>;
-          
-          const fullSchemaCreateProposeAContributionForm =
-            schemaCreateAgreementForm.extend(createAgreementFiles);
-            
-            /** Pre-fill values passed in via URL searchParams from an external bridge (e.g. ReGen Civics). */
-            export interface BridgeInitialValues {
-              title?: string;
-                description?: string;
-                  leadImage?: string;
-                    attachments?: Array<{ url: string; filename: string }>;
-                      payouts?: Array<{ amount: string; token: string }>;
-                      }
-                      
-                      interface CreateProposeAContributionFormProps {
-                        spaceId: number | undefined | null;
-                          web3SpaceId: number | undefined | null;
-                            successfulUrl: string;
-                              backUrl?: string;
-                                plugin: React.ReactNode;
-                                  /** Optional pre-fill values passed in via URL searchParams from an external bridge. */
-                                    initialValues?: BridgeInitialValues;
-                                      /** Bridge key for back-channel status tracking (embedded in the proposal title marker). */
-                                        bridgeKey?: string;
-                                        }
-                                        
-                                        export const CreateProposeAContributionForm = ({
-                                          successfulUrl,
-                                            backUrl,
-                                              spaceId,
-                                                web3SpaceId,
-                                                  plugin,
-                                                    initialValues,
-                                                      bridgeKey,
-                                                      }: CreateProposeAContributionFormProps) => {
-                                                        const tSpaces = useTranslations('Spaces');
-                                                          const tAgreementFlow = useTranslations('AgreementFlow');
-                                                            const router = useRouter();
-                                                              const { person } = useMe();
-                                                                const { jwt } = useJwt();
-                                                                  const config = useConfig();
-                                                                  
-                                                                    const {
-                                                                        createProposeAContribution,
-                                                                            reset,
-                                                                                currentAction,
-                                                                                    isError,
-                                                                                        isPending,
-                                                                                            progress,
-                                                                                              } = useCreateProposeAContributionOrchestrator({ authToken: jwt, config });
-                                                                                              
-                                                                                                const resolver = useLocalizedProposalResolver(
-                                                                                                    fullSchemaCreateProposeAContributionForm,
-                                                                                                        tAgreementFlow,
-                                                                                                          );
-                                                                                                          
-                                                                                                            const formRef = React.useRef<HTMLFormElement>(null);
-                                                                                                            
-                                                                                                              const form = useForm<FormValues>({
-                                                                                                                  resolver,
-                                                                                                                      defaultValues: {
-                                                                                                                            title: initialValues?.title ?? '',
-                                                                                                                                  description: initialValues?.description ?? '',
-                                                                                                                                        leadImage: initialValues?.leadImage ?? undefined,
-                                                                                                                                              attachments: undefined,
-                                                                                                                                                    spaceId: spaceId ?? undefined,
-                                                                                                                                                          creatorId: person?.id,
-                                                                                                                                                                recipient: '',
-                                                                                                                                                                      payouts: [
-                                                                                                                                                                              {
-                                                                                                                                                                                        amount: undefined,
-                                                                                                                                                                                                  token: undefined,
-                                                                                                                                                                                                          },
-                                                                                                                                                                                                                ],
-                                                                                                                                                                                                                      label: 'Contribution',
-                                                                                                                                                                                                                          },
-                                                                                                                                                                                                                            });
-                                                                                                                                                                                                                            
-                                                                                                                                                                                                                              useScrollToErrors(form, formRef);
-                                                                                                                                                                                                                                const { resubmitKey } = useResubmitProposalData(form, spaceId, person?.id);
-                                                                                                                                                                                                                                
-                                                                                                                                                                                                                                  // Apply payout pre-fills from the bridge after form mount.
-                                                                                                                                                                                                                                    // Done in an effect rather than defaultValues to avoid schema coercion issues.
-                                                                                                                                                                                                                                      React.useEffect(() => {
-                                                                                                                                                                                                                                          if (!initialValues?.payouts?.length) return;
-                                                                                                                                                                                                                                              form.setValue(
-                                                                                                                                                                                                                                                    'payouts',
-                                                                                                                                                                                                                                                          initialValues.payouts.map(({ amount, token }) => ({
-                                                                                                                                                                                                                                                                  amount: amount as unknown as undefined,
-                                                                                                                                                                                                                                                                          token: token as unknown as undefined,
-                                                                                                                                                                                                                                                                                })),
-                                                                                                                                                                                                                                                                                    );
-                                                                                                                                                                                                                                                                                      }, []); // eslint-disable-line react-hooks/exhaustive-deps
-                                                                                                                                                                                                                                                                                      
-                                                                                                                                                                                                                                                                                        React.useEffect(() => {
-                                                                                                                                                                                                                                                                                            if (progress === 100 && successfulUrl) {
-                                                                                                                                                                                                                                                                                                  router.push(successfulUrl);
-                                                                                                                                                                                                                                                                                                      }
-                                                                                                                                                                                                                                                                                                        }, [progress, successfulUrl, router]);
-                                                                                                                                                                                                                                                                                                        
-                                                                                                                                                                                                                                                                                                          const handleCreate = async (data: FormValues) => {
-                                                                                                                                                                                                                                                                                                              if (!data.recipient || !data.payouts || data.payouts.length === 0) {
-                                                                                                                                                                                                                                                                                                                    console.error('Recipient or payouts are missing');
-                                                                                                                                                                                                                                                                                                                          return;
-                                                                                                                                                                                                                                                                                                                              }
-                                                                                                                                                                                                                                                                                                                              
-                                                                                                                                                                                                                                                                                                                                  await createProposeAContribution({
-                                                                                                                                                                                                                                                                                                                                        ...data,
-                                                                                                                                                                                                                                                                                                                                              spaceId: spaceId as number,
-                                                                                                                                                                                                                                                                                                                                                    web3SpaceId: typeof web3SpaceId === 'number' ? web3SpaceId : undefined,
-                                                                                                                                                                                                                                                                                                                                                          recipient: data.recipient,
-                                                                                                                                                                                                                                                                                                                                                                payouts: data.payouts.map(({ amount, token }) => ({
-                                                                                                                                                                                                                                                                                                                                                                        amount: String(amount ?? '0'),
-                                                                                                                                                                                                                                                                                                                                                                                token: token ?? '',
-                                                                                                                                                                                                                                                                                                                                                                                      })),
-                                                                                                                                                                                                                                                                                                                                                                                          });
-                                                                                                                                                                                                                                                                                                                                                                                            };
-                                                                                                                                                                                                                                                                                                                                                                                            
-                                                                                                                                                                                                                                                                                                                                                                                              return (
-                                                                                                                                                                                                                                                                                                                                                                                                  <LoadingBackdrop
-                                                                                                                                                                                                                                                                                                                                                                                                        showKeepWindowOpenMessage={true}
-                                                                                                                                                                                                                                                                                                                                                                                                              keepWindowOpenMessage={tAgreementFlow('loadingBackdrop.keepWindowOpen')}
-                                                                                                                                                                                                                                                                                                                                                                                                                    fullHeight={true}
-                                                                                                                                                                                                                                                                                                                                                                                                                          progress={progress}
-                                                                                                                                                                                                                                                                                                                                                                                                                                isLoading={isPending}
-                                                                                                                                                                                                                                                                                                                                                                                                                                      message={
-                                                                                                                                                                                                                                                                                                                                                                                                                                              isError ? (
-                                                                                                                                                                                                                                                                                                                                                                                                                                                        <div className="flex flex-col">
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                    <div>{tSpaces('errorOhSnap')}</div>
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                <Button onClick={reset}>{tSpaces('reset')}</Button>
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          </div>
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  ) : (
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            <div>{currentAction}</div>
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    )
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          }
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              >
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    <Form {...form}>
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            <form
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      ref={formRef}
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                onSubmit={form.handleSubmit(handleCreate)}
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          className="flex flex-col gap-5"
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  >
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            <CreateAgreementBaseFields
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        key={resubmitKey}
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    creator={{
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  avatar: person?.avatarUrl || '',
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                name: person?.name || '',
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              surname: person?.surname || '',
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          }}
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      successfulUrl={successfulUrl}
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  closeUrl={successfulUrl}
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              backUrl={backUrl}
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          isLoading={false}
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      label={tAgreementFlow('labels.contribution')}
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  progress={progress}
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              initialValues={initialValues}
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          bridgeKey={bridgeKey}
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    />
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              {plugin}
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        <Separator />
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  <div className="flex justify-end w-full">
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              <Button type="submit">{tAgreementFlow('buttons.publish')}</Button>
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        </div>
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                </form>
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      </Form>
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          </LoadingBackdrop>
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            );
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            };'
+  createAgreementFiles,
+  useJwt,
+  useMe,
+  useCreateProposeAContributionOrchestrator,
+} from '@hypha-platform/core/client';
+import { z } from 'zod';
+import { Button, Form, Separator } from '@hypha-platform/ui';
+import React from 'react';
+import { useRouter } from 'next/navigation';
+import { LoadingBackdrop } from '@hypha-platform/ui/server';
+import { useConfig } from 'wagmi';
+import { useScrollToErrors, useResubmitProposalData } from '../../hooks';
+import {
+  CreateAgreementBaseFields,
+  type BridgeInitialValues,
+} from '../../agreements';
+import { useTranslations } from 'next-intl';
+import { useLocalizedProposalResolver } from '../hooks/use-localized-proposal-resolver';
+
+type FormValues = z.infer<typeof schemaCreateAgreementForm>;
+
+const fullSchemaCreateProposeAContributionForm =
+  schemaCreateAgreementForm.extend(createAgreementFiles);
+
+interface CreateProposeAContributionFormProps {
+  spaceId: number | undefined | null;
+  web3SpaceId: number | undefined | null;
+  successfulUrl: string;
+  backUrl?: string;
+  plugin: React.ReactNode;
+  /** Pre-fill values from an external bridge (e.g. ReGen Civics quest submission). */
+  initialValues?: BridgeInitialValues;
+  /** Bridge key embedded in the proposal title marker (e.g. "rc:abc12345"). */
+  bridgeKey?: string;
+}
+export const CreateProposeAContributionForm = ({
+  successfulUrl,
+  backUrl,
+  spaceId,
+  web3SpaceId,
+  plugin,
+  initialValues,
+  bridgeKey,
+}: CreateProposeAContributionFormProps) => {
+  const tSpaces = useTranslations('Spaces');
+  const tAgreementFlow = useTranslations('AgreementFlow');
+  const router = useRouter();
+  const { person } = useMe();
+  const { jwt } = useJwt();
+  const config = useConfig();
+  const {
+    createProposeAContribution,
+    reset,
+    currentAction,
+    isError,
+    isPending,
+    progress,
+  } = useCreateProposeAContributionOrchestrator({ authToken: jwt, config });
+  const resolver = useLocalizedProposalResolver(
+    fullSchemaCreateProposeAContributionForm,
+    tAgreementFlow,
+  );
+
+  const formRef = React.useRef<HTMLFormElement>(null);
+  const form = useForm<FormValues>({
+    resolver,
+    defaultValues: {
+      title: initialValues?.title ?? '',
+      description: initialValues?.description ?? '',
+      leadImage: undefined,
+      attachments: undefined,
+      spaceId: spaceId ?? undefined,
+      creatorId: person?.id,
+      recipient: '',
+      payouts: [
+        {
+          amount: undefined,
+          token: undefined,
+        },
+      ],
+      label: 'Contribution',
+    },
+  });
+
+  useScrollToErrors(form, formRef);
+  const { resubmitKey } = useResubmitProposalData(form, spaceId, person?.id);
+
+  // Pre-fill payouts from bridge initialValues on first render.
+  React.useEffect(() => {
+    if (!initialValues?.payouts?.length) return;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    form.setValue('payouts', initialValues.payouts as any);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  React.useEffect(() => {
+    if (progress === 100 && successfulUrl) {
+      router.push(successfulUrl);
+    }
+  }, [progress, successfulUrl, router]);
+  const handleCreate = async (data: FormValues) => {
+    if (!data.recipient || !data.payouts || data.payouts.length === 0) {
+      console.error('Recipient or payouts are missing');
+      return;
+    }
+    await createProposeAContribution({
+      ...data,
+      spaceId: spaceId as number,
+      web3SpaceId: typeof web3SpaceId === 'number' ? web3SpaceId : undefined,
+      recipient: data.recipient,
+      payouts: data.payouts.map(({ amount, token }) => ({
+        amount: String(amount ?? '0'),
+        token: token ?? '',
+      })),
+    });
+  };
+
+  return (
+    <LoadingBackdrop
+      showKeepWindowOpenMessage={true}
+      keepWindowOpenMessage={tAgreementFlow('loadingBackdrop.keepWindowOpen')}
+      fullHeight={true}
+      progress={progress}
+      isLoading={isPending}
+      message={
+        isError ? (
+          <div className="flex flex-col">
+            <div>{tSpaces('errorOhSnap')}</div>
+            <Button onClick={reset}>{tSpaces('reset')}</Button>
+          </div>
+        ) : (
+          <div>{currentAction}</div>
+        )
+      }
+    >
+      <Form {...form}>
+        <form
+          ref={formRef}
+          onSubmit={form.handleSubmit(handleCreate)}
+          className="flex flex-col gap-5"
+        >
+          <CreateAgreementBaseFields
+            key={resubmitKey}
+            creator={{
+              avatar: person?.avatarUrl || '',
+              name: person?.name || '',
+              surname: person?.surname || '',
+            }}
+            successfulUrl={successfulUrl}
+            closeUrl={successfulUrl}
+            backUrl={backUrl}
+            isLoading={false}
+            label={tAgreementFlow('labels.contribution')}
+            progress={progress}
+            initialValues={initialValues}
+            bridgeKey={bridgeKey}
+          />
+          {plugin}
+          <Separator />
+          <div className="flex justify-end w-full">
+            <Button type="submit">{tAgreementFlow('buttons.publish')}</Button>
+          </div>
+        </form>
+      </Form>
+    </LoadingBackdrop>
+  );
+};


### PR DESCRIPTION
## What this does

Adds `initialValues` and `bridgeKey` props to `CreateProposeAContributionForm` and `CreateAgreementBaseFields` so the proposal creation form can be pre-filled from URL searchParams passed by an external bridge (e.g. ReGen Civics quest submission flow).

**Depends on PR #2136** (searchParams support on the propose-contribution page) — that PR passes the parsed searchParams down as `initialValues` to this form. Both PRs need to land for the full flow to work.

## Changes

**`packages/epics/src/agreements/components/create-agreement-base-fields.tsx`**
- Exports a new `BridgeInitialValues` interface (`title`, `description`, `leadImage`, `attachments`, `payouts`)
- - Adds `initialValues?: BridgeInitialValues` and `bridgeKey?: string` to `CreateAgreementFormProps`
- - New `useEffect` applies `title` and `description` via `form.setValue` on first render
- - Existing sessionStorage `useEffect` extended to also seed `existingAttachments` from `initialValues.attachments` (cross-origin source, so not available in sessionStorage; takes priority over sessionStorage data)
- - `UploadLeadImage` `defaultImage` prop now checks `initialValues?.leadImage` first
**`packages/epics/src/governance/components/create-propose-a-contribution-form.tsx`**
- Accepts same `initialValues` and `bridgeKey` props
- - Passes `initialValues.title` and `initialValues.description` as `defaultValues` in `useForm`
- - New `useEffect` pre-fills `payouts` via `form.setValue` on first render
- - Passes `initialValues` and `bridgeKey` down to `CreateAgreementBaseFields`
## Context

ReGen Civics (https://regencivics.earth) runs quests. When a player completes a quest and clicks "Submit Proposal on DAO", they enter their deliverable URL and we package all quest metadata into a bridge record, then redirect them to Hypha with a URL like:

```
/en/dho/regen-games/agreements/create/propose-contribution
  ?bridgeKey=abc12345
  &title=[rc:abc12345] Quest 5: Rites of Love
  &description=...
  &payouts=[{"amount":"99","token":"0x4E617..."}]
  &attachments=[{"url":"https://youtube.com/...","filename":"My deliverable"}]
```

PR #2136 wires the page to read those searchParams and pass them into this form. This PR makes the form actually use them.

## Testing

Once both PRs land:
1. Go to `regencivics.earth/quest`
2. 2. Click "Submit Proposal on DAO" on any quest card
3. 3. Enter a YouTube URL
4. 4. On the bridge preview page, click "Continue to Hypha"
5. 5. Verify the Hypha form has title, description, and token amount pre-filled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Forms for creating agreements and proposals can be prefilled with title, description, lead image, attachments, and payouts to streamline imports or bridge-provided data.

* **Bug Fixes / Improvements**
  * Prefill now respects a clear precedence: bridge-provided initial values take priority over resubmit/session storage data; attachments and payouts are applied correctly on mount; lead image selection follows the new precedence logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->