### PR TITLE
refactor(chat): composer hint removal, padding balance, corner radius

### DIFF
--- a/packages/epics/src/common/human-chat-panel/human-chat-panel-chat-bar.tsx
+++ b/packages/epics/src/common/human-chat-panel/human-chat-panel-chat-bar.tsx
@@ -1157,9 +1157,6 @@ export function HumanChatPanelChatBar({
           </div>
         </div>
       </div>
-      <span className="mt-1.5 px-1 text-xs text-muted-foreground">
-        {t('newlineHint')}
-      </span>
     </div>
   );
 }

--- a/packages/epics/src/common/human-chat-panel/human-chat-panel-chat-bar.tsx
+++ b/packages/epics/src/common/human-chat-panel/human-chat-panel-chat-bar.tsx
@@ -698,7 +698,7 @@ export function HumanChatPanelChatBar({
     'flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-popover-foreground transition-colors hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent dark:hover:text-accent-foreground';
 
   return (
-    <div className="flex w-full min-w-0 flex-shrink-0 flex-col border-t border-border bg-background-2 p-3">
+    <div className="flex w-full min-w-0 flex-shrink-0 flex-col border-t border-border bg-background-2 px-3 pt-3 pb-3">
       <div
         ref={composerShellRef}
         className={cn(
@@ -1037,12 +1037,12 @@ export function HumanChatPanelChatBar({
           rows={1}
           className={cn(
             'min-h-[36px] min-w-0 max-h-[160px] w-full resize-none',
-            'bg-transparent px-3 pt-3 pb-1 text-sm leading-relaxed text-foreground',
+            'bg-transparent px-3 pt-3 pb-0 text-sm leading-relaxed text-foreground',
             'placeholder:text-muted-foreground focus:outline-none',
           )}
         />
 
-        <div className="flex min-w-0 flex-col gap-1 px-2 pb-2">
+        <div className="flex min-w-0 flex-col gap-1 px-2 pb-3">
           {voiceError && (
             <p role="alert" className="text-xs text-destructive">
               {voiceError}

--- a/packages/epics/src/common/human-chat-panel/human-chat-panel-chat-bar.tsx
+++ b/packages/epics/src/common/human-chat-panel/human-chat-panel-chat-bar.tsx
@@ -702,7 +702,7 @@ export function HumanChatPanelChatBar({
       <div
         ref={composerShellRef}
         className={cn(
-          'relative flex min-w-0 flex-col rounded-2xl border border-border bg-muted/50',
+          'relative flex min-w-0 flex-col rounded-lg border border-border bg-muted/50',
           'transition-all duration-200 focus-within:border-primary/50 focus-within:ring-2 focus-within:ring-primary/20',
         )}
       >


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Three **conventional commits** (one change each):

1. **`refactor(chat): remove composer newline hint text`** — Drops the `newlineHint` line under the composer (behavior unchanged; hints remain in placeholder/title where applicable).
2. **`style(chat): balance composer vertical padding with delimiter`** — Outer wrapper uses symmetric `px-3 pt-3 pb-3`; textarea bottom padding tightened (`pb-0`) and toolbar row uses `pb-3` so space below the shell matches the area above up to the top border delimiter.
3. **`style(chat): use subtler radius on composer shell`** — `rounded-2xl` → `rounded-lg` on the composer outline for a less pill-shaped box.

## Testing

- `pnpm run format:fix`
- `pnpm --filter @hypha-platform/epics check-types`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e906d607-1dea-403e-a5c7-57547b52ef7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e906d607-1dea-403e-a5c7-57547b52ef7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

