### PR TITLE
fix(chat): do not show dictation error on normal stop

### DIFF
--- a/packages/epics/src/common/human-chat-panel/human-chat-panel-chat-bar.tsx
+++ b/packages/epics/src/common/human-chat-panel/human-chat-panel-chat-bar.tsx
@@ -62,6 +62,11 @@ import {
 
 type SpeechRecognitionCtor = new () => SpeechRecognitionLike;
 
+/** Web Speech API error codes (subset). `aborted` is emitted when `abort()` stops recognition. */
+function isBenignSpeechRecognitionError(code: string | undefined): boolean {
+  return code === 'aborted';
+}
+
 type SpeechRecognitionLike = {
   continuous: boolean;
   interimResults: boolean;
@@ -1033,12 +1038,19 @@ export function HumanChatPanelChatBar({
         el.setSelectionRange(end, end);
       });
     };
-    rec.onerror = () => {
+    rec.onerror = (ev) => {
+      const code =
+        typeof ev === 'object' && ev !== null && 'error' in ev
+          ? (ev as { error?: string }).error
+          : undefined;
+      const benign = isBenignSpeechRecognitionError(code);
       speechRecognitionRef.current = null;
       dictationPrefixRef.current = '';
       setIsDictating(false);
       onChange(stripTrailingZeroWidthSpaces(valueRef.current));
-      setVoiceError(t('dictationError'));
+      if (!benign) {
+        setVoiceError(t('dictationError'));
+      }
     };
     rec.onend = () => {
       speechRecognitionRef.current = null;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The human chat composer uses the Web Speech API for dictation. When the user stops dictation, the code calls `stop()` (and may fall back to `abort()`), which typically dispatches `onerror` with `error: "aborted"`. The previous handler always set the red `dictationError` string, so users saw *"Dictation stopped due to an error"* even when transcription had worked.

We now treat the `aborted` error code as a benign, expected shutdown and only show the generic error for other failure codes.

## Test plan

- [ ] Open human chat, start dictation, speak, stop dictation — no red error if text was captured.
- [ ] Unplug mic or trigger a real network/speech error (if possible) — error still shows for non-`aborted` errors.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-534cd54a-f59d-4b7d-95cc-62fada6dece5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-534cd54a-f59d-4b7d-95cc-62fada6dece5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

