### PR TITLE
fix(ui): align proposal loading overlay with open right panel

### DIFF
--- a/packages/ui/src/molecules/loading-backdrop.tsx
+++ b/packages/ui/src/molecules/loading-backdrop.tsx
@@ -29,10 +29,18 @@ export const LoadingBackdrop = ({
         <div
           className={cn(
             fullHeight
-              ? 'fixed top-9 bottom-0 right-0 flex flex-col items-center justify-center space-y-2 bg-background/75 z-10 w-full md:w-container-sm p-4 lg:p-7'
+              ? 'fixed bottom-0 flex flex-col items-center justify-center space-y-2 bg-background/75 z-10 w-full md:w-container-sm p-4 lg:p-7'
               : 'absolute inset-0 flex flex-col items-center justify-center space-y-2 bg-background/75 z-10 min-h-full',
             className,
           )}
+          style={
+            fullHeight
+              ? {
+                  top: 'var(--menu-top-height, 65px)',
+                  right: 'var(--sidebar-right-width, 0px)',
+                }
+              : undefined
+          }
         >
           <Progress value={progress} className="h-2 w-3/4 max-w-md" />
           {showKeepWindowOpenMessage && (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When submitting a proposal, `LoadingBackdrop` with `fullHeight` used `position: fixed` with `right-0`, so the overlay was anchored to the viewport while the create form lives in `SidePanel`, which uses `right: var(--sidebar-right-width, 0px)` when the human chat panel is open. That shifted the overlay left and clipped content against the chat panel.

## Changes

- Match `SidePanel` positioning for the full-height loading layer: `top: var(--menu-top-height, 65px)` and `right: var(--sidebar-right-width, 0px)` via inline style (same variables as `packages/epics/src/common/side-panel.tsx`).

## Testing

- `pnpm run format:fix`
- `pnpm run lint` in `packages/ui` (pre-existing warnings only; no new errors)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1f8d3e3c-e87e-4d98-bcd0-45e4ef5c1f12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1f8d3e3c-e87e-4d98-bcd0-45e4ef5c1f12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed loading overlay positioning to properly align with menu and sidebar elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->