### PR TITLE
fix(ui): calendar weekday header alignment for react-day-picker v8

### DIFF
--- a/packages/ui/src/calendar.tsx
+++ b/packages/ui/src/calendar.tsx
@@ -39,13 +39,14 @@ function Calendar({
         ),
         nav_button_previous: 'absolute left-1',
         nav_button_next: 'absolute right-1',
-        table: 'w-full border-collapse space-y-1',
-        head_row: 'flex',
+        /** Native `<table>` layout — `flex` on `<tr>` breaks weekday / day columns (react-day-picker v8). */
+        table: 'w-full border-collapse',
+        head_row: 'table-row',
         head_cell:
-          'text-secondary-foreground rounded-md w-8 font-normal text-2 uppercase',
-        row: 'flex w-full mt-2',
+          'table-cell align-middle text-secondary-foreground rounded-md w-9 min-w-9 px-0 text-center font-normal text-[11px] uppercase text-muted-foreground',
+        row: 'table-row',
         cell: cn(
-          'relative p-0 text-center text-sm focus-within:relative focus-within:z-20 [&:has([aria-selected])]:bg-accent [&:has([aria-selected].day-outside)]:bg-accent [&:has([aria-selected].day-range-end)]:rounded-r-full [&:has([aria-selected].day-range-end)]:rounded-r-full',
+          'relative table-cell align-middle p-0 text-center text-sm focus-within:relative focus-within:z-20 [&:has([aria-selected])]:bg-accent [&:has([aria-selected].day-outside)]:bg-accent [&:has([aria-selected].day-range-end)]:rounded-r-full [&:has([aria-selected].day-range-end)]:rounded-r-full',
           props.mode === 'range'
             ? '[&:has(>.day-range-end)]:rounded-r-full [&:has(>.day-range-start)]:rounded-l-full first:[&:has([aria-selected])]:rounded-l-full last:[&:has([aria-selected])]:rounded-r-full'
             : '[&:has([aria-selected])]:rounded-full',
@@ -68,10 +69,12 @@ function Calendar({
         ...classNames,
       }}
       components={{
-        Chevron: ({ className, orientation, ...props }) => {
-          const Icon = orientation === 'left' ? ChevronLeft : ChevronRight;
-          return <Icon className={cn('h-4 w-4', className)} {...props} />;
-        },
+        IconLeft: ({ className, ...props }) => (
+          <ChevronLeft className={cn('h-4 w-4', className)} {...props} />
+        ),
+        IconRight: ({ className, ...props }) => (
+          <ChevronRight className={cn('h-4 w-4', className)} {...props} />
+        ),
       }}
       {...props}
     />

--- a/packages/ui/src/date-picker.tsx
+++ b/packages/ui/src/date-picker.tsx
@@ -81,7 +81,6 @@ export function DatePicker({
             selected={selected instanceof Date ? selected : undefined}
             onSelect={(date) => handleSelect(date)}
             locale={locale}
-            autoFocus
           />
         ) : (
           <Calendar
@@ -95,7 +94,6 @@ export function DatePicker({
             }
             onSelect={(range) => handleSelect(range)}
             locale={locale}
-            autoFocus
           />
         )}
       </PopoverContent>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Weekday labels (Su, Mo, …) were collapsing or drifting outside the grid because `head_row` / `row` used **flex** on native `<tr>` elements. **react-day-picker v8** renders a real `<table>`; flex on `<tr>` breaks column alignment.

Navigation icons also used a **v9-only** `Chevron` slot; v8 expects **`IconLeft` / `IconRight`**.

## Changes

- **`calendar.tsx`**: Use `table-row` / `table-cell` + `table-cell align-middle` for header cells and day cells; remove invalid `flex` from `<tr>` layout. Replace `components.Chevron` with `IconLeft` / `IconRight` (lucide chevrons).
- **`date-picker.tsx`**: Remove unsupported `autoFocus` passed through to `Calendar` / DayPicker v8.

## Verification

Lint on touched files passes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-963fc2c7-a91d-45e9-a521-4a0bbce71687"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-963fc2c7-a91d-45e9-a521-4a0bbce71687"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

