### PR TITLE
style(chat): composer icon hover feedback (primary tint)

### DIFF
--- a/packages/epics/src/common/human-chat-panel/human-chat-panel-chat-bar.tsx
+++ b/packages/epics/src/common/human-chat-panel/human-chat-panel-chat-bar.tsx
@@ -692,7 +692,7 @@ export function HumanChatPanelChatBar({
   }, []);
 
   const iconButtonClass =
-    'flex h-7 w-7 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-muted transition-colors';
+    'flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors duration-200 ease-out hover:bg-primary/12 hover:text-primary active:bg-primary/18 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/35 focus-visible:ring-offset-0';
 
   const fmtBtn =
     'flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-popover-foreground transition-colors hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent dark:hover:text-accent-foreground';
@@ -1144,9 +1144,9 @@ export function HumanChatPanelChatBar({
               onClick={onSend}
               disabled={!canSend}
               className={cn(
-                'flex h-7 w-7 shrink-0 items-center justify-center rounded transition-colors',
+                'flex h-7 w-7 shrink-0 items-center justify-center rounded-md transition-colors duration-200 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/35 focus-visible:ring-offset-0',
                 canSend
-                  ? 'text-primary hover:bg-primary/10'
+                  ? 'text-primary hover:bg-primary/12 hover:text-primary active:bg-primary/18'
                   : 'cursor-not-allowed text-muted-foreground/50',
               )}
               aria-label={t('sendButton')}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Improves **mouse-over feedback** on the chat composer footer icons (attach file, attach image, bold, emoji, mention, send) by switching from a subtle `hover:bg-muted` to a **primary-tinted** hover/active surface (`hover:bg-primary/12`, `active:bg-primary/18`) and **primary-colored icons on hover**, closer to the reference “light blue square” effect while staying on design tokens.

Also adds **`rounded-md`**, **`duration-200`**, and **`focus-visible` rings** for clearer keyboard affordance.

## Files

- `packages/epics/src/common/human-chat-panel/human-chat-panel-chat-bar.tsx`

## Testing

- `pnpm run format:fix`
- `pnpm --filter @hypha-platform/epics check-types`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e906d607-1dea-403e-a5c7-57547b52ef7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e906d607-1dea-403e-a5c7-57547b52ef7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

