### PR TITLE
feat(epics): dynamic DHO banner overlay from image tone

### DIFF
--- a/.github/actions/detect-changes/action.yml
+++ b/.github/actions/detect-changes/action.yml
@@ -12,7 +12,7 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - uses: dorny/paths-filter@v3
+    - uses: dorny/paths-filter@v4
       id: changes
       with:
         filters: |

--- a/apps/web/src/app/[lang]/dho/[id]/_components/navigation-tabs.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/navigation-tabs.tsx
@@ -60,7 +60,7 @@ export function NavigationTabs({
   ];
 
   return (
-    <Tabs value={activeTab} className="w-full mt-16 overflow-hidden">
+    <Tabs value={activeTab} className="w-full mt-6 overflow-hidden md:mt-7">
       <ScrollArea>
         <div className="w-full relative h-10 mb-4">
           <TabsList className="flex absolute h-10 md:w-full">

--- a/apps/web/src/app/[lang]/dho/[id]/_components/nested-spaces-button.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/nested-spaces-button.tsx
@@ -50,6 +50,7 @@ export const NestedSpacesButton = ({
 
   return (
     <Link
+      data-space-nav
       className={isDisabled ? 'cursor-not-allowed' : ''}
       href={
         hasAccess && !isLoading
@@ -62,7 +63,7 @@ export const NestedSpacesButton = ({
         variant="link"
         size="sm"
         disabled={isDisabled}
-        className="flex h-auto min-h-0 shrink-0 items-center gap-2 px-0 py-0 font-medium text-accent-11"
+        className="flex h-auto min-h-0 shrink-0 items-center gap-2 px-0 py-0 font-medium"
       >
         <Eye className="w-4 h-4" />
         <span>{tDho('nestedSpacesButton.label')}</span>

--- a/apps/web/src/app/[lang]/dho/[id]/_components/nested-spaces-button.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/nested-spaces-button.tsx
@@ -60,8 +60,9 @@ export const NestedSpacesButton = ({
     >
       <Button
         variant="link"
+        size="sm"
         disabled={isDisabled}
-        className="flex items-center gap-2 text-accent-11"
+        className="flex h-auto min-h-0 shrink-0 items-center gap-2 px-0 py-0 font-medium text-accent-11"
       >
         <Eye className="w-4 h-4" />
         <span>{tDho('nestedSpacesButton.label')}</span>

--- a/apps/web/src/app/[lang]/dho/[id]/layout.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/layout.tsx
@@ -122,7 +122,7 @@ export default async function DhoLayout({
               {canConvertToBigInt(spaceFromDb.web3SpaceId) && (
                 <SubscriptionBadge
                   web3SpaceId={spaceFromDb.web3SpaceId as number}
-                  className="rounded border-emerald-400/85 bg-transparent text-white hover:border-emerald-300 hover:bg-white/10 [&]:border-emerald-400/85 [&]:text-white"
+                  className="rounded-md border-emerald-400/85 bg-transparent text-white hover:border-emerald-300 hover:bg-white/10 [&]:rounded-md [&]:border-emerald-400/85 [&]:text-white"
                 />
               )}
               <SpaceModeLabel
@@ -140,7 +140,7 @@ export default async function DhoLayout({
                   lang,
                   daoSlug,
                 )}/space-configuration`}
-                className="[&_.border-accent-8]:rounded [&_.border-accent-8]:border-white/85 [&_.border-accent-8]:bg-transparent [&_.border-accent-8]:text-white [&_.border-accent-8]:hover:border-white [&_.border-accent-8]:hover:bg-white/10 [&_.border-error-8]:rounded [&_.border-error-8]:border-white/85 [&_.border-error-8]:bg-transparent [&_.border-error-8]:text-white [&_.border-warning-8]:rounded [&_.border-warning-8]:border-amber-200/90 [&_.border-warning-8]:bg-transparent [&_.border-warning-8]:text-white"
+                className="[&_.border-accent-8]:rounded-md [&_.border-accent-8]:border-white/85 [&_.border-accent-8]:bg-transparent [&_.border-accent-8]:text-white [&_.border-accent-8]:hover:border-white [&_.border-accent-8]:hover:bg-white/10 [&_.border-error-8]:rounded-md [&_.border-error-8]:border-white/85 [&_.border-error-8]:bg-transparent [&_.border-error-8]:text-white [&_.border-warning-8]:rounded-md [&_.border-warning-8]:border-amber-200/90 [&_.border-warning-8]:bg-transparent [&_.border-warning-8]:text-white"
               />
             </>
           }

--- a/apps/web/src/app/[lang]/dho/[id]/layout.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/layout.tsx
@@ -103,7 +103,7 @@ export default async function DhoLayout({
   return (
     <div className="mx-auto flex max-w-container-2xl">
       <Container className="min-w-0 flex-grow !px-4">
-        <div className="mb-3 flex flex-wrap items-center justify-between gap-x-3 gap-y-2 md:gap-x-4">
+        <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-2 md:gap-x-4">
           <div className="flex min-h-8 min-w-0 flex-1 items-center">
             <Breadcrumbs spaceId={spaceFromDb.id} lang={lang} />
           </div>
@@ -111,47 +111,49 @@ export default async function DhoLayout({
             <NestedSpacesButton web3SpaceId={web3SpaceId} spaceSlug={daoSlug} />
           ) : null}
         </div>
-        <CompactSpaceBanner
-          title={spaceFromDb.title}
-          description={spaceFromDb.description}
-          logoUrl={spaceFromDb.logoUrl}
-          logoAlt={spaceFromDb.title}
-          defaultLogoSrc={DEFAULT_SPACE_AVATAR_IMAGE}
-          links={spaceFromDb.links}
-          leadImageUrl={spaceFromDb.leadImage}
-          defaultLeadImageSrc={DEFAULT_SPACE_LEAD_IMAGE}
-          memberCount={spaceMembers}
-          agreementCount={spaceAgreements}
-          createdOnText={tCommon('createdOn', {
-            date: formatDate(spaceFromDb.createdAt, true),
-          })}
-          membersLabel={tCommon('Members')}
-          agreementsLabel={tCommon('Agreements')}
-          footerTrailing={
-            <>
-              {hasWeb3Id && web3SpaceId !== undefined && (
-                <SubscriptionBadge
+        <div className="my-3">
+          <CompactSpaceBanner
+            title={spaceFromDb.title}
+            description={spaceFromDb.description}
+            logoUrl={spaceFromDb.logoUrl}
+            logoAlt={spaceFromDb.title}
+            defaultLogoSrc={DEFAULT_SPACE_AVATAR_IMAGE}
+            links={spaceFromDb.links}
+            leadImageUrl={spaceFromDb.leadImage}
+            defaultLeadImageSrc={DEFAULT_SPACE_LEAD_IMAGE}
+            memberCount={spaceMembers}
+            agreementCount={spaceAgreements}
+            createdOnText={tCommon('createdOn', {
+              date: formatDate(spaceFromDb.createdAt, true),
+            })}
+            membersLabel={tCommon('Members')}
+            agreementsLabel={tCommon('Agreements')}
+            footerTrailing={
+              <>
+                {hasWeb3Id && web3SpaceId !== undefined && (
+                  <SubscriptionBadge
+                    web3SpaceId={web3SpaceId}
+                    className="rounded-md border-emerald-400/85 bg-transparent text-white hover:border-emerald-300 hover:bg-white/10 [&]:rounded-md [&]:border-emerald-400/85 [&]:text-white"
+                  />
+                )}
+                <SpaceModeLabel
                   web3SpaceId={web3SpaceId}
-                  className="rounded-md border-emerald-400/85 bg-transparent text-white hover:border-emerald-300 hover:bg-white/10 [&]:rounded-md [&]:border-emerald-400/85 [&]:text-white"
+                  isSandbox={spaceFromDb.flags.includes('sandbox')}
+                  isDemo={spaceFromDb.flags.includes('demo')}
+                  isArchived={
+                    spaceFromDb.flags.includes('archived') || spaceMembers === 0
+                  }
+                  configPath={`${getDhoPathAgreements(
+                    lang,
+                    daoSlug,
+                  )}/space-configuration`}
+                  className="[&_.border-accent-8]:rounded-md [&_.border-accent-8]:border-white/85 [&_.border-accent-8]:bg-transparent [&_.border-accent-8]:text-white [&_.border-accent-8]:hover:border-white [&_.border-accent-8]:hover:bg-white/10 [&_.border-error-8]:rounded-md [&_.border-error-8]:border-white/85 [&_.border-error-8]:bg-transparent [&_.border-error-8]:text-white [&_.border-warning-8]:rounded-md [&_.border-warning-8]:border-amber-200/90 [&_.border-warning-8]:bg-transparent [&_.border-warning-8]:text-white"
                 />
-              )}
-              <SpaceModeLabel
-                web3SpaceId={web3SpaceId}
-                isSandbox={spaceFromDb.flags.includes('sandbox')}
-                isDemo={spaceFromDb.flags.includes('demo')}
-                isArchived={
-                  spaceFromDb.flags.includes('archived') || spaceMembers === 0
-                }
-                configPath={`${getDhoPathAgreements(
-                  lang,
-                  daoSlug,
-                )}/space-configuration`}
-                className="[&_.border-accent-8]:rounded-md [&_.border-accent-8]:border-white/85 [&_.border-accent-8]:bg-transparent [&_.border-accent-8]:text-white [&_.border-accent-8]:hover:border-white [&_.border-accent-8]:hover:bg-white/10 [&_.border-error-8]:rounded-md [&_.border-error-8]:border-white/85 [&_.border-error-8]:bg-transparent [&_.border-error-8]:text-white [&_.border-warning-8]:rounded-md [&_.border-warning-8]:border-amber-200/90 [&_.border-warning-8]:bg-transparent [&_.border-warning-8]:text-white"
-              />
-            </>
-          }
-        />
-        <div className="mt-3 flex justify-end gap-2">
+              </>
+            }
+          />
+        </div>
+        <div className="flex justify-end gap-2">
           {web3SpaceId !== undefined && (
             <JoinSpace web3SpaceId={web3SpaceId} spaceId={spaceFromDb.id} />
           )}

--- a/apps/web/src/app/[lang]/dho/[id]/layout.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/layout.tsx
@@ -118,15 +118,19 @@ export default async function DhoLayout({
             fetchPriority="high"
           />
         ) : null}
-        <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-2 md:gap-x-4">
-          <div className="flex min-h-8 min-w-0 flex-1 items-center">
-            <Breadcrumbs spaceId={spaceFromDb.id} lang={lang} />
+        {/* Single column + gap-3: identical rhythm above banner, below banner, above actions */}
+        <div className="flex flex-col gap-3">
+          <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-2 md:gap-x-4">
+            <div className="flex min-w-0 flex-1 items-center">
+              <Breadcrumbs spaceId={spaceFromDb.id} lang={lang} />
+            </div>
+            {web3SpaceId !== undefined ? (
+              <NestedSpacesButton
+                web3SpaceId={web3SpaceId}
+                spaceSlug={daoSlug}
+              />
+            ) : null}
           </div>
-          {web3SpaceId !== undefined ? (
-            <NestedSpacesButton web3SpaceId={web3SpaceId} spaceSlug={daoSlug} />
-          ) : null}
-        </div>
-        <div className="my-3">
           <CompactSpaceBanner
             title={spaceFromDb.title}
             description={spaceFromDb.description}
@@ -167,12 +171,12 @@ export default async function DhoLayout({
               </>
             }
           />
-        </div>
-        <div className="flex justify-end gap-2">
-          {web3SpaceId !== undefined && (
-            <JoinSpace web3SpaceId={web3SpaceId} spaceId={spaceFromDb.id} />
-          )}
-          <ActionButtons web3SpaceId={web3SpaceId} />
+          <div className="flex justify-end gap-2">
+            {web3SpaceId !== undefined && (
+              <JoinSpace web3SpaceId={web3SpaceId} spaceId={spaceFromDb.id} />
+            )}
+            <ActionButtons web3SpaceId={web3SpaceId} />
+          </div>
         </div>
         <div className="mt-4 flex flex-col gap-3">
           <SalesBanner web3SpaceId={web3SpaceId} />

--- a/apps/web/src/app/[lang]/dho/[id]/layout.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/layout.tsx
@@ -29,6 +29,47 @@ import { Breadcrumbs } from './_components/breadcrumbs';
 import { canConvertToBigInt, formatDate } from '@hypha-platform/ui-utils';
 import { getTranslations } from 'next-intl/server';
 
+async function getSpaceMemberAndAgreementCounts(web3SpaceId: unknown): Promise<{
+  members: number;
+  agreements: number;
+}> {
+  if (!canConvertToBigInt(web3SpaceId)) {
+    return { members: 0, agreements: 0 };
+  }
+  const id = BigInt(web3SpaceId as number);
+  const [members, agreements] = await Promise.all([
+    (async () => {
+      try {
+        const [spaceDetails] = await fetchSpaceDetails({
+          spaceIds: [id],
+        });
+        return spaceDetails?.members.length ?? 0;
+      } catch (error) {
+        console.error(
+          `Failed to get space details for a space ${web3SpaceId}:`,
+          error,
+        );
+        return 0;
+      }
+    })(),
+    (async () => {
+      try {
+        const [proposals] = await fetchSpaceProposalsIds({
+          spaceIds: [id],
+        });
+        return proposals?.accepted?.length ?? 0;
+      } catch (error) {
+        console.error(
+          `Failed to get space proposals for a space ${web3SpaceId}:`,
+          error,
+        );
+        return 0;
+      }
+    })(),
+  ]);
+  return { members, agreements };
+}
+
 export default async function DhoLayout({
   aside,
   children,
@@ -49,42 +90,8 @@ export default async function DhoLayout({
     return notFound();
   }
 
-  const [spaceMembers, spaceAgreements] = await Promise.all([
-    (async () => {
-      try {
-        if (!canConvertToBigInt(spaceFromDb.web3SpaceId)) {
-          return 0;
-        }
-        const [spaceDetails] = await fetchSpaceDetails({
-          spaceIds: [BigInt(spaceFromDb.web3SpaceId as number)],
-        });
-        return spaceDetails?.members.length ?? 0;
-      } catch (error) {
-        console.error(
-          `Failed to get space details for a space ${spaceFromDb.web3SpaceId}:`,
-          error,
-        );
-        return 0;
-      }
-    })(),
-    (async () => {
-      try {
-        if (!canConvertToBigInt(spaceFromDb.web3SpaceId)) {
-          return 0;
-        }
-        const [proposals] = await fetchSpaceProposalsIds({
-          spaceIds: [BigInt(spaceFromDb.web3SpaceId as number)],
-        });
-        return proposals?.accepted?.length ?? 0;
-      } catch (error) {
-        console.error(
-          `Failed to get space proposals for a space ${spaceFromDb.web3SpaceId}:`,
-          error,
-        );
-        return 0;
-      }
-    })(),
-  ]);
+  const { members: spaceMembers, agreements: spaceAgreements } =
+    await getSpaceMemberAndAgreementCounts(spaceFromDb.web3SpaceId);
 
   const spaces = await getAllSpaces({ parentOnly: false, omitSandbox: true });
   return (

--- a/apps/web/src/app/[lang]/dho/[id]/layout.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/layout.tsx
@@ -6,7 +6,9 @@ import {
   SpaceModeLabel,
   SubscriptionBadge,
   CompactSpaceBanner,
+  SpaceAccentFromImages,
 } from '@hypha-platform/epics';
+import './space-accent.css';
 import { Locale } from '@hypha-platform/i18n';
 import { Container, Separator } from '@hypha-platform/ui';
 import { Text } from '@radix-ui/themes';
@@ -107,6 +109,13 @@ export default async function DhoLayout({
       ? rawLead
       : DEFAULT_SPACE_LEAD_IMAGE;
 
+  const accentLogoHref =
+    spaceFromDb.logoUrl?.trim() &&
+    (spaceFromDb.logoUrl.startsWith('/') ||
+      /^https?:\/\//i.test(spaceFromDb.logoUrl))
+      ? spaceFromDb.logoUrl.trim()
+      : DEFAULT_SPACE_AVATAR_IMAGE;
+
   return (
     <div className="mx-auto flex max-w-container-2xl">
       <Container className="min-w-0 flex-grow !px-4">
@@ -118,77 +127,83 @@ export default async function DhoLayout({
             fetchPriority="high"
           />
         ) : null}
-        {/* Single column + gap-2: tight rhythm under chrome; matches banner ↔ actions */}
-        <div className="flex flex-col gap-2">
-          <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-2 md:gap-x-4">
-            <div className="flex min-w-0 flex-1 items-center">
-              <Breadcrumbs spaceId={spaceFromDb.id} lang={lang} />
-            </div>
-            {web3SpaceId !== undefined ? (
-              <NestedSpacesButton
-                web3SpaceId={web3SpaceId}
-                spaceSlug={daoSlug}
-              />
-            ) : null}
-          </div>
-          <CompactSpaceBanner
-            title={spaceFromDb.title}
-            description={spaceFromDb.description}
-            logoUrl={spaceFromDb.logoUrl}
-            logoAlt={spaceFromDb.title}
-            defaultLogoSrc={DEFAULT_SPACE_AVATAR_IMAGE}
-            links={spaceFromDb.links}
-            leadImageUrl={spaceFromDb.leadImage}
-            defaultLeadImageSrc={DEFAULT_SPACE_LEAD_IMAGE}
-            memberCount={spaceMembers}
-            agreementCount={spaceAgreements}
-            createdOnText={tCommon('createdOn', {
-              date: formatDate(spaceFromDb.createdAt, true),
-            })}
-            membersLabel={tCommon('Members')}
-            agreementsLabel={tCommon('Agreements')}
-            footerTrailing={
-              <>
-                {hasWeb3Id && web3SpaceId !== undefined && (
-                  <SubscriptionBadge
-                    web3SpaceId={web3SpaceId}
-                    className="rounded-md border-emerald-400/85 bg-transparent text-white hover:border-emerald-300 hover:bg-white/10 [&]:rounded-md [&]:border-emerald-400/85 [&]:text-white"
-                  />
-                )}
-                <SpaceModeLabel
+        <SpaceAccentFromImages
+          bannerSrc={heroBannerImageHref}
+          logoSrc={accentLogoHref}
+        >
+          {/* Single column + gap-2: tight rhythm under chrome; matches banner ↔ actions */}
+          <div className="flex flex-col gap-2">
+            <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-2 md:gap-x-4">
+              <div className="flex min-w-0 flex-1 items-center">
+                <Breadcrumbs spaceId={spaceFromDb.id} lang={lang} />
+              </div>
+              {web3SpaceId !== undefined ? (
+                <NestedSpacesButton
                   web3SpaceId={web3SpaceId}
-                  isSandbox={spaceFromDb.flags.includes('sandbox')}
-                  isDemo={spaceFromDb.flags.includes('demo')}
-                  isArchived={
-                    spaceFromDb.flags.includes('archived') || spaceMembers === 0
-                  }
-                  configPath={`${getDhoPathAgreements(
-                    lang,
-                    daoSlug,
-                  )}/space-configuration`}
-                  className="[&_.border-accent-8]:rounded-md [&_.border-accent-8]:border-white/85 [&_.border-accent-8]:bg-transparent [&_.border-accent-8]:text-white [&_.border-accent-8]:hover:border-white [&_.border-accent-8]:hover:bg-white/10 [&_.border-error-8]:rounded-md [&_.border-error-8]:border-white/85 [&_.border-error-8]:bg-transparent [&_.border-error-8]:text-white [&_.border-warning-8]:rounded-md [&_.border-warning-8]:border-amber-200/90 [&_.border-warning-8]:bg-transparent [&_.border-warning-8]:text-white"
+                  spaceSlug={daoSlug}
                 />
-              </>
-            }
-          />
-          <div className="flex justify-end gap-2">
-            {web3SpaceId !== undefined && (
-              <JoinSpace web3SpaceId={web3SpaceId} spaceId={spaceFromDb.id} />
-            )}
-            <ActionButtons web3SpaceId={web3SpaceId} />
+              ) : null}
+            </div>
+            <CompactSpaceBanner
+              title={spaceFromDb.title}
+              description={spaceFromDb.description}
+              logoUrl={spaceFromDb.logoUrl}
+              logoAlt={spaceFromDb.title}
+              defaultLogoSrc={DEFAULT_SPACE_AVATAR_IMAGE}
+              links={spaceFromDb.links}
+              leadImageUrl={spaceFromDb.leadImage}
+              defaultLeadImageSrc={DEFAULT_SPACE_LEAD_IMAGE}
+              memberCount={spaceMembers}
+              agreementCount={spaceAgreements}
+              createdOnText={tCommon('createdOn', {
+                date: formatDate(spaceFromDb.createdAt, true),
+              })}
+              membersLabel={tCommon('Members')}
+              agreementsLabel={tCommon('Agreements')}
+              footerTrailing={
+                <>
+                  {hasWeb3Id && web3SpaceId !== undefined && (
+                    <SubscriptionBadge
+                      web3SpaceId={web3SpaceId}
+                      className="rounded-md border-emerald-400/85 bg-transparent text-white hover:border-emerald-300 hover:bg-white/10 [&]:rounded-md [&]:border-emerald-400/85 [&]:text-white"
+                    />
+                  )}
+                  <SpaceModeLabel
+                    web3SpaceId={web3SpaceId}
+                    isSandbox={spaceFromDb.flags.includes('sandbox')}
+                    isDemo={spaceFromDb.flags.includes('demo')}
+                    isArchived={
+                      spaceFromDb.flags.includes('archived') ||
+                      spaceMembers === 0
+                    }
+                    configPath={`${getDhoPathAgreements(
+                      lang,
+                      daoSlug,
+                    )}/space-configuration`}
+                    className="[&_.border-accent-8]:rounded-md [&_.border-accent-8]:border-white/85 [&_.border-accent-8]:bg-transparent [&_.border-accent-8]:text-white [&_.border-accent-8]:hover:border-white [&_.border-accent-8]:hover:bg-white/10 [&_.border-error-8]:rounded-md [&_.border-error-8]:border-white/85 [&_.border-error-8]:bg-transparent [&_.border-error-8]:text-white [&_.border-warning-8]:rounded-md [&_.border-warning-8]:border-amber-200/90 [&_.border-warning-8]:bg-transparent [&_.border-warning-8]:text-white"
+                  />
+                </>
+              }
+            />
+            <div className="flex justify-end gap-2">
+              {web3SpaceId !== undefined && (
+                <JoinSpace web3SpaceId={web3SpaceId} spaceId={spaceFromDb.id} />
+              )}
+              <ActionButtons web3SpaceId={web3SpaceId} />
+            </div>
           </div>
-        </div>
-        <div className="mt-4 flex flex-col gap-3">
-          <SalesBanner web3SpaceId={web3SpaceId} />
-          <SpaceEscrowDepositBanners
-            web3SpaceId={web3SpaceId}
-            spaceDbId={spaceFromDb.id}
-            spaceSlug={daoSlug}
-            lang={lang}
-          />
-        </div>
-        {tab}
-        {children}
+          <div className="mt-4 flex flex-col gap-3">
+            <SalesBanner web3SpaceId={web3SpaceId} />
+            <SpaceEscrowDepositBanners
+              web3SpaceId={web3SpaceId}
+              spaceDbId={spaceFromDb.id}
+              spaceSlug={daoSlug}
+              lang={lang}
+            />
+          </div>
+          {tab}
+          {children}
+        </SpaceAccentFromImages>
         <div className="space-y-9">
           <Separator />
           <div className="border-primary-foreground">

--- a/apps/web/src/app/[lang]/dho/[id]/layout.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/layout.tsx
@@ -90,16 +90,16 @@ export default async function DhoLayout({
   return (
     <div className="flex max-w-container-2xl mx-auto">
       <Container className="flex-grow min-w-0">
-        <div className="mb-6 flex items-center">
-          <Breadcrumbs spaceId={spaceFromDb.id} lang={lang} />
-        </div>
-        <div className="relative flex justify-end mb-2">
-          {typeof spaceFromDb.web3SpaceId === 'number' && (
+        <div className="mb-4 flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
+          <div className="flex min-h-9 min-w-0 flex-1 items-center">
+            <Breadcrumbs spaceId={spaceFromDb.id} lang={lang} />
+          </div>
+          {typeof spaceFromDb.web3SpaceId === 'number' ? (
             <NestedSpacesButton
               web3SpaceId={spaceFromDb.web3SpaceId as number}
               spaceSlug={daoSlug}
             />
-          )}
+          ) : null}
         </div>
         <CompactSpaceBanner
           title={spaceFromDb.title}

--- a/apps/web/src/app/[lang]/dho/[id]/layout.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/layout.tsx
@@ -88,10 +88,10 @@ export default async function DhoLayout({
 
   const spaces = await getAllSpaces({ parentOnly: false, omitSandbox: true });
   return (
-    <div className="flex max-w-container-2xl mx-auto">
-      <Container className="flex-grow min-w-0">
-        <div className="mb-4 flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
-          <div className="flex min-h-9 min-w-0 flex-1 items-center">
+    <div className="mx-auto flex max-w-container-2xl">
+      <Container className="min-w-0 flex-grow !px-4">
+        <div className="mb-3 flex flex-wrap items-center justify-between gap-x-3 gap-y-2 md:gap-x-4">
+          <div className="flex min-h-8 min-w-0 flex-1 items-center">
             <Breadcrumbs spaceId={spaceFromDb.id} lang={lang} />
           </div>
           {typeof spaceFromDb.web3SpaceId === 'number' ? (
@@ -145,7 +145,7 @@ export default async function DhoLayout({
             </>
           }
         />
-        <div className="mt-4 flex justify-end gap-2">
+        <div className="mt-3 flex justify-end gap-2">
           {typeof spaceFromDb.web3SpaceId === 'number' && (
             <JoinSpace
               web3SpaceId={spaceFromDb.web3SpaceId}

--- a/apps/web/src/app/[lang]/dho/[id]/layout.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/layout.tsx
@@ -157,7 +157,7 @@ export default async function DhoLayout({
           )}
           <ActionButtons web3SpaceId={web3SpaceId} />
         </div>
-        <div className="mt-8 flex flex-col gap-3">
+        <div className="mt-4 flex flex-col gap-3">
           <SalesBanner web3SpaceId={web3SpaceId} />
           <SpaceEscrowDepositBanners
             web3SpaceId={web3SpaceId}

--- a/apps/web/src/app/[lang]/dho/[id]/layout.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/layout.tsx
@@ -4,19 +4,12 @@ import {
   SpaceCard,
   SpaceEscrowDepositBanners,
   SpaceModeLabel,
-  WebLinks,
   SubscriptionBadge,
+  CompactSpaceBanner,
 } from '@hypha-platform/epics';
 import { Locale } from '@hypha-platform/i18n';
-import {
-  Container,
-  Card,
-  Avatar,
-  AvatarImage,
-  Separator,
-} from '@hypha-platform/ui';
+import { Container, Separator } from '@hypha-platform/ui';
 import { Text } from '@radix-ui/themes';
-import Image from 'next/image';
 import { Carousel, CarouselContent, CarouselItem } from '@hypha-platform/ui';
 import Link from 'next/link';
 import { getAllSpaces, findSpaceBySlug } from '@hypha-platform/core/server';
@@ -56,41 +49,42 @@ export default async function DhoLayout({
     return notFound();
   }
 
-  const spaceMembers = await (async () => {
-    try {
-      if (!canConvertToBigInt(spaceFromDb.web3SpaceId)) {
+  const [spaceMembers, spaceAgreements] = await Promise.all([
+    (async () => {
+      try {
+        if (!canConvertToBigInt(spaceFromDb.web3SpaceId)) {
+          return 0;
+        }
+        const [spaceDetails] = await fetchSpaceDetails({
+          spaceIds: [BigInt(spaceFromDb.web3SpaceId as number)],
+        });
+        return spaceDetails?.members.length ?? 0;
+      } catch (error) {
+        console.error(
+          `Failed to get space details for a space ${spaceFromDb.web3SpaceId}:`,
+          error,
+        );
         return 0;
       }
-      const [spaceDetails] = await fetchSpaceDetails({
-        spaceIds: [BigInt(spaceFromDb.web3SpaceId as number)],
-      });
-      return spaceDetails?.members.length ?? 0;
-    } catch (error) {
-      console.error(
-        `Failed to get space details for a space ${spaceFromDb.web3SpaceId}:`,
-        error,
-      );
-      return 0;
-    }
-  })();
-
-  const spaceAgreements = await (async () => {
-    try {
-      if (!canConvertToBigInt(spaceFromDb.web3SpaceId)) {
+    })(),
+    (async () => {
+      try {
+        if (!canConvertToBigInt(spaceFromDb.web3SpaceId)) {
+          return 0;
+        }
+        const [proposals] = await fetchSpaceProposalsIds({
+          spaceIds: [BigInt(spaceFromDb.web3SpaceId as number)],
+        });
+        return proposals?.accepted?.length ?? 0;
+      } catch (error) {
+        console.error(
+          `Failed to get space proposals for a space ${spaceFromDb.web3SpaceId}:`,
+          error,
+        );
         return 0;
       }
-      const [proposals] = await fetchSpaceProposalsIds({
-        spaceIds: [BigInt(spaceFromDb.web3SpaceId as number)],
-      });
-      return proposals?.accepted?.length ?? 0;
-    } catch (error) {
-      console.error(
-        `Failed to get space details for a space ${spaceFromDb.web3SpaceId}:`,
-        error,
-      );
-      return 0;
-    }
-  })();
+    })(),
+  ]);
 
   const spaces = await getAllSpaces({ parentOnly: false, omitSandbox: true });
   return (
@@ -107,22 +101,51 @@ export default async function DhoLayout({
             />
           )}
         </div>
-        <Card className="relative">
-          <Image
-            width={768}
-            height={270}
-            className="rounded-xl min-h-[270px] max-h-[270px] w-full object-cover"
-            src={spaceFromDb.leadImage || DEFAULT_SPACE_LEAD_IMAGE}
-            alt={spaceFromDb.title}
-          ></Image>
-          <Avatar className="w-[128px] h-[128px] absolute bottom-[-35px] left-[15px]">
-            <AvatarImage
-              src={spaceFromDb.logoUrl || DEFAULT_SPACE_AVATAR_IMAGE}
-              alt="logo"
-            />
-          </Avatar>
-        </Card>
-        <div className="flex justify-end mt-2 gap-2">
+        <CompactSpaceBanner
+          title={spaceFromDb.title}
+          description={spaceFromDb.description}
+          logoUrl={spaceFromDb.logoUrl}
+          logoAlt={spaceFromDb.title}
+          defaultLogoSrc={DEFAULT_SPACE_AVATAR_IMAGE}
+          links={spaceFromDb.links}
+          leadImageUrl={spaceFromDb.leadImage}
+          defaultLeadImageSrc={DEFAULT_SPACE_LEAD_IMAGE}
+          memberCount={spaceMembers}
+          agreementCount={spaceAgreements}
+          createdOnText={tCommon('createdOn', {
+            date: formatDate(spaceFromDb.createdAt, true),
+          })}
+          membersLabel={tCommon('Members')}
+          agreementsLabel={tCommon('Agreements')}
+          footerTrailing={
+            <>
+              {canConvertToBigInt(spaceFromDb.web3SpaceId) && (
+                <SubscriptionBadge
+                  web3SpaceId={spaceFromDb.web3SpaceId as number}
+                  className="rounded border-emerald-400/85 bg-transparent text-white hover:border-emerald-300 hover:bg-white/10 [&]:border-emerald-400/85 [&]:text-white"
+                />
+              )}
+              <SpaceModeLabel
+                web3SpaceId={
+                  typeof spaceFromDb.web3SpaceId === 'number'
+                    ? spaceFromDb.web3SpaceId
+                    : undefined
+                }
+                isSandbox={spaceFromDb.flags.includes('sandbox')}
+                isDemo={spaceFromDb.flags.includes('demo')}
+                isArchived={
+                  spaceFromDb.flags.includes('archived') || spaceMembers === 0
+                }
+                configPath={`${getDhoPathAgreements(
+                  lang,
+                  daoSlug,
+                )}/space-configuration`}
+                className="[&_.border-accent-8]:rounded [&_.border-accent-8]:border-white/85 [&_.border-accent-8]:bg-transparent [&_.border-accent-8]:text-white [&_.border-accent-8]:hover:border-white [&_.border-accent-8]:hover:bg-white/10 [&_.border-error-8]:rounded [&_.border-error-8]:border-white/85 [&_.border-error-8]:bg-transparent [&_.border-error-8]:text-white [&_.border-warning-8]:rounded [&_.border-warning-8]:border-amber-200/90 [&_.border-warning-8]:bg-transparent [&_.border-warning-8]:text-white"
+              />
+            </>
+          }
+        />
+        <div className="mt-4 flex justify-end gap-2">
           {typeof spaceFromDb.web3SpaceId === 'number' && (
             <JoinSpace
               web3SpaceId={spaceFromDb.web3SpaceId}
@@ -130,59 +153,6 @@ export default async function DhoLayout({
             />
           )}
           <ActionButtons web3SpaceId={spaceFromDb.web3SpaceId as number} />
-        </div>
-
-        <div className="flex flex-col mt-4 gap-2">
-          <Text className="text-7">{spaceFromDb.title}</Text>
-          <WebLinks links={spaceFromDb.links} />
-        </div>
-        <div className="mt-6">
-          <Text className="text-2">{spaceFromDb.description}</Text>
-        </div>
-        <div className="flex gap-4 items-start mt-6 flex-wrap">
-          <div className="flex flex-col gap-y-2 gap-x-4">
-            <div className="flex flex-row gap-y-2 gap-x-4">
-              <div className="flex">
-                <div className="font-bold text-1">{spaceMembers}</div>
-                <div className="text-gray-500 ml-1 text-1">
-                  {tCommon('Members')}
-                </div>
-              </div>
-              <div className="flex">
-                <div className="font-bold text-1">
-                  {/* @ts-ignore: TODO: infer types from relations */}
-                  {spaceAgreements}
-                </div>
-                <div className="text-gray-500 ml-1 text-1">
-                  {tCommon('Agreements')}
-                </div>
-              </div>
-            </div>
-            <div className="flex">
-              <div className="text-gray-500 text-1">
-                {tCommon('createdOn', {
-                  date: formatDate(spaceFromDb.createdAt, true),
-                })}
-              </div>
-            </div>
-          </div>
-          {canConvertToBigInt(spaceFromDb.web3SpaceId) && (
-            <SubscriptionBadge
-              web3SpaceId={spaceFromDb.web3SpaceId as number}
-            />
-          )}
-          <SpaceModeLabel
-            web3SpaceId={spaceFromDb.web3SpaceId as number}
-            isSandbox={spaceFromDb.flags.includes('sandbox')}
-            isDemo={spaceFromDb.flags.includes('demo')}
-            isArchived={
-              spaceFromDb.flags.includes('archived') || spaceMembers === 0
-            }
-            configPath={`${getDhoPathAgreements(
-              lang,
-              daoSlug,
-            )}/space-configuration`}
-          />
         </div>
         <div className="mt-8 flex flex-col gap-3">
           <SalesBanner web3SpaceId={spaceFromDb.web3SpaceId as number} />

--- a/apps/web/src/app/[lang]/dho/[id]/layout.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/layout.tsx
@@ -90,6 +90,12 @@ export default async function DhoLayout({
     return notFound();
   }
 
+  const web3SpaceId =
+    typeof spaceFromDb.web3SpaceId === 'number'
+      ? spaceFromDb.web3SpaceId
+      : undefined;
+  const hasWeb3Id = canConvertToBigInt(spaceFromDb.web3SpaceId);
+
   const { members: spaceMembers, agreements: spaceAgreements } =
     await getSpaceMemberAndAgreementCounts(spaceFromDb.web3SpaceId);
 
@@ -101,11 +107,8 @@ export default async function DhoLayout({
           <div className="flex min-h-8 min-w-0 flex-1 items-center">
             <Breadcrumbs spaceId={spaceFromDb.id} lang={lang} />
           </div>
-          {typeof spaceFromDb.web3SpaceId === 'number' ? (
-            <NestedSpacesButton
-              web3SpaceId={spaceFromDb.web3SpaceId as number}
-              spaceSlug={daoSlug}
-            />
+          {web3SpaceId !== undefined ? (
+            <NestedSpacesButton web3SpaceId={web3SpaceId} spaceSlug={daoSlug} />
           ) : null}
         </div>
         <CompactSpaceBanner
@@ -126,18 +129,14 @@ export default async function DhoLayout({
           agreementsLabel={tCommon('Agreements')}
           footerTrailing={
             <>
-              {canConvertToBigInt(spaceFromDb.web3SpaceId) && (
+              {hasWeb3Id && web3SpaceId !== undefined && (
                 <SubscriptionBadge
-                  web3SpaceId={spaceFromDb.web3SpaceId as number}
+                  web3SpaceId={web3SpaceId}
                   className="rounded-md border-emerald-400/85 bg-transparent text-white hover:border-emerald-300 hover:bg-white/10 [&]:rounded-md [&]:border-emerald-400/85 [&]:text-white"
                 />
               )}
               <SpaceModeLabel
-                web3SpaceId={
-                  typeof spaceFromDb.web3SpaceId === 'number'
-                    ? spaceFromDb.web3SpaceId
-                    : undefined
-                }
+                web3SpaceId={web3SpaceId}
                 isSandbox={spaceFromDb.flags.includes('sandbox')}
                 isDemo={spaceFromDb.flags.includes('demo')}
                 isArchived={
@@ -153,18 +152,15 @@ export default async function DhoLayout({
           }
         />
         <div className="mt-3 flex justify-end gap-2">
-          {typeof spaceFromDb.web3SpaceId === 'number' && (
-            <JoinSpace
-              web3SpaceId={spaceFromDb.web3SpaceId}
-              spaceId={spaceFromDb.id}
-            />
+          {web3SpaceId !== undefined && (
+            <JoinSpace web3SpaceId={web3SpaceId} spaceId={spaceFromDb.id} />
           )}
-          <ActionButtons web3SpaceId={spaceFromDb.web3SpaceId as number} />
+          <ActionButtons web3SpaceId={web3SpaceId} />
         </div>
         <div className="mt-8 flex flex-col gap-3">
-          <SalesBanner web3SpaceId={spaceFromDb.web3SpaceId as number} />
+          <SalesBanner web3SpaceId={web3SpaceId} />
           <SpaceEscrowDepositBanners
-            web3SpaceId={spaceFromDb.web3SpaceId as number}
+            web3SpaceId={web3SpaceId}
             spaceDbId={spaceFromDb.id}
             spaceSlug={daoSlug}
             lang={lang}

--- a/apps/web/src/app/[lang]/dho/[id]/layout.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/layout.tsx
@@ -118,8 +118,8 @@ export default async function DhoLayout({
             fetchPriority="high"
           />
         ) : null}
-        {/* Single column + gap-3: identical rhythm above banner, below banner, above actions */}
-        <div className="flex flex-col gap-3">
+        {/* Single column + gap-2: tight rhythm under chrome; matches banner ↔ actions */}
+        <div className="flex flex-col gap-2">
           <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-2 md:gap-x-4">
             <div className="flex min-w-0 flex-1 items-center">
               <Breadcrumbs spaceId={spaceFromDb.id} lang={lang} />

--- a/apps/web/src/app/[lang]/dho/[id]/layout.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/layout.tsx
@@ -100,9 +100,24 @@ export default async function DhoLayout({
     await getSpaceMemberAndAgreementCounts(spaceFromDb.web3SpaceId);
 
   const spaces = await getAllSpaces({ parentOnly: false, omitSandbox: true });
+
+  const rawLead = spaceFromDb.leadImage?.trim();
+  const heroBannerImageHref =
+    rawLead && (rawLead.startsWith('/') || /^https?:\/\//i.test(rawLead))
+      ? rawLead
+      : DEFAULT_SPACE_LEAD_IMAGE;
+
   return (
     <div className="mx-auto flex max-w-container-2xl">
       <Container className="min-w-0 flex-grow !px-4">
+        {heroBannerImageHref ? (
+          <link
+            rel="preload"
+            as="image"
+            href={heroBannerImageHref}
+            fetchPriority="high"
+          />
+        ) : null}
         <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-2 md:gap-x-4">
           <div className="flex min-h-8 min-w-0 flex-1 items-center">
             <Breadcrumbs spaceId={spaceFromDb.id} lang={lang} />

--- a/apps/web/src/app/[lang]/dho/[id]/space-accent.css
+++ b/apps/web/src/app/[lang]/dho/[id]/space-accent.css
@@ -1,0 +1,19 @@
+/**
+ * Space-scoped accent from imagery (--space-* set by SpaceAccentFromImages).
+ * Keeps global theme intact; only descendants of [data-space-accent-scope] use these hooks.
+ */
+[data-space-accent-scope] {
+  --space-tab-active-border: var(--space-accent, #3b82f6);
+}
+
+[data-space-accent-scope] .tabs-root [data-state='active'] {
+  border-bottom-color: var(--space-tab-active-border) !important;
+}
+
+[data-space-accent-scope] [data-space-nav] {
+  color: var(--space-accent, var(--color-accent-11, #4a65d8));
+}
+
+[data-space-accent-scope] [data-space-nav]:hover {
+  opacity: 0.92;
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -187,7 +187,7 @@ export default async function RootLayout({
                           routerConfig={extractRouterConfig(fileRouter)}
                         />
                         <div className="mb-auto pb-8">
-                          <div className="pt-9 h-full flex justify-normal">
+                          <div className="pt-6 h-full flex justify-normal md:pt-7">
                             <div className="w-full h-full">{children}</div>
                           </div>
                         </div>

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -187,7 +187,7 @@ export default async function RootLayout({
                           routerConfig={extractRouterConfig(fileRouter)}
                         />
                         <div className="mb-auto pb-8">
-                          <div className="pt-6 h-full flex justify-normal md:pt-7">
+                          <div className="flex h-full justify-normal pt-4 md:pt-5">
                             <div className="w-full h-full">{children}</div>
                           </div>
                         </div>

--- a/packages/epics/package.json
+++ b/packages/epics/package.json
@@ -9,7 +9,8 @@
   },
   "devDependencies": {
     "@hypha-platform/config-eslint": "workspace:*",
-    "@hypha-platform/config-typescript": "workspace:*"
+    "@hypha-platform/config-typescript": "workspace:*",
+    "next": "^15.1.6"
   },
   "dependencies": {
     "@ai-sdk/react": "^3.0.107",

--- a/packages/epics/src/spaces/components/compact-space-banner-lead.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner-lead.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import * as React from 'react';
+import Image from 'next/image';
+import { cn } from '@hypha-platform/ui-utils';
+
+type Props = {
+  src: string;
+};
+
+/**
+ * Hero lead image with stable branded placeholder + fade-in.
+ * Avoids the grey flash from CSS background-image decoding on first paint.
+ */
+export function CompactSpaceBannerLead({ src }: Props) {
+  const [ready, setReady] = React.useState(false);
+
+  return (
+    <div className="pointer-events-none absolute inset-0 z-0 overflow-hidden rounded-[inherit]">
+      {/* Same atmosphere as no-lead fallback — visible until decode */}
+      <div
+        className="absolute inset-0 bg-[radial-gradient(ellipse_140%_100%_at_12%_-5%,rgb(41,115,78)_0%,rgb(14,54,38)_42%,rgb(7,38,26)_68%,rgb(2,14,10)_100%)]"
+        aria-hidden
+      />
+      <Image
+        src={src}
+        alt=""
+        fill
+        priority
+        sizes="(max-width: 1280px) 100vw, min(1280px, 100vw)"
+        className={cn(
+          'object-cover object-center transition-opacity duration-500 ease-out',
+          ready ? 'opacity-100' : 'opacity-0',
+        )}
+        onLoadingComplete={() => setReady(true)}
+      />
+    </div>
+  );
+}

--- a/packages/epics/src/spaces/components/compact-space-banner.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner.tsx
@@ -107,9 +107,9 @@ export function CompactSpaceBanner({
         />
       )}
 
-      {/* Readability veil — keeps text crisp over photo */}
+      {/* Readability veil — darken foliage under typography (neutral-* tokens are for light surfaces) */}
       <div
-        className="pointer-events-none absolute inset-0 bg-gradient-to-br from-black/35 via-transparent to-emerald-950/55"
+        className="pointer-events-none absolute inset-0 bg-gradient-to-br from-black/45 via-black/25 to-emerald-950/65"
         aria-hidden
       />
 
@@ -151,7 +151,7 @@ export function CompactSpaceBanner({
         {/* Body — scroll when copy exceeds max height (same interaction model as #2165 hero purpose) */}
         {description ? (
           <div className={DESCRIPTION_SCROLL_BOX}>
-            <p className="text-pretty text-2 leading-[1.5] text-white">
+            <p className="text-pretty text-2 leading-[1.5] text-white/95 [text-shadow:0_1px_2px_rgba(0,0,0,0.55)]">
               {description}
             </p>
           </div>
@@ -160,22 +160,26 @@ export function CompactSpaceBanner({
         <div className="h-px w-full bg-white/12" role="presentation" />
 
         <div className="flex flex-col gap-4 gap-x-6 sm:flex-row sm:items-center sm:justify-between">
-          <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-1 text-neutral-11">
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-1 text-white/88 [text-shadow:0_1px_2px_rgba(0,0,0,0.45)]">
             <span>
-              <span className="font-bold text-white">{memberCount}</span>{' '}
-              {membersLabel}
+              <span className="font-bold tabular-nums text-white">
+                {memberCount}
+              </span>{' '}
+              <span className="text-white/92">{membersLabel}</span>
             </span>
-            <span className="text-neutral-10" aria-hidden>
+            <span className="text-white/45" aria-hidden>
               ·
             </span>
             <span>
-              <span className="font-bold text-white">{agreementCount}</span>{' '}
-              {agreementsLabel}
+              <span className="font-bold tabular-nums text-white">
+                {agreementCount}
+              </span>{' '}
+              <span className="text-white/92">{agreementsLabel}</span>
             </span>
-            <span className="text-neutral-10" aria-hidden>
+            <span className="text-white/45" aria-hidden>
               ·
             </span>
-            <span>{createdOnText}</span>
+            <span className="text-white/88">{createdOnText}</span>
           </div>
 
           {footerTrailing ? (

--- a/packages/epics/src/spaces/components/compact-space-banner.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner.tsx
@@ -54,7 +54,7 @@ export function CompactSpaceBanner({
   return (
     <section
       className={cn(
-        'relative overflow-hidden rounded-3xl',
+        'relative overflow-hidden rounded-xl',
         'shadow-[0_24px_48px_-12px_rgba(5,33,22,0.55)]',
         'p-8',
         className,
@@ -203,7 +203,7 @@ export function CompactSpaceBanner({
           </div>
 
           {footerTrailing ? (
-            <div className="flex flex-wrap items-center justify-start gap-2 sm:justify-end [&_.rounded-lg]:rounded-full [&_button]:rounded-full">
+            <div className="flex flex-wrap items-center justify-start gap-2 sm:justify-end [&_.rounded-lg]:rounded-md [&_button]:rounded-md">
               {footerTrailing}
             </div>
           ) : null}

--- a/packages/epics/src/spaces/components/compact-space-banner.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner.tsx
@@ -98,41 +98,69 @@ export function CompactSpaceBanner({
       {textureSrc ? (
         <>
           <CompactSpaceBannerLead src={textureSrc} />
-          {/* Exact overlay stack from PR #2165 SpaceHeaderHeroCard */}
+          {/* PR #2165 stack + depth pass — alphas modulated via inherited CSS vars from SpaceAccentFromImages */}
           <div
-            className="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/88 via-black/42 via-[52%] to-black/22"
-            aria-hidden
-          />
-          <div
-            className="pointer-events-none absolute inset-0 bg-gradient-to-r from-black/58 via-transparent to-black/40"
-            aria-hidden
-          />
-          <div
-            className="pointer-events-none absolute inset-0 bg-gradient-to-br from-accent-11/18 via-transparent to-transparent"
-            aria-hidden
-          />
-          {/* Depth pass — cinematic WOW without fighting hero readability */}
-          <div
-            className="pointer-events-none absolute inset-0 mix-blend-soft-light opacity-90 bg-[radial-gradient(ellipse_55%_45%_at_82%_8%,rgba(209,250,229,0.38),transparent_62%)]"
-            aria-hidden
-          />
-          <div
-            className="pointer-events-none absolute inset-0 bg-gradient-to-br from-white/[0.07] from-[-10%] via-transparent via-40% to-transparent to-55%"
-            aria-hidden
-          />
-          <div
-            className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_115%_95%_at_50%_72%,transparent_22%,rgba(0,18,12,0.62)_88%,rgba(0,8,5,0.92)_100%)]"
-            aria-hidden
-          />
-          <div
-            className="pointer-events-none absolute inset-0 rounded-[inherit] opacity-[0.055] mix-blend-overlay"
+            className="pointer-events-none absolute inset-0"
             style={{
+              backgroundImage:
+                'linear-gradient(to top, rgba(0,0,0,var(--banner-ov-v-bottom, 0.88)) 0%, rgba(0,0,0,var(--banner-ov-v-mid, 0.42)) var(--banner-ov-v-mid-at, 52%), rgba(0,0,0,var(--banner-ov-v-top, 0.22)) 100%)',
+            }}
+            aria-hidden
+          />
+          <div
+            className="pointer-events-none absolute inset-0"
+            style={{
+              backgroundImage:
+                'linear-gradient(to right, rgba(0,0,0,var(--banner-ov-h-from, 0.58)), transparent, rgba(0,0,0,var(--banner-ov-h-to, 0.4)))',
+            }}
+            aria-hidden
+          />
+          <div
+            className="pointer-events-none absolute inset-0"
+            style={{
+              backgroundImage:
+                'linear-gradient(to bottom right, color-mix(in srgb, var(--accent-11, #4f46e5) calc(var(--banner-ov-accent-wash, 0.18) * 100%), transparent), transparent, transparent)',
+            }}
+            aria-hidden
+          />
+          <div
+            className="pointer-events-none absolute inset-0 mix-blend-soft-light"
+            style={{
+              backgroundImage:
+                'radial-gradient(ellipse 55% 45% at 82% 8%, rgba(209,250,229,calc(0.38 * var(--banner-ov-skylight-op, 0.9))), transparent 62%)',
+            }}
+            aria-hidden
+          />
+          <div
+            className="pointer-events-none absolute inset-0"
+            style={{
+              backgroundImage:
+                'linear-gradient(to bottom right, rgba(255,255,255,var(--banner-ov-sheen-op, 0.07)) -10%, transparent 40%, transparent 55%)',
+            }}
+            aria-hidden
+          />
+          <div
+            className="pointer-events-none absolute inset-0"
+            style={{
+              backgroundImage:
+                'radial-gradient(ellipse 115% 95% at 50% 72%, transparent 22%, rgba(0,18,12,calc(0.62 * var(--banner-ov-vignette-strength, 1))) 88%, rgba(0,8,5,calc(0.92 * var(--banner-ov-vignette-strength, 1))) 100%)',
+            }}
+            aria-hidden
+          />
+          <div
+            className="pointer-events-none absolute inset-0 rounded-[inherit] mix-blend-overlay"
+            style={{
+              opacity: 'var(--banner-ov-grain-op, 0.055)',
               backgroundImage: `url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.78' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E")`,
             }}
             aria-hidden
           />
           <div
-            className="pointer-events-none absolute inset-0 rounded-[inherit] shadow-[inset_0_1px_0_rgba(255,255,255,0.09),inset_0_-1px_0_rgba(0,0,0,0.18)]"
+            className="pointer-events-none absolute inset-0 rounded-[inherit]"
+            style={{
+              boxShadow:
+                'inset 0 1px 0 rgba(255,255,255,var(--banner-ov-inner-top, 0.09)), inset 0 -1px 0 rgba(0,0,0,var(--banner-ov-inner-bot, 0.18))',
+            }}
             aria-hidden
           />
         </>

--- a/packages/epics/src/spaces/components/compact-space-banner.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner.tsx
@@ -4,6 +4,17 @@ import { LinkLabel } from '../../common/link-label';
 import { Avatar, AvatarImage } from '@hypha-platform/ui';
 import { cn } from '@hypha-platform/ui-utils';
 
+function isSafeLinkHref(url: string): boolean {
+  const t = url.trim();
+  if (!t) return false;
+  try {
+    const u = new URL(t, 'https://example.com');
+    return u.protocol === 'https:' || u.protocol === 'http:';
+  } catch {
+    return false;
+  }
+}
+
 /** Scrollable purpose block — mirrors #2165 hero (`overflow-y-auto`, thin scrollbar). */
 const DESCRIPTION_SCROLL_BOX = cn(
   'max-h-[min(45vh,280px)] w-full min-h-0 overflow-y-auto overscroll-y-contain pr-1 touch-pan-y',
@@ -50,6 +61,9 @@ export function CompactSpaceBanner({
   className,
 }: CompactSpaceBannerProps) {
   const textureSrc = leadImageUrl || defaultLeadImageSrc || undefined;
+
+  const safeLinks =
+    links?.filter((l) => typeof l === 'string' && isSafeLinkHref(l)) ?? [];
 
   return (
     <section
@@ -145,9 +159,9 @@ export function CompactSpaceBanner({
             <h1 className="text-7 font-bold leading-tight tracking-tight text-white">
               {title}
             </h1>
-            {links && links.length > 0 ? (
+            {safeLinks.length > 0 ? (
               <div className="flex flex-wrap gap-x-5 gap-y-2">
-                {links.map((link, index) => (
+                {safeLinks.map((link, index) => (
                   <a
                     key={`${link}_${index}`}
                     href={link}

--- a/packages/epics/src/spaces/components/compact-space-banner.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner.tsx
@@ -15,7 +15,6 @@ function isSafeLinkHref(url: string): boolean {
   }
 }
 
-/** Same-origin paths or absolute http(s) — safe for CSS url() without injection. */
 function isSafeTextureUrl(raw: string): boolean {
   const t = raw.trim();
   if (!t) return false;
@@ -32,7 +31,13 @@ function cssUrlQuoted(url: string): string {
   return JSON.stringify(url);
 }
 
-/** Scrollable purpose block — narrow column (~50% on sm+) so copy wraps like design ref. */
+/** Matches PR #2165 `SpaceHeaderInsetAvatar` footprint */
+const AVATAR_CLASS = cn(
+  'h-16 w-16 shrink-0 rounded-full sm:h-[72px] sm:w-[72px]',
+  'shadow-[0_18px_40px_-12px_rgba(0,0,0,0.55)] ring-1 ring-white/15',
+);
+
+/** Purpose column — narrow on sm+; left edge aligns with avatar (full-width column below header row). */
 const DESCRIPTION_SCROLL_BOX = cn(
   'max-h-[min(45vh,280px)] w-full max-w-full min-h-0 overflow-y-auto overscroll-y-contain touch-pan-y sm:max-w-[50%]',
   '[scrollbar-gutter:stable]',
@@ -47,16 +52,13 @@ export type CompactSpaceBannerProps = {
   logoAlt: string;
   defaultLogoSrc: string;
   links?: string[] | null;
-  /** Shown faintly on the right; reinforces the space visual identity */
   leadImageUrl?: string | null;
   defaultLeadImageSrc?: string;
   memberCount: number;
   agreementCount: number;
-  /** Pre-formatted created date string (locale-aware) */
   createdOnText: string;
   membersLabel: string;
   agreementsLabel: string;
-  /** Trial / sandbox badges — typically `SubscriptionBadge` + `SpaceModeLabel` */
   footerTrailing?: React.ReactNode;
   className?: string;
 };
@@ -88,7 +90,6 @@ export function CompactSpaceBanner({
   return (
     <section
       className={cn(
-        /* Card chrome: ~12–16px radius, subtle blue-gray rim (design ref image 1) */
         'relative overflow-hidden rounded-xl border border-[#30363d]',
         'shadow-[0_24px_48px_-12px_rgba(5,33,22,0.55)]',
         'px-8 pt-8 pb-5',
@@ -96,87 +97,48 @@ export function CompactSpaceBanner({
       )}
       aria-label={title}
     >
-      {/* Atmosphere — deep forest base + spotlight (distinct from flat single gradient) */}
-      <div
-        className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_140%_100%_at_12%_-5%,rgb(41,115,78)_0%,rgb(18,72,52)_38%,rgb(7,38,26)_68%,rgb(2,14,10)_100%)]"
-        aria-hidden
-      />
-      <div
-        className="pointer-events-none absolute inset-0 mix-blend-overlay opacity-90 bg-[radial-gradient(ellipse_60%_45%_at_85%_20%,rgba(52,211,153,0.28),transparent_65%)]"
-        aria-hidden
-      />
-
-      {/* Fine grain — film texture */}
-      <div
-        className="pointer-events-none absolute inset-0 opacity-[0.07] mix-blend-overlay"
-        style={{
-          backgroundImage: `url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E")`,
-        }}
-        aria-hidden
-      />
-
-      {/* Hero image — richer bokeh + color pop, then a cool grade for “studio” depth */}
+      {/* Lead image fill — PR #2165 hero-style base */}
       {textureSrc ? (
         <>
           <div
-            className="pointer-events-none absolute inset-0 bg-cover bg-center opacity-[0.48]"
-            style={{
-              backgroundImage: `url(${cssUrlQuoted(textureSrc)})`,
-              filter: 'blur(32px) saturate(1.35) contrast(1.08)',
-              transform: 'scale(1.12)',
-            }}
-            aria-hidden
-          />
-          <div
-            className="pointer-events-none absolute inset-0 bg-cover bg-[center_28%] bg-no-repeat opacity-[0.38] mix-blend-soft-light"
+            className="pointer-events-none absolute inset-0 bg-cover bg-center"
             style={{ backgroundImage: `url(${cssUrlQuoted(textureSrc)})` }}
             aria-hidden
           />
+          {/* Exact overlay stack from PR #2165 SpaceHeaderHeroCard */}
           <div
-            className="pointer-events-none absolute inset-0 mix-blend-color opacity-[0.22] bg-gradient-to-br from-teal-600/80 via-emerald-900/40 to-slate-950/90"
+            className="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/88 via-black/42 via-[52%] to-black/22"
+            aria-hidden
+          />
+          <div
+            className="pointer-events-none absolute inset-0 bg-gradient-to-r from-black/58 via-transparent to-black/40"
+            aria-hidden
+          />
+          <div
+            className="pointer-events-none absolute inset-0 bg-gradient-to-br from-accent-11/18 via-transparent to-transparent"
             aria-hidden
           />
         </>
       ) : (
         <div
-          className="pointer-events-none absolute inset-0 opacity-[0.1]"
-          style={{
-            backgroundImage: `
-              radial-gradient(ellipse 70% 55% at 85% 35%, rgba(52, 211, 153, 0.4), transparent 60%),
-              radial-gradient(circle at 25% 75%, rgba(16, 185, 129, 0.25), transparent 50%)
-            `,
-          }}
+          className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_140%_100%_at_12%_-5%,rgb(41,115,78)_0%,rgb(14,54,38)_42%,rgb(7,38,26)_68%,rgb(2,14,10)_100%)]"
           aria-hidden
         />
       )}
 
-      {/* Cinematic stack: vignette + rim light + footer anchor (replaces single flat veil) */}
-      <div
-        className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_95%_80%_at_50%_42%,transparent_0%,rgba(0,12,8,0.55)_78%,rgba(0,8,5,0.88)_100%)]"
-        aria-hidden
-      />
-      <div
-        className="pointer-events-none absolute inset-0 bg-gradient-to-b from-emerald-300/14 from-0% via-transparent via-35% to-transparent to-55%"
-        aria-hidden
-      />
-      <div
-        className="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/45 from-0% via-black/12 via-38% to-transparent to-58%"
-        aria-hidden
-      />
-      <div
-        className="pointer-events-none absolute inset-0 bg-gradient-to-r from-black/35 from-[-5%] via-transparent via-50% to-black/30 to-[105%]"
-        aria-hidden
-      />
+      <div className="relative z-10 flex flex-col gap-5">
+        {/* Row 1: avatar + title/links — avatar size matches PR #2165 */}
+        <div className="flex items-start gap-6">
+          <Avatar className={AVATAR_CLASS}>
+            <AvatarImage
+              src={logoUrl || defaultLogoSrc}
+              alt={logoAlt}
+              className="object-cover"
+            />
+          </Avatar>
 
-      <div className="relative z-10 flex items-start gap-6">
-        <Avatar className="h-20 w-20 shrink-0 rounded-full">
-          <AvatarImage src={logoUrl || defaultLogoSrc} alt={logoAlt} />
-        </Avatar>
-
-        {/* Title, purpose, divider, footer share one column so left edges align pixel-true */}
-        <div className="flex min-w-0 flex-1 flex-col gap-5">
-          <div className="space-y-2">
-            <h1 className="text-7 font-bold leading-tight tracking-tight text-white">
+          <div className="min-w-0 flex-1 space-y-2">
+            <h1 className="text-balance text-6 font-semibold tracking-tight text-white drop-shadow-sm sm:text-7">
               {title}
             </h1>
             {safeLinks.length > 0 ? (
@@ -201,46 +163,47 @@ export function CompactSpaceBanner({
               </div>
             ) : null}
           </div>
+        </div>
 
-          {description ? (
-            <div className={DESCRIPTION_SCROLL_BOX}>
-              <p className="text-pretty text-2 leading-[1.5] text-white/95 [text-shadow:0_1px_2px_rgba(0,0,0,0.55)]">
-                {description}
-              </p>
+        {/* Below header: same horizontal origin as avatar — not nested in title column */}
+        {description ? (
+          <div className={DESCRIPTION_SCROLL_BOX}>
+            <p className="text-pretty text-2 leading-[1.5] text-white/95 [text-shadow:0_1px_2px_rgba(0,0,0,0.55)]">
+              {description}
+            </p>
+          </div>
+        ) : null}
+
+        <div className="h-px w-full bg-white/12" role="presentation" />
+
+        <div className="flex flex-col gap-3 gap-x-5 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-1 text-white/88 [text-shadow:0_1px_2px_rgba(0,0,0,0.45)]">
+            <span>
+              <span className="font-bold tabular-nums text-white">
+                {memberCount}
+              </span>{' '}
+              <span className="text-white/92">{membersLabel}</span>
+            </span>
+            <span className="text-white/45" aria-hidden>
+              ·
+            </span>
+            <span>
+              <span className="font-bold tabular-nums text-white">
+                {agreementCount}
+              </span>{' '}
+              <span className="text-white/92">{agreementsLabel}</span>
+            </span>
+            <span className="text-white/45" aria-hidden>
+              ·
+            </span>
+            <span className="text-white/88">{createdOnText}</span>
+          </div>
+
+          {footerTrailing ? (
+            <div className="flex flex-wrap items-center justify-start gap-2 sm:justify-end [&_.rounded-lg]:rounded-md [&_a]:inline-flex [&_a]:items-center [&_button]:rounded-md [&_div]:inline-flex [&_div]:items-center">
+              {footerTrailing}
             </div>
           ) : null}
-
-          <div className="h-px w-full bg-white/12" role="presentation" />
-
-          <div className="flex flex-col gap-3 gap-x-5 sm:flex-row sm:items-center sm:justify-between">
-            <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-1 text-white/88 [text-shadow:0_1px_2px_rgba(0,0,0,0.45)]">
-              <span>
-                <span className="font-bold tabular-nums text-white">
-                  {memberCount}
-                </span>{' '}
-                <span className="text-white/92">{membersLabel}</span>
-              </span>
-              <span className="text-white/45" aria-hidden>
-                ·
-              </span>
-              <span>
-                <span className="font-bold tabular-nums text-white">
-                  {agreementCount}
-                </span>{' '}
-                <span className="text-white/92">{agreementsLabel}</span>
-              </span>
-              <span className="text-white/45" aria-hidden>
-                ·
-              </span>
-              <span className="text-white/88">{createdOnText}</span>
-            </div>
-
-            {footerTrailing ? (
-              <div className="flex flex-wrap items-center justify-start gap-2 sm:justify-end [&_.rounded-lg]:rounded-md [&_a]:inline-flex [&_a]:items-center [&_button]:rounded-md [&_div]:inline-flex [&_div]:items-center">
-                {footerTrailing}
-              </div>
-            ) : null}
-          </div>
         </div>
       </div>
     </section>

--- a/packages/epics/src/spaces/components/compact-space-banner.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner.tsx
@@ -54,7 +54,7 @@ export function CompactSpaceBanner({
   return (
     <section
       className={cn(
-        'relative overflow-hidden rounded-3xl border border-white/25',
+        'relative overflow-hidden rounded-3xl',
         'shadow-[0_24px_48px_-12px_rgba(5,33,22,0.55)]',
         'p-8',
         className,

--- a/packages/epics/src/spaces/components/compact-space-banner.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner.tsx
@@ -54,7 +54,8 @@ export function CompactSpaceBanner({
   return (
     <section
       className={cn(
-        'relative overflow-hidden rounded-xl',
+        /* Production-style corner: large smooth radius + hairline dark rim (ref image 1) */
+        'relative overflow-hidden rounded-[40px] border border-[#1a1a1a]',
         'shadow-[0_24px_48px_-12px_rgba(5,33,22,0.55)]',
         'p-8',
         className,

--- a/packages/epics/src/spaces/components/compact-space-banner.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner.tsx
@@ -109,7 +109,7 @@ export function CompactSpaceBanner({
       <div className="relative z-10 flex flex-col gap-6">
         {/* Header row: avatar + title stack only (Image 2) */}
         <div className="flex items-start gap-6">
-          <Avatar className="h-20 w-20 shrink-0 rounded-full ring-2 ring-emerald-400/90 ring-offset-[3px] ring-offset-[#0a2818]">
+          <Avatar className="h-20 w-20 shrink-0 rounded-full">
             <AvatarImage src={logoUrl || defaultLogoSrc} alt={logoAlt} />
           </Avatar>
 

--- a/packages/epics/src/spaces/components/compact-space-banner.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner.tsx
@@ -3,6 +3,7 @@ import { LinkIcon } from '../../common/link-icon';
 import { LinkLabel } from '../../common/link-label';
 import { Avatar, AvatarImage } from '@hypha-platform/ui';
 import { cn } from '@hypha-platform/ui-utils';
+import { CompactSpaceBannerLead } from './compact-space-banner-lead';
 
 function isSafeLinkHref(url: string): boolean {
   const t = url.trim();
@@ -25,10 +26,6 @@ function isSafeTextureUrl(raw: string): boolean {
   } catch {
     return false;
   }
-}
-
-function cssUrlQuoted(url: string): string {
-  return JSON.stringify(url);
 }
 
 /** Matches PR #2165 `SpaceHeaderInsetAvatar` footprint */
@@ -97,14 +94,10 @@ export function CompactSpaceBanner({
       )}
       aria-label={title}
     >
-      {/* Lead image fill — PR #2165 hero-style base */}
+      {/* Lead image — Image + preload avoids grey decode flash; overlays unchanged */}
       {textureSrc ? (
         <>
-          <div
-            className="pointer-events-none absolute inset-0 bg-cover bg-center"
-            style={{ backgroundImage: `url(${cssUrlQuoted(textureSrc)})` }}
-            aria-hidden
-          />
+          <CompactSpaceBannerLead src={textureSrc} />
           {/* Exact overlay stack from PR #2165 SpaceHeaderHeroCard */}
           <div
             className="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/88 via-black/42 via-[52%] to-black/22"

--- a/packages/epics/src/spaces/components/compact-space-banner.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner.tsx
@@ -1,0 +1,159 @@
+import * as React from 'react';
+import { LinkIcon } from '../../common/link-icon';
+import { LinkLabel } from '../../common/link-label';
+import { Avatar, AvatarImage } from '@hypha-platform/ui';
+import { cn } from '@hypha-platform/ui-utils';
+
+export type CompactSpaceBannerProps = {
+  title: string;
+  description: string | null | undefined;
+  logoUrl: string | null | undefined;
+  logoAlt: string;
+  defaultLogoSrc: string;
+  links?: string[] | null;
+  /** Shown faintly on the right; reinforces the space visual identity */
+  leadImageUrl?: string | null;
+  defaultLeadImageSrc?: string;
+  memberCount: number;
+  agreementCount: number;
+  /** Pre-formatted created date string (locale-aware) */
+  createdOnText: string;
+  membersLabel: string;
+  agreementsLabel: string;
+  /** Trial / sandbox badges — typically `SubscriptionBadge` + `SpaceModeLabel` */
+  footerTrailing?: React.ReactNode;
+  className?: string;
+};
+
+export function CompactSpaceBanner({
+  title,
+  description,
+  logoUrl,
+  logoAlt,
+  defaultLogoSrc,
+  links,
+  leadImageUrl,
+  defaultLeadImageSrc,
+  memberCount,
+  agreementCount,
+  createdOnText,
+  membersLabel,
+  agreementsLabel,
+  footerTrailing,
+  className,
+}: CompactSpaceBannerProps) {
+  const textureSrc = leadImageUrl || defaultLeadImageSrc || undefined;
+
+  return (
+    <section
+      className={cn(
+        'relative overflow-hidden rounded-2xl border border-white/10',
+        'bg-gradient-to-br from-[#0b2214] via-[#143d28] to-[#0d2818]',
+        'p-6 sm:p-8 shadow-lg',
+        className,
+      )}
+      aria-label={title}
+    >
+      {/* Foliage-like noise + lead image texture */}
+      <div
+        className="pointer-events-none absolute inset-0 opacity-[0.12]"
+        style={{
+          backgroundImage: `
+            radial-gradient(ellipse 80% 60% at 90% 40%, rgba(34, 197, 94, 0.35), transparent 55%),
+            radial-gradient(circle at 20% 80%, rgba(16, 185, 129, 0.2), transparent 45%),
+            repeating-linear-gradient(
+              -18deg,
+              transparent,
+              transparent 2px,
+              rgba(0, 0, 0, 0.08) 2px,
+              rgba(0, 0, 0, 0.08) 4px
+            )
+          `,
+        }}
+        aria-hidden
+      />
+      {textureSrc ? (
+        <div
+          className="pointer-events-none absolute inset-0 bg-cover bg-right bg-no-repeat opacity-[0.18] mix-blend-overlay"
+          style={{ backgroundImage: `url(${textureSrc})` }}
+          aria-hidden
+        />
+      ) : null}
+      <div
+        className="pointer-events-none absolute inset-0 bg-gradient-to-r from-black/25 via-transparent to-emerald-950/40"
+        aria-hidden
+      />
+
+      <div className="relative z-10 flex flex-col gap-5">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:gap-6">
+          <Avatar className="h-20 w-20 shrink-0 rounded-full ring-2 ring-white/25 ring-offset-2 ring-offset-[#0f331f]">
+            <AvatarImage src={logoUrl || defaultLogoSrc} alt={logoAlt} />
+          </Avatar>
+
+          <div className="min-w-0 flex-1 space-y-3">
+            <h1 className="text-7 font-semibold leading-tight tracking-tight text-white">
+              {title}
+            </h1>
+            {links && links.length > 0 ? (
+              <div className="flex flex-wrap gap-x-5 gap-y-2">
+                {links.map((link, index) => (
+                  <a
+                    key={`${link}_${index}`}
+                    href={link}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1.5 text-1 text-white/95 hover:text-white"
+                  >
+                    <span className="text-white/90 [&_svg]:h-4 [&_svg]:w-4">
+                      <LinkIcon url={link} />
+                    </span>
+                    <LinkLabel
+                      url={link}
+                      className="underline-offset-4 hover:underline"
+                    />
+                  </a>
+                ))}
+              </div>
+            ) : null}
+
+            {description ? (
+              <p className="max-w-full text-2 leading-relaxed text-white/90 sm:max-w-[52%]">
+                {description}
+              </p>
+            ) : null}
+          </div>
+        </div>
+
+        <div className="h-px w-full bg-white/15" role="presentation" />
+
+        <div className="flex flex-col gap-4 gap-x-6 md:flex-row md:items-center md:justify-between">
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-1 text-white/75">
+            <span>
+              <span className="font-semibold text-white/95">{memberCount}</span>{' '}
+              {membersLabel}
+            </span>
+            <span className="text-white/40" aria-hidden>
+              ·
+            </span>
+            <span>
+              <span className="font-semibold text-white/95">
+                {agreementCount}
+              </span>{' '}
+              {agreementsLabel}
+            </span>
+            <span className="text-white/40" aria-hidden>
+              ·
+            </span>
+            <span>{createdOnText}</span>
+          </div>
+
+          {footerTrailing ? (
+            <div className="flex flex-wrap items-center justify-start gap-2 md:justify-end">
+              {footerTrailing}
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/packages/epics/src/spaces/components/compact-space-banner.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner.tsx
@@ -237,7 +237,7 @@ export function CompactSpaceBanner({
           </div>
 
           {footerTrailing ? (
-            <div className="flex flex-wrap items-center justify-start gap-2 sm:justify-end [&_.rounded-lg]:rounded-md [&_button]:rounded-md">
+            <div className="flex flex-wrap items-center justify-start gap-2 sm:justify-end [&_.rounded-lg]:rounded-md [&_a]:inline-flex [&_a]:items-center [&_button]:rounded-md [&_div]:inline-flex [&_div]:items-center">
               {footerTrailing}
             </div>
           ) : null}

--- a/packages/epics/src/spaces/components/compact-space-banner.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner.tsx
@@ -47,51 +47,74 @@ export function CompactSpaceBanner({
   return (
     <section
       className={cn(
-        'relative overflow-hidden rounded-2xl border border-white/10',
-        'bg-gradient-to-br from-[#0b2214] via-[#143d28] to-[#0d2818]',
-        'p-6 sm:p-8 shadow-lg',
+        'relative overflow-hidden rounded-3xl border border-white/25',
+        'shadow-[0_24px_48px_-12px_rgba(5,33,22,0.55)]',
+        'p-8',
         className,
       )}
       aria-label={title}
     >
-      {/* Foliage-like noise + lead image texture */}
+      {/* Base gradient — lighter top-left (Image 2), darker bottom-right */}
       <div
-        className="pointer-events-none absolute inset-0 opacity-[0.12]"
+        className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_120%_90%_at_10%_-10%,rgb(34,94,62)_0%,rgb(14,54,38)_42%,rgb(5,33,22)_72%,rgb(2,18,12)_100%)]"
+        aria-hidden
+      />
+
+      {/* Fine grain */}
+      <div
+        className="pointer-events-none absolute inset-0 opacity-[0.06]"
         style={{
-          backgroundImage: `
-            radial-gradient(ellipse 80% 60% at 90% 40%, rgba(34, 197, 94, 0.35), transparent 55%),
-            radial-gradient(circle at 20% 80%, rgba(16, 185, 129, 0.2), transparent 45%),
-            repeating-linear-gradient(
-              -18deg,
-              transparent,
-              transparent 2px,
-              rgba(0, 0, 0, 0.08) 2px,
-              rgba(0, 0, 0, 0.08) 4px
-            )
-          `,
+          backgroundImage: `url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E")`,
         }}
         aria-hidden
       />
+
+      {/* Bokeh foliage — full-bleed, visibly layered like Image 2 */}
       {textureSrc ? (
+        <>
+          <div
+            className="pointer-events-none absolute inset-0 bg-cover bg-center opacity-[0.42]"
+            style={{
+              backgroundImage: `url(${textureSrc})`,
+              filter: 'blur(28px) saturate(1.15)',
+              transform: 'scale(1.08)',
+            }}
+            aria-hidden
+          />
+          <div
+            className="pointer-events-none absolute inset-0 bg-cover bg-[center_30%] bg-no-repeat opacity-[0.35] mix-blend-soft-light"
+            style={{ backgroundImage: `url(${textureSrc})` }}
+            aria-hidden
+          />
+        </>
+      ) : (
         <div
-          className="pointer-events-none absolute inset-0 bg-cover bg-right bg-no-repeat opacity-[0.18] mix-blend-overlay"
-          style={{ backgroundImage: `url(${textureSrc})` }}
+          className="pointer-events-none absolute inset-0 opacity-[0.08]"
+          style={{
+            backgroundImage: `
+              radial-gradient(ellipse 70% 55% at 85% 35%, rgba(34, 197, 94, 0.35), transparent 60%),
+              radial-gradient(circle at 25% 75%, rgba(16, 185, 129, 0.22), transparent 50%)
+            `,
+          }}
           aria-hidden
         />
-      ) : null}
+      )}
+
+      {/* Readability veil — keeps text crisp over photo */}
       <div
-        className="pointer-events-none absolute inset-0 bg-gradient-to-r from-black/25 via-transparent to-emerald-950/40"
+        className="pointer-events-none absolute inset-0 bg-gradient-to-br from-black/35 via-transparent to-emerald-950/55"
         aria-hidden
       />
 
-      <div className="relative z-10 flex flex-col gap-5">
-        <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:gap-6">
-          <Avatar className="h-20 w-20 shrink-0 rounded-full ring-2 ring-white/25 ring-offset-2 ring-offset-[#0f331f]">
+      <div className="relative z-10 flex flex-col gap-6">
+        {/* Header row: avatar + title stack only (Image 2) */}
+        <div className="flex items-start gap-6">
+          <Avatar className="h-20 w-20 shrink-0 rounded-full ring-2 ring-emerald-400/90 ring-offset-[3px] ring-offset-[#0a2818]">
             <AvatarImage src={logoUrl || defaultLogoSrc} alt={logoAlt} />
           </Avatar>
 
-          <div className="min-w-0 flex-1 space-y-3">
-            <h1 className="text-7 font-semibold leading-tight tracking-tight text-white">
+          <div className="min-w-0 flex-1 space-y-2">
+            <h1 className="text-7 font-bold leading-tight tracking-tight text-white">
               {title}
             </h1>
             {links && links.length > 0 ? (
@@ -102,9 +125,9 @@ export function CompactSpaceBanner({
                     href={link}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="inline-flex items-center gap-1.5 text-1 text-white/95 hover:text-white"
+                    className="inline-flex items-center gap-1.5 text-1 text-white/80 hover:text-white"
                   >
-                    <span className="text-white/90 [&_svg]:h-4 [&_svg]:w-4">
+                    <span className="text-white/80 [&_svg]:h-4 [&_svg]:w-4">
                       <LinkIcon url={link} />
                     </span>
                     <LinkLabel
@@ -115,40 +138,39 @@ export function CompactSpaceBanner({
                 ))}
               </div>
             ) : null}
-
-            {description ? (
-              <p className="max-w-full text-2 leading-relaxed text-white/90 sm:max-w-[52%]">
-                {description}
-              </p>
-            ) : null}
           </div>
         </div>
 
-        <div className="h-px w-full bg-white/15" role="presentation" />
+        {/* Body — full width under header (Image 2); not constrained to half column */}
+        {description ? (
+          <p className="max-w-none text-2 leading-[1.5] text-white">
+            {description}
+          </p>
+        ) : null}
 
-        <div className="flex flex-col gap-4 gap-x-6 md:flex-row md:items-center md:justify-between">
-          <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-1 text-white/75">
+        <div className="h-px w-full bg-white/12" role="presentation" />
+
+        <div className="flex flex-col gap-4 gap-x-6 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-1 text-neutral-11">
             <span>
-              <span className="font-semibold text-white/95">{memberCount}</span>{' '}
+              <span className="font-bold text-white">{memberCount}</span>{' '}
               {membersLabel}
             </span>
-            <span className="text-white/40" aria-hidden>
+            <span className="text-neutral-10" aria-hidden>
               ·
             </span>
             <span>
-              <span className="font-semibold text-white/95">
-                {agreementCount}
-              </span>{' '}
+              <span className="font-bold text-white">{agreementCount}</span>{' '}
               {agreementsLabel}
             </span>
-            <span className="text-white/40" aria-hidden>
+            <span className="text-neutral-10" aria-hidden>
               ·
             </span>
             <span>{createdOnText}</span>
           </div>
 
           {footerTrailing ? (
-            <div className="flex flex-wrap items-center justify-start gap-2 md:justify-end">
+            <div className="flex flex-wrap items-center justify-start gap-2 sm:justify-end [&_.rounded-lg]:rounded-full [&_button]:rounded-full">
               {footerTrailing}
             </div>
           ) : null}

--- a/packages/epics/src/spaces/components/compact-space-banner.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner.tsx
@@ -15,6 +15,23 @@ function isSafeLinkHref(url: string): boolean {
   }
 }
 
+/** Same-origin paths or absolute http(s) — safe for CSS url() without injection. */
+function isSafeTextureUrl(raw: string): boolean {
+  const t = raw.trim();
+  if (!t) return false;
+  if (t.startsWith('/')) return true;
+  try {
+    const u = new URL(t);
+    return u.protocol === 'http:' || u.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+function cssUrlQuoted(url: string): string {
+  return JSON.stringify(url);
+}
+
 /** Scrollable purpose block — mirrors #2165 hero (`overflow-y-auto`, thin scrollbar). */
 const DESCRIPTION_SCROLL_BOX = cn(
   'max-h-[min(45vh,280px)] w-full min-h-0 overflow-y-auto overscroll-y-contain pr-1 touch-pan-y',
@@ -60,7 +77,9 @@ export function CompactSpaceBanner({
   footerTrailing,
   className,
 }: CompactSpaceBannerProps) {
-  const textureSrc = leadImageUrl || defaultLeadImageSrc || undefined;
+  const rawTexture = leadImageUrl || defaultLeadImageSrc || '';
+  const textureSrc =
+    rawTexture && isSafeTextureUrl(rawTexture) ? rawTexture.trim() : '';
 
   const safeLinks =
     links?.filter((l) => typeof l === 'string' && isSafeLinkHref(l)) ?? [];
@@ -101,7 +120,7 @@ export function CompactSpaceBanner({
           <div
             className="pointer-events-none absolute inset-0 bg-cover bg-center opacity-[0.48]"
             style={{
-              backgroundImage: `url(${textureSrc})`,
+              backgroundImage: `url(${cssUrlQuoted(textureSrc)})`,
               filter: 'blur(32px) saturate(1.35) contrast(1.08)',
               transform: 'scale(1.12)',
             }}
@@ -109,7 +128,7 @@ export function CompactSpaceBanner({
           />
           <div
             className="pointer-events-none absolute inset-0 bg-cover bg-[center_28%] bg-no-repeat opacity-[0.38] mix-blend-soft-light"
-            style={{ backgroundImage: `url(${textureSrc})` }}
+            style={{ backgroundImage: `url(${cssUrlQuoted(textureSrc)})` }}
             aria-hidden
           />
           <div

--- a/packages/epics/src/spaces/components/compact-space-banner.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner.tsx
@@ -61,55 +61,75 @@ export function CompactSpaceBanner({
       )}
       aria-label={title}
     >
-      {/* Base gradient — lighter top-left (Image 2), darker bottom-right */}
+      {/* Atmosphere — deep forest base + spotlight (distinct from flat single gradient) */}
       <div
-        className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_120%_90%_at_10%_-10%,rgb(34,94,62)_0%,rgb(14,54,38)_42%,rgb(5,33,22)_72%,rgb(2,18,12)_100%)]"
+        className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_140%_100%_at_12%_-5%,rgb(41,115,78)_0%,rgb(18,72,52)_38%,rgb(7,38,26)_68%,rgb(2,14,10)_100%)]"
+        aria-hidden
+      />
+      <div
+        className="pointer-events-none absolute inset-0 mix-blend-overlay opacity-90 bg-[radial-gradient(ellipse_60%_45%_at_85%_20%,rgba(52,211,153,0.28),transparent_65%)]"
         aria-hidden
       />
 
-      {/* Fine grain */}
+      {/* Fine grain — film texture */}
       <div
-        className="pointer-events-none absolute inset-0 opacity-[0.06]"
+        className="pointer-events-none absolute inset-0 opacity-[0.07] mix-blend-overlay"
         style={{
           backgroundImage: `url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E")`,
         }}
         aria-hidden
       />
 
-      {/* Bokeh foliage — full-bleed, visibly layered like Image 2 */}
+      {/* Hero image — richer bokeh + color pop, then a cool grade for “studio” depth */}
       {textureSrc ? (
         <>
           <div
-            className="pointer-events-none absolute inset-0 bg-cover bg-center opacity-[0.42]"
+            className="pointer-events-none absolute inset-0 bg-cover bg-center opacity-[0.48]"
             style={{
               backgroundImage: `url(${textureSrc})`,
-              filter: 'blur(28px) saturate(1.15)',
-              transform: 'scale(1.08)',
+              filter: 'blur(32px) saturate(1.35) contrast(1.08)',
+              transform: 'scale(1.12)',
             }}
             aria-hidden
           />
           <div
-            className="pointer-events-none absolute inset-0 bg-cover bg-[center_30%] bg-no-repeat opacity-[0.35] mix-blend-soft-light"
+            className="pointer-events-none absolute inset-0 bg-cover bg-[center_28%] bg-no-repeat opacity-[0.38] mix-blend-soft-light"
             style={{ backgroundImage: `url(${textureSrc})` }}
+            aria-hidden
+          />
+          <div
+            className="pointer-events-none absolute inset-0 mix-blend-color opacity-[0.22] bg-gradient-to-br from-teal-600/80 via-emerald-900/40 to-slate-950/90"
             aria-hidden
           />
         </>
       ) : (
         <div
-          className="pointer-events-none absolute inset-0 opacity-[0.08]"
+          className="pointer-events-none absolute inset-0 opacity-[0.1]"
           style={{
             backgroundImage: `
-              radial-gradient(ellipse 70% 55% at 85% 35%, rgba(34, 197, 94, 0.35), transparent 60%),
-              radial-gradient(circle at 25% 75%, rgba(16, 185, 129, 0.22), transparent 50%)
+              radial-gradient(ellipse 70% 55% at 85% 35%, rgba(52, 211, 153, 0.4), transparent 60%),
+              radial-gradient(circle at 25% 75%, rgba(16, 185, 129, 0.25), transparent 50%)
             `,
           }}
           aria-hidden
         />
       )}
 
-      {/* Readability veil — darken foliage under typography (neutral-* tokens are for light surfaces) */}
+      {/* Cinematic stack: vignette + rim light + footer anchor (replaces single flat veil) */}
       <div
-        className="pointer-events-none absolute inset-0 bg-gradient-to-br from-black/45 via-black/25 to-emerald-950/65"
+        className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_95%_80%_at_50%_42%,transparent_0%,rgba(0,12,8,0.55)_78%,rgba(0,8,5,0.88)_100%)]"
+        aria-hidden
+      />
+      <div
+        className="pointer-events-none absolute inset-0 bg-gradient-to-b from-emerald-300/14 from-0% via-transparent via-35% to-transparent to-55%"
+        aria-hidden
+      />
+      <div
+        className="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/60 from-0% via-black/18 via-45% to-transparent to-72%"
+        aria-hidden
+      />
+      <div
+        className="pointer-events-none absolute inset-0 bg-gradient-to-r from-black/35 from-[-5%] via-transparent via-50% to-black/30 to-[105%]"
         aria-hidden
       />
 

--- a/packages/epics/src/spaces/components/compact-space-banner.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner.tsx
@@ -34,7 +34,8 @@ function cssUrlQuoted(url: string): string {
 
 /** Scrollable purpose block — narrow column (~50% on sm+) so copy wraps like design ref. */
 const DESCRIPTION_SCROLL_BOX = cn(
-  'max-h-[min(45vh,280px)] w-full max-w-full min-h-0 overflow-y-auto overscroll-y-contain pr-1 touch-pan-y sm:max-w-[50%]',
+  'max-h-[min(45vh,280px)] w-full max-w-full min-h-0 overflow-y-auto overscroll-y-contain touch-pan-y sm:max-w-[50%]',
+  '[scrollbar-gutter:stable]',
   '[scrollbar-color:rgba(255,255,255,0.35)_transparent] [scrollbar-width:thin]',
   '[&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-white/30 [&::-webkit-scrollbar-track]:bg-transparent',
 );
@@ -167,14 +168,14 @@ export function CompactSpaceBanner({
         aria-hidden
       />
 
-      <div className="relative z-10 flex flex-col gap-5">
-        {/* Header row: avatar + title stack only (Image 2) */}
-        <div className="flex items-start gap-6">
-          <Avatar className="h-20 w-20 shrink-0 rounded-full">
-            <AvatarImage src={logoUrl || defaultLogoSrc} alt={logoAlt} />
-          </Avatar>
+      <div className="relative z-10 flex items-start gap-6">
+        <Avatar className="h-20 w-20 shrink-0 rounded-full">
+          <AvatarImage src={logoUrl || defaultLogoSrc} alt={logoAlt} />
+        </Avatar>
 
-          <div className="min-w-0 flex-1 space-y-2">
+        {/* Title, purpose, divider, footer share one column so left edges align pixel-true */}
+        <div className="flex min-w-0 flex-1 flex-col gap-5">
+          <div className="space-y-2">
             <h1 className="text-7 font-bold leading-tight tracking-tight text-white">
               {title}
             </h1>
@@ -200,47 +201,46 @@ export function CompactSpaceBanner({
               </div>
             ) : null}
           </div>
-        </div>
 
-        {/* Body — scroll when copy exceeds max height (same interaction model as #2165 hero purpose) */}
-        {description ? (
-          <div className={DESCRIPTION_SCROLL_BOX}>
-            <p className="text-pretty text-2 leading-[1.5] text-white/95 [text-shadow:0_1px_2px_rgba(0,0,0,0.55)]">
-              {description}
-            </p>
-          </div>
-        ) : null}
-
-        <div className="h-px w-full bg-white/12" role="presentation" />
-
-        <div className="flex flex-col gap-3 gap-x-5 sm:flex-row sm:items-center sm:justify-between">
-          <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-1 text-white/88 [text-shadow:0_1px_2px_rgba(0,0,0,0.45)]">
-            <span>
-              <span className="font-bold tabular-nums text-white">
-                {memberCount}
-              </span>{' '}
-              <span className="text-white/92">{membersLabel}</span>
-            </span>
-            <span className="text-white/45" aria-hidden>
-              ·
-            </span>
-            <span>
-              <span className="font-bold tabular-nums text-white">
-                {agreementCount}
-              </span>{' '}
-              <span className="text-white/92">{agreementsLabel}</span>
-            </span>
-            <span className="text-white/45" aria-hidden>
-              ·
-            </span>
-            <span className="text-white/88">{createdOnText}</span>
-          </div>
-
-          {footerTrailing ? (
-            <div className="flex flex-wrap items-center justify-start gap-2 sm:justify-end [&_.rounded-lg]:rounded-md [&_a]:inline-flex [&_a]:items-center [&_button]:rounded-md [&_div]:inline-flex [&_div]:items-center">
-              {footerTrailing}
+          {description ? (
+            <div className={DESCRIPTION_SCROLL_BOX}>
+              <p className="text-pretty text-2 leading-[1.5] text-white/95 [text-shadow:0_1px_2px_rgba(0,0,0,0.55)]">
+                {description}
+              </p>
             </div>
           ) : null}
+
+          <div className="h-px w-full bg-white/12" role="presentation" />
+
+          <div className="flex flex-col gap-3 gap-x-5 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-1 text-white/88 [text-shadow:0_1px_2px_rgba(0,0,0,0.45)]">
+              <span>
+                <span className="font-bold tabular-nums text-white">
+                  {memberCount}
+                </span>{' '}
+                <span className="text-white/92">{membersLabel}</span>
+              </span>
+              <span className="text-white/45" aria-hidden>
+                ·
+              </span>
+              <span>
+                <span className="font-bold tabular-nums text-white">
+                  {agreementCount}
+                </span>{' '}
+                <span className="text-white/92">{agreementsLabel}</span>
+              </span>
+              <span className="text-white/45" aria-hidden>
+                ·
+              </span>
+              <span className="text-white/88">{createdOnText}</span>
+            </div>
+
+            {footerTrailing ? (
+              <div className="flex flex-wrap items-center justify-start gap-2 sm:justify-end [&_.rounded-lg]:rounded-md [&_a]:inline-flex [&_a]:items-center [&_button]:rounded-md [&_div]:inline-flex [&_div]:items-center">
+                {footerTrailing}
+              </div>
+            ) : null}
+          </div>
         </div>
       </div>
     </section>

--- a/packages/epics/src/spaces/components/compact-space-banner.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner.tsx
@@ -118,12 +118,46 @@ export function CompactSpaceBanner({
             className="pointer-events-none absolute inset-0 bg-gradient-to-br from-accent-11/18 via-transparent to-transparent"
             aria-hidden
           />
+          {/* Depth pass — cinematic WOW without fighting hero readability */}
+          <div
+            className="pointer-events-none absolute inset-0 mix-blend-soft-light opacity-90 bg-[radial-gradient(ellipse_55%_45%_at_82%_8%,rgba(209,250,229,0.38),transparent_62%)]"
+            aria-hidden
+          />
+          <div
+            className="pointer-events-none absolute inset-0 bg-gradient-to-br from-white/[0.07] from-[-10%] via-transparent via-40% to-transparent to-55%"
+            aria-hidden
+          />
+          <div
+            className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_115%_95%_at_50%_72%,transparent_22%,rgba(0,18,12,0.62)_88%,rgba(0,8,5,0.92)_100%)]"
+            aria-hidden
+          />
+          <div
+            className="pointer-events-none absolute inset-0 rounded-[inherit] opacity-[0.055] mix-blend-overlay"
+            style={{
+              backgroundImage: `url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.78' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E")`,
+            }}
+            aria-hidden
+          />
+          <div
+            className="pointer-events-none absolute inset-0 rounded-[inherit] shadow-[inset_0_1px_0_rgba(255,255,255,0.09),inset_0_-1px_0_rgba(0,0,0,0.18)]"
+            aria-hidden
+          />
         </>
       ) : (
-        <div
-          className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_140%_100%_at_12%_-5%,rgb(41,115,78)_0%,rgb(14,54,38)_42%,rgb(7,38,26)_68%,rgb(2,14,10)_100%)]"
-          aria-hidden
-        />
+        <>
+          <div
+            className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_140%_100%_at_12%_-5%,rgb(41,115,78)_0%,rgb(14,54,38)_42%,rgb(7,38,26)_68%,rgb(2,14,10)_100%)]"
+            aria-hidden
+          />
+          <div
+            className="pointer-events-none absolute inset-0 mix-blend-soft-light opacity-80 bg-[radial-gradient(ellipse_50%_40%_at_80%_5%,rgba(52,211,153,0.2),transparent_60%)]"
+            aria-hidden
+          />
+          <div
+            className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_110%_90%_at_50%_78%,transparent_35%,rgba(0,14,10,0.72)_92%)]"
+            aria-hidden
+          />
+        </>
       )}
 
       <div className="relative z-10 flex flex-col gap-5">

--- a/packages/epics/src/spaces/components/compact-space-banner.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner.tsx
@@ -87,8 +87,8 @@ export function CompactSpaceBanner({
   return (
     <section
       className={cn(
-        /* Production-style corner: large smooth radius + hairline dark rim (ref image 1) */
-        'relative overflow-hidden rounded-[40px] border border-[#1a1a1a]',
+        /* Card chrome: ~12–16px radius, subtle blue-gray rim (design ref image 1) */
+        'relative overflow-hidden rounded-xl border border-[#30363d]',
         'shadow-[0_24px_48px_-12px_rgba(5,33,22,0.55)]',
         'p-8',
         className,

--- a/packages/epics/src/spaces/components/compact-space-banner.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner.tsx
@@ -90,7 +90,7 @@ export function CompactSpaceBanner({
         /* Card chrome: ~12–16px radius, subtle blue-gray rim (design ref image 1) */
         'relative overflow-hidden rounded-xl border border-[#30363d]',
         'shadow-[0_24px_48px_-12px_rgba(5,33,22,0.55)]',
-        'p-8',
+        'px-8 pt-8 pb-5',
         className,
       )}
       aria-label={title}
@@ -159,7 +159,7 @@ export function CompactSpaceBanner({
         aria-hidden
       />
       <div
-        className="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/60 from-0% via-black/18 via-45% to-transparent to-72%"
+        className="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/45 from-0% via-black/12 via-38% to-transparent to-58%"
         aria-hidden
       />
       <div
@@ -167,7 +167,7 @@ export function CompactSpaceBanner({
         aria-hidden
       />
 
-      <div className="relative z-10 flex flex-col gap-6">
+      <div className="relative z-10 flex flex-col gap-5">
         {/* Header row: avatar + title stack only (Image 2) */}
         <div className="flex items-start gap-6">
           <Avatar className="h-20 w-20 shrink-0 rounded-full">
@@ -213,7 +213,7 @@ export function CompactSpaceBanner({
 
         <div className="h-px w-full bg-white/12" role="presentation" />
 
-        <div className="flex flex-col gap-4 gap-x-6 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex flex-col gap-3 gap-x-5 sm:flex-row sm:items-center sm:justify-between">
           <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-1 text-white/88 [text-shadow:0_1px_2px_rgba(0,0,0,0.45)]">
             <span>
               <span className="font-bold tabular-nums text-white">

--- a/packages/epics/src/spaces/components/compact-space-banner.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner.tsx
@@ -4,6 +4,13 @@ import { LinkLabel } from '../../common/link-label';
 import { Avatar, AvatarImage } from '@hypha-platform/ui';
 import { cn } from '@hypha-platform/ui-utils';
 
+/** Scrollable purpose block — mirrors #2165 hero (`overflow-y-auto`, thin scrollbar). */
+const DESCRIPTION_SCROLL_BOX = cn(
+  'max-h-[min(45vh,280px)] w-full min-h-0 overflow-y-auto overscroll-y-contain pr-1 touch-pan-y',
+  '[scrollbar-color:rgba(255,255,255,0.35)_transparent] [scrollbar-width:thin]',
+  '[&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-white/30 [&::-webkit-scrollbar-track]:bg-transparent',
+);
+
 export type CompactSpaceBannerProps = {
   title: string;
   description: string | null | undefined;
@@ -141,11 +148,13 @@ export function CompactSpaceBanner({
           </div>
         </div>
 
-        {/* Body — full width under header (Image 2); not constrained to half column */}
+        {/* Body — scroll when copy exceeds max height (same interaction model as #2165 hero purpose) */}
         {description ? (
-          <p className="max-w-none text-2 leading-[1.5] text-white">
-            {description}
-          </p>
+          <div className={DESCRIPTION_SCROLL_BOX}>
+            <p className="text-pretty text-2 leading-[1.5] text-white">
+              {description}
+            </p>
+          </div>
         ) : null}
 
         <div className="h-px w-full bg-white/12" role="presentation" />

--- a/packages/epics/src/spaces/components/compact-space-banner.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner.tsx
@@ -32,9 +32,9 @@ function cssUrlQuoted(url: string): string {
   return JSON.stringify(url);
 }
 
-/** Scrollable purpose block — mirrors #2165 hero (`overflow-y-auto`, thin scrollbar). */
+/** Scrollable purpose block — narrow column (~50% on sm+) so copy wraps like design ref. */
 const DESCRIPTION_SCROLL_BOX = cn(
-  'max-h-[min(45vh,280px)] w-full min-h-0 overflow-y-auto overscroll-y-contain pr-1 touch-pan-y',
+  'max-h-[min(45vh,280px)] w-full max-w-full min-h-0 overflow-y-auto overscroll-y-contain pr-1 touch-pan-y sm:max-w-[50%]',
   '[scrollbar-color:rgba(255,255,255,0.35)_transparent] [scrollbar-width:thin]',
   '[&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-white/30 [&::-webkit-scrollbar-track]:bg-transparent',
 );

--- a/packages/epics/src/spaces/components/index.ts
+++ b/packages/epics/src/spaces/components/index.ts
@@ -1,4 +1,5 @@
 export * from './activate-proposals-banner';
+export * from './compact-space-banner';
 export * from './category-search';
 export * from './category-spaces';
 export * from './create-space-form';

--- a/packages/epics/src/spaces/components/index.ts
+++ b/packages/epics/src/spaces/components/index.ts
@@ -1,5 +1,6 @@
 export * from './activate-proposals-banner';
 export * from './compact-space-banner';
+export * from './space-accent-from-images';
 export * from './category-search';
 export * from './category-spaces';
 export * from './create-space-form';

--- a/packages/epics/src/spaces/components/space-accent-from-images.tsx
+++ b/packages/epics/src/spaces/components/space-accent-from-images.tsx
@@ -7,6 +7,11 @@ import {
   mixHexColors,
   SPACE_ACCENT_FALLBACK,
 } from '../utils/extract-space-accent';
+import {
+  analyzeBannerToneFromImageData,
+  DEFAULT_BANNER_OVERLAY_CSS_VARS,
+  overlayCssVarsFromTone,
+} from '../utils/banner-overlay-tone';
 
 export type SpaceAccentFromImagesProps = {
   bannerSrc: string;
@@ -60,6 +65,42 @@ async function sampleImageToAccent(src: string): Promise<string | null> {
   });
 }
 
+/** Larger sample grid for luminance / contrast / edge analysis (banner only). */
+async function sampleBannerToneOverlayVars(
+  src: string,
+): Promise<Record<string, string> | null> {
+  return new Promise((resolve) => {
+    const img = new Image();
+    if (!src.startsWith('/')) {
+      img.crossOrigin = 'anonymous';
+    }
+    img.onload = () => {
+      try {
+        const maxSide = 112;
+        const scale = Math.min(maxSide / img.width, maxSide / img.height, 1);
+        const w = Math.max(16, Math.round(img.width * scale));
+        const h = Math.max(16, Math.round(img.height * scale));
+        const canvas = document.createElement('canvas');
+        canvas.width = w;
+        canvas.height = h;
+        const ctx = canvas.getContext('2d');
+        if (!ctx) {
+          resolve(null);
+          return;
+        }
+        ctx.drawImage(img, 0, 0, w, h);
+        const data = ctx.getImageData(0, 0, w, h);
+        const tone = analyzeBannerToneFromImageData(data);
+        resolve(overlayCssVarsFromTone(tone));
+      } catch {
+        resolve(null);
+      }
+    };
+    img.onerror = () => resolve(null);
+    img.src = src;
+  });
+}
+
 /**
  * Computes a dominant saturated accent from banner + logo imagery and exposes
  * `--space-accent`, `--space-accent-foreground`, `--space-accent-muted` on the wrapper.
@@ -76,9 +117,10 @@ export function SpaceAccentFromImages({
     let cancelled = false;
 
     (async () => {
-      const [bannerAccent, logoAccent] = await Promise.all([
+      const [bannerAccent, logoAccent, overlayVars] = await Promise.all([
         sampleImageToAccent(bannerSrc),
         sampleImageToAccent(logoSrc),
+        sampleBannerToneOverlayVars(bannerSrc),
       ]);
       if (cancelled || !ref.current) return;
 
@@ -98,10 +140,16 @@ export function SpaceAccentFromImages({
         0.45,
       );
 
-      ref.current.style.setProperty('--space-accent', accent);
-      ref.current.style.setProperty('--space-accent-foreground', fg);
-      ref.current.style.setProperty('--space-accent-muted', subtle);
-      ref.current.style.setProperty('--space-accent-contrast', fg);
+      const el = ref.current;
+      el.style.setProperty('--space-accent', accent);
+      el.style.setProperty('--space-accent-foreground', fg);
+      el.style.setProperty('--space-accent-muted', subtle);
+      el.style.setProperty('--space-accent-contrast', fg);
+
+      const ov = overlayVars ?? DEFAULT_BANNER_OVERLAY_CSS_VARS;
+      for (const [k, v] of Object.entries(ov)) {
+        el.style.setProperty(k, v);
+      }
     })();
 
     return () => {
@@ -110,7 +158,12 @@ export function SpaceAccentFromImages({
   }, [bannerSrc, logoSrc]);
 
   return (
-    <div ref={ref} data-space-accent-scope className={cn(className)}>
+    <div
+      ref={ref}
+      data-space-accent-scope
+      className={cn(className)}
+      style={DEFAULT_BANNER_OVERLAY_CSS_VARS as React.CSSProperties}
+    >
       {children}
     </div>
   );

--- a/packages/epics/src/spaces/components/space-accent-from-images.tsx
+++ b/packages/epics/src/spaces/components/space-accent-from-images.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import * as React from 'react';
+import { cn } from '@hypha-platform/ui-utils';
+import {
+  extractAccentHexFromImageData,
+  mixHexColors,
+  SPACE_ACCENT_FALLBACK,
+} from '../utils/extract-space-accent';
+
+export type SpaceAccentFromImagesProps = {
+  bannerSrc: string;
+  logoSrc: string;
+  children: React.ReactNode;
+  /** Optional class on the wrapping element that receives CSS variables */
+  className?: string;
+};
+
+/** Perceived brightness 0–255 */
+function brightness(hex: string): number {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  return (r * 299 + g * 587 + b * 114) / 1000;
+}
+
+function contrastingForeground(hex: string): string {
+  return brightness(hex) > 186 ? '#0f172a' : '#f8fafc';
+}
+
+async function sampleImageToAccent(src: string): Promise<string | null> {
+  return new Promise((resolve) => {
+    const img = new Image();
+    if (!src.startsWith('/')) {
+      img.crossOrigin = 'anonymous';
+    }
+    img.onload = () => {
+      try {
+        const maxSide = 56;
+        const scale = Math.min(maxSide / img.width, maxSide / img.height, 1);
+        const w = Math.max(8, Math.round(img.width * scale));
+        const h = Math.max(8, Math.round(img.height * scale));
+        const canvas = document.createElement('canvas');
+        canvas.width = w;
+        canvas.height = h;
+        const ctx = canvas.getContext('2d');
+        if (!ctx) {
+          resolve(null);
+          return;
+        }
+        ctx.drawImage(img, 0, 0, w, h);
+        const data = ctx.getImageData(0, 0, w, h);
+        resolve(extractAccentHexFromImageData(data));
+      } catch {
+        resolve(null);
+      }
+    };
+    img.onerror = () => resolve(null);
+    img.src = src;
+  });
+}
+
+/**
+ * Computes a dominant saturated accent from banner + logo imagery and exposes
+ * `--space-accent`, `--space-accent-foreground`, `--space-accent-muted` on the wrapper.
+ */
+export function SpaceAccentFromImages({
+  bannerSrc,
+  logoSrc,
+  children,
+  className,
+}: SpaceAccentFromImagesProps) {
+  const ref = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    let cancelled = false;
+
+    (async () => {
+      const [bannerAccent, logoAccent] = await Promise.all([
+        sampleImageToAccent(bannerSrc),
+        sampleImageToAccent(logoSrc),
+      ]);
+      if (cancelled || !ref.current) return;
+
+      let accent = SPACE_ACCENT_FALLBACK;
+      if (bannerAccent && logoAccent) {
+        accent = mixHexColors(bannerAccent, logoAccent, 0.55);
+      } else if (bannerAccent) {
+        accent = bannerAccent;
+      } else if (logoAccent) {
+        accent = logoAccent;
+      }
+
+      const fg = contrastingForeground(accent);
+      const subtle = mixHexColors(
+        accent,
+        brightness(accent) > 186 ? '#0f172a' : '#ffffff',
+        0.45,
+      );
+
+      ref.current.style.setProperty('--space-accent', accent);
+      ref.current.style.setProperty('--space-accent-foreground', fg);
+      ref.current.style.setProperty('--space-accent-muted', subtle);
+      ref.current.style.setProperty('--space-accent-contrast', fg);
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [bannerSrc, logoSrc]);
+
+  return (
+    <div ref={ref} data-space-accent-scope className={cn(className)}>
+      {children}
+    </div>
+  );
+}

--- a/packages/epics/src/spaces/components/space-mode-label.tsx
+++ b/packages/epics/src/spaces/components/space-mode-label.tsx
@@ -32,6 +32,7 @@ const LabelButton = ({
       className="flex cursor-pointer"
       colorVariant={colorVariant}
       variant="outline"
+      size={1}
       role="link"
       title={t('changeSpaceConfiguration')}
       onClick={(e) => {
@@ -59,7 +60,12 @@ const LabelBadge = ({
   caption: string;
   colorVariant?: 'accent' | 'error';
 }) => (
-  <Badge className="flex" colorVariant={colorVariant} variant="outline">
+  <Badge
+    className="flex"
+    colorVariant={colorVariant}
+    variant="outline"
+    size={1}
+  >
     {caption}
   </Badge>
 );

--- a/packages/epics/src/spaces/utils/banner-overlay-tone.ts
+++ b/packages/epics/src/spaces/utils/banner-overlay-tone.ts
@@ -1,0 +1,236 @@
+/**
+ * Derive tone metrics from RGBA image data for dynamic hero overlay modulation.
+ * Focus: perceived luminance (intensity), spread (local contrast / "texture"),
+ * and saturation (color radiance).
+ */
+
+function clamp01(n: number): number {
+  return Math.min(1, Math.max(0, n));
+}
+
+/** Perceived luminance in [0, 1] (standard sRGB approximation) */
+function luminance(r: number, g: number, b: number): number {
+  return (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+}
+
+export type BannerToneMetrics = {
+  /** Mean perceived brightness [0, 1] */
+  luminanceMean: number;
+  /** Std. dev. of luminance — higher = busier / more contrast (edges, texture) */
+  luminanceStd: number;
+  /** Mean HSL saturation [0, 1] on reasonably opaque pixels */
+  saturationMean: number;
+  /** Mean gradient magnitude on a downscaled luma grid [0, ~1], normalized */
+  edgeEnergy: number;
+};
+
+/**
+ * Population variance (divide by n, not n-1) for stable small samples.
+ */
+function populationStdDev(values: number[], mean: number): number {
+  if (values.length === 0) return 0;
+  let acc = 0;
+  for (const v of values) {
+    const d = v - mean;
+    acc += d * d;
+  }
+  return Math.sqrt(acc / values.length);
+}
+
+/**
+ * Sobel magnitude on grayscale grid; returns mean normalized gradient [0,1].
+ */
+function meanEdgeEnergy(
+  gray: number[][],
+  width: number,
+  height: number,
+): number {
+  if (width < 3 || height < 3) return 0;
+
+  let sum = 0;
+  let count = 0;
+
+  for (let y = 1; y < height - 1; y++) {
+    for (let x = 1; x < width - 1; x++) {
+      const rowUp = gray[y - 1];
+      const rowMid = gray[y];
+      const rowDn = gray[y + 1];
+      const tl = rowUp?.[x - 1] ?? 0;
+      const t = rowUp?.[x] ?? 0;
+      const tr = rowUp?.[x + 1] ?? 0;
+      const l = rowMid?.[x - 1] ?? 0;
+      const r = rowMid?.[x + 1] ?? 0;
+      const bl = rowDn?.[x - 1] ?? 0;
+      const b = rowDn?.[x] ?? 0;
+      const br = rowDn?.[x + 1] ?? 0;
+
+      const gx = -tl + tr - 2 * l + 2 * r - bl + br;
+      const gy = -tl - 2 * t - tr + bl + 2 * b + br;
+
+      sum += Math.hypot(gx, gy);
+      count++;
+    }
+  }
+
+  if (count === 0) return 0;
+  /** Typical max Sobel magnitude for 0–1 luma grid is ~4; soften with sqrt for spread */
+  return clamp01(Math.sqrt(sum / count / 4));
+}
+
+export function analyzeBannerToneFromImageData(
+  data: ImageData,
+): BannerToneMetrics {
+  const px = data.data;
+  const { width, height } = data;
+  const lumas: number[] = [];
+  let satSum = 0;
+  let satN = 0;
+
+  const gray: number[][] = Array.from({ length: height }, () =>
+    Array.from({ length: width }, () => 0),
+  );
+  const sampled: boolean[][] = Array.from({ length: height }, () =>
+    Array.from({ length: width }, () => false),
+  );
+
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const i = (y * width + x) * 4;
+      const a = px[i + 3] ?? 0;
+      if (a < 24) continue;
+
+      const r = px[i] ?? 0;
+      const g = px[i + 1] ?? 0;
+      const b = px[i + 2] ?? 0;
+
+      const l = luminance(r, g, b);
+      lumas.push(l);
+
+      gray[y]![x] = l;
+      sampled[y]![x] = true;
+
+      const max = Math.max(r, g, b) / 255;
+      const min = Math.min(r, g, b) / 255;
+      const sat = max === 0 ? 0 : (max - min) / max;
+      satSum += sat;
+      satN++;
+    }
+  }
+
+  if (lumas.length < 16) {
+    return {
+      luminanceMean: 0.42,
+      luminanceStd: 0.12,
+      saturationMean: 0.35,
+      edgeEnergy: 0.25,
+    };
+  }
+
+  let meanL = 0;
+  for (const v of lumas) meanL += v;
+  meanL /= lumas.length;
+
+  /** Avoid fake edges at transparent corners (e.g. logo PNG): fill gaps with mean luma */
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      if (!sampled[y]?.[x]) {
+        gray[y]![x] = meanL;
+      }
+    }
+  }
+
+  const stdL = populationStdDev(lumas, meanL);
+  const edgeEnergy = meanEdgeEnergy(gray, width, height);
+  const saturationMean = satN > 0 ? satSum / satN : 0.35;
+
+  return {
+    luminanceMean: clamp01(meanL),
+    luminanceStd: clamp01(stdL * 2),
+    saturationMean: clamp01(saturationMean),
+    edgeEnergy: clamp01(edgeEnergy),
+  };
+}
+
+export type BannerOverlayCssVars = Record<string, string>;
+
+/**
+ * Maps tone metrics to CSS variables consumed by `CompactSpaceBanner` overlays.
+ * Defaults are tuned to match the previous static PR #2165 stack when metrics are neutral.
+ */
+export function overlayCssVarsFromTone(
+  m: BannerToneMetrics,
+): BannerOverlayCssVars {
+  const {
+    luminanceMean: L,
+    luminanceStd: spread,
+    saturationMean: S,
+    edgeEnergy: E,
+  } = m;
+
+  /**
+   * brighter image → stronger scrim for text legibility
+   * (anchor around mid-photographic tone ~0.38)
+   */
+  const brightNeed = clamp01((L - 0.36) / 0.46);
+  /**
+   * very dark hero → ease the bottom crush so mud doesn't swallow midtones
+   */
+  const darkEase = clamp01((0.22 - L) / 0.22) * 0.55;
+  /**
+   * Radiance: colorful + luminous + micro-contrast → lift the WOW sheen slightly
+   */
+  const radiance = clamp01(0.35 * S + 0.35 * L + 0.3 * E);
+  /**
+   * Busy / high-frequency → soften film grain & glow so overlays don't shimmer
+   */
+  const calmGrain = clamp01(0.55 * spread + 0.45 * E);
+
+  /** Vertical gradient stops (bottom → mid → top), PR #2165 baseline embedded */
+  const vBottom = clamp01(0.88 + brightNeed * 0.09 - darkEase * 0.14);
+  const vMid = clamp01(0.42 + brightNeed * 0.11 - darkEase * 0.08);
+  const vTop = clamp01(0.22 + brightNeed * 0.09 - darkEase * 0.06);
+
+  /** Horizontal vignette sides */
+  const hFrom = clamp01(0.58 + brightNeed * 0.12 - darkEase * 0.06);
+  const hTo = clamp01(0.4 + brightNeed * 0.08);
+
+  /** Accent tint wash (was accent-11/18) — scales slightly with saturation radiance */
+  const accentWash = clamp01(0.14 + radiance * 0.12);
+
+  /** Depth pass layers */
+  const skylightOpacity = clamp01(0.78 + radiance * 0.14 - calmGrain * 0.12);
+  const sheenOpacity = clamp01(0.06 + radiance * 0.06);
+  /** Scales alphas inside the bottom vignette radial (brighter heroes need a touch more) */
+  const vignetteStrength = clamp01(0.92 + brightNeed * 0.14 - darkEase * 0.1);
+  const grainOpacity = clamp01(0.055 + radiance * 0.025 - calmGrain * 0.028);
+
+  const innerTop = clamp01(0.09 + radiance * 0.04);
+  const innerBot = clamp01(0.18 + brightNeed * 0.04);
+
+  return {
+    '--banner-ov-v-bottom': String(vBottom),
+    '--banner-ov-v-mid': String(vMid),
+    '--banner-ov-v-top': String(vTop),
+    '--banner-ov-v-mid-at': '52%',
+    '--banner-ov-h-from': String(hFrom),
+    '--banner-ov-h-to': String(hTo),
+    '--banner-ov-accent-wash': String(accentWash),
+    '--banner-ov-skylight-op': String(skylightOpacity),
+    '--banner-ov-sheen-op': String(sheenOpacity),
+    '--banner-ov-vignette-strength': String(vignetteStrength),
+    '--banner-ov-grain-op': String(grainOpacity),
+    '--banner-ov-inner-top': String(innerTop),
+    '--banner-ov-inner-bot': String(innerBot),
+  };
+}
+
+/** Neutral metrics → static overlay tuning (SSR / before client analysis) */
+export const BANNER_OVERLAY_FALLBACK_METRICS: BannerToneMetrics = {
+  luminanceMean: 0.42,
+  luminanceStd: 0.12,
+  saturationMean: 0.35,
+  edgeEnergy: 0.25,
+};
+
+export const DEFAULT_BANNER_OVERLAY_CSS_VARS: BannerOverlayCssVars =
+  overlayCssVarsFromTone(BANNER_OVERLAY_FALLBACK_METRICS);

--- a/packages/epics/src/spaces/utils/extract-space-accent.ts
+++ b/packages/epics/src/spaces/utils/extract-space-accent.ts
@@ -1,0 +1,101 @@
+/**
+ * Derive a single accent hex from RGBA image data by averaging saturated,
+ * mid-tone pixels (skips near-gray / near-black / near-white).
+ */
+
+export const SPACE_ACCENT_FALLBACK = '#4a65d8';
+
+function clamp(n: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, n));
+}
+
+export function rgbToHex(r: number, g: number, b: number): string {
+  const to = (x: number) =>
+    clamp(Math.round(x), 0, 255).toString(16).padStart(2, '0');
+  return `#${to(r)}${to(g)}${to(b)}`;
+}
+
+/** HSL in [0,1] ranges */
+export function rgbToHsl(
+  r: number,
+  g: number,
+  b: number,
+): { h: number; s: number; l: number } {
+  r /= 255;
+  g /= 255;
+  b /= 255;
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  let h = 0;
+  let s = 0;
+  const l = (max + min) / 2;
+
+  if (max !== min) {
+    const d = max - min;
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    switch (max) {
+      case r:
+        h = ((g - b) / d + (g < b ? 6 : 0)) / 6;
+        break;
+      case g:
+        h = ((b - r) / d + 2) / 6;
+        break;
+      default:
+        h = ((r - g) / d + 4) / 6;
+        break;
+    }
+  }
+
+  return { h, s, l };
+}
+
+export function extractAccentHexFromImageData(data: ImageData): string {
+  const px = data.data;
+  const { width, height } = data;
+  let rSum = 0;
+  let gSum = 0;
+  let bSum = 0;
+  let n = 0;
+
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const i = (y * width + x) * 4;
+      const a = px[i + 3] ?? 0;
+      if (a < 40) continue;
+
+      const r = px[i] ?? 0;
+      const g = px[i + 1] ?? 0;
+      const b = px[i + 2] ?? 0;
+      const { s, l } = rgbToHsl(r, g, b);
+
+      if (s < 0.12) continue;
+      if (l < 0.06 || l > 0.94) continue;
+
+      rSum += r;
+      gSum += g;
+      bSum += b;
+      n++;
+    }
+  }
+
+  if (n < 8) {
+    return SPACE_ACCENT_FALLBACK;
+  }
+
+  return rgbToHex(rSum / n, gSum / n, bSum / n);
+}
+
+export function mixHexColors(a: string, b: string, weightA: number): string {
+  const pa = parseInt(a.slice(1, 3), 16);
+  const ga = parseInt(a.slice(3, 5), 16);
+  const ba = parseInt(a.slice(5, 7), 16);
+  const pb = parseInt(b.slice(1, 3), 16);
+  const gb = parseInt(b.slice(3, 5), 16);
+  const bb = parseInt(b.slice(5, 7), 16);
+  const w = clamp(weightA, 0, 1);
+  return rgbToHex(
+    pa * w + pb * (1 - w),
+    ga * w + gb * (1 - w),
+    ba * w + bb * (1 - w),
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1043,6 +1043,9 @@ importers:
       '@hypha-platform/config-typescript':
         specifier: workspace:*
         version: link:../../config/typescript
+      next:
+        specifier: ^15.1.6
+        version: 15.4.8(@babel/core@7.26.10)(@opentelemetry/api@1.9.0)(@playwright/test@1.52.0)(babel-plugin-macros@3.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(sass@1.86.3)
 
   packages/evm:
     devDependencies:
@@ -11684,10 +11687,6 @@ packages:
     resolution: {integrity: sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==}
     engines: {node: '>=0.10'}
     hasBin: true
-
-  detect-libc@2.0.3:
-    resolution: {integrity: sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==}
-    engines: {node: '>=8'}
 
   detect-libc@2.0.4:
     resolution: {integrity: sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==}
@@ -35075,9 +35074,6 @@ snapshots:
 
   detect-libc@1.0.3: {}
 
-  detect-libc@2.0.3:
-    optional: true
-
   detect-libc@2.0.4: {}
 
   detect-newline@3.1.0: {}
@@ -43554,7 +43550,7 @@ snapshots:
   sharp@0.33.5:
     dependencies:
       color: 4.2.3
-      detect-libc: 2.0.3
+      detect-libc: 2.0.4
       semver: 7.7.2
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.33.5


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The compact space hero overlay now **adapts to the lead/banner image** after a client-side sample: we measure **perceived brightness (luminance)**, **luminance spread (local busyness)**, **color saturation**, and **edge energy** (Sobel on a downscaled luma grid). Those metrics drive scoped CSS variables (`--banner-ov-*`) inherited from `[data-space-accent-scope]`.

## Behavior

- **Bright / high-key photos**: stronger vertical and horizontal scrims so white text stays legible.
- **Very dark heroes**: slightly eased bottom gradients so mids don’t turn to mud.
- **Radiant / saturated / glossy imagery**: lifts the skylight/sheen subtly.
- **Busy / high-frequency texture**: dials down film grain so overlays don’t shimmer.

SSR uses neutral fallbacks aligned with the previous static stack; hydration updates values when analysis completes.

## Files

- `packages/epics/src/spaces/utils/banner-overlay-tone.ts` — analysis + mapping to CSS vars
- `packages/epics/src/spaces/components/space-accent-from-images.tsx` — samples banner & sets `--banner-ov-*` alongside accent colors
- `packages/epics/src/spaces/components/compact-space-banner.tsx` — overlay layers consume variables with inline fallbacks
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e14cf819-9450-46db-9687-6979aa1fc014"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e14cf819-9450-46db-9687-6979aa1fc014"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

