### PR TITLE
fix(chat): space Matrix room id persistence and join hardening

### DIFF
--- a/packages/core/src/matrix/client/providers/matrix-provider.tsx
+++ b/packages/core/src/matrix/client/providers/matrix-provider.tsx
@@ -413,6 +413,7 @@ export const MatrixProvider: React.FC<MatrixProviderProps> = ({ children }) => {
         await client.joinRoom(roomId);
       } catch (error) {
         console.warn('Cannot join to room:', error);
+        throw error;
       }
     },
     [client],

--- a/packages/core/src/space/client/hooks/index.ts
+++ b/packages/core/src/space/client/hooks/index.ts
@@ -1,6 +1,7 @@
 export { useCreateSpaceOrchestrator } from './useCreateSpaceOrchestrator';
 export { useJoinSpaceWeb3Rpc } from './useJoinSpace.web3.rpc';
 export { useSpaceBySlug } from './useSpaceBySlug';
+export { useSpaceMutationsWeb2Rsc } from './useSpaceMutations.web2.rsc';
 export { useSpaceBySlugExists } from './useSpaceBySlugExists';
 export { useSpaceDetailsWeb3Rpc } from './useSpaceDetails.web3.rpc';
 export { useSpaceHasVoiceToken } from './useSpaceHasVoiceToken';

--- a/packages/core/src/space/types.ts
+++ b/packages/core/src/space/types.ts
@@ -22,6 +22,8 @@ export interface Space {
   documentCount?: number;
   documents?: Document[];
   address?: string | null;
+  /** Matrix room id for space chat when provisioned. */
+  chatRoomId?: string | null;
   flags: SpaceFlags[];
   parent?: Space | null;
   organisationSpaces?: Space[];
@@ -50,6 +52,7 @@ export interface UpdateSpaceInput {
   parentId?: number | null;
   web3SpaceId?: number;
   address?: string;
+  chatRoomId?: string | null;
   flags?: SpaceFlags[];
 }
 

--- a/packages/core/src/space/validation.ts
+++ b/packages/core/src/space/validation.ts
@@ -37,6 +37,11 @@ export const spaceMembersHttpPaginationQuerySchema = z
     };
   });
 
+const matrixRoomIdSchema = z
+  .string()
+  .trim()
+  .regex(/^![^:]+:[^:]+$/, 'Invalid Matrix room id');
+
 const createSpaceWeb2Props = {
   title: z
     .string()
@@ -119,6 +124,7 @@ export const updateSpaceProps = {
   categories: createSpaceWeb2Props.categories.optional(),
   links: createSpaceWeb2Props.links.optional(),
   flags: createSpaceWeb2Props.flags.optional(),
+  chatRoomId: matrixRoomIdSchema.nullable().optional(),
 };
 
 export const schemaUpdateSpace = z.object(updateSpaceProps);

--- a/packages/core/src/space/validation.ts
+++ b/packages/core/src/space/validation.ts
@@ -37,10 +37,11 @@ export const spaceMembersHttpPaginationQuerySchema = z
     };
   });
 
+/** `!opaque:server` where server may include extra colons (ports, IPv6 literals). */
 const matrixRoomIdSchema = z
   .string()
   .trim()
-  .regex(/^![^:]+:[^:]+$/, 'Invalid Matrix room id');
+  .regex(/^![^:]+:.+$/, 'Invalid Matrix room id format');
 
 const createSpaceWeb2Props = {
   title: z

--- a/packages/epics/src/common/human-right-panel.tsx
+++ b/packages/epics/src/common/human-right-panel.tsx
@@ -188,6 +188,11 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
   const { space, isLoading: isSpaceLoading } = useSpaceBySlug(spaceSlug ?? '');
   const { updateSpaceBySlug } = useSpaceMutationsWeb2Rsc(authToken);
   const { updateCoherenceBySlug } = useCoherenceMutationsWeb2Rsc(authToken);
+
+  const authTokenRef = useRef(authToken);
+  authTokenRef.current = authToken;
+  const updateSpaceBySlugRef = useRef(updateSpaceBySlug);
+  updateSpaceBySlugRef.current = updateSpaceBySlug;
   const { open: sidebarOpen } = useSidebar();
 
   const currentUserAvatarUrl = me?.avatarUrl;
@@ -365,9 +370,9 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
           }
           targetRoomId = newRoomId;
           storeRoomId(spaceSlug, newRoomId);
