### PR TITLE
ci: harden Vercel prebuilt deploy (archive, pin, retry)

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -112,7 +112,7 @@ jobs:
           echo "BRANCH_DB_URL=${{ steps.create-branch.outputs.db_url_with_pooler }}" >> $GITHUB_ENV
 
       - name: Install Vercel CLI
-        run: npm install --global vercel@latest
+        run: npm install --global vercel@51.8.0
 
       - name: Pull Vercel Environment Information
         run: vercel pull --yes --environment=preview --token=${{ env.VERCEL_TOKEN }}
@@ -144,7 +144,28 @@ jobs:
         id: deploy
         env:
           BRANCH_DB_URL: ${{ steps.create-branch.outputs.db_url_with_pooler }}
-        run: echo preview_url=$(vercel deploy --prebuilt --token=${{ env.VERCEL_TOKEN }} --env BRANCH_DB_URL=${{ env.BRANCH_DB_URL }}) >> $GITHUB_OUTPUT
+          VERCEL_TOKEN: ${{ env.VERCEL_TOKEN }}
+        run: |
+          set -euo pipefail
+          delay=8
+          log=$(mktemp)
+          trap 'rm -f "$log"' EXIT
+          for attempt in 1 2 3 4; do
+            if vercel deploy --prebuilt --yes --archive=tgz \
+              --token="$VERCEL_TOKEN" \
+              --env "BRANCH_DB_URL=${BRANCH_DB_URL:-}" >"$log" 2>&1; then
+              preview_url=$(grep -oE 'https://[^[:space:]]+' "$log" | tail -n1)
+              echo "preview_url=$preview_url" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "::warning::vercel deploy attempt $attempt failed; retrying after transient upload errors…"
+            cat "$log" || true
+            if [ "$attempt" -lt 4 ]; then
+              sleep "$delay"
+              delay=$((delay * 2))
+            fi
+          done
+          exit 1
 
   main:
     needs: [detect-changes]

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -36,7 +36,7 @@ jobs:
           DEFAULT_DB_URL: ${{ secrets.POSTGRES_URL }}
 
       - name: Install Vercel CLI
-        run: npm install --global vercel@latest
+        run: npm install --global vercel@51.8.0
 
       - name: Pull Vercel Environment Information
         run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
@@ -50,7 +50,22 @@ jobs:
           DEFAULT_DB_ANONYMOUS_URL: ${{secrets.POSTGRES_ANONYMOUS_URL}}
 
       - name: Deploy Project Artifacts to Vercel
-        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          set -euo pipefail
+          delay=8
+          for attempt in 1 2 3 4; do
+            if vercel deploy --prebuilt --prod --yes --archive=tgz --token="$VERCEL_TOKEN"; then
+              exit 0
+            fi
+            echo "::warning::vercel deploy attempt $attempt failed; retrying…"
+            if [ "$attempt" -lt 4 ]; then
+              sleep "$delay"
+              delay=$((delay * 2))
+            fi
+          done
+          exit 1
 
       - name: Setup Upterm Session On Failure
         uses: lhotari/action-upterm@v1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Docs check

Verified [GitHub Actions](https://github.com/features/actions) still supports YAML workflows, concurrency, secrets, and environment variables — changes stay within normal workflow semantics.

## Problem analysis

PR preview deploy failed during `vercel deploy --prebuilt`: upload stayed at **0 B**, then **AbortError / Upload aborted** loops. Typical causes:

- Transient CLI/API or network timeouts on large uploads (log showed **~139 MB**).
- Non-deterministic **`vercel@latest`** installs.
- Many small-file uploads vs one compressed artifact.

## Changes

**`.github/workflows/deploy-preview.yml`**

- Pin **`vercel@51.8.0`** instead of `@latest`.
- **`vercel deploy --prebuilt --yes --archive=tgz`** — gzip archive before upload (fewer/chunked requests).
- **Retry loop** (4 attempts, exponential backoff 8s→16s→32s).
- Capture preview URL by logging deploy output and taking the **last HTTPS URL** from stdout.
- On retry, surface failed attempt log via `cat` for debugging.

**`.github/workflows/deploy-production.yml`**

- Same pin + **`--archive=tgz`** + **`--yes`** + retry for production `--prebuilt` deploy.

## Risk / rollback

- If `grep -oE` fails to match a preview URL format change, preview_url could be empty — revisit URL parsing.
- Archive format `tgz` must remain supported by the pinned CLI (verified in `vercel deploy --help` for 51.8.0).

## Follow-ups

- Optionally add `ACTIONS_STEP_DEBUG` documentation for flaky runs.
- Monitor next PR preview; if failures persist, consider splitting build output or contacting Vercel status.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e14cf819-9450-46db-9687-6979aa1fc014"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e14cf819-9450-46db-9687-6979aa1fc014"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

