### PR TITLE
feat(feature-flags): enable human chat by default for production

### DIFF
--- a/apps/web-e2e/src/human-chat-panel-avatar.spec.ts
+++ b/apps/web-e2e/src/human-chat-panel-avatar.spec.ts
@@ -7,9 +7,6 @@ import { HumanChatPanelPage } from './pages/human-chat-panel.page';
  * Verifies that the PersonAvatar component is used in chat message bubbles
  * and that an authenticated user's profile image appears on their own messages.
  *
- * Feature flag: HYPHA_ENABLE_HUMAN_CHAT must be enabled.
- * We use the two-layer cookie strategy (extraHTTPHeaders for SSR + addCookies
- * for client navigation) — see .agents/skills/e2e-testing/references/feature-flags.md
  */
 
 const MOCK_AVATAR_URL = 'https://example.com/test-avatar.png';
@@ -26,17 +23,7 @@ const MOCK_USER = {
 test.describe('Human Chat Panel — Avatar in Messages', () => {
   let chatPanel: HumanChatPanelPage;
 
-  // Layer 1: Send cookie on SSR request
-  test.use({
-    extraHTTPHeaders: {
-      Cookie: 'HYPHA_ENABLE_HUMAN_CHAT=true',
-    },
-  });
-
-  test.beforeEach(async ({ page, context }) => {
-    // Layer 2: Persist cookie for client-side navigations
-    await HumanChatPanelPage.enableHumanChat(context);
-
+  test.beforeEach(async ({ page }) => {
     chatPanel = new HumanChatPanelPage(page);
     await chatPanel.open();
   });
@@ -83,17 +70,7 @@ test.describe('Human Chat Panel — Avatar in Messages', () => {
 test.describe('Human Chat Panel — Authenticated User Avatar', () => {
   let chatPanel: HumanChatPanelPage;
 
-  // Layer 1: Send cookie on SSR request
-  test.use({
-    extraHTTPHeaders: {
-      Cookie: 'HYPHA_ENABLE_HUMAN_CHAT=true',
-    },
-  });
-
-  test.beforeEach(async ({ page, context }) => {
-    // Layer 2: Persist cookie for client-side navigations
-    await HumanChatPanelPage.enableHumanChat(context);
-
+  test.beforeEach(async ({ page }) => {
     // Mock the /api/v1/people/me endpoint to return a user with an avatar
     await page.route('**/api/v1/people/me', (route) => {
       route.fulfill({

--- a/apps/web-e2e/src/human-chat-panel-feature-flag.spec.ts
+++ b/apps/web-e2e/src/human-chat-panel-feature-flag.spec.ts
@@ -2,25 +2,14 @@ import { test, expect } from '@playwright/test';
 import { HumanChatPanelPage } from './pages/human-chat-panel.page';
 
 /**
- * Feature Flag: NEXT_PUBLIC_ENABLE_HUMAN_CHAT
- *
- * Controls the visibility of the Human Chat panel. When set to "true",
- * the panel trigger button and sidebar are rendered. When unset or
- * any other value, only the page children render (no Human Chat panel).
- *
- * Note: This is a NEXT_PUBLIC_ env var, bundled at build time.
- * The "flag disabled" tests require a separate build without the flag.
+ * Human Chat is enabled by default. Emergency rollback uses the kill-switch cookie
+ * `HYPHA_DISABLE_HUMAN_CHAT=true` (see `getEnableHumanChat` in feature-flags).
  */
 
-test.describe('Human Chat Panel — Feature Flag Enabled', () => {
+test.describe('Human Chat Panel — default (enabled)', () => {
   let chatPanel: HumanChatPanelPage;
 
-  test.use({
-    extraHTTPHeaders: { Cookie: 'HYPHA_ENABLE_HUMAN_CHAT=true' },
-  });
-
-  test.beforeEach(async ({ page, context }) => {
-    await HumanChatPanelPage.enableHumanChat(context);
+  test.beforeEach(async ({ page }) => {
     chatPanel = new HumanChatPanelPage(page);
     await chatPanel.open();
   });
@@ -57,29 +46,22 @@ test.describe('Human Chat Panel — Feature Flag Enabled', () => {
   });
 });
 
-test.describe('Human Chat Panel — Feature Flag Disabled', () => {
-  /**
-   * These tests verify behavior when NEXT_PUBLIC_ENABLE_HUMAN_CHAT is NOT "true".
-   *
-   * Since this is a build-time env var bundled by Next.js, toggling it requires
-   * a separate build/dev server started without the flag. These tests are skipped
-   * in the default test run (which assumes the flag is enabled for development).
-   *
-   * To run these tests:
-   * 1. Start the dev server without the flag: `NEXT_PUBLIC_ENABLE_HUMAN_CHAT= npx nx start web`
-   * 2. Run only this describe block: `npx playwright test human-chat-panel-feature-flag --grep "Disabled"`
-   *
-   * Expected behavior when disabled:
-   * - No "Open chat panel" button rendered
-   * - No right sidebar/panel markup in the DOM
-   * - Page content renders normally without any Human Chat wrapper
-   */
+test.describe('Human Chat Panel — kill switch (disabled)', () => {
+  test.use({
+    extraHTTPHeaders: { Cookie: 'HYPHA_DISABLE_HUMAN_CHAT=true' },
+  });
 
-  // eslint-disable-next-line playwright/no-skipped-test
-  test.skip(
-    true,
-    'Requires a build without NEXT_PUBLIC_ENABLE_HUMAN_CHAT=true',
-  );
+  test.beforeEach(async ({ context }) => {
+    await context.addCookies([
+      {
+        name: 'HYPHA_DISABLE_HUMAN_CHAT',
+        value: 'true',
+        domain: new URL(process.env.BASE_URL || 'http://127.0.0.1:4200')
+          .hostname,
+        path: '/',
+      },
+    ]);
+  });
 
   test('should not render Human Chat trigger button on space page', async ({
     page,
@@ -97,7 +79,6 @@ test.describe('Human Chat Panel — Feature Flag Disabled', () => {
     await page.goto('/en/dho/hypha/agreements');
     await page.waitForLoadState('domcontentloaded');
 
-    // Space page content should still render
     await expect(page.getByText('Agreements')).toBeVisible();
   });
 });

--- a/apps/web-e2e/src/human-chat-panel-header.spec.ts
+++ b/apps/web-e2e/src/human-chat-panel-header.spec.ts
@@ -13,12 +13,7 @@ import { HumanChatPanelPage } from './pages/human-chat-panel.page';
 test.describe('Human Chat Panel Header Layout', () => {
   let chatPanel: HumanChatPanelPage;
 
-  test.use({
-    extraHTTPHeaders: { Cookie: 'HYPHA_ENABLE_HUMAN_CHAT=true' },
-  });
-
-  test.beforeEach(async ({ page, context }) => {
-    await HumanChatPanelPage.enableHumanChat(context);
+  test.beforeEach(async ({ page }) => {
     chatPanel = new HumanChatPanelPage(page);
     await chatPanel.open();
     await chatPanel.openPanel();

--- a/apps/web-e2e/src/human-chat-panel-members.spec.ts
+++ b/apps/web-e2e/src/human-chat-panel-members.spec.ts
@@ -71,13 +71,7 @@ test.describe('Human Chat Panel – Members Tab', () => {
 
   let chatPanel: HumanChatPanelPage;
 
-  test.use({
-    extraHTTPHeaders: { Cookie: 'HYPHA_ENABLE_HUMAN_CHAT=true' },
-  });
-
-  test.beforeEach(async ({ page, context }) => {
-    await HumanChatPanelPage.enableHumanChat(context);
-
+  test.beforeEach(async ({ page }) => {
     // Intercept the members API to return deterministic mock data
     await page.route('**/api/v1/spaces/*/members*', (route) => {
       route.fulfill({

--- a/apps/web-e2e/src/human-chat-panel-resize.spec.ts
+++ b/apps/web-e2e/src/human-chat-panel-resize.spec.ts
@@ -9,7 +9,6 @@ import { HumanChatPanelPage } from './pages/human-chat-panel.page';
  * drag-to-resize, keyboard support, double-click reset, and layout
  * integration.
  *
- * Uses the two-layer cookie strategy for the feature flag.
  */
 
 // Source: packages/ui/src/sidebar.tsx — SIDEBAR_RESIZE_DEFAULT, SIDEBAR_RESIZE_STEP
@@ -19,12 +18,7 @@ const RESIZE_STEP = 10;
 test.describe('Human Chat Panel — Resize Handle', () => {
   let chatPanel: HumanChatPanelPage;
 
-  test.use({
-    extraHTTPHeaders: { Cookie: 'HYPHA_ENABLE_HUMAN_CHAT=true' },
-  });
-
-  test.beforeEach(async ({ page, context }) => {
-    await HumanChatPanelPage.enableHumanChat(context);
+  test.beforeEach(async ({ page }) => {
     chatPanel = new HumanChatPanelPage(page);
     await chatPanel.open();
     await chatPanel.openPanel();

--- a/apps/web-e2e/src/human-chat-panel-space-switch.spec.ts
+++ b/apps/web-e2e/src/human-chat-panel-space-switch.spec.ts
@@ -9,7 +9,6 @@ import { HumanChatPanelPage } from './pages/human-chat-panel.page';
  * - Navigating to a different space resets the chat (clears messages, input)
  * - Navigating back to the original space re-joins its room
  *
- * These tests require NEXT_PUBLIC_ENABLE_HUMAN_CHAT=true.
  */
 test.describe('Human Chat Panel — Space Switching', () => {
   test.setTimeout(60_000); // Space navigation can be slow in production builds
@@ -17,10 +16,6 @@ test.describe('Human Chat Panel — Space Switching', () => {
   const SPACE_B = 'hypha-platform';
 
   let chatPanel: HumanChatPanelPage;
-
-  test.beforeEach(async ({ context }) => {
-    await HumanChatPanelPage.enableHumanChat(context);
-  });
 
   test('should show welcome message on a fresh space', async ({ page }) => {
     chatPanel = new HumanChatPanelPage(page);

--- a/apps/web-e2e/src/menu-top-consistent-height.spec.ts
+++ b/apps/web-e2e/src/menu-top-consistent-height.spec.ts
@@ -13,18 +13,12 @@ import { LayoutPage } from './pages/layout.page';
 test.describe('MenuTop consistent height', () => {
   test.use({
     extraHTTPHeaders: {
-      Cookie: 'HYPHA_ENABLE_HUMAN_CHAT=true; HYPHA_ENABLE_AI_CHAT=true',
+      Cookie: 'HYPHA_ENABLE_AI_CHAT=true',
     },
   });
 
   test.beforeEach(async ({ context }) => {
     await context.addCookies([
-      {
-        name: 'HYPHA_ENABLE_HUMAN_CHAT',
-        value: 'true',
-        domain: '127.0.0.1',
-        path: '/',
-      },
       {
         name: 'HYPHA_ENABLE_AI_CHAT',
         value: 'true',

--- a/apps/web-e2e/src/pages/human-chat-panel.page.ts
+++ b/apps/web-e2e/src/pages/human-chat-panel.page.ts
@@ -1,11 +1,5 @@
-import { Page, Locator, BrowserContext } from '@playwright/test';
+import { Page, Locator } from '@playwright/test';
 import { BasePage } from './base.page';
-
-/**
- * Cookie name for the Human Chat feature flag.
- * Canonical source: packages/cookie/src/constants.ts → HYPHA_ENABLE_HUMAN_CHAT
- */
-const HYPHA_ENABLE_HUMAN_CHAT = 'HYPHA_ENABLE_HUMAN_CHAT';
 
 export class HumanChatPanelPage extends BasePage {
   readonly openButton: Locator;
@@ -62,26 +56,6 @@ export class HumanChatPanelPage extends BasePage {
       .getByRole('button', { name: /^chat$/i });
     this.membersContainer = page.getByTestId('chat-panel-members');
     this.memberItems = page.getByTestId('chat-panel-member-item');
-  }
-
-  /**
-   * Enable the Human Chat feature flag.
-   *
-   * The flag is evaluated during SSR via cookie, so we set
-   * browser cookies for client-side navigations.
-   *
-   * Call this BEFORE open() in test setup, or use the static helper.
-   */
-  static async enableHumanChat(context: BrowserContext) {
-    await context.addCookies([
-      {
-        name: HYPHA_ENABLE_HUMAN_CHAT,
-        value: 'true',
-        domain: new URL(process.env.BASE_URL || 'http://127.0.0.1:4200')
-          .hostname,
-        path: '/',
-      },
-    ]);
   }
 
   /** Navigate to a space's agreements page. Defaults to 'hypha'. */

--- a/apps/web-e2e/src/panel-layout.spec.ts
+++ b/apps/web-e2e/src/panel-layout.spec.ts
@@ -6,7 +6,7 @@ test.describe('Panel Layout', () => {
 
   test.use({
     extraHTTPHeaders: {
-      Cookie: 'HYPHA_ENABLE_AI_CHAT=true; HYPHA_ENABLE_HUMAN_CHAT=true',
+      Cookie: 'HYPHA_ENABLE_AI_CHAT=true',
     },
   });
 
@@ -14,12 +14,6 @@ test.describe('Panel Layout', () => {
     await context.addCookies([
       {
         name: 'HYPHA_ENABLE_AI_CHAT',
-        value: 'true',
-        domain: '127.0.0.1',
-        path: '/',
-      },
-      {
-        name: 'HYPHA_ENABLE_HUMAN_CHAT',
         value: 'true',
         domain: '127.0.0.1',
         path: '/',

--- a/apps/web-e2e/src/panels-space-context.spec.ts
+++ b/apps/web-e2e/src/panels-space-context.spec.ts
@@ -7,7 +7,7 @@ import { test, expect } from '@playwright/test';
  * rendered within a space context (/[lang]/dho/[id]/...) and are absent
  * on non-space pages (network, my-spaces, profile).
  *
- * Uses two-layer cookie strategy for feature flags:
+ * Uses two-layer cookie strategy for AI Chat:
  * - extraHTTPHeaders for SSR
  * - addCookies for client-side navigation
  */
@@ -18,18 +18,12 @@ const AI_TRIGGER = /open hypha ai panel/i;
 test.describe('Panels visible on space pages', () => {
   test.use({
     extraHTTPHeaders: {
-      Cookie: 'HYPHA_ENABLE_HUMAN_CHAT=true; HYPHA_ENABLE_AI_CHAT=true',
+      Cookie: 'HYPHA_ENABLE_AI_CHAT=true',
     },
   });
 
   test.beforeEach(async ({ context }) => {
     await context.addCookies([
-      {
-        name: 'HYPHA_ENABLE_HUMAN_CHAT',
-        value: 'true',
-        domain: '127.0.0.1',
-        path: '/',
-      },
       {
         name: 'HYPHA_ENABLE_AI_CHAT',
         value: 'true',
@@ -59,18 +53,12 @@ test.describe('Panels visible on space pages', () => {
 test.describe('Panels hidden on non-space pages', () => {
   test.use({
     extraHTTPHeaders: {
-      Cookie: 'HYPHA_ENABLE_HUMAN_CHAT=true; HYPHA_ENABLE_AI_CHAT=true',
+      Cookie: 'HYPHA_ENABLE_AI_CHAT=true',
     },
   });
 
   test.beforeEach(async ({ context }) => {
     await context.addCookies([
-      {
-        name: 'HYPHA_ENABLE_HUMAN_CHAT',
-        value: 'true',
-        domain: '127.0.0.1',
-        path: '/',
-      },
       {
         name: 'HYPHA_ENABLE_AI_CHAT',
         value: 'true',
@@ -127,18 +115,12 @@ test.describe('Panels hidden on non-space pages', () => {
 test.describe('Panels appear after navigating into a space', () => {
   test.use({
     extraHTTPHeaders: {
-      Cookie: 'HYPHA_ENABLE_HUMAN_CHAT=true; HYPHA_ENABLE_AI_CHAT=true',
+      Cookie: 'HYPHA_ENABLE_AI_CHAT=true',
     },
   });
 
   test.beforeEach(async ({ context }) => {
     await context.addCookies([
-      {
-        name: 'HYPHA_ENABLE_HUMAN_CHAT',
-        value: 'true',
-        domain: '127.0.0.1',
-        path: '/',
-      },
       {
         name: 'HYPHA_ENABLE_AI_CHAT',
         value: 'true',

--- a/apps/web/src/app/[lang]/dho/[id]/@tab/coherence/page.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@tab/coherence/page.tsx
@@ -3,10 +3,7 @@ import {
   CoherenceBlock,
   CoherenceOrder,
 } from '@hypha-platform/epics';
-import {
-  getEnableCoherence,
-  getEnableHumanChat,
-} from '@hypha-platform/feature-flags';
+import { getEnableCoherence } from '@hypha-platform/feature-flags';
 import { Locale } from '@hypha-platform/i18n';
 import { notFound } from 'next/navigation';
 
@@ -24,8 +21,6 @@ export default async function CoherencePage(props: PageProps) {
     notFound();
   }
 
-  const humanChatEnabled = await getEnableHumanChat();
-
   const params = await props.params;
   const searchParams = await props.searchParams;
 
@@ -37,12 +32,5 @@ export default async function CoherencePage(props: PageProps) {
       ? (orderRaw as CoherenceOrder)
       : 'mostrecent';
 
-  return (
-    <CoherenceBlock
-      lang={lang}
-      spaceSlug={id}
-      order={order}
-      humanChatEnabled={humanChatEnabled}
-    />
-  );
+  return <CoherenceBlock lang={lang} spaceSlug={id} order={order} />;
 }

--- a/packages/cookie/src/constants.ts
+++ b/packages/cookie/src/constants.ts
@@ -3,4 +3,6 @@ export const HYPHA_AUTH_PROVIDER = 'HYPHA_AUTH_PROVIDER';
 export const HYPHA_SHOW_LANGUAGE_SELECT = 'HYPHA_SHOW_LANGUAGE_SELECT';
 export const HYPHA_ENABLE_AI_CHAT = 'HYPHA_ENABLE_AI_CHAT';
 export const HYPHA_ENABLE_HUMAN_CHAT = 'HYPHA_ENABLE_HUMAN_CHAT';
+/** When `true`, hides Human Chat and disables Matrix token issuance (emergency kill switch). */
+export const HYPHA_DISABLE_HUMAN_CHAT = 'HYPHA_DISABLE_HUMAN_CHAT';
 export const HYPHA_ENABLE_COHERENCE = 'HYPHA_ENABLE_COHERENCE';

--- a/packages/epics/src/coherence/components/coherence-block.tsx
+++ b/packages/epics/src/coherence/components/coherence-block.tsx
@@ -19,14 +19,12 @@ type CoherenceBlockProps = {
   lang: Locale;
   spaceSlug: string;
   order?: CoherenceOrder;
-  humanChatEnabled?: boolean;
 };
 
 export function CoherenceBlock({
   lang,
   spaceSlug,
   order,
-  humanChatEnabled = false,
 }: CoherenceBlockProps) {
   const t = useTranslations('CoherenceTab');
   const [hideArchived, setHideArchived] = React.useState(true);
@@ -64,8 +62,6 @@ export function CoherenceBlock({
     [openCoherenceChat],
   );
 
-  const onSignalClick = humanChatEnabled ? handleSignalClick : undefined;
-
   return (
     <div className="flex flex-col gap-6 py-4">
       {isAuthenticated ? (
@@ -79,7 +75,7 @@ export function CoherenceBlock({
             firstPageSize={3}
             pageSize={3}
             refresh={refresh}
-            onSignalClick={onSignalClick}
+            onSignalClick={handleSignalClick}
           />
           <SpaceMemorySection spaceSlug={spaceSlug} />
         </>

--- a/packages/feature-flags/src/index.ts
+++ b/packages/feature-flags/src/index.ts
@@ -1,6 +1,7 @@
 import { cookies } from 'next/headers';
 import {
   HYPHA_AUTH_PROVIDER,
+  HYPHA_DISABLE_HUMAN_CHAT,
   HYPHA_ENABLE_AI_CHAT,
   HYPHA_ENABLE_COHERENCE,
   HYPHA_ENABLE_HUMAN_CHAT,
@@ -48,13 +49,6 @@ export const flagDefinitionsForDiscovery = {
     defaultValue: false,
     description:
       'Enable Coherence signals, threads, and conversation features in space pages',
-    origin: 'hypha' as const,
-    options: undefined as undefined,
-  },
-  enableHumanChat: {
-    key: 'enable-human-chat',
-    defaultValue: false,
-    description: 'Enable the Human Chat panel in space pages',
     origin: 'hypha' as const,
     options: undefined as undefined,
   },
@@ -109,10 +103,30 @@ export async function getEnableCoherence(): Promise<boolean> {
   );
 }
 
+/**
+ * Human Chat is **on by default** (including production). Rollback uses a kill switch:
+ * - Cookie `HYPHA_DISABLE_HUMAN_CHAT=true`
+ * - Or legacy opt-out: `HYPHA_ENABLE_HUMAN_CHAT=false`
+ * - Or env: `NEXT_PUBLIC_DISABLE_HUMAN_CHAT=true` / `NEXT_PUBLIC_ENABLE_HUMAN_CHAT=false`
+ * - Or Vercel Flags Toolbar override `enable-human-chat` → `false` (when FLAGS_SECRET is set)
+ */
 export async function getEnableHumanChat(): Promise<boolean> {
-  return getBooleanFlagFromToolbarCookieOrEnv(
-    'enable-human-chat',
-    HYPHA_ENABLE_HUMAN_CHAT,
-    process.env.NEXT_PUBLIC_ENABLE_HUMAN_CHAT,
-  );
+  const overrides = await getVercelToolbarFlagOverrides();
+  const toolbarHumanChat = readBooleanOverride(overrides, 'enable-human-chat');
+  if (toolbarHumanChat === true) return true;
+  if (toolbarHumanChat === false) return false;
+
+  const store = await cookies();
+
+  if (store.get(HYPHA_DISABLE_HUMAN_CHAT)?.value === 'true') {
+    return false;
+  }
+
+  const legacyEnable = store.get(HYPHA_ENABLE_HUMAN_CHAT)?.value;
+  if (legacyEnable === 'false') return false;
+
+  if (process.env.NEXT_PUBLIC_DISABLE_HUMAN_CHAT === 'true') return false;
+  if (process.env.NEXT_PUBLIC_ENABLE_HUMAN_CHAT === 'false') return false;
+
+  return true;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Human Chat (space general room chat, Matrix-backed) is **enabled by default**, including production. The previous opt-in gate (`NEXT_PUBLIC_ENABLE_HUMAN_CHAT`, `HYPHA_ENABLE_HUMAN_CHAT`) is replaced by an **optional kill switch** so incidents can still disable chat without reverting code.

## Behavior

- **Default:** `getEnableHumanChat()` returns **true** unless overridden.
- **Emergency disable:**
  - Cookie **`HYPHA_DISABLE_HUMAN_CHAT=true`** (added in `@hypha-platform/cookie`)
  - Legacy cookie **`HYPHA_ENABLE_HUMAN_CHAT=false`**
  - Env **`NEXT_PUBLIC_DISABLE_HUMAN_CHAT=true`** or **`NEXT_PUBLIC_ENABLE_HUMAN_CHAT=false`**
  - Vercel Flags Toolbar override **`enable-human-chat`** → **`false`** (still honored when `FLAGS_SECRET` is set); **`true`** forces enable even if kill-switch cookies are set.

## Other changes

- Removed **`enable-human-chat`** from `flagDefinitionsForDiscovery` (no longer listed in `/.well-known/vercel/flags`).
- **`CoherenceBlock`** always wires signal → panel open (no separate `humanChatEnabled` prop).
- **E2E:** Dropped redundant Human Chat cookies; added kill-switch coverage in `human-chat-panel-feature-flag.spec.ts`.

## Deploy note

After merge, remove **`NEXT_PUBLIC_ENABLE_HUMAN_CHAT`** from Vercel production env if it was used to gate the feature (optional cleanup). Rollback uses **`NEXT_PUBLIC_DISABLE_HUMAN_CHAT=true`** or **`HYPHA_DISABLE_HUMAN_CHAT`** if needed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-917f9739-bf3e-4438-9bdb-407ebf348013"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-917f9739-bf3e-4438-9bdb-407ebf348013"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

