### PR TITLE
feat(epics): proposal form Reset when dirty

### DIFF
--- a/packages/epics/src/agreements/components/create-agreement-base-fields.tsx
+++ b/packages/epics/src/agreements/components/create-agreement-base-fields.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useFormContext, useWatch } from 'react-hook-form';
+import { useFormContext } from 'react-hook-form';
 import {
+  Button,
   Input,
   FormControl,
   FormDescription,
@@ -42,6 +43,7 @@ import { ButtonBack, ButtonClose } from '../../common';
 import { useProposalNotifications } from '../../governance/hooks';
 import React from 'react';
 import { useTranslations } from 'next-intl';
+import { RotateCcw } from 'lucide-react';
 
 type Creator = { avatar: string; name: string; surname: string };
 
@@ -272,6 +274,12 @@ export function CreateAgreementBaseFields({
     postProposalCreated,
   });
 
+  const handleResetForm = React.useCallback(() => {
+    form.reset();
+    setExistingAttachments([]);
+    setResubmitFormData(null);
+  }, [form]);
+
   return (
     <>
       <div className="flex flex-col-reverse md:flex-row justify-between gap-4 md:gap-2">
@@ -299,6 +307,18 @@ export function CreateAgreementBaseFields({
                   </Badge>
                 )}
                 <div className="flex grow"></div>
+                {form.formState.isDirty ? (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    colorVariant="neutral"
+                    className="inline-flex items-center gap-1 px-0 text-neutral-10 md:px-3"
+                    onClick={handleResetForm}
+                  >
+                    <RotateCcw className="size-4 shrink-0" aria-hidden />
+                    {tAgreementFlow('createAgreementBaseFields.resetForm')}
+                  </Button>
+                ) : null}
                 {backUrl && (
                   <ButtonBack
                     label={resolvedBackLabel}

--- a/packages/i18n/src/messages/de.json
+++ b/packages/i18n/src/messages/de.json
@@ -910,6 +910,7 @@
     "createAgreementBaseFields": {
       "agreementLabel": "Vereinbarung",
       "backToCreate": "Zurück zum Erstellen",
+      "resetForm": "Zurücksetzen",
       "formContextMissing": "Formular-Kontext fehlt!",
       "delegate": "Delegierter",
       "proposalTitlePlaceholder": "Vorschlagstitel...",

--- a/packages/i18n/src/messages/en.json
+++ b/packages/i18n/src/messages/en.json
@@ -910,6 +910,7 @@
     "createAgreementBaseFields": {
       "agreementLabel": "Agreement",
       "backToCreate": "Back to Create",
+      "resetForm": "Reset",
       "formContextMissing": "Form context is missing!",
       "delegate": "Delegate",
       "proposalTitlePlaceholder": "Proposal title...",

--- a/packages/i18n/src/messages/es.json
+++ b/packages/i18n/src/messages/es.json
@@ -585,6 +585,7 @@
     "createAgreementBaseFields": {
       "agreementLabel": "Acuerdo",
       "backToCreate": "Volver a Crear",
+      "resetForm": "Restablecer",
       "formContextMissing": "¡Falta el contexto del formulario!",
       "delegate": "Delegar",
       "proposalTitlePlaceholder": "Título de la propuesta...",

--- a/packages/i18n/src/messages/fr.json
+++ b/packages/i18n/src/messages/fr.json
@@ -910,6 +910,7 @@
     "createAgreementBaseFields": {
       "agreementLabel": "Accord",
       "backToCreate": "Retour à la création",
+      "resetForm": "Réinitialiser",
       "formContextMissing": "Le contexte du formulaire est manquant !",
       "delegate": "Délégué",
       "proposalTitlePlaceholder": "Titre de la proposition...",

--- a/packages/i18n/src/messages/pt.json
+++ b/packages/i18n/src/messages/pt.json
@@ -585,6 +585,7 @@
     "createAgreementBaseFields": {
       "agreementLabel": "Acordo",
       "backToCreate": "Voltar para criar",
+      "resetForm": "Repor",
       "formContextMissing": "O contexto do formulário está faltando!",
       "delegate": "Delegar",
       "proposalTitlePlaceholder": "Título da proposta...",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **Reset** control to the proposal creation header row (same pattern as Back / Close): ghost button with rotate-undo icon, placed before Back. It clears the react-hook-form state via `reset()`, clears local resubmit attachments state, and clears resubmit metadata so the UI stays consistent.

Visibility uses **`form.formState.isDirty`** so the button appears only after the user has changed something from defaults (including auto-filled space banner, which uses `setValue` without marking dirty).

## i18n

Added `AgreementFlow.createAgreementBaseFields.resetForm` in `en`, `de`, `es`, `fr`, `pt`.

## Scope

Applies to all flows using `CreateAgreementBaseFields` (Backing Vault and other proposals).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-963fc2c7-a91d-45e9-a521-4a0bbce71687"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-963fc2c7-a91d-45e9-a521-4a0bbce71687"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Reset" button to the agreement creation form that clears all entered data and attached documents when clicked.
  * The reset button only appears when the form contains unsaved changes.
  * Multilingual support added for the reset button label in English, German, Spanish, French, and Portuguese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->