-          if (authToken) {
+          if (authTokenRef.current) {
             try {
-              await updateSpaceBySlug({
+              await updateSpaceBySlugRef.current({
                 slug: spaceSlug,
                 chatRoomId: newRoomId,
               });
@@ -419,8 +424,6 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
     spaceSlug,
     isSpaceLoading,
     space?.chatRoomId,
-    authToken,
-    updateSpaceBySlug,
   ]);
 
   // Track previous mode to detect actual transitions (not initial mount)

--- a/packages/epics/src/common/human-right-panel.tsx
+++ b/packages/epics/src/common/human-right-panel.tsx
@@ -15,6 +15,8 @@ import {
   useCoherenceMutationsWeb2Rsc,
   useJwt,
   useMe,
+  useSpaceBySlug,
+  useSpaceMutationsWeb2Rsc,
   Message,
   firstLineForReplyPreview,
   RoomEvent,
@@ -84,6 +86,14 @@ function getStoredRoomId(spaceSlug: string): string | null {
 function storeRoomId(spaceSlug: string, roomId: string): void {
   try {
     localStorage.setItem(`${ROOM_STORAGE_KEY}${spaceSlug}`, roomId);
+  } catch {
+    // localStorage not available
+  }
+}
+
+function clearStoredRoomId(spaceSlug: string): void {
+  try {
+    localStorage.removeItem(`${ROOM_STORAGE_KEY}${spaceSlug}`);
   } catch {
     // localStorage not available
   }
@@ -175,6 +185,8 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
   } = useHumanChatPanel();
   const { jwt: authToken } = useJwt();
   const { person: me } = useMe();
+  const { space, isLoading: isSpaceLoading } = useSpaceBySlug(spaceSlug ?? '');
+  const { updateSpaceBySlug } = useSpaceMutationsWeb2Rsc(authToken);
   const { updateCoherenceBySlug } = useCoherenceMutationsWeb2Rsc(authToken);
   const { open: sidebarOpen } = useSidebar();
 
@@ -301,31 +313,71 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
     )
       return;
     if (!spaceSlug) return;
+    if (isSpaceLoading) return;
 
     let cancelled = false;
-    const { joinRoom, createRoom, getRoomMessages } = matrixRef.current;
+    const { joinRoom, createRoom, getRoomMessages, client } = matrixRef.current;
 
     const initRoom = async () => {
       setIsJoining(true);
       setError(null);
       try {
-        let targetRoomId = getStoredRoomId(spaceSlug);
+        const canonicalRoomId = space?.chatRoomId?.trim() || null;
+        const storedRoomId = getStoredRoomId(spaceSlug);
+
+        if (
+          canonicalRoomId &&
+          storedRoomId &&
+          canonicalRoomId !== storedRoomId
+        ) {
+          clearStoredRoomId(spaceSlug);
+        }
+
+        let targetRoomId: string | null = canonicalRoomId || storedRoomId;
+
+        const ensureJoined = async (roomId: string) => {
+          await joinRoom(roomId);
+          const room = client?.getRoom(roomId);
+          if (!room) {
+            throw new Error('Room not available in Matrix client after join');
+          }
+        };
 
         if (targetRoomId) {
           try {
-            await joinRoom(targetRoomId);
-          } catch {
+            await ensureJoined(targetRoomId);
+          } catch (joinErr) {
+            if (canonicalRoomId && targetRoomId === canonicalRoomId) {
+              throw joinErr;
+            }
+            clearStoredRoomId(spaceSlug);
             targetRoomId = null;
           }
         }
 
         if (!targetRoomId) {
+          if (canonicalRoomId) {
+            throw new Error('Failed to join canonical space chat room');
+          }
           const { roomId: newRoomId } = await createRoom(`space-${spaceSlug}`);
           if (!newRoomId) {
             throw new Error('Failed to create room: empty roomId returned');
           }
           targetRoomId = newRoomId;
           storeRoomId(spaceSlug, newRoomId);
+          if (authToken) {
+            try {
+              await updateSpaceBySlug({
+                slug: spaceSlug,
+                chatRoomId: newRoomId,
+              });
+            } catch (persistErr) {
+              console.warn(
+                '[HumanRightPanel] Failed to persist chat room id on space:',
+                persistErr,
+              );
+            }
+          }
         }
 
         if (cancelled) return;
@@ -360,7 +412,16 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
     return () => {
       cancelled = true;
     };
-  }, [mode, isMatrixAvailable, isMatrixAuthenticated, spaceSlug]);
+  }, [
+    mode,
+    isMatrixAvailable,
+    isMatrixAuthenticated,
+    spaceSlug,
+    isSpaceLoading,
+    space?.chatRoomId,
+    authToken,
+    updateSpaceBySlug,
+  ]);
 
   // Track previous mode to detect actual transitions (not initial mount)
   const prevModeRef = useRef(mode);

--- a/packages/storage-postgres/migrations/0046_space_chat_room_id.sql
+++ b/packages/storage-postgres/migrations/0046_space_chat_room_id.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "spaces" ADD COLUMN "chat_room_id" text;

--- a/packages/storage-postgres/migrations/meta/_journal.json
+++ b/packages/storage-postgres/migrations/meta/_journal.json
@@ -323,6 +323,13 @@
       "when": 1775100000001,
       "tag": "0045_foamy_ronan",
       "breakpoints": true
+    },
+    {
+      "idx": 46,
+      "version": "7",
+      "when": 1775200000000,
+      "tag": "0046_space_chat_room_id",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/storage-postgres/src/schema/space.ts
+++ b/packages/storage-postgres/src/schema/space.ts
@@ -40,6 +40,8 @@ export const spaces = pgTable(
       .$type<Array<(typeof spaceFlags.enumValues)[number]>>()
       .notNull()
       .default([]),
+    /** Canonical Matrix room id for space-level chat (!id:server). */
+    chatRoomId: text('chat_room_id'),
     ...commonDateFields,
   },
   (table) => [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Matrix:** `joinRoom` now rethrows after logging so callers can recover from failed joins instead of continuing with a stale room id.
- **Database:** Add nullable `spaces.chat_room_id` (migration `0046_space_chat_room_id`) as the canonical Matrix room id for space-level chat.
- **API / validation:** `schemaUpdateSpace` accepts optional `chatRoomId` validated as a Matrix room id (`!…:…`).
- **Human chat panel:** Waits for space fetch from `GET /api/v1/spaces/[slug]`, prefers `space.chatRoomId` over localStorage, clears local cache when it disagrees with the server, verifies the room exists in the client after join, creates a room when none is set, and persists the new id with `updateSpaceBySlug` when the user has a JWT (warn-only on failure).
- **Exports:** Re-export `useSpaceMutationsWeb2Rsc` from core client hooks for the epics panel.

## Deploy / ops

Apply migration `0046_space_chat_room_id.sql` to environments that use this schema.

## Testing

Not run in this environment (Matrix and full dependency graph). Recommend exercising space chat after migration and verifying unauthenticated users still get local chat creation without API persist.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-003524b7-6cd5-4987-a740-6f8cccefb32a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-003524b7-6cd5-4987-a740-6f8cccefb32a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Spaces now support a dedicated chat room ID with persistence and synchronized updates.
  * Space initialization improved: prefers canonical room IDs, clears stale mappings, and re-runs when space data changes.

* **Bug Fixes**
  * Room join failures now propagate as errors so callers can detect and handle join problems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->