### PR TITLE
fix(epics): stop automatic download when opening Coherence Space Memory

### DIFF
--- a/packages/epics/src/coherence/components/space-memory-timeline-item.tsx
+++ b/packages/epics/src/coherence/components/space-memory-timeline-item.tsx
@@ -19,6 +19,10 @@ function isSafeAssetUrl(url: string): boolean {
   }
 }
 
+function looksLikePdf(name: string, url: string): boolean {
+  return /\.pdf(\?|#|$)/i.test(name) || /\.pdf(\?|#|$)/i.test(url);
+}
+
 type SpaceMemoryTimelineItemProps = {
   item: SpaceMemoryItem;
   contextLine: string;
@@ -47,6 +51,16 @@ export function SpaceMemoryTimelineItem({
       );
     }
     if (item.kind === 'image' && !imageFailed) {
+      // Signed PDF URLs are sometimes misclassified as "image"; never load them in <img>
+      // (can trigger a download or a broken preview).
+      if (looksLikePdf(item.name, item.url)) {
+        return (
+          <FileIcon
+            className="h-12 w-12 text-muted-foreground"
+            strokeWidth={1.25}
+          />
+        );
+      }
       return (
         // eslint-disable-next-line @next/next/no-img-element -- CDN / signed URLs
         <img
@@ -74,11 +88,21 @@ export function SpaceMemoryTimelineItem({
           src={item.url}
           muted
           playsInline
-          preload="metadata"
+          preload="none"
           className="max-h-full max-w-full object-contain bg-black"
         >
           <track kind="captions" />
         </video>
+      );
+    }
+    // Never embed PDFs in an iframe: many CDNs respond with Content-Disposition: attachment,
+    // which makes the browser save the file as soon as Coherence loads (regression guard).
+    if (safe && item.kind === 'document' && looksLikePdf(item.name, item.url)) {
+      return (
+        <FileIcon
+          className="h-12 w-12 text-muted-foreground"
+          strokeWidth={1.25}
+        />
       );
     }
     return (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Opening the Coherence tab could trigger an automatic file download. The most likely cause is **Space Memory** loading **PDF** proposal attachments: embedding or prefetching PDF URLs that respond with **`Content-Disposition: attachment`** (common on UploadThing / signed CDNs) forces the browser to download as soon as the resource is requested.

## Fix

- **`space-memory-timeline-item.tsx`**: never load PDFs in an `<img>` (guards misclassified `kind: image` + `.pdf` URL) and never embed PDFs in an `<iframe>`; show the generic **file icon** instead. Users still open the asset via the existing **link** (explicit navigation).
- Set **`preload="none"`** on preview `<video>` elements so opening Coherence does not start media fetches until the user interacts.

## Testing

- Manual: open DHO → Coherence with Space Memory containing PDFs; confirm no download starts until the user clicks an asset link.

Refs: `packages/epics/src/coherence/components/space-memory-timeline-item.tsx`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7cc15b9d-c108-4eea-a4c8-4b1b10b61793"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7cc15b9d-c108-4eea-a4c8-4b1b10b61793"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

