### PR TITLE
Compact Space Header

### DIFF
--- a/.github/actions/detect-changes/action.yml
+++ b/.github/actions/detect-changes/action.yml
@@ -12,7 +12,7 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - uses: dorny/paths-filter@v3
+    - uses: dorny/paths-filter@v4
       id: changes
       with:
         filters: |

--- a/.github/actions/detect-changes/action.yml
+++ b/.github/actions/detect-changes/action.yml
@@ -12,7 +12,8 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - uses: dorny/paths-filter@v4
+    # Immutable pin for supply-chain safety (tag v4.0.0 moves on re-tags)
+    - uses: dorny/paths-filter@9d7afb8d214ad99e78fbd4247752c4caed2b6e4c # v4.0.0
       id: changes
       with:
         filters: |

--- a/apps/web/src/app/(mobile)/signin/layout.tsx
+++ b/apps/web/src/app/(mobile)/signin/layout.tsx
@@ -11,6 +11,7 @@ import { fileRouter } from '@hypha-platform/core/server';
 import { MenuTop } from '@hypha-platform/ui';
 
 import '@hypha-platform/ui-utils/global.css';
+import { ThemeStorageNormalize } from '@web/components/theme-storage-normalize';
 
 const lato = Lato({
   subsets: ['latin'],
@@ -49,6 +50,7 @@ export default async function RootLayout({
           storageKey="theme"
           disableTransitionOnChange
         >
+          <ThemeStorageNormalize />
           <EvmProvider>
             <MenuTop logoHref={`/signin`} />
             <NextSSRPlugin routerConfig={extractRouterConfig(fileRouter)} />

--- a/apps/web/src/app/(mobile)/signin/layout.tsx
+++ b/apps/web/src/app/(mobile)/signin/layout.tsx
@@ -44,8 +44,9 @@ export default async function RootLayout({
       >
         <ThemeProvider
           attribute="class"
-          defaultTheme="system"
-          enableSystem
+          defaultTheme="dark"
+          enableSystem={false}
+          storageKey="theme"
           disableTransitionOnChange
         >
           <EvmProvider>

--- a/apps/web/src/app/[lang]/dho/[id]/_components/dho-sticky-space-chrome.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/dho-sticky-space-chrome.tsx
@@ -20,6 +20,10 @@ export type DhoStickySpaceChromeProps = {
   defaultLogoSrc: string;
 };
 
+/** Match CSS transition duration + small buffer before unmounting the sticky shell (portal timing). */
+const STICKY_CHROME_TRANSITION_MS = 300;
+const STICKY_CHROME_UNMOUNT_DELAY_MS = STICKY_CHROME_TRANSITION_MS + 40;
+
 function useMenuTopOffsetPx(): number {
   const [px, setPx] = React.useState(64);
 
@@ -50,6 +54,22 @@ function useMenuTopOffsetPx(): number {
   return px;
 }
 
+function usePrefersReducedMotion(): boolean {
+  const [reduce, setReduce] = React.useState(false);
+
+  React.useEffect(() => {
+    const mq = window.matchMedia?.('(prefers-reduced-motion: reduce)');
+    if (!mq) return;
+
+    const sync = () => setReduce(mq.matches);
+    sync();
+    mq.addEventListener('change', sync);
+    return () => mq.removeEventListener('change', sync);
+  }, []);
+
+  return reduce;
+}
+
 /**
  * Desktop (md+): pin a compact chrome row under `MenuTop`. Actions / nested-space move
  * via portal so the same React trees (hooks) transition between positions — pixel-identical Button UI.
@@ -65,6 +85,7 @@ export function DhoStickySpaceChrome({
   defaultLogoSrc,
 }: DhoStickySpaceChromeProps) {
   const menuTopPx = useMenuTopOffsetPx();
+  const prefersReducedMotion = usePrefersReducedMotion();
   /** Bottom edge of the space image banner — sticky engages when this passes under MenuTop */
   const bannerBottomSentinelRef = React.useRef<HTMLDivElement>(null);
 
@@ -78,6 +99,15 @@ export function DhoStickySpaceChrome({
 
   const [stuck, setStuck] = React.useState(false);
   const stuckRef = React.useRef(false);
+
+  /** Kept mounted briefly after `stuck` false so opacity/transform transition can finish. */
+  const [stickyShellMounted, setStickyShellMounted] = React.useState(false);
+  /** Drives visible state; false on first paint when mounting for enter animation. */
+  const [stickyShellOpen, setStickyShellOpen] = React.useState(false);
+  const stickyUnmountTimerRef = React.useRef<ReturnType<
+    typeof setTimeout
+  > | null>(null);
+  const stickyEnterRafRef = React.useRef(0);
 
   const [flowMinH, setFlowMinH] = React.useState(44);
 
@@ -138,50 +168,105 @@ export function DhoStickySpaceChrome({
     };
   }, [menuTopPx]);
 
+  React.useEffect(() => {
+    if (stickyUnmountTimerRef.current) {
+      clearTimeout(stickyUnmountTimerRef.current);
+      stickyUnmountTimerRef.current = null;
+    }
+    if (stickyEnterRafRef.current) {
+      cancelAnimationFrame(stickyEnterRafRef.current);
+      stickyEnterRafRef.current = 0;
+    }
+
+    if (stuck) {
+      setStickyShellMounted(true);
+      if (prefersReducedMotion) {
+        setStickyShellOpen(true);
+        return;
+      }
+      setStickyShellOpen(false);
+      stickyEnterRafRef.current = requestAnimationFrame(() => {
+        stickyEnterRafRef.current = requestAnimationFrame(() => {
+          stickyEnterRafRef.current = 0;
+          setStickyShellOpen(true);
+        });
+      });
+      return () => {
+        if (stickyEnterRafRef.current) {
+          cancelAnimationFrame(stickyEnterRafRef.current);
+          stickyEnterRafRef.current = 0;
+        }
+      };
+    }
+
+    setStickyShellOpen(false);
+    stickyUnmountTimerRef.current = setTimeout(() => {
+      stickyUnmountTimerRef.current = null;
+      setStickyShellMounted(false);
+    }, STICKY_CHROME_UNMOUNT_DELAY_MS);
+
+    return () => {
+      if (stickyUnmountTimerRef.current) {
+        clearTimeout(stickyUnmountTimerRef.current);
+        stickyUnmountTimerRef.current = null;
+      }
+    };
+  }, [stuck, prefersReducedMotion]);
+
   const logoSrc = logoUrl || defaultLogoSrc;
 
   const actionsPortalTarget = stuck ? stickyActionsEl : flowActionsEl;
   const nestedPortalTarget = nestedSpacesSlot ? flowNestedEl : null;
 
+  const stickyChromeVisible = stickyShellMounted && stickyShellOpen;
+
   return (
     <>
-      <div
-        className={cn(
-          'pointer-events-none fixed inset-x-0 z-[25] hidden md:block',
-          'border-b border-border bg-background-2 transition-[opacity,transform,box-shadow] duration-200 ease-out',
-          stuck
-            ? 'pointer-events-auto translate-y-0 opacity-100 shadow-md'
-            : '-translate-y-2 opacity-0',
-        )}
-        style={{ top: 'var(--menu-top-height, 4rem)' }}
-        aria-hidden={!stuck}
-      >
-        <div className="mx-auto flex max-w-container-2xl items-center gap-3 px-8 py-2.5">
-          {/* Match CompactSpaceBanner row: same avatar, title tokens, gap-6; px-8 L/R balances chrome */}
-          <div className="flex min-w-0 flex-1 items-center gap-6">
-            <Avatar className={COMPACT_SPACE_BANNER_AVATAR_CLASSNAME}>
-              <AvatarImage
-                src={logoSrc}
-                alt={logoAlt}
-                className="object-cover"
-              />
-            </Avatar>
-            <p
-              className={cn(
-                COMPACT_SPACE_BANNER_TITLE_CLASSNAME,
-                'min-w-0 flex-1 truncate text-foreground',
-              )}
-              aria-hidden
-            >
-              {title}
-            </p>
+      {stickyShellMounted ? (
+        <div
+          className={cn(
+            'fixed inset-x-0 z-[25] hidden md:block',
+            'border-b border-border bg-background-2',
+            prefersReducedMotion
+              ? 'transition-opacity'
+              : 'transition-[opacity,transform,box-shadow]',
+            prefersReducedMotion
+              ? 'duration-150 ease-out'
+              : 'duration-300 ease-out',
+            stickyChromeVisible
+              ? 'pointer-events-auto translate-y-0 opacity-100 shadow-md'
+              : 'pointer-events-none -translate-y-1.5 opacity-0 shadow-none',
+          )}
+          style={{ top: 'var(--menu-top-height, 4rem)' }}
+          aria-hidden={!stickyChromeVisible}
+        >
+          <div className="mx-auto flex max-w-container-2xl items-center gap-3 px-8 py-2.5">
+            {/* Match CompactSpaceBanner row: same avatar, title tokens, gap-6; px-8 L/R balances chrome */}
+            <div className="flex min-w-0 flex-1 items-center gap-6">
+              <Avatar className={COMPACT_SPACE_BANNER_AVATAR_CLASSNAME}>
+                <AvatarImage
+                  src={logoSrc}
+                  alt={logoAlt}
+                  className="object-cover"
+                />
+              </Avatar>
+              <p
+                className={cn(
+                  COMPACT_SPACE_BANNER_TITLE_CLASSNAME,
+                  'min-w-0 flex-1 truncate text-foreground',
+                )}
+                aria-hidden
+              >
+                {title}
+              </p>
+            </div>
+            <div
+              ref={setStickyActionsEl}
+              className="flex shrink-0 flex-nowrap items-center gap-2"
+            />
           </div>
-          <div
-            ref={setStickyActionsEl}
-            className="flex shrink-0 flex-nowrap items-center gap-2"
-          />
         </div>
-      </div>
+      ) : null}
 
       <div className="flex flex-col gap-4">
         <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-2 md:flex-nowrap md:gap-x-4">

--- a/apps/web/src/app/[lang]/dho/[id]/_components/dho-sticky-space-chrome.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/dho-sticky-space-chrome.tsx
@@ -47,6 +47,10 @@ function useMenuTopOffsetPx(): number {
 /**
  * Desktop (md+): pin a compact chrome row under `MenuTop`. Actions / nested-space move
  * via portal so the same React trees (hooks) transition between positions — pixel-identical Button UI.
+ *
+ * Note: `createPortal` remounts its subtree when the container DOM node changes (e.g. when
+ * `actionsPortalTarget` swaps between in-flow and sticky targets). Stateful descendants reset;
+ * lift state above the portaled subtree if that becomes a problem.
  */
 export function DhoStickySpaceChrome({
   breadcrumbsRow,

--- a/apps/web/src/app/[lang]/dho/[id]/_components/dho-sticky-space-chrome.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/dho-sticky-space-chrome.tsx
@@ -157,18 +157,15 @@ export function DhoStickySpaceChrome({
         aria-hidden={!stuck}
       >
         <div className="mx-auto flex max-w-container-2xl items-center gap-3 px-8 py-2.5">
-          <div className="flex min-w-0 flex-1 items-start gap-6">
-            <div className="relative h-9 w-9 shrink-0">
-              <div className="absolute left-0 top-1/2 -translate-y-1/2 origin-top-left scale-50">
-                <Avatar className={COMPACT_SPACE_BANNER_AVATAR_CLASSNAME}>
-                  <AvatarImage
-                    src={logoSrc}
-                    alt={logoAlt}
-                    className="object-cover"
-                  />
-                </Avatar>
-              </div>
-            </div>
+          {/* Match CompactSpaceBanner row: same avatar, title tokens, gap-6, vertical centre in bar */}
+          <div className="flex min-w-0 flex-1 items-center gap-6">
+            <Avatar className={COMPACT_SPACE_BANNER_AVATAR_CLASSNAME}>
+              <AvatarImage
+                src={logoSrc}
+                alt={logoAlt}
+                className="object-cover"
+              />
+            </Avatar>
             <p
               className={cn(
                 COMPACT_SPACE_BANNER_TITLE_CLASSNAME,

--- a/apps/web/src/app/[lang]/dho/[id]/_components/dho-sticky-space-chrome.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/dho-sticky-space-chrome.tsx
@@ -1,0 +1,239 @@
+'use client';
+
+import * as React from 'react';
+import { createPortal } from 'react-dom';
+import Image from 'next/image';
+import { cn } from '@hypha-platform/ui-utils';
+
+export type DhoStickySpaceChromeProps = {
+  breadcrumbsRow: React.ReactNode;
+  breadcrumbsSticky: React.ReactNode;
+  banner: React.ReactNode;
+  actionsSlot: React.ReactNode;
+  nestedSpacesSlot: React.ReactNode;
+  title: string;
+  logoUrl: string;
+  logoAlt: string;
+  defaultLogoSrc: string;
+};
+
+function useMenuTopOffsetPx(): number {
+  const [px, setPx] = React.useState(64);
+
+  React.useLayoutEffect(() => {
+    const read = () => {
+      const raw = getComputedStyle(document.documentElement).getPropertyValue(
+        '--menu-top-height',
+      );
+      const n = parseFloat(raw);
+      setPx(Number.isFinite(n) && n > 0 ? n : 64);
+    };
+    read();
+    const ro = new ResizeObserver(read);
+    ro.observe(document.documentElement);
+    window.addEventListener('resize', read);
+    const mo = new MutationObserver(read);
+    mo.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['style'],
+    });
+    return () => {
+      ro.disconnect();
+      mo.disconnect();
+      window.removeEventListener('resize', read);
+    };
+  }, []);
+
+  return px;
+}
+
+/**
+ * Desktop (md+): pin a compact chrome row under `MenuTop`. Actions / nested-space move
+ * via portal so the same React trees (hooks) transition between positions — pixel-identical Button UI.
+ */
+export function DhoStickySpaceChrome({
+  breadcrumbsRow,
+  breadcrumbsSticky,
+  banner,
+  actionsSlot,
+  nestedSpacesSlot,
+  title,
+  logoUrl,
+  logoAlt,
+  defaultLogoSrc,
+}: DhoStickySpaceChromeProps) {
+  const menuTopPx = useMenuTopOffsetPx();
+  const sentinelRef = React.useRef<HTMLDivElement>(null);
+
+  const [flowActionsEl, setFlowActionsEl] =
+    React.useState<HTMLDivElement | null>(null);
+  const [stickyActionsEl, setStickyActionsEl] =
+    React.useState<HTMLDivElement | null>(null);
+  const [flowNestedEl, setFlowNestedEl] = React.useState<HTMLDivElement | null>(
+    null,
+  );
+  const [stickyNestedEl, setStickyNestedEl] =
+    React.useState<HTMLDivElement | null>(null);
+
+  const [stuck, setStuck] = React.useState(false);
+  const stuckRef = React.useRef(false);
+
+  const [flowMinH, setFlowMinH] = React.useState(44);
+
+  React.useLayoutEffect(() => {
+    const el = flowActionsEl;
+    if (!el || stuck) return;
+    const measure = () => {
+      const h = Math.ceil(el.getBoundingClientRect().height);
+      if (h > 0) setFlowMinH(h);
+    };
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [stuck, flowActionsEl, actionsSlot]);
+
+  React.useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+
+    const mq = window.matchMedia('(min-width: 768px)');
+    const HYST = 12;
+    let raf = 0;
+
+    const tick = () => {
+      raf = 0;
+      if (!mq.matches) {
+        if (stuckRef.current) {
+          stuckRef.current = false;
+          setStuck(false);
+        }
+        return;
+      }
+      const top = sentinel.getBoundingClientRect().top;
+      let next = stuckRef.current;
+      if (!next && top <= menuTopPx) next = true;
+      if (next && top >= menuTopPx + HYST) next = false;
+      if (next !== stuckRef.current) {
+        stuckRef.current = next;
+        setStuck(next);
+      }
+    };
+
+    const onScroll = () => {
+      if (raf) return;
+      raf = requestAnimationFrame(tick);
+    };
+
+    tick();
+    mq.addEventListener('change', onScroll);
+    window.addEventListener('scroll', onScroll, { passive: true });
+    window.addEventListener('resize', onScroll);
+    return () => {
+      mq.removeEventListener('change', onScroll);
+      window.removeEventListener('scroll', onScroll);
+      window.removeEventListener('resize', onScroll);
+      if (raf) cancelAnimationFrame(raf);
+    };
+  }, [menuTopPx]);
+
+  const logoSrc = logoUrl || defaultLogoSrc;
+
+  const actionsPortalTarget = stuck ? stickyActionsEl : flowActionsEl;
+  const nestedPortalTarget =
+    nestedSpacesSlot && (stuck ? stickyNestedEl : flowNestedEl);
+
+  return (
+    <>
+      <div
+        className={cn(
+          'pointer-events-none fixed inset-x-0 z-[25] hidden md:block',
+          'border-b border-border bg-background-2 transition-[opacity,transform,box-shadow] duration-200 ease-out',
+          stuck
+            ? 'pointer-events-auto translate-y-0 opacity-100 shadow-md'
+            : '-translate-y-2 opacity-0',
+        )}
+        style={{ top: 'var(--menu-top-height, 4rem)' }}
+        aria-hidden={!stuck}
+      >
+        <div className="mx-auto flex max-w-container-2xl items-center gap-3 px-4 py-2.5">
+          <div className="flex min-w-0 flex-1 items-center gap-3">
+            <div className="min-w-0 shrink">{breadcrumbsSticky}</div>
+            <div className="relative h-9 w-9 shrink-0 overflow-hidden rounded-full ring-1 ring-black/10 dark:ring-white/15">
+              <Image
+                src={logoSrc}
+                alt=""
+                fill
+                className="object-cover"
+                sizes="36px"
+              />
+              <span className="sr-only">{logoAlt}</span>
+            </div>
+            <p
+              className="truncate text-4 font-semibold text-foreground"
+              aria-hidden
+            >
+              {title}
+            </p>
+          </div>
+          <div className="flex shrink-0 items-center gap-2">
+            <div
+              ref={setStickyActionsEl}
+              className="flex flex-nowrap items-center gap-2"
+            />
+            {nestedSpacesSlot ? (
+              <>
+                <div
+                  className="hidden h-8 w-px shrink-0 bg-border md:block"
+                  aria-hidden
+                />
+                <div
+                  ref={setStickyNestedEl}
+                  className="flex shrink-0 items-center"
+                />
+              </>
+            ) : null}
+          </div>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-2 md:flex-nowrap md:gap-x-4">
+          <div className="flex min-w-0 flex-1 items-center">
+            {breadcrumbsRow}
+          </div>
+          {nestedSpacesSlot ? (
+            <div
+              ref={setFlowNestedEl}
+              className={cn('shrink-0', stuck && 'hidden')}
+            />
+          ) : null}
+        </div>
+
+        {banner}
+
+        <div
+          ref={sentinelRef}
+          className="pointer-events-none hidden h-px w-full shrink-0 md:block"
+          aria-hidden
+        />
+
+        <div
+          ref={setFlowActionsEl}
+          className={cn(
+            'flex justify-end gap-2 md:flex-nowrap',
+            stuck && 'pointer-events-none invisible opacity-0',
+          )}
+          style={stuck ? { minHeight: flowMinH } : undefined}
+        />
+      </div>
+
+      {actionsPortalTarget
+        ? createPortal(actionsSlot, actionsPortalTarget)
+        : null}
+      {nestedSpacesSlot && nestedPortalTarget
+        ? createPortal(nestedSpacesSlot, nestedPortalTarget)
+        : null}
+    </>
+  );
+}

--- a/apps/web/src/app/[lang]/dho/[id]/_components/dho-sticky-space-chrome.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/dho-sticky-space-chrome.tsx
@@ -2,7 +2,11 @@
 
 import * as React from 'react';
 import { createPortal } from 'react-dom';
-import Image from 'next/image';
+import {
+  COMPACT_SPACE_BANNER_AVATAR_CLASSNAME,
+  COMPACT_SPACE_BANNER_TITLE_CLASSNAME,
+} from '@hypha-platform/epics';
+import { Avatar, AvatarImage } from '@hypha-platform/ui';
 import { cn } from '@hypha-platform/ui-utils';
 
 export type DhoStickySpaceChromeProps = {
@@ -151,31 +155,33 @@ export function DhoStickySpaceChrome({
         style={{ top: 'var(--menu-top-height, 4rem)' }}
         aria-hidden={!stuck}
       >
-        <div className="mx-auto flex max-w-container-2xl items-center gap-3 px-4 py-2.5">
-          <div className="flex min-w-0 flex-1 items-center gap-3">
-            <div className="relative h-9 w-9 shrink-0 overflow-hidden rounded-full ring-1 ring-black/10 dark:ring-white/15">
-              <Image
-                src={logoSrc}
-                alt=""
-                fill
-                className="object-cover"
-                sizes="36px"
-              />
-              <span className="sr-only">{logoAlt}</span>
+        <div className="mx-auto flex max-w-container-2xl items-center gap-3 px-8 py-2.5">
+          <div className="flex min-w-0 flex-1 items-start gap-6">
+            <div className="relative h-9 w-9 shrink-0">
+              <div className="absolute left-0 top-1/2 -translate-y-1/2 origin-top-left scale-50">
+                <Avatar className={COMPACT_SPACE_BANNER_AVATAR_CLASSNAME}>
+                  <AvatarImage
+                    src={logoSrc}
+                    alt={logoAlt}
+                    className="object-cover"
+                  />
+                </Avatar>
+              </div>
             </div>
             <p
-              className="truncate text-4 font-semibold text-foreground"
+              className={cn(
+                COMPACT_SPACE_BANNER_TITLE_CLASSNAME,
+                'min-w-0 flex-1 truncate text-foreground',
+              )}
               aria-hidden
             >
               {title}
             </p>
           </div>
-          <div className="flex shrink-0 items-center gap-2">
-            <div
-              ref={setStickyActionsEl}
-              className="flex flex-nowrap items-center gap-2"
-            />
-          </div>
+          <div
+            ref={setStickyActionsEl}
+            className="flex shrink-0 flex-nowrap items-center gap-2"
+          />
         </div>
       </div>
 
@@ -200,7 +206,7 @@ export function DhoStickySpaceChrome({
         <div
           ref={setFlowActionsEl}
           className={cn(
-            'flex justify-end gap-2 md:flex-nowrap',
+            'flex justify-end gap-2 px-8 md:flex-nowrap',
             stuck && 'pointer-events-none invisible opacity-0',
           )}
           style={stuck ? { minHeight: flowMinH } : undefined}

--- a/apps/web/src/app/[lang]/dho/[id]/_components/dho-sticky-space-chrome.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/dho-sticky-space-chrome.tsx
@@ -208,7 +208,8 @@ export function DhoStickySpaceChrome({
         <div
           ref={setFlowActionsEl}
           className={cn(
-            'flex justify-end gap-2 px-8 md:flex-nowrap',
+            /* Nudge in-flow actions up so they overlap the sticky row when it engages */
+            'flex justify-end gap-2 px-8 md:-mt-2.5 md:flex-nowrap',
             stuck && 'pointer-events-none invisible opacity-0',
           )}
           style={stuck ? { minHeight: flowMinH } : undefined}

--- a/apps/web/src/app/[lang]/dho/[id]/_components/dho-sticky-space-chrome.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/dho-sticky-space-chrome.tsx
@@ -86,7 +86,7 @@ export function DhoStickySpaceChrome({
     const ro = new ResizeObserver(measure);
     ro.observe(el);
     return () => ro.disconnect();
-  }, [stuck, flowActionsEl, actionsSlot]);
+  }, [stuck, flowActionsEl]);
 
   React.useEffect(() => {
     const sentinel = bannerBottomSentinelRef.current;

--- a/apps/web/src/app/[lang]/dho/[id]/_components/dho-sticky-space-chrome.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/dho-sticky-space-chrome.tsx
@@ -7,7 +7,6 @@ import { cn } from '@hypha-platform/ui-utils';
 
 export type DhoStickySpaceChromeProps = {
   breadcrumbsRow: React.ReactNode;
-  breadcrumbsSticky: React.ReactNode;
   banner: React.ReactNode;
   actionsSlot: React.ReactNode;
   nestedSpacesSlot: React.ReactNode;
@@ -53,7 +52,6 @@ function useMenuTopOffsetPx(): number {
  */
 export function DhoStickySpaceChrome({
   breadcrumbsRow,
-  breadcrumbsSticky,
   banner,
   actionsSlot,
   nestedSpacesSlot,
@@ -72,8 +70,6 @@ export function DhoStickySpaceChrome({
   const [flowNestedEl, setFlowNestedEl] = React.useState<HTMLDivElement | null>(
     null,
   );
-  const [stickyNestedEl, setStickyNestedEl] =
-    React.useState<HTMLDivElement | null>(null);
 
   const [stuck, setStuck] = React.useState(false);
   const stuckRef = React.useRef(false);
@@ -140,8 +136,7 @@ export function DhoStickySpaceChrome({
   const logoSrc = logoUrl || defaultLogoSrc;
 
   const actionsPortalTarget = stuck ? stickyActionsEl : flowActionsEl;
-  const nestedPortalTarget =
-    nestedSpacesSlot && (stuck ? stickyNestedEl : flowNestedEl);
+  const nestedPortalTarget = nestedSpacesSlot ? flowNestedEl : null;
 
   return (
     <>
@@ -158,7 +153,6 @@ export function DhoStickySpaceChrome({
       >
         <div className="mx-auto flex max-w-container-2xl items-center gap-3 px-4 py-2.5">
           <div className="flex min-w-0 flex-1 items-center gap-3">
-            <div className="min-w-0 shrink">{breadcrumbsSticky}</div>
             <div className="relative h-9 w-9 shrink-0 overflow-hidden rounded-full ring-1 ring-black/10 dark:ring-white/15">
               <Image
                 src={logoSrc}
@@ -181,18 +175,6 @@ export function DhoStickySpaceChrome({
               ref={setStickyActionsEl}
               className="flex flex-nowrap items-center gap-2"
             />
-            {nestedSpacesSlot ? (
-              <>
-                <div
-                  className="hidden h-8 w-px shrink-0 bg-border md:block"
-                  aria-hidden
-                />
-                <div
-                  ref={setStickyNestedEl}
-                  className="flex shrink-0 items-center"
-                />
-              </>
-            ) : null}
           </div>
         </div>
       </div>
@@ -203,10 +185,7 @@ export function DhoStickySpaceChrome({
             {breadcrumbsRow}
           </div>
           {nestedSpacesSlot ? (
-            <div
-              ref={setFlowNestedEl}
-              className={cn('shrink-0', stuck && 'hidden')}
-            />
+            <div ref={setFlowNestedEl} className="shrink-0" />
           ) : null}
         </div>
 

--- a/apps/web/src/app/[lang]/dho/[id]/_components/dho-sticky-space-chrome.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/dho-sticky-space-chrome.tsx
@@ -205,8 +205,7 @@ export function DhoStickySpaceChrome({
         <div
           ref={setFlowActionsEl}
           className={cn(
-            /* Nudge in-flow actions up so they overlap the sticky row when it engages */
-            'flex justify-end gap-2 px-8 md:-mt-2.5 md:flex-nowrap',
+            'flex justify-end gap-2 px-8 md:flex-nowrap',
             stuck && 'pointer-events-none invisible opacity-0',
           )}
           style={stuck ? { minHeight: flowMinH } : undefined}

--- a/apps/web/src/app/[lang]/dho/[id]/_components/dho-sticky-space-chrome.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/dho-sticky-space-chrome.tsx
@@ -20,10 +20,6 @@ export type DhoStickySpaceChromeProps = {
   defaultLogoSrc: string;
 };
 
-/** Match CSS transition duration + small buffer before unmounting the sticky shell (portal timing). */
-const STICKY_CHROME_TRANSITION_MS = 300;
-const STICKY_CHROME_UNMOUNT_DELAY_MS = STICKY_CHROME_TRANSITION_MS + 40;
-
 function useMenuTopOffsetPx(): number {
   const [px, setPx] = React.useState(64);
 
@@ -54,22 +50,6 @@ function useMenuTopOffsetPx(): number {
   return px;
 }
 
-function usePrefersReducedMotion(): boolean {
-  const [reduce, setReduce] = React.useState(false);
-
-  React.useEffect(() => {
-    const mq = window.matchMedia?.('(prefers-reduced-motion: reduce)');
-    if (!mq) return;
-
-    const sync = () => setReduce(mq.matches);
-    sync();
-    mq.addEventListener('change', sync);
-    return () => mq.removeEventListener('change', sync);
-  }, []);
-
-  return reduce;
-}
-
 /**
  * Desktop (md+): pin a compact chrome row under `MenuTop`. Actions / nested-space move
  * via portal so the same React trees (hooks) transition between positions — pixel-identical Button UI.
@@ -85,7 +65,6 @@ export function DhoStickySpaceChrome({
   defaultLogoSrc,
 }: DhoStickySpaceChromeProps) {
   const menuTopPx = useMenuTopOffsetPx();
-  const prefersReducedMotion = usePrefersReducedMotion();
   /** Bottom edge of the space image banner — sticky engages when this passes under MenuTop */
   const bannerBottomSentinelRef = React.useRef<HTMLDivElement>(null);
 
@@ -99,15 +78,6 @@ export function DhoStickySpaceChrome({
 
   const [stuck, setStuck] = React.useState(false);
   const stuckRef = React.useRef(false);
-
-  /** Kept mounted briefly after `stuck` false so opacity/transform transition can finish. */
-  const [stickyShellMounted, setStickyShellMounted] = React.useState(false);
-  /** Drives visible state; false on first paint when mounting for enter animation. */
-  const [stickyShellOpen, setStickyShellOpen] = React.useState(false);
-  const stickyUnmountTimerRef = React.useRef<ReturnType<
-    typeof setTimeout
-  > | null>(null);
-  const stickyEnterRafRef = React.useRef(0);
 
   const [flowMinH, setFlowMinH] = React.useState(44);
 
@@ -168,105 +138,50 @@ export function DhoStickySpaceChrome({
     };
   }, [menuTopPx]);
 
-  React.useEffect(() => {
-    if (stickyUnmountTimerRef.current) {
-      clearTimeout(stickyUnmountTimerRef.current);
-      stickyUnmountTimerRef.current = null;
-    }
-    if (stickyEnterRafRef.current) {
-      cancelAnimationFrame(stickyEnterRafRef.current);
-      stickyEnterRafRef.current = 0;
-    }
-
-    if (stuck) {
-      setStickyShellMounted(true);
-      if (prefersReducedMotion) {
-        setStickyShellOpen(true);
-        return;
-      }
-      setStickyShellOpen(false);
-      stickyEnterRafRef.current = requestAnimationFrame(() => {
-        stickyEnterRafRef.current = requestAnimationFrame(() => {
-          stickyEnterRafRef.current = 0;
-          setStickyShellOpen(true);
-        });
-      });
-      return () => {
-        if (stickyEnterRafRef.current) {
-          cancelAnimationFrame(stickyEnterRafRef.current);
-          stickyEnterRafRef.current = 0;
-        }
-      };
-    }
-
-    setStickyShellOpen(false);
-    stickyUnmountTimerRef.current = setTimeout(() => {
-      stickyUnmountTimerRef.current = null;
-      setStickyShellMounted(false);
-    }, STICKY_CHROME_UNMOUNT_DELAY_MS);
-
-    return () => {
-      if (stickyUnmountTimerRef.current) {
-        clearTimeout(stickyUnmountTimerRef.current);
-        stickyUnmountTimerRef.current = null;
-      }
-    };
-  }, [stuck, prefersReducedMotion]);
-
   const logoSrc = logoUrl || defaultLogoSrc;
 
   const actionsPortalTarget = stuck ? stickyActionsEl : flowActionsEl;
   const nestedPortalTarget = nestedSpacesSlot ? flowNestedEl : null;
 
-  const stickyChromeVisible = stickyShellMounted && stickyShellOpen;
-
   return (
     <>
-      {stickyShellMounted ? (
-        <div
-          className={cn(
-            'fixed inset-x-0 z-[25] hidden md:block',
-            'border-b border-border bg-background-2',
-            prefersReducedMotion
-              ? 'transition-opacity'
-              : 'transition-[opacity,transform,box-shadow]',
-            prefersReducedMotion
-              ? 'duration-150 ease-out'
-              : 'duration-300 ease-out',
-            stickyChromeVisible
-              ? 'pointer-events-auto translate-y-0 opacity-100 shadow-md'
-              : 'pointer-events-none -translate-y-1.5 opacity-0 shadow-none',
-          )}
-          style={{ top: 'var(--menu-top-height, 4rem)' }}
-          aria-hidden={!stickyChromeVisible}
-        >
-          <div className="mx-auto flex max-w-container-2xl items-center gap-3 px-8 py-2.5">
-            {/* Match CompactSpaceBanner row: same avatar, title tokens, gap-6; px-8 L/R balances chrome */}
-            <div className="flex min-w-0 flex-1 items-center gap-6">
-              <Avatar className={COMPACT_SPACE_BANNER_AVATAR_CLASSNAME}>
-                <AvatarImage
-                  src={logoSrc}
-                  alt={logoAlt}
-                  className="object-cover"
-                />
-              </Avatar>
-              <p
-                className={cn(
-                  COMPACT_SPACE_BANNER_TITLE_CLASSNAME,
-                  'min-w-0 flex-1 truncate text-foreground',
-                )}
-                aria-hidden
-              >
-                {title}
-              </p>
-            </div>
-            <div
-              ref={setStickyActionsEl}
-              className="flex shrink-0 flex-nowrap items-center gap-2"
-            />
+      <div
+        className={cn(
+          'pointer-events-none fixed inset-x-0 z-[25] hidden md:block',
+          'border-b border-border bg-background-2 transition-[opacity,transform,box-shadow] duration-200 ease-out',
+          stuck
+            ? 'pointer-events-auto translate-y-0 opacity-100 shadow-md'
+            : '-translate-y-2 opacity-0',
+        )}
+        style={{ top: 'var(--menu-top-height, 4rem)' }}
+        aria-hidden={!stuck}
+      >
+        <div className="mx-auto flex max-w-container-2xl items-center gap-3 px-8 py-2.5">
+          {/* Match CompactSpaceBanner row: same avatar, title tokens, gap-6; px-8 L/R balances chrome */}
+          <div className="flex min-w-0 flex-1 items-center gap-6">
+            <Avatar className={COMPACT_SPACE_BANNER_AVATAR_CLASSNAME}>
+              <AvatarImage
+                src={logoSrc}
+                alt={logoAlt}
+                className="object-cover"
+              />
+            </Avatar>
+            <p
+              className={cn(
+                COMPACT_SPACE_BANNER_TITLE_CLASSNAME,
+                'min-w-0 flex-1 truncate text-foreground',
+              )}
+              aria-hidden
+            >
+              {title}
+            </p>
           </div>
+          <div
+            ref={setStickyActionsEl}
+            className="flex shrink-0 flex-nowrap items-center gap-2"
+          />
         </div>
-      ) : null}
+      </div>
 
       <div className="flex flex-col gap-4">
         <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-2 md:flex-nowrap md:gap-x-4">

--- a/apps/web/src/app/[lang]/dho/[id]/_components/dho-sticky-space-chrome.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/dho-sticky-space-chrome.tsx
@@ -35,14 +35,8 @@ function useMenuTopOffsetPx(): number {
     const ro = new ResizeObserver(read);
     ro.observe(document.documentElement);
     window.addEventListener('resize', read);
-    const mo = new MutationObserver(read);
-    mo.observe(document.documentElement, {
-      attributes: true,
-      attributeFilter: ['style'],
-    });
     return () => {
       ro.disconnect();
-      mo.disconnect();
       window.removeEventListener('resize', read);
     };
   }, []);

--- a/apps/web/src/app/[lang]/dho/[id]/_components/dho-sticky-space-chrome.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/dho-sticky-space-chrome.tsx
@@ -156,9 +156,9 @@ export function DhoStickySpaceChrome({
         style={{ top: 'var(--menu-top-height, 4rem)' }}
         aria-hidden={!stuck}
       >
-        <div className="mx-auto flex max-w-container-2xl items-center gap-3 px-4 py-2.5">
-          {/* Match CompactSpaceBanner row: same avatar, title tokens, gap-6, vertical centre in bar */}
-          <div className="flex min-w-0 flex-1 items-center gap-6 pl-8">
+        <div className="mx-auto flex max-w-container-2xl items-center gap-3 px-8 py-2.5">
+          {/* Match CompactSpaceBanner row: same avatar, title tokens, gap-6; px-8 L/R balances chrome */}
+          <div className="flex min-w-0 flex-1 items-center gap-6">
             <Avatar className={COMPACT_SPACE_BANNER_AVATAR_CLASSNAME}>
               <AvatarImage
                 src={logoSrc}

--- a/apps/web/src/app/[lang]/dho/[id]/_components/dho-sticky-space-chrome.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/dho-sticky-space-chrome.tsx
@@ -156,9 +156,9 @@ export function DhoStickySpaceChrome({
         style={{ top: 'var(--menu-top-height, 4rem)' }}
         aria-hidden={!stuck}
       >
-        <div className="mx-auto flex max-w-container-2xl items-center gap-3 px-8 py-2.5">
+        <div className="mx-auto flex max-w-container-2xl items-center gap-3 px-4 py-2.5">
           {/* Match CompactSpaceBanner row: same avatar, title tokens, gap-6, vertical centre in bar */}
-          <div className="flex min-w-0 flex-1 items-center gap-6">
+          <div className="flex min-w-0 flex-1 items-center gap-6 pl-8">
             <Avatar className={COMPACT_SPACE_BANNER_AVATAR_CLASSNAME}>
               <AvatarImage
                 src={logoSrc}
@@ -205,7 +205,8 @@ export function DhoStickySpaceChrome({
         <div
           ref={setFlowActionsEl}
           className={cn(
-            'flex justify-end gap-2 px-8 md:flex-nowrap',
+            /* No extra horizontal padding: tab content (e.g. Claim) uses full container width */
+            'flex justify-end gap-2 px-0 md:flex-nowrap',
             stuck && 'pointer-events-none invisible opacity-0',
           )}
           style={stuck ? { minHeight: flowMinH } : undefined}

--- a/apps/web/src/app/[lang]/dho/[id]/_components/dho-sticky-space-chrome.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/dho-sticky-space-chrome.tsx
@@ -65,7 +65,8 @@ export function DhoStickySpaceChrome({
   defaultLogoSrc,
 }: DhoStickySpaceChromeProps) {
   const menuTopPx = useMenuTopOffsetPx();
-  const sentinelRef = React.useRef<HTMLDivElement>(null);
+  /** Bottom edge of the space image banner — sticky engages when this passes under MenuTop */
+  const bannerBottomSentinelRef = React.useRef<HTMLDivElement>(null);
 
   const [flowActionsEl, setFlowActionsEl] =
     React.useState<HTMLDivElement | null>(null);
@@ -94,7 +95,7 @@ export function DhoStickySpaceChrome({
   }, [stuck, flowActionsEl, actionsSlot]);
 
   React.useEffect(() => {
-    const sentinel = sentinelRef.current;
+    const sentinel = bannerBottomSentinelRef.current;
     if (!sentinel) return;
 
     const mq = window.matchMedia('(min-width: 768px)');
@@ -110,10 +111,10 @@ export function DhoStickySpaceChrome({
         }
         return;
       }
-      const top = sentinel.getBoundingClientRect().top;
+      const bannerBottom = sentinel.getBoundingClientRect().bottom;
       let next = stuckRef.current;
-      if (!next && top <= menuTopPx) next = true;
-      if (next && top >= menuTopPx + HYST) next = false;
+      if (!next && bannerBottom <= menuTopPx) next = true;
+      if (next && bannerBottom >= menuTopPx + HYST) next = false;
       if (next !== stuckRef.current) {
         stuckRef.current = next;
         setStuck(next);
@@ -195,13 +196,14 @@ export function DhoStickySpaceChrome({
           ) : null}
         </div>
 
-        {banner}
-
-        <div
-          ref={sentinelRef}
-          className="pointer-events-none hidden h-px w-full shrink-0 md:block"
-          aria-hidden
-        />
+        <div className="relative">
+          {banner}
+          <div
+            ref={bannerBottomSentinelRef}
+            className="pointer-events-none absolute bottom-0 left-0 h-px w-full opacity-0"
+            aria-hidden
+          />
+        </div>
 
         <div
           ref={setFlowActionsEl}

--- a/apps/web/src/app/[lang]/dho/[id]/_components/navigation-tabs.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/navigation-tabs.tsx
@@ -60,7 +60,7 @@ export function NavigationTabs({
   ];
 
   return (
-    <Tabs value={activeTab} className="w-full mt-16 overflow-hidden">
+    <Tabs value={activeTab} className="w-full mt-6 overflow-hidden md:mt-7">
       <ScrollArea>
         <div className="w-full relative h-10 mb-4">
           <TabsList className="flex absolute h-10 md:w-full">

--- a/apps/web/src/app/[lang]/dho/[id]/_components/navigation-tabs.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/navigation-tabs.tsx
@@ -29,6 +29,13 @@ function clampTabParallaxScrollY(): number {
   );
 }
 
+function isReducedMotionPreferred(): boolean {
+  if (typeof window === 'undefined') return false;
+  return (
+    window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false
+  );
+}
+
 export function NavigationTabs({
   lang,
   id,
@@ -42,23 +49,24 @@ export function NavigationTabs({
   const pathname = usePathname();
   const activeTab = getEffectiveDhoTab(pathname, { coherenceEnabled });
 
-  const [tabParallaxY, setTabParallaxY] = React.useState(
-    clampTabParallaxScrollY,
-  );
+  const [tabParallaxY, setTabParallaxY] = React.useState(0);
   const [preferReducedMotion, setPreferReducedMotion] = React.useState(false);
 
   React.useEffect(() => {
     const mq = window.matchMedia?.('(prefers-reduced-motion: reduce)');
     if (!mq) return;
 
-    const sync = () => setPreferReducedMotion(mq.matches);
+    const sync = () => {
+      setPreferReducedMotion(mq.matches);
+      if (mq.matches) setTabParallaxY(0);
+    };
     sync();
     mq.addEventListener('change', sync);
     return () => mq.removeEventListener('change', sync);
   }, []);
 
   React.useEffect(() => {
-    if (preferReducedMotion) {
+    if (preferReducedMotion || isReducedMotionPreferred()) {
       setTabParallaxY(0);
       return;
     }

--- a/apps/web/src/app/[lang]/dho/[id]/_components/navigation-tabs.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/navigation-tabs.tsx
@@ -132,7 +132,7 @@ export function NavigationTabs({
       <div
         className={cn(
           'mb-4 w-full overflow-x-auto overflow-y-visible overscroll-x-contain py-[18px]',
-          'touch-pan-x [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden',
+          'touch-pan-x touch-pan-y [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden',
         )}
       >
         <TabsList

--- a/apps/web/src/app/[lang]/dho/[id]/_components/navigation-tabs.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/navigation-tabs.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import * as React from 'react';
 import { Locale } from '@hypha-platform/i18n';
 import { Tabs, TabsList, TabsTrigger } from '@hypha-platform/ui/server';
 import Link from 'next/link';
@@ -9,9 +10,24 @@ import { getDhoPathAgreements } from '../@tab/agreements/constants';
 import { getDhoPathMembers } from '../@tab/members/constants';
 import { getDhoPathTreasury } from '../@tab/treasury/constants';
 // import { getDhoPathOverview } from '../@tab/overview/constants'; // Overview tab removed
-import { ScrollArea, ScrollBar } from '@hypha-platform/ui';
+import { cn } from '@hypha-platform/ui-utils';
 import { getEffectiveDhoTab } from '@hypha-platform/epics';
 import { getDhoPathCoherence } from '../@tab/coherence/constants';
+
+/** Subtle scroll parallax: tab strip drifts slightly vs page for depth (see CompactSpaceBannerLead). */
+const TAB_PARALLAX_SCROLL_RATE = 0.07;
+const TAB_PARALLAX_MAX_SHIFT_PX = 18;
+
+function clampTabParallaxScrollY(): number {
+  if (typeof window === 'undefined') return 0;
+  return Math.min(
+    TAB_PARALLAX_MAX_SHIFT_PX,
+    Math.max(
+      -TAB_PARALLAX_MAX_SHIFT_PX,
+      window.scrollY * TAB_PARALLAX_SCROLL_RATE,
+    ),
+  );
+}
 
 export function NavigationTabs({
   lang,
@@ -25,6 +41,46 @@ export function NavigationTabs({
   const t = useTranslations('Common');
   const pathname = usePathname();
   const activeTab = getEffectiveDhoTab(pathname, { coherenceEnabled });
+
+  const [tabParallaxY, setTabParallaxY] = React.useState(
+    clampTabParallaxScrollY,
+  );
+  const [preferReducedMotion, setPreferReducedMotion] = React.useState(false);
+
+  React.useEffect(() => {
+    const mq = window.matchMedia?.('(prefers-reduced-motion: reduce)');
+    if (!mq) return;
+
+    const sync = () => setPreferReducedMotion(mq.matches);
+    sync();
+    mq.addEventListener('change', sync);
+    return () => mq.removeEventListener('change', sync);
+  }, []);
+
+  React.useEffect(() => {
+    if (preferReducedMotion) {
+      setTabParallaxY(0);
+      return;
+    }
+
+    let raf = 0;
+
+    const tick = () => {
+      setTabParallaxY(clampTabParallaxScrollY());
+    };
+
+    const onScroll = () => {
+      cancelAnimationFrame(raf);
+      raf = requestAnimationFrame(tick);
+    };
+
+    tick();
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => {
+      window.removeEventListener('scroll', onScroll);
+      cancelAnimationFrame(raf);
+    };
+  }, [preferReducedMotion]);
 
   const tabs = [
     // Overview tab removed - functionality replaced by space-visualization
@@ -60,21 +116,34 @@ export function NavigationTabs({
   ];
 
   return (
-    <Tabs value={activeTab} className="w-full mt-6 overflow-hidden md:mt-7">
-      <ScrollArea>
-        <div className="w-full relative h-10 mb-4">
-          <TabsList className="flex absolute h-10 md:w-full">
-            {tabs.map(({ name, href, title }) => (
-              <TabsTrigger asChild key={name} value={name} variant="ghost">
-                <Link href={href} className="w-full" passHref>
-                  {title}
-                </Link>
-              </TabsTrigger>
-            ))}
-          </TabsList>
-        </div>
-        <ScrollBar orientation="horizontal" className="hidden" />
-      </ScrollArea>
+    <Tabs value={activeTab} className="mt-6 w-full md:mt-7">
+      {/*
+        Radix ScrollArea's viewport forces overflow-y: hidden, which clips vertical parallax.
+        Native overflow-x-auto keeps horizontal swipe/scroll; vertical padding absorbs translate.
+      */}
+      <div
+        className={cn(
+          'mb-4 w-full overflow-x-auto overflow-y-visible overscroll-x-contain py-[18px]',
+          'touch-pan-x [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden',
+        )}
+      >
+        <TabsList
+          className="flex h-10 min-w-max will-change-transform md:min-w-0 md:w-full"
+          style={
+            preferReducedMotion
+              ? undefined
+              : { transform: `translate3d(0, ${tabParallaxY}px, 0)` }
+          }
+        >
+          {tabs.map(({ name, href, title }) => (
+            <TabsTrigger asChild key={name} value={name} variant="ghost">
+              <Link href={href} className="w-full" passHref>
+                {title}
+              </Link>
+            </TabsTrigger>
+          ))}
+        </TabsList>
+      </div>
     </Tabs>
   );
 }

--- a/apps/web/src/app/[lang]/dho/[id]/_components/nested-spaces-button.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/nested-spaces-button.tsx
@@ -61,9 +61,8 @@ export const NestedSpacesButton = ({
     >
       <Button
         variant="link"
-        size="sm"
         disabled={isDisabled}
-        className="flex h-auto min-h-0 shrink-0 items-center gap-2 px-0 py-0 font-medium"
+        className="flex h-auto min-h-0 shrink-0 items-center gap-2 px-0 py-0 text-xs font-medium"
       >
         <Eye className="w-4 h-4" />
         <span>{tDho('nestedSpacesButton.label')}</span>

--- a/apps/web/src/app/[lang]/dho/[id]/_components/nested-spaces-button.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/nested-spaces-button.tsx
@@ -50,6 +50,7 @@ export const NestedSpacesButton = ({
 
   return (
     <Link
+      data-space-nav
       className={isDisabled ? 'cursor-not-allowed' : ''}
       href={
         hasAccess && !isLoading
@@ -62,7 +63,7 @@ export const NestedSpacesButton = ({
         variant="link"
         size="sm"
         disabled={isDisabled}
-        className="flex h-auto min-h-0 shrink-0 items-center gap-2 px-0 py-0 font-medium text-accent-11"
+        className="flex h-auto min-h-0 shrink-0 items-center gap-2 px-0 py-0 font-medium"
       >
         <Eye className="w-4 h-4" />
         <span>{tDho('nestedSpacesButton.label')}</span>

--- a/apps/web/src/app/[lang]/dho/[id]/_components/nested-spaces-button.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/nested-spaces-button.tsx
@@ -60,8 +60,9 @@ export const NestedSpacesButton = ({
     >
       <Button
         variant="link"
+        size="sm"
         disabled={isDisabled}
-        className="flex items-center gap-2 text-accent-11"
+        className="flex h-auto min-h-0 shrink-0 items-center gap-2 px-0 py-0 font-medium text-accent-11"
       >
         <Eye className="w-4 h-4" />
         <span>{tDho('nestedSpacesButton.label')}</span>

--- a/apps/web/src/app/[lang]/dho/[id]/layout.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/layout.tsx
@@ -150,6 +150,9 @@ export default async function DhoLayout({
                   })}
                   membersLabel={tCommon('Members')}
                   agreementsLabel={tCommon('Agreements')}
+                  descriptionLabel={tCommon('spaceBannerDescriptionAria', {
+                    title: spaceFromDb.title,
+                  })}
                   footerTrailing={
                     <>
                       {web3SpaceId !== undefined && (

--- a/apps/web/src/app/[lang]/dho/[id]/layout.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/layout.tsx
@@ -144,9 +144,6 @@ export default async function DhoLayout({
               breadcrumbsRow={
                 <Breadcrumbs spaceId={spaceFromDb.id} lang={lang} />
               }
-              breadcrumbsSticky={
-                <Breadcrumbs spaceId={spaceFromDb.id} lang={lang} />
-              }
               banner={
                 <CompactSpaceBanner
                   title={spaceFromDb.title}

--- a/apps/web/src/app/[lang]/dho/[id]/layout.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/layout.tsx
@@ -122,7 +122,7 @@ export default async function DhoLayout({
               {canConvertToBigInt(spaceFromDb.web3SpaceId) && (
                 <SubscriptionBadge
                   web3SpaceId={spaceFromDb.web3SpaceId as number}
-                  className="rounded border-emerald-400/85 bg-transparent text-white hover:border-emerald-300 hover:bg-white/10 [&]:border-emerald-400/85 [&]:text-white"
+                  className="rounded-md border-emerald-400/85 bg-transparent text-white hover:border-emerald-300 hover:bg-white/10 [&]:rounded-md [&]:border-emerald-400/85 [&]:text-white"
                 />
               )}
               <SpaceModeLabel
@@ -140,7 +140,7 @@ export default async function DhoLayout({
                   lang,
                   daoSlug,
                 )}/space-configuration`}
-                className="[&_.border-accent-8]:rounded [&_.border-accent-8]:border-white/85 [&_.border-accent-8]:bg-transparent [&_.border-accent-8]:text-white [&_.border-accent-8]:hover:border-white [&_.border-accent-8]:hover:bg-white/10 [&_.border-error-8]:rounded [&_.border-error-8]:border-white/85 [&_.border-error-8]:bg-transparent [&_.border-error-8]:text-white [&_.border-warning-8]:rounded [&_.border-warning-8]:border-amber-200/90 [&_.border-warning-8]:bg-transparent [&_.border-warning-8]:text-white"
+                className="[&_.border-accent-8]:rounded-md [&_.border-accent-8]:border-white/85 [&_.border-accent-8]:bg-transparent [&_.border-accent-8]:text-white [&_.border-accent-8]:hover:border-white [&_.border-accent-8]:hover:bg-white/10 [&_.border-error-8]:rounded-md [&_.border-error-8]:border-white/85 [&_.border-error-8]:bg-transparent [&_.border-error-8]:text-white [&_.border-warning-8]:rounded-md [&_.border-warning-8]:border-amber-200/90 [&_.border-warning-8]:bg-transparent [&_.border-warning-8]:text-white"
               />
             </>
           }

--- a/apps/web/src/app/[lang]/dho/[id]/layout.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/layout.tsx
@@ -103,7 +103,7 @@ export default async function DhoLayout({
   return (
     <div className="mx-auto flex max-w-container-2xl">
       <Container className="min-w-0 flex-grow !px-4">
-        <div className="mb-3 flex flex-wrap items-center justify-between gap-x-3 gap-y-2 md:gap-x-4">
+        <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-2 md:gap-x-4">
           <div className="flex min-h-8 min-w-0 flex-1 items-center">
             <Breadcrumbs spaceId={spaceFromDb.id} lang={lang} />
           </div>
@@ -111,47 +111,49 @@ export default async function DhoLayout({
             <NestedSpacesButton web3SpaceId={web3SpaceId} spaceSlug={daoSlug} />
           ) : null}
         </div>
-        <CompactSpaceBanner
-          title={spaceFromDb.title}
-          description={spaceFromDb.description}
-          logoUrl={spaceFromDb.logoUrl}
-          logoAlt={spaceFromDb.title}
-          defaultLogoSrc={DEFAULT_SPACE_AVATAR_IMAGE}
-          links={spaceFromDb.links}
-          leadImageUrl={spaceFromDb.leadImage}
-          defaultLeadImageSrc={DEFAULT_SPACE_LEAD_IMAGE}
-          memberCount={spaceMembers}
-          agreementCount={spaceAgreements}
-          createdOnText={tCommon('createdOn', {
-            date: formatDate(spaceFromDb.createdAt, true),
-          })}
-          membersLabel={tCommon('Members')}
-          agreementsLabel={tCommon('Agreements')}
-          footerTrailing={
-            <>
-              {hasWeb3Id && web3SpaceId !== undefined && (
-                <SubscriptionBadge
+        <div className="my-3">
+          <CompactSpaceBanner
+            title={spaceFromDb.title}
+            description={spaceFromDb.description}
+            logoUrl={spaceFromDb.logoUrl}
+            logoAlt={spaceFromDb.title}
+            defaultLogoSrc={DEFAULT_SPACE_AVATAR_IMAGE}
+            links={spaceFromDb.links}
+            leadImageUrl={spaceFromDb.leadImage}
+            defaultLeadImageSrc={DEFAULT_SPACE_LEAD_IMAGE}
+            memberCount={spaceMembers}
+            agreementCount={spaceAgreements}
+            createdOnText={tCommon('createdOn', {
+              date: formatDate(spaceFromDb.createdAt, true),
+            })}
+            membersLabel={tCommon('Members')}
+            agreementsLabel={tCommon('Agreements')}
+            footerTrailing={
+              <>
+                {hasWeb3Id && web3SpaceId !== undefined && (
+                  <SubscriptionBadge
+                    web3SpaceId={web3SpaceId}
+                    className="rounded-md border-emerald-400/85 bg-transparent text-white hover:border-emerald-300 hover:bg-white/10 [&]:rounded-md [&]:border-emerald-400/85 [&]:text-white"
+                  />
+                )}
+                <SpaceModeLabel
                   web3SpaceId={web3SpaceId}
-                  className="rounded-md border-emerald-400/85 bg-transparent text-white hover:border-emerald-300 hover:bg-white/10 [&]:rounded-md [&]:border-emerald-400/85 [&]:text-white"
+                  isSandbox={spaceFromDb.flags.includes('sandbox')}
+                  isDemo={spaceFromDb.flags.includes('demo')}
+                  isArchived={
+                    spaceFromDb.flags.includes('archived') || spaceMembers === 0
+                  }
+                  configPath={`${getDhoPathAgreements(
+                    lang,
+                    daoSlug,
+                  )}/space-configuration`}
+                  className="[&_.border-accent-8]:rounded-md [&_.border-accent-8]:border-white/85 [&_.border-accent-8]:bg-transparent [&_.border-accent-8]:text-white [&_.border-accent-8]:hover:border-white [&_.border-accent-8]:hover:bg-white/10 [&_.border-error-8]:rounded-md [&_.border-error-8]:border-white/85 [&_.border-error-8]:bg-transparent [&_.border-error-8]:text-white [&_.border-warning-8]:rounded-md [&_.border-warning-8]:border-amber-200/90 [&_.border-warning-8]:bg-transparent [&_.border-warning-8]:text-white"
                 />
-              )}
-              <SpaceModeLabel
-                web3SpaceId={web3SpaceId}
-                isSandbox={spaceFromDb.flags.includes('sandbox')}
-                isDemo={spaceFromDb.flags.includes('demo')}
-                isArchived={
-                  spaceFromDb.flags.includes('archived') || spaceMembers === 0
-                }
-                configPath={`${getDhoPathAgreements(
-                  lang,
-                  daoSlug,
-                )}/space-configuration`}
-                className="[&_.border-accent-8]:rounded-md [&_.border-accent-8]:border-white/85 [&_.border-accent-8]:bg-transparent [&_.border-accent-8]:text-white [&_.border-accent-8]:hover:border-white [&_.border-accent-8]:hover:bg-white/10 [&_.border-error-8]:rounded-md [&_.border-error-8]:border-white/85 [&_.border-error-8]:bg-transparent [&_.border-error-8]:text-white [&_.border-warning-8]:rounded-md [&_.border-warning-8]:border-amber-200/90 [&_.border-warning-8]:bg-transparent [&_.border-warning-8]:text-white"
-              />
-            </>
-          }
-        />
-        <div className="mt-3 flex justify-end gap-2">
+              </>
+            }
+          />
+        </div>
+        <div className="flex justify-end gap-2">
           {web3SpaceId !== undefined && (
             <JoinSpace web3SpaceId={web3SpaceId} spaceId={spaceFromDb.id} />
           )}

--- a/apps/web/src/app/[lang]/dho/[id]/layout.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/layout.tsx
@@ -118,9 +118,9 @@ export default async function DhoLayout({
       : DEFAULT_SPACE_AVATAR_IMAGE;
 
   return (
-    <div className="mx-auto flex max-w-container-2xl">
-      <Container className="min-w-0 flex-grow !px-4">
-        <SpaceAccentPortalBridge>
+    <SpaceAccentPortalBridge>
+      <div className="mx-auto flex max-w-container-2xl">
+        <Container className="min-w-0 flex-grow !px-4">
           {heroBannerImageHref ? (
             <link
               rel="preload"
@@ -208,51 +208,53 @@ export default async function DhoLayout({
             </div>
             {tab}
             {children}
-            {aside}
           </SpaceAccentFromImages>
-        </SpaceAccentPortalBridge>
-        <div className="space-y-9">
-          <Separator />
-          <div className="border-primary-foreground">
-            <Text className="text-4 font-medium pb-4 pt-4">
-              {tSpaces('spacesYouMightLike')}
-            </Text>
-            <Carousel className="my-6 mt-6">
-              <CarouselContent className="pb-5" showScrollbar>
-                {spaces.map((space) => (
-                  <CarouselItem
-                    key={space.id}
-                    className="w-full sm:w-[454px] max-w-[454px] flex-shrink-0"
-                  >
-                    <Link
-                      className="flex flex-col flex-1"
-                      href={getDhoPathAgreements(lang, space.slug as string)}
+          <div className="space-y-9">
+            <Separator />
+            <div className="border-primary-foreground">
+              <Text className="text-4 font-medium pb-4 pt-4">
+                {tSpaces('spacesYouMightLike')}
+              </Text>
+              <Carousel className="my-6 mt-6">
+                <CarouselContent className="pb-5" showScrollbar>
+                  {spaces.map((space) => (
+                    <CarouselItem
+                      key={space.id}
+                      className="w-full sm:w-[454px] max-w-[454px] flex-shrink-0"
                     >
-                      <SpaceCard
-                        description={space.description as string}
-                        icon={space.logoUrl || ''}
-                        leadImage={space.leadImage || DEFAULT_SPACE_LEAD_IMAGE}
-                        members={space.memberCount}
-                        agreements={space.documentCount}
-                        title={space.title as string}
-                        isSandbox={space.flags?.includes('sandbox') ?? false}
-                        isDemo={space.flags?.includes('demo') ?? false}
-                        isArchived={isSpaceArchived(space)}
-                        web3SpaceId={space.web3SpaceId as number}
-                        configPath={`${getDhoPathAgreements(
-                          lang,
-                          space.slug,
-                        )}/space-configuration`}
-                        createdAt={space.createdAt}
-                      />
-                    </Link>
-                  </CarouselItem>
-                ))}
-              </CarouselContent>
-            </Carousel>
+                      <Link
+                        className="flex flex-col flex-1"
+                        href={getDhoPathAgreements(lang, space.slug as string)}
+                      >
+                        <SpaceCard
+                          description={space.description as string}
+                          icon={space.logoUrl || ''}
+                          leadImage={
+                            space.leadImage || DEFAULT_SPACE_LEAD_IMAGE
+                          }
+                          members={space.memberCount}
+                          agreements={space.documentCount}
+                          title={space.title as string}
+                          isSandbox={space.flags?.includes('sandbox') ?? false}
+                          isDemo={space.flags?.includes('demo') ?? false}
+                          isArchived={isSpaceArchived(space)}
+                          web3SpaceId={space.web3SpaceId as number}
+                          configPath={`${getDhoPathAgreements(
+                            lang,
+                            space.slug,
+                          )}/space-configuration`}
+                          createdAt={space.createdAt}
+                        />
+                      </Link>
+                    </CarouselItem>
+                  ))}
+                </CarouselContent>
+              </Carousel>
+            </div>
           </div>
-        </div>
-      </Container>
-    </div>
+        </Container>
+        {aside}
+      </div>
+    </SpaceAccentPortalBridge>
   );
 }

--- a/apps/web/src/app/[lang]/dho/[id]/layout.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/layout.tsx
@@ -113,7 +113,7 @@ export default async function DhoLayout({
   return (
     <SpaceAccentPortalBridge>
       <div className="mx-auto flex max-w-container-2xl">
-        <Container className="min-w-0 flex-grow !px-4">
+        <Container className="min-w-0 flex-grow px-4!">
           {/* React 19+: link rel="preload" is hoisted to document head */}
           {heroBannerImageHref !== DEFAULT_SPACE_LEAD_IMAGE ? (
             <link
@@ -158,7 +158,7 @@ export default async function DhoLayout({
                       {web3SpaceId !== undefined && (
                         <SubscriptionBadge
                           web3SpaceId={web3SpaceId}
-                          className="rounded-md !border-accent-8 bg-transparent text-white hover:!border-accent-9 hover:bg-white/10"
+                          className="rounded-md border-accent-8! bg-transparent text-white hover:border-accent-9! hover:bg-white/10"
                         />
                       )}
                       <SpaceModeLabel
@@ -172,8 +172,8 @@ export default async function DhoLayout({
                         )}/space-configuration`}
                         className={
                           compactBannerSpaceArchived
-                            ? '[&_.border-error-8]:rounded-md [&_.border-error-8]:!border-error-8 [&_.border-error-8]:bg-transparent [&_.border-error-8]:text-white [&_.border-error-8]:hover:!border-error-9 [&_.border-error-8]:hover:bg-white/10'
-                            : '[&_.border-accent-8]:rounded-md [&_.border-accent-8]:!border-accent-8 [&_.border-accent-8]:bg-transparent [&_.border-accent-8]:text-white [&_.border-accent-8]:hover:!border-accent-9 [&_.border-accent-8]:hover:bg-white/10'
+                            ? '[&_.border-error-8]:rounded-md [&_.border-error-8]:border-error-8! [&_.border-error-8]:bg-transparent [&_.border-error-8]:text-white [&_.border-error-8]:hover:border-error-9! [&_.border-error-8]:hover:bg-white/10'
+                            : '[&_.border-accent-8]:rounded-md [&_.border-accent-8]:border-accent-8! [&_.border-accent-8]:bg-transparent [&_.border-accent-8]:text-white [&_.border-accent-8]:hover:border-accent-9! [&_.border-accent-8]:hover:bg-white/10'
                         }
                       />
                     </>

--- a/apps/web/src/app/[lang]/dho/[id]/layout.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/layout.tsx
@@ -118,15 +118,19 @@ export default async function DhoLayout({
             fetchPriority="high"
           />
         ) : null}
-        <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-2 md:gap-x-4">
-          <div className="flex min-h-8 min-w-0 flex-1 items-center">
-            <Breadcrumbs spaceId={spaceFromDb.id} lang={lang} />
+        {/* Single column + gap-3: identical rhythm above banner, below banner, above actions */}
+        <div className="flex flex-col gap-3">
+          <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-2 md:gap-x-4">
+            <div className="flex min-w-0 flex-1 items-center">
+              <Breadcrumbs spaceId={spaceFromDb.id} lang={lang} />
+            </div>
+            {web3SpaceId !== undefined ? (
+              <NestedSpacesButton
+                web3SpaceId={web3SpaceId}
+                spaceSlug={daoSlug}
+              />
+            ) : null}
           </div>
-          {web3SpaceId !== undefined ? (
-            <NestedSpacesButton web3SpaceId={web3SpaceId} spaceSlug={daoSlug} />
-          ) : null}
-        </div>
-        <div className="my-3">
           <CompactSpaceBanner
             title={spaceFromDb.title}
             description={spaceFromDb.description}
@@ -167,12 +171,12 @@ export default async function DhoLayout({
               </>
             }
           />
-        </div>
-        <div className="flex justify-end gap-2">
-          {web3SpaceId !== undefined && (
-            <JoinSpace web3SpaceId={web3SpaceId} spaceId={spaceFromDb.id} />
-          )}
-          <ActionButtons web3SpaceId={web3SpaceId} />
+          <div className="flex justify-end gap-2">
+            {web3SpaceId !== undefined && (
+              <JoinSpace web3SpaceId={web3SpaceId} spaceId={spaceFromDb.id} />
+            )}
+            <ActionButtons web3SpaceId={web3SpaceId} />
+          </div>
         </div>
         <div className="mt-4 flex flex-col gap-3">
           <SalesBanner web3SpaceId={web3SpaceId} />

--- a/apps/web/src/app/[lang]/dho/[id]/layout.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/layout.tsx
@@ -135,7 +135,7 @@ export default async function DhoLayout({
           >
             {/* gap-4 (16px) matches mt-4 above SalesBanner: breadcrumb→banner and banner→actions */}
             <div className="flex flex-col gap-4">
-              <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-2 md:gap-x-4">
+              <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-2 py-2 md:gap-x-4">
                 <div className="flex min-w-0 flex-1 items-center">
                   <Breadcrumbs spaceId={spaceFromDb.id} lang={lang} />
                 </div>

--- a/apps/web/src/app/[lang]/dho/[id]/layout.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/layout.tsx
@@ -29,6 +29,47 @@ import { Breadcrumbs } from './_components/breadcrumbs';
 import { canConvertToBigInt, formatDate } from '@hypha-platform/ui-utils';
 import { getTranslations } from 'next-intl/server';
 
+async function getSpaceMemberAndAgreementCounts(web3SpaceId: unknown): Promise<{
+  members: number;
+  agreements: number;
+}> {
+  if (!canConvertToBigInt(web3SpaceId)) {
+    return { members: 0, agreements: 0 };
+  }
+  const id = BigInt(web3SpaceId as number);
+  const [members, agreements] = await Promise.all([
+    (async () => {
+      try {
+        const [spaceDetails] = await fetchSpaceDetails({
+          spaceIds: [id],
+        });
+        return spaceDetails?.members.length ?? 0;
+      } catch (error) {
+        console.error(
+          `Failed to get space details for a space ${web3SpaceId}:`,
+          error,
+        );
+        return 0;
+      }
+    })(),
+    (async () => {
+      try {
+        const [proposals] = await fetchSpaceProposalsIds({
+          spaceIds: [id],
+        });
+        return proposals?.accepted?.length ?? 0;
+      } catch (error) {
+        console.error(
+          `Failed to get space proposals for a space ${web3SpaceId}:`,
+          error,
+        );
+        return 0;
+      }
+    })(),
+  ]);
+  return { members, agreements };
+}
+
 export default async function DhoLayout({
   aside,
   children,
@@ -49,42 +90,8 @@ export default async function DhoLayout({
     return notFound();
   }
 
-  const [spaceMembers, spaceAgreements] = await Promise.all([
-    (async () => {
-      try {
-        if (!canConvertToBigInt(spaceFromDb.web3SpaceId)) {
-          return 0;
-        }
-        const [spaceDetails] = await fetchSpaceDetails({
-          spaceIds: [BigInt(spaceFromDb.web3SpaceId as number)],
-        });
-        return spaceDetails?.members.length ?? 0;
-      } catch (error) {
-        console.error(
-          `Failed to get space details for a space ${spaceFromDb.web3SpaceId}:`,
-          error,
-        );
-        return 0;
-      }
-    })(),
-    (async () => {
-      try {
-        if (!canConvertToBigInt(spaceFromDb.web3SpaceId)) {
-          return 0;
-        }
-        const [proposals] = await fetchSpaceProposalsIds({
-          spaceIds: [BigInt(spaceFromDb.web3SpaceId as number)],
-        });
-        return proposals?.accepted?.length ?? 0;
-      } catch (error) {
-        console.error(
-          `Failed to get space proposals for a space ${spaceFromDb.web3SpaceId}:`,
-          error,
-        );
-        return 0;
-      }
-    })(),
-  ]);
+  const { members: spaceMembers, agreements: spaceAgreements } =
+    await getSpaceMemberAndAgreementCounts(spaceFromDb.web3SpaceId);
 
   const spaces = await getAllSpaces({ parentOnly: false, omitSandbox: true });
   return (

--- a/apps/web/src/app/[lang]/dho/[id]/layout.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/layout.tsx
@@ -29,6 +29,7 @@ import {
 import { notFound } from 'next/navigation';
 import { db } from '@hypha-platform/storage-postgres';
 import { Breadcrumbs } from './_components/breadcrumbs';
+import { DhoStickySpaceChrome } from './_components/dho-sticky-space-chrome';
 import { canConvertToBigInt, formatDate } from '@hypha-platform/ui-utils';
 import { getTranslations } from 'next-intl/server';
 
@@ -139,69 +140,80 @@ export default async function DhoLayout({
             logoSrc={accentLogoHref}
           >
             {/* gap-4 (16px) matches mt-4 above SalesBanner: breadcrumb→banner and banner→actions */}
-            <div className="flex flex-col gap-4">
-              <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-2 md:gap-x-4">
-                <div className="flex min-w-0 flex-1 items-center">
-                  <Breadcrumbs spaceId={spaceFromDb.id} lang={lang} />
-                </div>
-                {web3SpaceId !== undefined ? (
+            <DhoStickySpaceChrome
+              breadcrumbsRow={
+                <Breadcrumbs spaceId={spaceFromDb.id} lang={lang} />
+              }
+              breadcrumbsSticky={
+                <Breadcrumbs spaceId={spaceFromDb.id} lang={lang} />
+              }
+              banner={
+                <CompactSpaceBanner
+                  title={spaceFromDb.title}
+                  description={spaceFromDb.description}
+                  logoUrl={accentLogoHref}
+                  logoAlt={spaceFromDb.title}
+                  defaultLogoSrc={DEFAULT_SPACE_AVATAR_IMAGE}
+                  links={spaceFromDb.links}
+                  leadImageUrl={heroBannerImageHref}
+                  defaultLeadImageSrc={DEFAULT_SPACE_LEAD_IMAGE}
+                  memberCount={spaceMembers ?? 0}
+                  agreementCount={spaceAgreements ?? 0}
+                  createdOnText={tCommon('createdOn', {
+                    date: formatDate(spaceFromDb.createdAt, true),
+                  })}
+                  membersLabel={tCommon('Members')}
+                  agreementsLabel={tCommon('Agreements')}
+                  footerTrailing={
+                    <>
+                      {hasWeb3Id && web3SpaceId !== undefined && (
+                        <SubscriptionBadge
+                          web3SpaceId={web3SpaceId}
+                          className="rounded-md border-emerald-400/85 bg-transparent text-white hover:border-emerald-300 hover:bg-white/10 [&]:rounded-md [&]:border-emerald-400/85 [&]:text-white"
+                        />
+                      )}
+                      <SpaceModeLabel
+                        web3SpaceId={web3SpaceId}
+                        isSandbox={spaceFromDb.flags.includes('sandbox')}
+                        isDemo={spaceFromDb.flags.includes('demo')}
+                        isArchived={
+                          spaceFromDb.flags.includes('archived') ||
+                          (spaceMembers !== null && spaceMembers === 0)
+                        }
+                        configPath={`${getDhoPathAgreements(
+                          lang,
+                          daoSlug,
+                        )}/space-configuration`}
+                        className="[&_.border-accent-8]:rounded-md [&_.border-accent-8]:border-white/85 [&_.border-accent-8]:bg-transparent [&_.border-accent-8]:text-white [&_.border-accent-8]:hover:border-white [&_.border-accent-8]:hover:bg-white/10 [&_.border-error-8]:rounded-md [&_.border-error-8]:border-white/85 [&_.border-error-8]:bg-transparent [&_.border-error-8]:text-white [&_.border-warning-8]:rounded-md [&_.border-warning-8]:border-amber-200/90 [&_.border-warning-8]:bg-transparent [&_.border-warning-8]:text-white"
+                      />
+                    </>
+                  }
+                />
+              }
+              actionsSlot={
+                <>
+                  {web3SpaceId !== undefined && (
+                    <JoinSpace
+                      web3SpaceId={web3SpaceId}
+                      spaceId={spaceFromDb.id}
+                    />
+                  )}
+                  <ActionButtons web3SpaceId={web3SpaceId} />
+                </>
+              }
+              nestedSpacesSlot={
+                web3SpaceId !== undefined ? (
                   <NestedSpacesButton
                     web3SpaceId={web3SpaceId}
                     spaceSlug={daoSlug}
                   />
-                ) : null}
-              </div>
-              <CompactSpaceBanner
-                title={spaceFromDb.title}
-                description={spaceFromDb.description}
-                logoUrl={accentLogoHref}
-                logoAlt={spaceFromDb.title}
-                defaultLogoSrc={DEFAULT_SPACE_AVATAR_IMAGE}
-                links={spaceFromDb.links}
-                leadImageUrl={heroBannerImageHref}
-                defaultLeadImageSrc={DEFAULT_SPACE_LEAD_IMAGE}
-                memberCount={spaceMembers ?? 0}
-                agreementCount={spaceAgreements ?? 0}
-                createdOnText={tCommon('createdOn', {
-                  date: formatDate(spaceFromDb.createdAt, true),
-                })}
-                membersLabel={tCommon('Members')}
-                agreementsLabel={tCommon('Agreements')}
-                footerTrailing={
-                  <>
-                    {hasWeb3Id && web3SpaceId !== undefined && (
-                      <SubscriptionBadge
-                        web3SpaceId={web3SpaceId}
-                        className="rounded-md border-emerald-400/85 bg-transparent text-white hover:border-emerald-300 hover:bg-white/10 [&]:rounded-md [&]:border-emerald-400/85 [&]:text-white"
-                      />
-                    )}
-                    <SpaceModeLabel
-                      web3SpaceId={web3SpaceId}
-                      isSandbox={spaceFromDb.flags.includes('sandbox')}
-                      isDemo={spaceFromDb.flags.includes('demo')}
-                      isArchived={
-                        spaceFromDb.flags.includes('archived') ||
-                        (spaceMembers !== null && spaceMembers === 0)
-                      }
-                      configPath={`${getDhoPathAgreements(
-                        lang,
-                        daoSlug,
-                      )}/space-configuration`}
-                      className="[&_.border-accent-8]:rounded-md [&_.border-accent-8]:border-white/85 [&_.border-accent-8]:bg-transparent [&_.border-accent-8]:text-white [&_.border-accent-8]:hover:border-white [&_.border-accent-8]:hover:bg-white/10 [&_.border-error-8]:rounded-md [&_.border-error-8]:border-white/85 [&_.border-error-8]:bg-transparent [&_.border-error-8]:text-white [&_.border-warning-8]:rounded-md [&_.border-warning-8]:border-amber-200/90 [&_.border-warning-8]:bg-transparent [&_.border-warning-8]:text-white"
-                    />
-                  </>
-                }
-              />
-              <div className="flex justify-end gap-2">
-                {web3SpaceId !== undefined && (
-                  <JoinSpace
-                    web3SpaceId={web3SpaceId}
-                    spaceId={spaceFromDb.id}
-                  />
-                )}
-                <ActionButtons web3SpaceId={web3SpaceId} />
-              </div>
-            </div>
+                ) : null
+              }
+              title={spaceFromDb.title}
+              logoUrl={accentLogoHref}
+              logoAlt={spaceFromDb.title}
+              defaultLogoSrc={DEFAULT_SPACE_AVATAR_IMAGE}
+            />
             <div className="mt-4 flex flex-col gap-3">
               <SalesBanner web3SpaceId={web3SpaceId} />
               <SpaceEscrowDepositBanners

--- a/apps/web/src/app/[lang]/dho/[id]/layout.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/layout.tsx
@@ -33,11 +33,12 @@ import { canConvertToBigInt, formatDate } from '@hypha-platform/ui-utils';
 import { getTranslations } from 'next-intl/server';
 
 async function getSpaceMemberAndAgreementCounts(web3SpaceId: unknown): Promise<{
-  members: number;
-  agreements: number;
+  /** null when enrichment failed — do not treat as “zero members” */
+  members: number | null;
+  agreements: number | null;
 }> {
   if (!canConvertToBigInt(web3SpaceId)) {
-    return { members: 0, agreements: 0 };
+    return { members: null, agreements: null };
   }
   const id = BigInt(web3SpaceId as number);
   const [members, agreements] = await Promise.all([
@@ -52,7 +53,7 @@ async function getSpaceMemberAndAgreementCounts(web3SpaceId: unknown): Promise<{
           `Failed to get space details for a space ${web3SpaceId}:`,
           error,
         );
-        return 0;
+        return null;
       }
     })(),
     (async () => {
@@ -66,7 +67,7 @@ async function getSpaceMemberAndAgreementCounts(web3SpaceId: unknown): Promise<{
           `Failed to get space proposals for a space ${web3SpaceId}:`,
           error,
         );
-        return 0;
+        return null;
       }
     })(),
   ]);
@@ -155,8 +156,8 @@ export default async function DhoLayout({
                 links={spaceFromDb.links}
                 leadImageUrl={spaceFromDb.leadImage}
                 defaultLeadImageSrc={DEFAULT_SPACE_LEAD_IMAGE}
-                memberCount={spaceMembers}
-                agreementCount={spaceAgreements}
+                memberCount={spaceMembers ?? 0}
+                agreementCount={spaceAgreements ?? 0}
                 createdOnText={tCommon('createdOn', {
                   date: formatDate(spaceFromDb.createdAt, true),
                 })}
@@ -176,7 +177,7 @@ export default async function DhoLayout({
                       isDemo={spaceFromDb.flags.includes('demo')}
                       isArchived={
                         spaceFromDb.flags.includes('archived') ||
-                        spaceMembers === 0
+                        (spaceMembers !== null && spaceMembers === 0)
                       }
                       configPath={`${getDhoPathAgreements(
                         lang,

--- a/apps/web/src/app/[lang]/dho/[id]/layout.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/layout.tsx
@@ -36,7 +36,7 @@ async function getSpaceMemberAndAgreementCounts(web3SpaceId: unknown): Promise<{
   if (!canConvertToBigInt(web3SpaceId)) {
     return { members: null, agreements: null };
   }
-  const id = BigInt(web3SpaceId as number);
+  const id = BigInt(web3SpaceId);
   const [members, agreements] = await Promise.all([
     (async () => {
       try {

--- a/apps/web/src/app/[lang]/dho/[id]/layout.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/layout.tsx
@@ -6,7 +6,9 @@ import {
   SpaceModeLabel,
   SubscriptionBadge,
   CompactSpaceBanner,
+  SpaceAccentFromImages,
 } from '@hypha-platform/epics';
+import './space-accent.css';
 import { Locale } from '@hypha-platform/i18n';
 import { Container, Separator } from '@hypha-platform/ui';
 import { Text } from '@radix-ui/themes';
@@ -107,6 +109,13 @@ export default async function DhoLayout({
       ? rawLead
       : DEFAULT_SPACE_LEAD_IMAGE;
 
+  const accentLogoHref =
+    spaceFromDb.logoUrl?.trim() &&
+    (spaceFromDb.logoUrl.startsWith('/') ||
+      /^https?:\/\//i.test(spaceFromDb.logoUrl))
+      ? spaceFromDb.logoUrl.trim()
+      : DEFAULT_SPACE_AVATAR_IMAGE;
+
   return (
     <div className="mx-auto flex max-w-container-2xl">
       <Container className="min-w-0 flex-grow !px-4">
@@ -118,77 +127,83 @@ export default async function DhoLayout({
             fetchPriority="high"
           />
         ) : null}
-        {/* Single column + gap-2: tight rhythm under chrome; matches banner ↔ actions */}
-        <div className="flex flex-col gap-2">
-          <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-2 md:gap-x-4">
-            <div className="flex min-w-0 flex-1 items-center">
-              <Breadcrumbs spaceId={spaceFromDb.id} lang={lang} />
-            </div>
-            {web3SpaceId !== undefined ? (
-              <NestedSpacesButton
-                web3SpaceId={web3SpaceId}
-                spaceSlug={daoSlug}
-              />
-            ) : null}
-          </div>
-          <CompactSpaceBanner
-            title={spaceFromDb.title}
-            description={spaceFromDb.description}
-            logoUrl={spaceFromDb.logoUrl}
-            logoAlt={spaceFromDb.title}
-            defaultLogoSrc={DEFAULT_SPACE_AVATAR_IMAGE}
-            links={spaceFromDb.links}
-            leadImageUrl={spaceFromDb.leadImage}
-            defaultLeadImageSrc={DEFAULT_SPACE_LEAD_IMAGE}
-            memberCount={spaceMembers}
-            agreementCount={spaceAgreements}
-            createdOnText={tCommon('createdOn', {
-              date: formatDate(spaceFromDb.createdAt, true),
-            })}
-            membersLabel={tCommon('Members')}
-            agreementsLabel={tCommon('Agreements')}
-            footerTrailing={
-              <>
-                {hasWeb3Id && web3SpaceId !== undefined && (
-                  <SubscriptionBadge
-                    web3SpaceId={web3SpaceId}
-                    className="rounded-md border-emerald-400/85 bg-transparent text-white hover:border-emerald-300 hover:bg-white/10 [&]:rounded-md [&]:border-emerald-400/85 [&]:text-white"
-                  />
-                )}
-                <SpaceModeLabel
+        <SpaceAccentFromImages
+          bannerSrc={heroBannerImageHref}
+          logoSrc={accentLogoHref}
+        >
+          {/* Single column + gap-2: tight rhythm under chrome; matches banner ↔ actions */}
+          <div className="flex flex-col gap-2">
+            <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-2 md:gap-x-4">
+              <div className="flex min-w-0 flex-1 items-center">
+                <Breadcrumbs spaceId={spaceFromDb.id} lang={lang} />
+              </div>
+              {web3SpaceId !== undefined ? (
+                <NestedSpacesButton
                   web3SpaceId={web3SpaceId}
-                  isSandbox={spaceFromDb.flags.includes('sandbox')}
-                  isDemo={spaceFromDb.flags.includes('demo')}
-                  isArchived={
-                    spaceFromDb.flags.includes('archived') || spaceMembers === 0
-                  }
-                  configPath={`${getDhoPathAgreements(
-                    lang,
-                    daoSlug,
-                  )}/space-configuration`}
-                  className="[&_.border-accent-8]:rounded-md [&_.border-accent-8]:border-white/85 [&_.border-accent-8]:bg-transparent [&_.border-accent-8]:text-white [&_.border-accent-8]:hover:border-white [&_.border-accent-8]:hover:bg-white/10 [&_.border-error-8]:rounded-md [&_.border-error-8]:border-white/85 [&_.border-error-8]:bg-transparent [&_.border-error-8]:text-white [&_.border-warning-8]:rounded-md [&_.border-warning-8]:border-amber-200/90 [&_.border-warning-8]:bg-transparent [&_.border-warning-8]:text-white"
+                  spaceSlug={daoSlug}
                 />
-              </>
-            }
-          />
-          <div className="flex justify-end gap-2">
-            {web3SpaceId !== undefined && (
-              <JoinSpace web3SpaceId={web3SpaceId} spaceId={spaceFromDb.id} />
-            )}
-            <ActionButtons web3SpaceId={web3SpaceId} />
+              ) : null}
+            </div>
+            <CompactSpaceBanner
+              title={spaceFromDb.title}
+              description={spaceFromDb.description}
+              logoUrl={spaceFromDb.logoUrl}
+              logoAlt={spaceFromDb.title}
+              defaultLogoSrc={DEFAULT_SPACE_AVATAR_IMAGE}
+              links={spaceFromDb.links}
+              leadImageUrl={spaceFromDb.leadImage}
+              defaultLeadImageSrc={DEFAULT_SPACE_LEAD_IMAGE}
+              memberCount={spaceMembers}
+              agreementCount={spaceAgreements}
+              createdOnText={tCommon('createdOn', {
+                date: formatDate(spaceFromDb.createdAt, true),
+              })}
+              membersLabel={tCommon('Members')}
+              agreementsLabel={tCommon('Agreements')}
+              footerTrailing={
+                <>
+                  {hasWeb3Id && web3SpaceId !== undefined && (
+                    <SubscriptionBadge
+                      web3SpaceId={web3SpaceId}
+                      className="rounded-md border-emerald-400/85 bg-transparent text-white hover:border-emerald-300 hover:bg-white/10 [&]:rounded-md [&]:border-emerald-400/85 [&]:text-white"
+                    />
+                  )}
+                  <SpaceModeLabel
+                    web3SpaceId={web3SpaceId}
+                    isSandbox={spaceFromDb.flags.includes('sandbox')}
+                    isDemo={spaceFromDb.flags.includes('demo')}
+                    isArchived={
+                      spaceFromDb.flags.includes('archived') ||
+                      spaceMembers === 0
+                    }
+                    configPath={`${getDhoPathAgreements(
+                      lang,
+                      daoSlug,
+                    )}/space-configuration`}
+                    className="[&_.border-accent-8]:rounded-md [&_.border-accent-8]:border-white/85 [&_.border-accent-8]:bg-transparent [&_.border-accent-8]:text-white [&_.border-accent-8]:hover:border-white [&_.border-accent-8]:hover:bg-white/10 [&_.border-error-8]:rounded-md [&_.border-error-8]:border-white/85 [&_.border-error-8]:bg-transparent [&_.border-error-8]:text-white [&_.border-warning-8]:rounded-md [&_.border-warning-8]:border-amber-200/90 [&_.border-warning-8]:bg-transparent [&_.border-warning-8]:text-white"
+                  />
+                </>
+              }
+            />
+            <div className="flex justify-end gap-2">
+              {web3SpaceId !== undefined && (
+                <JoinSpace web3SpaceId={web3SpaceId} spaceId={spaceFromDb.id} />
+              )}
+              <ActionButtons web3SpaceId={web3SpaceId} />
+            </div>
           </div>
-        </div>
-        <div className="mt-4 flex flex-col gap-3">
-          <SalesBanner web3SpaceId={web3SpaceId} />
-          <SpaceEscrowDepositBanners
-            web3SpaceId={web3SpaceId}
-            spaceDbId={spaceFromDb.id}
-            spaceSlug={daoSlug}
-            lang={lang}
-          />
-        </div>
-        {tab}
-        {children}
+          <div className="mt-4 flex flex-col gap-3">
+            <SalesBanner web3SpaceId={web3SpaceId} />
+            <SpaceEscrowDepositBanners
+              web3SpaceId={web3SpaceId}
+              spaceDbId={spaceFromDb.id}
+              spaceSlug={daoSlug}
+              lang={lang}
+            />
+          </div>
+          {tab}
+          {children}
+        </SpaceAccentFromImages>
         <div className="space-y-9">
           <Separator />
           <div className="border-primary-foreground">

--- a/apps/web/src/app/[lang]/dho/[id]/layout.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/layout.tsx
@@ -90,16 +90,16 @@ export default async function DhoLayout({
   return (
     <div className="flex max-w-container-2xl mx-auto">
       <Container className="flex-grow min-w-0">
-        <div className="mb-6 flex items-center">
-          <Breadcrumbs spaceId={spaceFromDb.id} lang={lang} />
-        </div>
-        <div className="relative flex justify-end mb-2">
-          {typeof spaceFromDb.web3SpaceId === 'number' && (
+        <div className="mb-4 flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
+          <div className="flex min-h-9 min-w-0 flex-1 items-center">
+            <Breadcrumbs spaceId={spaceFromDb.id} lang={lang} />
+          </div>
+          {typeof spaceFromDb.web3SpaceId === 'number' ? (
             <NestedSpacesButton
               web3SpaceId={spaceFromDb.web3SpaceId as number}
               spaceSlug={daoSlug}
             />
-          )}
+          ) : null}
         </div>
         <CompactSpaceBanner
           title={spaceFromDb.title}

--- a/apps/web/src/app/[lang]/dho/[id]/layout.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/layout.tsx
@@ -122,6 +122,10 @@ export default async function DhoLayout({
       ? rawLogo
       : DEFAULT_SPACE_AVATAR_IMAGE;
 
+  const compactBannerSpaceArchived =
+    spaceFromDb.flags.includes('archived') ||
+    (spaceMembers !== null && spaceMembers === 0);
+
   return (
     <SpaceAccentPortalBridge>
       <div className="mx-auto flex max-w-container-2xl">
@@ -166,22 +170,23 @@ export default async function DhoLayout({
                       {hasWeb3Id && web3SpaceId !== undefined && (
                         <SubscriptionBadge
                           web3SpaceId={web3SpaceId}
-                          className="rounded-md border-emerald-400/85 bg-transparent text-white hover:border-emerald-300 hover:bg-white/10 [&]:rounded-md [&]:border-emerald-400/85 [&]:text-white"
+                          className="rounded-md !border-accent-8 bg-transparent text-white hover:!border-accent-9 hover:bg-white/10"
                         />
                       )}
                       <SpaceModeLabel
                         web3SpaceId={web3SpaceId}
                         isSandbox={spaceFromDb.flags.includes('sandbox')}
                         isDemo={spaceFromDb.flags.includes('demo')}
-                        isArchived={
-                          spaceFromDb.flags.includes('archived') ||
-                          (spaceMembers !== null && spaceMembers === 0)
-                        }
+                        isArchived={compactBannerSpaceArchived}
                         configPath={`${getDhoPathAgreements(
                           lang,
                           daoSlug,
                         )}/space-configuration`}
-                        className="[&_.border-accent-8]:rounded-md [&_.border-accent-8]:border-white/85 [&_.border-accent-8]:bg-transparent [&_.border-accent-8]:text-white [&_.border-accent-8]:hover:border-white [&_.border-accent-8]:hover:bg-white/10 [&_.border-error-8]:rounded-md [&_.border-error-8]:border-white/85 [&_.border-error-8]:bg-transparent [&_.border-error-8]:text-white [&_.border-warning-8]:rounded-md [&_.border-warning-8]:border-amber-200/90 [&_.border-warning-8]:bg-transparent [&_.border-warning-8]:text-white"
+                        className={
+                          compactBannerSpaceArchived
+                            ? '[&_.border-error-8]:rounded-md [&_.border-error-8]:!border-error-8 [&_.border-error-8]:bg-transparent [&_.border-error-8]:text-white [&_.border-error-8]:hover:!border-error-9 [&_.border-error-8]:hover:bg-white/10'
+                            : '[&_.border-accent-8]:rounded-md [&_.border-accent-8]:!border-accent-8 [&_.border-accent-8]:bg-transparent [&_.border-accent-8]:text-white [&_.border-accent-8]:hover:!border-accent-9 [&_.border-accent-8]:hover:bg-white/10'
+                        }
                       />
                     </>
                   }

--- a/apps/web/src/app/[lang]/dho/[id]/layout.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/layout.tsx
@@ -88,10 +88,10 @@ export default async function DhoLayout({
 
   const spaces = await getAllSpaces({ parentOnly: false, omitSandbox: true });
   return (
-    <div className="flex max-w-container-2xl mx-auto">
-      <Container className="flex-grow min-w-0">
-        <div className="mb-4 flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
-          <div className="flex min-h-9 min-w-0 flex-1 items-center">
+    <div className="mx-auto flex max-w-container-2xl">
+      <Container className="min-w-0 flex-grow !px-4">
+        <div className="mb-3 flex flex-wrap items-center justify-between gap-x-3 gap-y-2 md:gap-x-4">
+          <div className="flex min-h-8 min-w-0 flex-1 items-center">
             <Breadcrumbs spaceId={spaceFromDb.id} lang={lang} />
           </div>
           {typeof spaceFromDb.web3SpaceId === 'number' ? (
@@ -145,7 +145,7 @@ export default async function DhoLayout({
             </>
           }
         />
-        <div className="mt-4 flex justify-end gap-2">
+        <div className="mt-3 flex justify-end gap-2">
           {typeof spaceFromDb.web3SpaceId === 'number' && (
             <JoinSpace
               web3SpaceId={spaceFromDb.web3SpaceId}

--- a/apps/web/src/app/[lang]/dho/[id]/layout.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/layout.tsx
@@ -157,7 +157,7 @@ export default async function DhoLayout({
           )}
           <ActionButtons web3SpaceId={web3SpaceId} />
         </div>
-        <div className="mt-8 flex flex-col gap-3">
+        <div className="mt-4 flex flex-col gap-3">
           <SalesBanner web3SpaceId={web3SpaceId} />
           <SpaceEscrowDepositBanners
             web3SpaceId={web3SpaceId}

--- a/apps/web/src/app/[lang]/dho/[id]/layout.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/layout.tsx
@@ -4,19 +4,12 @@ import {
   SpaceCard,
   SpaceEscrowDepositBanners,
   SpaceModeLabel,
-  WebLinks,
   SubscriptionBadge,
+  CompactSpaceBanner,
 } from '@hypha-platform/epics';
 import { Locale } from '@hypha-platform/i18n';
-import {
-  Container,
-  Card,
-  Avatar,
-  AvatarImage,
-  Separator,
-} from '@hypha-platform/ui';
+import { Container, Separator } from '@hypha-platform/ui';
 import { Text } from '@radix-ui/themes';
-import Image from 'next/image';
 import { Carousel, CarouselContent, CarouselItem } from '@hypha-platform/ui';
 import Link from 'next/link';
 import { getAllSpaces, findSpaceBySlug } from '@hypha-platform/core/server';
@@ -56,41 +49,42 @@ export default async function DhoLayout({
     return notFound();
   }
 
-  const spaceMembers = await (async () => {
-    try {
-      if (!canConvertToBigInt(spaceFromDb.web3SpaceId)) {
+  const [spaceMembers, spaceAgreements] = await Promise.all([
+    (async () => {
+      try {
+        if (!canConvertToBigInt(spaceFromDb.web3SpaceId)) {
+          return 0;
+        }
+        const [spaceDetails] = await fetchSpaceDetails({
+          spaceIds: [BigInt(spaceFromDb.web3SpaceId as number)],
+        });
+        return spaceDetails?.members.length ?? 0;
+      } catch (error) {
+        console.error(
+          `Failed to get space details for a space ${spaceFromDb.web3SpaceId}:`,
+          error,
+        );
         return 0;
       }
-      const [spaceDetails] = await fetchSpaceDetails({
-        spaceIds: [BigInt(spaceFromDb.web3SpaceId as number)],
-      });
-      return spaceDetails?.members.length ?? 0;
-    } catch (error) {
-      console.error(
-        `Failed to get space details for a space ${spaceFromDb.web3SpaceId}:`,
-        error,
-      );
-      return 0;
-    }
-  })();
-
-  const spaceAgreements = await (async () => {
-    try {
-      if (!canConvertToBigInt(spaceFromDb.web3SpaceId)) {
+    })(),
+    (async () => {
+      try {
+        if (!canConvertToBigInt(spaceFromDb.web3SpaceId)) {
+          return 0;
+        }
+        const [proposals] = await fetchSpaceProposalsIds({
+          spaceIds: [BigInt(spaceFromDb.web3SpaceId as number)],
+        });
+        return proposals?.accepted?.length ?? 0;
+      } catch (error) {
+        console.error(
+          `Failed to get space proposals for a space ${spaceFromDb.web3SpaceId}:`,
+          error,
+        );
         return 0;
       }
-      const [proposals] = await fetchSpaceProposalsIds({
-        spaceIds: [BigInt(spaceFromDb.web3SpaceId as number)],
-      });
-      return proposals?.accepted?.length ?? 0;
-    } catch (error) {
-      console.error(
-        `Failed to get space details for a space ${spaceFromDb.web3SpaceId}:`,
-        error,
-      );
-      return 0;
-    }
-  })();
+    })(),
+  ]);
 
   const spaces = await getAllSpaces({ parentOnly: false, omitSandbox: true });
   return (
@@ -107,22 +101,51 @@ export default async function DhoLayout({
             />
           )}
         </div>
-        <Card className="relative">
-          <Image
-            width={768}
-            height={270}
-            className="rounded-xl min-h-[270px] max-h-[270px] w-full object-cover"
-            src={spaceFromDb.leadImage || DEFAULT_SPACE_LEAD_IMAGE}
-            alt={spaceFromDb.title}
-          ></Image>
-          <Avatar className="w-[128px] h-[128px] absolute bottom-[-35px] left-[15px]">
-            <AvatarImage
-              src={spaceFromDb.logoUrl || DEFAULT_SPACE_AVATAR_IMAGE}
-              alt="logo"
-            />
-          </Avatar>
-        </Card>
-        <div className="flex justify-end mt-2 gap-2">
+        <CompactSpaceBanner
+          title={spaceFromDb.title}
+          description={spaceFromDb.description}
+          logoUrl={spaceFromDb.logoUrl}
+          logoAlt={spaceFromDb.title}
+          defaultLogoSrc={DEFAULT_SPACE_AVATAR_IMAGE}
+          links={spaceFromDb.links}
+          leadImageUrl={spaceFromDb.leadImage}
+          defaultLeadImageSrc={DEFAULT_SPACE_LEAD_IMAGE}
+          memberCount={spaceMembers}
+          agreementCount={spaceAgreements}
+          createdOnText={tCommon('createdOn', {
+            date: formatDate(spaceFromDb.createdAt, true),
+          })}
+          membersLabel={tCommon('Members')}
+          agreementsLabel={tCommon('Agreements')}
+          footerTrailing={
+            <>
+              {canConvertToBigInt(spaceFromDb.web3SpaceId) && (
+                <SubscriptionBadge
+                  web3SpaceId={spaceFromDb.web3SpaceId as number}
+                  className="rounded border-emerald-400/85 bg-transparent text-white hover:border-emerald-300 hover:bg-white/10 [&]:border-emerald-400/85 [&]:text-white"
+                />
+              )}
+              <SpaceModeLabel
+                web3SpaceId={
+                  typeof spaceFromDb.web3SpaceId === 'number'
+                    ? spaceFromDb.web3SpaceId
+                    : undefined
+                }
+                isSandbox={spaceFromDb.flags.includes('sandbox')}
+                isDemo={spaceFromDb.flags.includes('demo')}
+                isArchived={
+                  spaceFromDb.flags.includes('archived') || spaceMembers === 0
+                }
+                configPath={`${getDhoPathAgreements(
+                  lang,
+                  daoSlug,
+                )}/space-configuration`}
+                className="[&_.border-accent-8]:rounded [&_.border-accent-8]:border-white/85 [&_.border-accent-8]:bg-transparent [&_.border-accent-8]:text-white [&_.border-accent-8]:hover:border-white [&_.border-accent-8]:hover:bg-white/10 [&_.border-error-8]:rounded [&_.border-error-8]:border-white/85 [&_.border-error-8]:bg-transparent [&_.border-error-8]:text-white [&_.border-warning-8]:rounded [&_.border-warning-8]:border-amber-200/90 [&_.border-warning-8]:bg-transparent [&_.border-warning-8]:text-white"
+              />
+            </>
+          }
+        />
+        <div className="mt-4 flex justify-end gap-2">
           {typeof spaceFromDb.web3SpaceId === 'number' && (
             <JoinSpace
               web3SpaceId={spaceFromDb.web3SpaceId}
@@ -130,59 +153,6 @@ export default async function DhoLayout({
             />
           )}
           <ActionButtons web3SpaceId={spaceFromDb.web3SpaceId as number} />
-        </div>
-
-        <div className="flex flex-col mt-4 gap-2">
-          <Text className="text-7">{spaceFromDb.title}</Text>
-          <WebLinks links={spaceFromDb.links} />
-        </div>
-        <div className="mt-6">
-          <Text className="text-2">{spaceFromDb.description}</Text>
-        </div>
-        <div className="flex gap-4 items-start mt-6 flex-wrap">
-          <div className="flex flex-col gap-y-2 gap-x-4">
-            <div className="flex flex-row gap-y-2 gap-x-4">
-              <div className="flex">
-                <div className="font-bold text-1">{spaceMembers}</div>
-                <div className="text-gray-500 ml-1 text-1">
-                  {tCommon('Members')}
-                </div>
-              </div>
-              <div className="flex">
-                <div className="font-bold text-1">
-                  {/* @ts-ignore: TODO: infer types from relations */}
-                  {spaceAgreements}
-                </div>
-                <div className="text-gray-500 ml-1 text-1">
-                  {tCommon('Agreements')}
-                </div>
-              </div>
-            </div>
-            <div className="flex">
-              <div className="text-gray-500 text-1">
-                {tCommon('createdOn', {
-                  date: formatDate(spaceFromDb.createdAt, true),
-                })}
-              </div>
-            </div>
-          </div>
-          {canConvertToBigInt(spaceFromDb.web3SpaceId) && (
-            <SubscriptionBadge
-              web3SpaceId={spaceFromDb.web3SpaceId as number}
-            />
-          )}
-          <SpaceModeLabel
-            web3SpaceId={spaceFromDb.web3SpaceId as number}
-            isSandbox={spaceFromDb.flags.includes('sandbox')}
-            isDemo={spaceFromDb.flags.includes('demo')}
-            isArchived={
-              spaceFromDb.flags.includes('archived') || spaceMembers === 0
-            }
-            configPath={`${getDhoPathAgreements(
-              lang,
-              daoSlug,
-            )}/space-configuration`}
-          />
         </div>
         <div className="mt-8 flex flex-col gap-3">
           <SalesBanner web3SpaceId={spaceFromDb.web3SpaceId as number} />

--- a/apps/web/src/app/[lang]/dho/[id]/layout.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/layout.tsx
@@ -116,7 +116,7 @@ export default async function DhoLayout({
       <div className="mx-auto flex max-w-container-2xl">
         <Container className="min-w-0 flex-grow !px-4">
           {/* React 19+: link rel="preload" is hoisted to document head */}
-          {heroBannerImageHref ? (
+          {heroBannerImageHref !== DEFAULT_SPACE_LEAD_IMAGE ? (
             <link
               rel="preload"
               as="image"

--- a/apps/web/src/app/[lang]/dho/[id]/layout.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/layout.tsx
@@ -107,15 +107,18 @@ export default async function DhoLayout({
 
   const rawLead = spaceFromDb.leadImage?.trim();
   const heroBannerImageHref =
-    rawLead && (rawLead.startsWith('/') || /^https?:\/\//i.test(rawLead))
+    rawLead &&
+    ((rawLead.startsWith('/') && !rawLead.startsWith('//')) ||
+      /^https?:\/\//i.test(rawLead))
       ? rawLead
       : DEFAULT_SPACE_LEAD_IMAGE;
 
+  const rawLogo = spaceFromDb.logoUrl?.trim();
   const accentLogoHref =
-    spaceFromDb.logoUrl?.trim() &&
-    (spaceFromDb.logoUrl.startsWith('/') ||
-      /^https?:\/\//i.test(spaceFromDb.logoUrl))
-      ? spaceFromDb.logoUrl.trim()
+    rawLogo &&
+    ((rawLogo.startsWith('/') && !rawLogo.startsWith('//')) ||
+      /^https?:\/\//i.test(rawLogo))
+      ? rawLogo
       : DEFAULT_SPACE_AVATAR_IMAGE;
 
   return (
@@ -151,11 +154,11 @@ export default async function DhoLayout({
               <CompactSpaceBanner
                 title={spaceFromDb.title}
                 description={spaceFromDb.description}
-                logoUrl={spaceFromDb.logoUrl}
+                logoUrl={accentLogoHref}
                 logoAlt={spaceFromDb.title}
                 defaultLogoSrc={DEFAULT_SPACE_AVATAR_IMAGE}
                 links={spaceFromDb.links}
-                leadImageUrl={spaceFromDb.leadImage}
+                leadImageUrl={heroBannerImageHref}
                 defaultLeadImageSrc={DEFAULT_SPACE_LEAD_IMAGE}
                 memberCount={spaceMembers ?? 0}
                 agreementCount={spaceAgreements ?? 0}

--- a/apps/web/src/app/[lang]/dho/[id]/layout.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/layout.tsx
@@ -143,8 +143,8 @@ export default async function DhoLayout({
                   links={spaceFromDb.links}
                   leadImageUrl={heroBannerImageHref}
                   defaultLeadImageSrc={DEFAULT_SPACE_LEAD_IMAGE}
-                  memberCount={spaceMembers ?? 0}
-                  agreementCount={spaceAgreements ?? 0}
+                  memberCount={spaceMembers}
+                  agreementCount={spaceAgreements}
                   createdOnText={tCommon('createdOn', {
                     date: formatDate(spaceFromDb.createdAt, true),
                   })}

--- a/apps/web/src/app/[lang]/dho/[id]/layout.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/layout.tsx
@@ -90,6 +90,12 @@ export default async function DhoLayout({
     return notFound();
   }
 
+  const web3SpaceId =
+    typeof spaceFromDb.web3SpaceId === 'number'
+      ? spaceFromDb.web3SpaceId
+      : undefined;
+  const hasWeb3Id = canConvertToBigInt(spaceFromDb.web3SpaceId);
+
   const { members: spaceMembers, agreements: spaceAgreements } =
     await getSpaceMemberAndAgreementCounts(spaceFromDb.web3SpaceId);
 
@@ -101,11 +107,8 @@ export default async function DhoLayout({
           <div className="flex min-h-8 min-w-0 flex-1 items-center">
             <Breadcrumbs spaceId={spaceFromDb.id} lang={lang} />
           </div>
-          {typeof spaceFromDb.web3SpaceId === 'number' ? (
-            <NestedSpacesButton
-              web3SpaceId={spaceFromDb.web3SpaceId as number}
-              spaceSlug={daoSlug}
-            />
+          {web3SpaceId !== undefined ? (
+            <NestedSpacesButton web3SpaceId={web3SpaceId} spaceSlug={daoSlug} />
           ) : null}
         </div>
         <CompactSpaceBanner
@@ -126,18 +129,14 @@ export default async function DhoLayout({
           agreementsLabel={tCommon('Agreements')}
           footerTrailing={
             <>
-              {canConvertToBigInt(spaceFromDb.web3SpaceId) && (
+              {hasWeb3Id && web3SpaceId !== undefined && (
                 <SubscriptionBadge
-                  web3SpaceId={spaceFromDb.web3SpaceId as number}
+                  web3SpaceId={web3SpaceId}
                   className="rounded-md border-emerald-400/85 bg-transparent text-white hover:border-emerald-300 hover:bg-white/10 [&]:rounded-md [&]:border-emerald-400/85 [&]:text-white"
                 />
               )}
               <SpaceModeLabel
-                web3SpaceId={
-                  typeof spaceFromDb.web3SpaceId === 'number'
-                    ? spaceFromDb.web3SpaceId
-                    : undefined
-                }
+                web3SpaceId={web3SpaceId}
                 isSandbox={spaceFromDb.flags.includes('sandbox')}
                 isDemo={spaceFromDb.flags.includes('demo')}
                 isArchived={
@@ -153,18 +152,15 @@ export default async function DhoLayout({
           }
         />
         <div className="mt-3 flex justify-end gap-2">
-          {typeof spaceFromDb.web3SpaceId === 'number' && (
-            <JoinSpace
-              web3SpaceId={spaceFromDb.web3SpaceId}
-              spaceId={spaceFromDb.id}
-            />
+          {web3SpaceId !== undefined && (
+            <JoinSpace web3SpaceId={web3SpaceId} spaceId={spaceFromDb.id} />
           )}
-          <ActionButtons web3SpaceId={spaceFromDb.web3SpaceId as number} />
+          <ActionButtons web3SpaceId={web3SpaceId} />
         </div>
         <div className="mt-8 flex flex-col gap-3">
-          <SalesBanner web3SpaceId={spaceFromDb.web3SpaceId as number} />
+          <SalesBanner web3SpaceId={web3SpaceId} />
           <SpaceEscrowDepositBanners
-            web3SpaceId={spaceFromDb.web3SpaceId as number}
+            web3SpaceId={web3SpaceId}
             spaceDbId={spaceFromDb.id}
             spaceSlug={daoSlug}
             lang={lang}

--- a/apps/web/src/app/[lang]/dho/[id]/layout.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/layout.tsx
@@ -94,7 +94,6 @@ export default async function DhoLayout({
     typeof spaceFromDb.web3SpaceId === 'number'
       ? spaceFromDb.web3SpaceId
       : undefined;
-  const hasWeb3Id = canConvertToBigInt(spaceFromDb.web3SpaceId);
 
   const { members: spaceMembers, agreements: spaceAgreements } =
     await getSpaceMemberAndAgreementCounts(spaceFromDb.web3SpaceId);
@@ -153,7 +152,7 @@ export default async function DhoLayout({
                   agreementsLabel={tCommon('Agreements')}
                   footerTrailing={
                     <>
-                      {hasWeb3Id && web3SpaceId !== undefined && (
+                      {web3SpaceId !== undefined && (
                         <SubscriptionBadge
                           web3SpaceId={web3SpaceId}
                           className="rounded-md !border-accent-8 bg-transparent text-white hover:!border-accent-9 hover:bg-white/10"

--- a/apps/web/src/app/[lang]/dho/[id]/layout.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/layout.tsx
@@ -1,7 +1,6 @@
 import {
   JoinSpace,
   SalesBanner,
-  SpaceCard,
   SpaceEscrowDepositBanners,
   SpaceModeLabel,
   SubscriptionBadge,
@@ -11,11 +10,8 @@ import {
 } from '@hypha-platform/epics';
 import './space-accent.css';
 import { Locale } from '@hypha-platform/i18n';
-import { Container, Separator } from '@hypha-platform/ui';
-import { Text } from '@radix-ui/themes';
-import { Carousel, CarouselContent, CarouselItem } from '@hypha-platform/ui';
-import Link from 'next/link';
-import { getAllSpaces, findSpaceBySlug } from '@hypha-platform/core/server';
+import { Container } from '@hypha-platform/ui';
+import { findSpaceBySlug } from '@hypha-platform/core/server';
 import { getDhoPathAgreements } from './@tab/agreements/constants';
 import { ActionButtons } from './_components/action-buttons';
 import { NestedSpacesButton } from './_components/nested-spaces-button';
@@ -24,7 +20,6 @@ import {
   DEFAULT_SPACE_LEAD_IMAGE,
   fetchSpaceDetails,
   fetchSpaceProposalsIds,
-  isSpaceArchived,
 } from '@hypha-platform/core/client';
 import { notFound } from 'next/navigation';
 import { db } from '@hypha-platform/storage-postgres';
@@ -88,7 +83,6 @@ export default async function DhoLayout({
 }) {
   const { id: daoSlug, lang } = await params;
   const tCommon = await getTranslations('Common');
-  const tSpaces = await getTranslations('Spaces');
 
   const spaceFromDb = await findSpaceBySlug({ slug: daoSlug }, { db });
   if (!spaceFromDb) {
@@ -103,8 +97,6 @@ export default async function DhoLayout({
 
   const { members: spaceMembers, agreements: spaceAgreements } =
     await getSpaceMemberAndAgreementCounts(spaceFromDb.web3SpaceId);
-
-  const spaces = await getAllSpaces({ parentOnly: false, omitSandbox: true });
 
   const rawLead = spaceFromDb.leadImage?.trim();
   const heroBannerImageHref =
@@ -228,49 +220,6 @@ export default async function DhoLayout({
             {tab}
             {children}
           </SpaceAccentFromImages>
-          <div className="space-y-9">
-            <Separator />
-            <div className="border-primary-foreground">
-              <Text className="text-4 font-medium pb-4 pt-4">
-                {tSpaces('spacesYouMightLike')}
-              </Text>
-              <Carousel className="my-6 mt-6">
-                <CarouselContent className="pb-5" showScrollbar>
-                  {spaces.map((space) => (
-                    <CarouselItem
-                      key={space.id}
-                      className="w-full sm:w-[454px] max-w-[454px] flex-shrink-0"
-                    >
-                      <Link
-                        className="flex flex-col flex-1"
-                        href={getDhoPathAgreements(lang, space.slug as string)}
-                      >
-                        <SpaceCard
-                          description={space.description as string}
-                          icon={space.logoUrl || ''}
-                          leadImage={
-                            space.leadImage || DEFAULT_SPACE_LEAD_IMAGE
-                          }
-                          members={space.memberCount}
-                          agreements={space.documentCount}
-                          title={space.title as string}
-                          isSandbox={space.flags?.includes('sandbox') ?? false}
-                          isDemo={space.flags?.includes('demo') ?? false}
-                          isArchived={isSpaceArchived(space)}
-                          web3SpaceId={space.web3SpaceId as number}
-                          configPath={`${getDhoPathAgreements(
-                            lang,
-                            space.slug,
-                          )}/space-configuration`}
-                          createdAt={space.createdAt}
-                        />
-                      </Link>
-                    </CarouselItem>
-                  ))}
-                </CarouselContent>
-              </Carousel>
-            </div>
-          </div>
         </Container>
         {aside}
       </div>

--- a/apps/web/src/app/[lang]/dho/[id]/layout.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/layout.tsx
@@ -118,8 +118,8 @@ export default async function DhoLayout({
             fetchPriority="high"
           />
         ) : null}
-        {/* Single column + gap-3: identical rhythm above banner, below banner, above actions */}
-        <div className="flex flex-col gap-3">
+        {/* Single column + gap-2: tight rhythm under chrome; matches banner ↔ actions */}
+        <div className="flex flex-col gap-2">
           <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-2 md:gap-x-4">
             <div className="flex min-w-0 flex-1 items-center">
               <Breadcrumbs spaceId={spaceFromDb.id} lang={lang} />

--- a/apps/web/src/app/[lang]/dho/[id]/layout.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/layout.tsx
@@ -122,6 +122,7 @@ export default async function DhoLayout({
     <SpaceAccentPortalBridge>
       <div className="mx-auto flex max-w-container-2xl">
         <Container className="min-w-0 flex-grow !px-4">
+          {/* React 19+: link rel="preload" is hoisted to document head */}
           {heroBannerImageHref ? (
             <link
               rel="preload"

--- a/apps/web/src/app/[lang]/dho/[id]/layout.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/layout.tsx
@@ -100,9 +100,24 @@ export default async function DhoLayout({
     await getSpaceMemberAndAgreementCounts(spaceFromDb.web3SpaceId);
 
   const spaces = await getAllSpaces({ parentOnly: false, omitSandbox: true });
+
+  const rawLead = spaceFromDb.leadImage?.trim();
+  const heroBannerImageHref =
+    rawLead && (rawLead.startsWith('/') || /^https?:\/\//i.test(rawLead))
+      ? rawLead
+      : DEFAULT_SPACE_LEAD_IMAGE;
+
   return (
     <div className="mx-auto flex max-w-container-2xl">
       <Container className="min-w-0 flex-grow !px-4">
+        {heroBannerImageHref ? (
+          <link
+            rel="preload"
+            as="image"
+            href={heroBannerImageHref}
+            fetchPriority="high"
+          />
+        ) : null}
         <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-2 md:gap-x-4">
           <div className="flex min-h-8 min-w-0 flex-1 items-center">
             <Breadcrumbs spaceId={spaceFromDb.id} lang={lang} />

--- a/apps/web/src/app/[lang]/dho/[id]/layout.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/layout.tsx
@@ -140,7 +140,7 @@ export default async function DhoLayout({
           >
             {/* gap-4 (16px) matches mt-4 above SalesBanner: breadcrumb→banner and banner→actions */}
             <div className="flex flex-col gap-4">
-              <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-2 py-2 md:gap-x-4">
+              <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-2 md:gap-x-4">
                 <div className="flex min-w-0 flex-1 items-center">
                   <Breadcrumbs spaceId={spaceFromDb.id} lang={lang} />
                 </div>

--- a/apps/web/src/app/[lang]/dho/[id]/layout.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/layout.tsx
@@ -131,8 +131,8 @@ export default async function DhoLayout({
           bannerSrc={heroBannerImageHref}
           logoSrc={accentLogoHref}
         >
-          {/* Single column + gap-2: tight rhythm under chrome; matches banner ↔ actions */}
-          <div className="flex flex-col gap-2">
+          {/* gap-4 (16px) matches mt-4 above SalesBanner: breadcrumb→banner and banner→actions */}
+          <div className="flex flex-col gap-4">
             <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-2 md:gap-x-4">
               <div className="flex min-w-0 flex-1 items-center">
                 <Breadcrumbs spaceId={spaceFromDb.id} lang={lang} />

--- a/apps/web/src/app/[lang]/dho/[id]/layout.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/layout.tsx
@@ -7,6 +7,7 @@ import {
   SubscriptionBadge,
   CompactSpaceBanner,
   SpaceAccentFromImages,
+  SpaceAccentPortalBridge,
 } from '@hypha-platform/epics';
 import './space-accent.css';
 import { Locale } from '@hypha-platform/i18n';
@@ -119,91 +120,97 @@ export default async function DhoLayout({
   return (
     <div className="mx-auto flex max-w-container-2xl">
       <Container className="min-w-0 flex-grow !px-4">
-        {heroBannerImageHref ? (
-          <link
-            rel="preload"
-            as="image"
-            href={heroBannerImageHref}
-            fetchPriority="high"
-          />
-        ) : null}
-        <SpaceAccentFromImages
-          bannerSrc={heroBannerImageHref}
-          logoSrc={accentLogoHref}
-        >
-          {/* gap-4 (16px) matches mt-4 above SalesBanner: breadcrumb→banner and banner→actions */}
-          <div className="flex flex-col gap-4">
-            <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-2 md:gap-x-4">
-              <div className="flex min-w-0 flex-1 items-center">
-                <Breadcrumbs spaceId={spaceFromDb.id} lang={lang} />
-              </div>
-              {web3SpaceId !== undefined ? (
-                <NestedSpacesButton
-                  web3SpaceId={web3SpaceId}
-                  spaceSlug={daoSlug}
-                />
-              ) : null}
-            </div>
-            <CompactSpaceBanner
-              title={spaceFromDb.title}
-              description={spaceFromDb.description}
-              logoUrl={spaceFromDb.logoUrl}
-              logoAlt={spaceFromDb.title}
-              defaultLogoSrc={DEFAULT_SPACE_AVATAR_IMAGE}
-              links={spaceFromDb.links}
-              leadImageUrl={spaceFromDb.leadImage}
-              defaultLeadImageSrc={DEFAULT_SPACE_LEAD_IMAGE}
-              memberCount={spaceMembers}
-              agreementCount={spaceAgreements}
-              createdOnText={tCommon('createdOn', {
-                date: formatDate(spaceFromDb.createdAt, true),
-              })}
-              membersLabel={tCommon('Members')}
-              agreementsLabel={tCommon('Agreements')}
-              footerTrailing={
-                <>
-                  {hasWeb3Id && web3SpaceId !== undefined && (
-                    <SubscriptionBadge
-                      web3SpaceId={web3SpaceId}
-                      className="rounded-md border-emerald-400/85 bg-transparent text-white hover:border-emerald-300 hover:bg-white/10 [&]:rounded-md [&]:border-emerald-400/85 [&]:text-white"
-                    />
-                  )}
-                  <SpaceModeLabel
+        <SpaceAccentPortalBridge>
+          {heroBannerImageHref ? (
+            <link
+              rel="preload"
+              as="image"
+              href={heroBannerImageHref}
+              fetchPriority="high"
+            />
+          ) : null}
+          <SpaceAccentFromImages
+            bannerSrc={heroBannerImageHref}
+            logoSrc={accentLogoHref}
+          >
+            {/* gap-4 (16px) matches mt-4 above SalesBanner: breadcrumb→banner and banner→actions */}
+            <div className="flex flex-col gap-4">
+              <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-2 md:gap-x-4">
+                <div className="flex min-w-0 flex-1 items-center">
+                  <Breadcrumbs spaceId={spaceFromDb.id} lang={lang} />
+                </div>
+                {web3SpaceId !== undefined ? (
+                  <NestedSpacesButton
                     web3SpaceId={web3SpaceId}
-                    isSandbox={spaceFromDb.flags.includes('sandbox')}
-                    isDemo={spaceFromDb.flags.includes('demo')}
-                    isArchived={
-                      spaceFromDb.flags.includes('archived') ||
-                      spaceMembers === 0
-                    }
-                    configPath={`${getDhoPathAgreements(
-                      lang,
-                      daoSlug,
-                    )}/space-configuration`}
-                    className="[&_.border-accent-8]:rounded-md [&_.border-accent-8]:border-white/85 [&_.border-accent-8]:bg-transparent [&_.border-accent-8]:text-white [&_.border-accent-8]:hover:border-white [&_.border-accent-8]:hover:bg-white/10 [&_.border-error-8]:rounded-md [&_.border-error-8]:border-white/85 [&_.border-error-8]:bg-transparent [&_.border-error-8]:text-white [&_.border-warning-8]:rounded-md [&_.border-warning-8]:border-amber-200/90 [&_.border-warning-8]:bg-transparent [&_.border-warning-8]:text-white"
+                    spaceSlug={daoSlug}
                   />
-                </>
-              }
-            />
-            <div className="flex justify-end gap-2">
-              {web3SpaceId !== undefined && (
-                <JoinSpace web3SpaceId={web3SpaceId} spaceId={spaceFromDb.id} />
-              )}
-              <ActionButtons web3SpaceId={web3SpaceId} />
+                ) : null}
+              </div>
+              <CompactSpaceBanner
+                title={spaceFromDb.title}
+                description={spaceFromDb.description}
+                logoUrl={spaceFromDb.logoUrl}
+                logoAlt={spaceFromDb.title}
+                defaultLogoSrc={DEFAULT_SPACE_AVATAR_IMAGE}
+                links={spaceFromDb.links}
+                leadImageUrl={spaceFromDb.leadImage}
+                defaultLeadImageSrc={DEFAULT_SPACE_LEAD_IMAGE}
+                memberCount={spaceMembers}
+                agreementCount={spaceAgreements}
+                createdOnText={tCommon('createdOn', {
+                  date: formatDate(spaceFromDb.createdAt, true),
+                })}
+                membersLabel={tCommon('Members')}
+                agreementsLabel={tCommon('Agreements')}
+                footerTrailing={
+                  <>
+                    {hasWeb3Id && web3SpaceId !== undefined && (
+                      <SubscriptionBadge
+                        web3SpaceId={web3SpaceId}
+                        className="rounded-md border-emerald-400/85 bg-transparent text-white hover:border-emerald-300 hover:bg-white/10 [&]:rounded-md [&]:border-emerald-400/85 [&]:text-white"
+                      />
+                    )}
+                    <SpaceModeLabel
+                      web3SpaceId={web3SpaceId}
+                      isSandbox={spaceFromDb.flags.includes('sandbox')}
+                      isDemo={spaceFromDb.flags.includes('demo')}
+                      isArchived={
+                        spaceFromDb.flags.includes('archived') ||
+                        spaceMembers === 0
+                      }
+                      configPath={`${getDhoPathAgreements(
+                        lang,
+                        daoSlug,
+                      )}/space-configuration`}
+                      className="[&_.border-accent-8]:rounded-md [&_.border-accent-8]:border-white/85 [&_.border-accent-8]:bg-transparent [&_.border-accent-8]:text-white [&_.border-accent-8]:hover:border-white [&_.border-accent-8]:hover:bg-white/10 [&_.border-error-8]:rounded-md [&_.border-error-8]:border-white/85 [&_.border-error-8]:bg-transparent [&_.border-error-8]:text-white [&_.border-warning-8]:rounded-md [&_.border-warning-8]:border-amber-200/90 [&_.border-warning-8]:bg-transparent [&_.border-warning-8]:text-white"
+                    />
+                  </>
+                }
+              />
+              <div className="flex justify-end gap-2">
+                {web3SpaceId !== undefined && (
+                  <JoinSpace
+                    web3SpaceId={web3SpaceId}
+                    spaceId={spaceFromDb.id}
+                  />
+                )}
+                <ActionButtons web3SpaceId={web3SpaceId} />
+              </div>
             </div>
-          </div>
-          <div className="mt-4 flex flex-col gap-3">
-            <SalesBanner web3SpaceId={web3SpaceId} />
-            <SpaceEscrowDepositBanners
-              web3SpaceId={web3SpaceId}
-              spaceDbId={spaceFromDb.id}
-              spaceSlug={daoSlug}
-              lang={lang}
-            />
-          </div>
-          {tab}
-          {children}
-        </SpaceAccentFromImages>
+            <div className="mt-4 flex flex-col gap-3">
+              <SalesBanner web3SpaceId={web3SpaceId} />
+              <SpaceEscrowDepositBanners
+                web3SpaceId={web3SpaceId}
+                spaceDbId={spaceFromDb.id}
+                spaceSlug={daoSlug}
+                lang={lang}
+              />
+            </div>
+            {tab}
+            {children}
+            {aside}
+          </SpaceAccentFromImages>
+        </SpaceAccentPortalBridge>
         <div className="space-y-9">
           <Separator />
           <div className="border-primary-foreground">
@@ -246,7 +253,6 @@ export default async function DhoLayout({
           </div>
         </div>
       </Container>
-      {aside}
     </div>
   );
 }

--- a/apps/web/src/app/[lang]/dho/[id]/layout.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/layout.tsx
@@ -7,6 +7,7 @@ import {
   CompactSpaceBanner,
   SpaceAccentFromImages,
   SpaceAccentPortalBridge,
+  isSafeImageUrl,
 } from '@hypha-platform/epics';
 import './space-accent.css';
 import { Locale } from '@hypha-platform/i18n';
@@ -100,19 +101,11 @@ export default async function DhoLayout({
 
   const rawLead = spaceFromDb.leadImage?.trim();
   const heroBannerImageHref =
-    rawLead &&
-    ((rawLead.startsWith('/') && !rawLead.startsWith('//')) ||
-      /^https?:\/\//i.test(rawLead))
-      ? rawLead
-      : DEFAULT_SPACE_LEAD_IMAGE;
+    rawLead && isSafeImageUrl(rawLead) ? rawLead : DEFAULT_SPACE_LEAD_IMAGE;
 
   const rawLogo = spaceFromDb.logoUrl?.trim();
   const accentLogoHref =
-    rawLogo &&
-    ((rawLogo.startsWith('/') && !rawLogo.startsWith('//')) ||
-      /^https?:\/\//i.test(rawLogo))
-      ? rawLogo
-      : DEFAULT_SPACE_AVATAR_IMAGE;
+    rawLogo && isSafeImageUrl(rawLogo) ? rawLogo : DEFAULT_SPACE_AVATAR_IMAGE;
 
   const compactBannerSpaceArchived =
     spaceFromDb.flags.includes('archived') ||

--- a/apps/web/src/app/[lang]/dho/[id]/layout.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/layout.tsx
@@ -134,8 +134,9 @@ export default async function DhoLayout({
           <SpaceAccentFromImages
             bannerSrc={heroBannerImageHref}
             logoSrc={accentLogoHref}
+            className="pt-1 md:pt-1.5"
           >
-            {/* gap-4 (16px) matches mt-4 above SalesBanner: breadcrumb→banner and banner→actions */}
+            {/* gap-4 (16px) matches mt-4 above SalesBanner; slight pt above breadcrumbs vs MenuTop */}
             <DhoStickySpaceChrome
               breadcrumbsRow={
                 <Breadcrumbs spaceId={spaceFromDb.id} lang={lang} />

--- a/apps/web/src/app/[lang]/dho/[id]/space-accent.css
+++ b/apps/web/src/app/[lang]/dho/[id]/space-accent.css
@@ -8,11 +8,11 @@
 
 [data-space-accent-scope] .tabs-root [data-state='active'] {
   border-bottom-color: var(--space-tab-active-border) !important;
-  color: var(--color-accent-11, var(--space-accent, #4a65d8)) !important;
+  color: var(--color-accent-11, #4a65d8) !important;
 }
 
 [data-space-accent-scope] [data-space-nav] {
-  color: var(--color-accent-11, var(--space-accent, #4a65d8));
+  color: var(--color-accent-11, #4a65d8);
 }
 
 [data-space-accent-scope] [data-space-nav]:hover {

--- a/apps/web/src/app/[lang]/dho/[id]/space-accent.css
+++ b/apps/web/src/app/[lang]/dho/[id]/space-accent.css
@@ -1,0 +1,19 @@
+/**
+ * Space-scoped accent from imagery (--space-* set by SpaceAccentFromImages).
+ * Keeps global theme intact; only descendants of [data-space-accent-scope] use these hooks.
+ */
+[data-space-accent-scope] {
+  --space-tab-active-border: var(--space-accent, #3b82f6);
+}
+
+[data-space-accent-scope] .tabs-root [data-state='active'] {
+  border-bottom-color: var(--space-tab-active-border) !important;
+}
+
+[data-space-accent-scope] [data-space-nav] {
+  color: var(--space-accent, var(--color-accent-11, #4a65d8));
+}
+
+[data-space-accent-scope] [data-space-nav]:hover {
+  opacity: 0.92;
+}

--- a/apps/web/src/app/[lang]/dho/[id]/space-accent.css
+++ b/apps/web/src/app/[lang]/dho/[id]/space-accent.css
@@ -8,10 +8,11 @@
 
 [data-space-accent-scope] .tabs-root [data-state='active'] {
   border-bottom-color: var(--space-tab-active-border) !important;
+  color: var(--color-accent-11, var(--space-accent, #4a65d8)) !important;
 }
 
 [data-space-accent-scope] [data-space-nav] {
-  color: var(--space-accent, var(--color-accent-11, #4a65d8));
+  color: var(--color-accent-11, var(--space-accent, #4a65d8));
 }
 
 [data-space-accent-scope] [data-space-nav]:hover {

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -187,7 +187,7 @@ export default async function RootLayout({
                           routerConfig={extractRouterConfig(fileRouter)}
                         />
                         <div className="mb-auto pb-8">
-                          <div className="pt-9 h-full flex justify-normal">
+                          <div className="pt-6 h-full flex justify-normal md:pt-7">
                             <div className="w-full h-full">{children}</div>
                           </div>
                         </div>

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -120,8 +120,9 @@ export default async function RootLayout({
       >
         <ThemeProvider
           attribute="class"
-          defaultTheme="system"
-          enableSystem
+          defaultTheme="dark"
+          enableSystem={false}
+          storageKey="theme"
           disableTransitionOnChange
         >
           <EvmProvider>

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -38,6 +38,7 @@ import { ConnectedLanguageSelect } from '@web/components/connected-language-sele
 import { getShowLanguageSelect } from '@hypha-platform/feature-flags';
 import ScrollUp from '@web/components/scroll-up';
 import SeamlessScrollPolyfill from '@web/components/seamless-scroll-polyfill';
+import { ThemeStorageNormalize } from '@web/components/theme-storage-normalize';
 import '@web/utils/initialize-proxy';
 
 const lato = Lato({
@@ -125,6 +126,7 @@ export default async function RootLayout({
           storageKey="theme"
           disableTransitionOnChange
         >
+          <ThemeStorageNormalize />
           <EvmProvider>
             <NextIntlClientProvider messages={messages}>
               <TooltipProvider>

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -187,7 +187,7 @@ export default async function RootLayout({
                           routerConfig={extractRouterConfig(fileRouter)}
                         />
                         <div className="mb-auto pb-8">
-                          <div className="pt-6 h-full flex justify-normal md:pt-7">
+                          <div className="flex h-full justify-normal pt-4 md:pt-5">
                             <div className="w-full h-full">{children}</div>
                           </div>
                         </div>

--- a/apps/web/src/components/theme-storage-normalize.tsx
+++ b/apps/web/src/components/theme-storage-normalize.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import * as React from 'react';
+import { useTheme } from 'next-themes';
+
+/**
+ * When `enableSystem` is false, a previously stored `theme=system` from localStorage
+ * would leave next-themes in an inconsistent state. Normalize to `dark` on the client.
+ */
+export function ThemeStorageNormalize() {
+  const { theme, setTheme } = useTheme();
+
+  React.useEffect(() => {
+    if (theme === 'system') {
+      setTheme('dark');
+    }
+  }, [theme, setTheme]);
+
+  return null;
+}

--- a/packages/epics/package.json
+++ b/packages/epics/package.json
@@ -9,7 +9,8 @@
   },
   "devDependencies": {
     "@hypha-platform/config-eslint": "workspace:*",
-    "@hypha-platform/config-typescript": "workspace:*"
+    "@hypha-platform/config-typescript": "workspace:*",
+    "next": "^15.1.6"
   },
   "dependencies": {
     "@ai-sdk/react": "^3.0.107",

--- a/packages/epics/src/coherence/components/create-signal-form.tsx
+++ b/packages/epics/src/coherence/components/create-signal-form.tsx
@@ -11,12 +11,12 @@ import {
   FormLabel,
   FormMessage,
   Input,
-  LoadingBackdrop,
   LucideReactIcon,
   MultiSelect,
   RequirementMark,
   RichTextEditor,
 } from '@hypha-platform/ui';
+import { SpaceLoadingBackdrop } from '../../spaces/components/space-loading-backdrop';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import {
@@ -220,7 +220,7 @@ export const CreateSignalForm = ({
   };
 
   return (
-    <LoadingBackdrop
+    <SpaceLoadingBackdrop
       showKeepWindowOpenMessage={true}
       progress={progress}
       isLoading={isCreatingCoherence}
@@ -403,6 +403,6 @@ export const CreateSignalForm = ({
           </div>
         </form>
       </Form>
-    </LoadingBackdrop>
+    </SpaceLoadingBackdrop>
   );
 };

--- a/packages/epics/src/common/proposal-overlay-shell.tsx
+++ b/packages/epics/src/common/proposal-overlay-shell.tsx
@@ -6,6 +6,7 @@ import * as DialogPrimitive from '@radix-ui/react-dialog';
 import { AsideOverlayLayoutProvider } from '@hypha-platform/ui';
 import { cn } from '@hypha-platform/ui-utils';
 import { useTranslations } from 'next-intl';
+import { useSpaceAccentPortalStyles } from '../spaces/components/space-accent-portal-context';
 
 /**
  * Reference-counted body scroll lock for desktop modal stacks.
@@ -70,6 +71,7 @@ export function ProposalOverlayShell({
   className,
 }: ProposalOverlayShellProps) {
   const tModalAside = useTranslations('ModalAside');
+  const spaceAccentPortalStyle = useSpaceAccentPortalStyles();
 
   useEffect(() => {
     const mq = window.matchMedia('(min-width: 768px)');
@@ -132,6 +134,8 @@ export function ProposalOverlayShell({
               id="proposal-overlay-panel"
               role="document"
               tabIndex={-1}
+              style={spaceAccentPortalStyle}
+              data-space-accent-scope
             >
               <div className="p-4 lg:p-7">{children}</div>
             </div>

--- a/packages/epics/src/common/select-action.tsx
+++ b/packages/epics/src/common/select-action.tsx
@@ -120,9 +120,10 @@ export const SelectAction = ({
                 >
                   <div
                     className={clsx(
-                      'flex size-11 shrink-0 items-center justify-center rounded-xl border border-border/70 bg-muted/40 text-accent-11 transition-colors duration-200',
+                      'flex size-11 shrink-0 items-center justify-center rounded-xl border border-border/70 bg-muted/40 text-accent-11 transition-colors duration-200 [&_svg]:shrink-0',
                       !action.disabled &&
-                        'group-hover:border-accent-8/50 group-hover:bg-accent-3/50',
+                        /* Lucide uses currentColor — accent on accent wash was illegible */
+                        'group-hover:border-accent-8/50 group-hover:bg-accent-3/50 group-hover:text-foreground group-focus-within:text-foreground',
                     )}
                     aria-hidden
                   >

--- a/packages/epics/src/common/select-action.tsx
+++ b/packages/epics/src/common/select-action.tsx
@@ -105,9 +105,9 @@ export const SelectAction = ({
               const card = (
                 <Card
                   className={clsx(
-                    'group flex cursor-pointer items-start gap-4 border-border/80 p-5 shadow-sm transition-[border-color,box-shadow,background-color] duration-200 ease-out md:p-6',
+                    'group flex cursor-pointer items-start gap-4 border-border/80 p-5 shadow-sm ring-2 ring-transparent transition-[border-color,box-shadow,ring-color] duration-200 ease-out md:p-6',
                     !action.disabled &&
-                      'hover:border-accent-8/60 hover:bg-accent-2/40 hover:shadow-md',
+                      'hover:border-accent-9 hover:shadow-md hover:ring-accent-10/45',
                     !action.disabled &&
                       'focus-within:border-accent-9 focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 focus-within:ring-offset-background-2',
                     {
@@ -120,10 +120,10 @@ export const SelectAction = ({
                 >
                   <div
                     className={clsx(
-                      'flex size-11 shrink-0 items-center justify-center rounded-xl border border-border/70 bg-muted/40 text-accent-11 transition-colors duration-200 [&_svg]:shrink-0',
+                      'flex size-11 shrink-0 items-center justify-center rounded-xl border border-border/70 bg-muted/40 text-accent-11 ring-2 ring-transparent transition-[border-color,box-shadow,ring-color,color] duration-200 [&_svg]:shrink-0',
                       !action.disabled &&
-                        /* Lucide uses currentColor — accent on accent wash was illegible */
-                        'group-hover:border-accent-8/50 group-hover:bg-accent-3/50 group-hover:text-foreground group-focus-within:text-foreground',
+                        /* Outline-style hover: ring + border — no solid fill */
+                        'group-hover:border-accent-9 group-hover:text-foreground group-hover:ring-accent-10/50 group-focus-within:text-foreground',
                     )}
                     aria-hidden
                   >

--- a/packages/epics/src/common/select-action.tsx
+++ b/packages/epics/src/common/select-action.tsx
@@ -105,7 +105,7 @@ export const SelectAction = ({
               const card = (
                 <Card
                   className={clsx(
-                    'group flex cursor-pointer items-start gap-4 border-border/80 p-5 shadow-sm ring-2 ring-transparent transition-[border-color,box-shadow,ring-color] duration-200 ease-out md:p-6',
+                    'group flex cursor-pointer items-start gap-4 border-border/80 p-5 shadow-sm ring-2 ring-transparent transition-[border-color,box-shadow,--tw-ring-color] duration-200 ease-out md:p-6',
                     !action.disabled &&
                       'hover:border-accent-9 hover:shadow-md hover:ring-accent-10/45',
                     !action.disabled &&
@@ -120,7 +120,7 @@ export const SelectAction = ({
                 >
                   <div
                     className={clsx(
-                      'flex size-11 shrink-0 items-center justify-center rounded-xl border border-border/70 bg-muted/40 text-accent-11 ring-2 ring-transparent transition-[border-color,box-shadow,ring-color,color] duration-200 [&_svg]:shrink-0',
+                      'flex size-11 shrink-0 items-center justify-center rounded-xl border border-border/70 bg-muted/40 text-accent-11 ring-2 ring-transparent transition-[border-color,box-shadow,--tw-ring-color,color] duration-200 [&_svg]:shrink-0',
                       !action.disabled &&
                         /* Outline-style hover: ring + border — no solid fill */
                         'group-hover:border-accent-9 group-hover:text-foreground group-hover:ring-accent-10/50 group-focus-within:text-foreground',

--- a/packages/epics/src/governance/components/activate-spaces-form-space.tsx
+++ b/packages/epics/src/governance/components/activate-spaces-form-space.tsx
@@ -11,7 +11,8 @@ import {
   useSpaceDetailsWeb3Rpc,
 } from '@hypha-platform/core/client';
 import { z } from 'zod';
-import { LoadingBackdrop, Form, Separator, Button } from '@hypha-platform/ui';
+import { Form, Separator, Button } from '@hypha-platform/ui';
+import { SpaceLoadingBackdrop } from '../../spaces/components/space-loading-backdrop';
 import { CreateAgreementBaseFields } from '../../agreements';
 import { useConfig } from 'wagmi';
 import { useParams } from 'next/navigation';
@@ -163,7 +164,7 @@ export const ActivateSpacesFormSpace = ({
   };
 
   return (
-    <LoadingBackdrop
+    <SpaceLoadingBackdrop
       showKeepWindowOpenMessage={true}
       keepWindowOpenMessage={tAgreementFlow('loadingBackdrop.keepWindowOpen')}
       fullHeight={true}
@@ -253,6 +254,6 @@ export const ActivateSpacesFormSpace = ({
           </div>
         </form>
       </Form>
-    </LoadingBackdrop>
+    </SpaceLoadingBackdrop>
   );
 };

--- a/packages/epics/src/governance/components/buy-hypha-tokens-form.tsx
+++ b/packages/epics/src/governance/components/buy-hypha-tokens-form.tsx
@@ -11,7 +11,8 @@ import {
   useSpaceDetailsWeb3Rpc,
 } from '@hypha-platform/core/client';
 import { z } from 'zod';
-import { LoadingBackdrop, Form, Separator, Button } from '@hypha-platform/ui';
+import { Form, Separator, Button } from '@hypha-platform/ui';
+import { SpaceLoadingBackdrop } from '../../spaces/components/space-loading-backdrop';
 import { CreateAgreementBaseFields } from '../../agreements';
 import { useConfig } from 'wagmi';
 import { useAssets, useFundWallet } from '../../treasury';
@@ -137,7 +138,7 @@ export const BuyHyphaTokensForm = ({
   };
 
   return (
-    <LoadingBackdrop
+    <SpaceLoadingBackdrop
       showKeepWindowOpenMessage={true}
       keepWindowOpenMessage={tAgreementFlow('loadingBackdrop.keepWindowOpen')}
       fullHeight={true}
@@ -220,6 +221,6 @@ export const BuyHyphaTokensForm = ({
           </div>
         </form>
       </Form>
-    </LoadingBackdrop>
+    </SpaceLoadingBackdrop>
   );
 };

--- a/packages/epics/src/governance/components/create-accept-investment-form.tsx
+++ b/packages/epics/src/governance/components/create-accept-investment-form.tsx
@@ -10,7 +10,7 @@ import {
 import { z } from 'zod';
 import { Button, Form, Separator } from '@hypha-platform/ui';
 import { useCreateAcceptInvestmentOrchestrator } from '@hypha-platform/core/client';
-import { LoadingBackdrop } from '@hypha-platform/ui/server';
+import { SpaceLoadingBackdrop } from '../../spaces/components/space-loading-backdrop';
 import { useConfig } from 'wagmi';
 import { useScrollToErrors, useResubmitProposalData } from '../../hooks';
 import { CreateAgreementBaseFields } from '../../agreements';
@@ -111,7 +111,7 @@ export const CreateAcceptInvestmentForm = ({
   };
 
   return (
-    <LoadingBackdrop
+    <SpaceLoadingBackdrop
       showKeepWindowOpenMessage={true}
       keepWindowOpenMessage={tAgreementFlow('loadingBackdrop.keepWindowOpen')}
       fullHeight={true}
@@ -160,6 +160,6 @@ export const CreateAcceptInvestmentForm = ({
           </div>
         </form>
       </Form>
-    </LoadingBackdrop>
+    </SpaceLoadingBackdrop>
   );
 };

--- a/packages/epics/src/governance/components/create-agreement-form.tsx
+++ b/packages/epics/src/governance/components/create-agreement-form.tsx
@@ -11,7 +11,7 @@ import {
 import { z } from 'zod';
 import { Button, Form } from '@hypha-platform/ui';
 import React from 'react';
-import { LoadingBackdrop } from '@hypha-platform/ui/server';
+import { SpaceLoadingBackdrop } from '../../spaces/components/space-loading-backdrop';
 import { useConfig } from 'wagmi';
 import {
   useClearResubmitOnSuccess,
@@ -107,7 +107,7 @@ export const CreateAgreementForm = ({
   };
 
   return (
-    <LoadingBackdrop
+    <SpaceLoadingBackdrop
       showKeepWindowOpenMessage={true}
       keepWindowOpenMessage={tAgreementFlow('loadingBackdrop.keepWindowOpen')}
       progress={progress}
@@ -150,6 +150,6 @@ export const CreateAgreementForm = ({
           </div>
         </form>
       </Form>
-    </LoadingBackdrop>
+    </SpaceLoadingBackdrop>
   );
 };

--- a/packages/epics/src/governance/components/create-deploy-funds-form.tsx
+++ b/packages/epics/src/governance/components/create-deploy-funds-form.tsx
@@ -11,7 +11,7 @@ import {
 import { z } from 'zod';
 import { Button, Form, Separator } from '@hypha-platform/ui';
 import React from 'react';
-import { LoadingBackdrop } from '@hypha-platform/ui/server';
+import { SpaceLoadingBackdrop } from '../../spaces/components/space-loading-backdrop';
 import { useConfig } from 'wagmi';
 import {
   useClearResubmitOnSuccess,
@@ -123,7 +123,7 @@ export const CreateDeployFundsForm = ({
   };
 
   return (
-    <LoadingBackdrop
+    <SpaceLoadingBackdrop
       showKeepWindowOpenMessage={true}
       keepWindowOpenMessage={tAgreementFlow('loadingBackdrop.keepWindowOpen')}
       fullHeight={true}
@@ -167,6 +167,6 @@ export const CreateDeployFundsForm = ({
           </div>
         </form>
       </Form>
-    </LoadingBackdrop>
+    </SpaceLoadingBackdrop>
   );
 };

--- a/packages/epics/src/governance/components/create-exchange-stakes-and-tokens-form.tsx
+++ b/packages/epics/src/governance/components/create-exchange-stakes-and-tokens-form.tsx
@@ -10,7 +10,7 @@ import {
 import { z } from 'zod';
 import { Button, Form, Separator } from '@hypha-platform/ui';
 import React from 'react';
-import { LoadingBackdrop } from '@hypha-platform/ui/server';
+import { SpaceLoadingBackdrop } from '../../spaces/components/space-loading-backdrop';
 import { useConfig } from 'wagmi';
 import { useScrollToErrors, useResubmitProposalData } from '../../hooks';
 import { CreateAgreementBaseFields } from '../../agreements';
@@ -267,7 +267,7 @@ export const CreateExchangeStakesAndTokensForm = ({
   };
 
   return (
-    <LoadingBackdrop
+    <SpaceLoadingBackdrop
       showKeepWindowOpenMessage={true}
       keepWindowOpenMessage={tAgreementFlow('loadingBackdrop.keepWindowOpen')}
       fullHeight={true}
@@ -318,6 +318,6 @@ export const CreateExchangeStakesAndTokensForm = ({
           </div>
         </form>
       </Form>
-    </LoadingBackdrop>
+    </SpaceLoadingBackdrop>
   );
 };

--- a/packages/epics/src/governance/components/create-pay-for-expenses-form.tsx
+++ b/packages/epics/src/governance/components/create-pay-for-expenses-form.tsx
@@ -11,7 +11,7 @@ import {
 import { z } from 'zod';
 import { Button, Form, Separator } from '@hypha-platform/ui';
 import React from 'react';
-import { LoadingBackdrop } from '@hypha-platform/ui/server';
+import { SpaceLoadingBackdrop } from '../../spaces/components/space-loading-backdrop';
 import { useConfig } from 'wagmi';
 import {
   useClearResubmitOnSuccess,
@@ -123,7 +123,7 @@ export const CreatePayForExpensesForm = ({
   };
 
   return (
-    <LoadingBackdrop
+    <SpaceLoadingBackdrop
       showKeepWindowOpenMessage={true}
       keepWindowOpenMessage={tAgreementFlow('loadingBackdrop.keepWindowOpen')}
       fullHeight={true}
@@ -167,6 +167,6 @@ export const CreatePayForExpensesForm = ({
           </div>
         </form>
       </Form>
-    </LoadingBackdrop>
+    </SpaceLoadingBackdrop>
   );
 };

--- a/packages/epics/src/governance/components/create-proposal-change-entry-method-form.tsx
+++ b/packages/epics/src/governance/components/create-proposal-change-entry-method-form.tsx
@@ -11,7 +11,7 @@ import {
   useSpaceDetailsWeb3Rpc,
   type Space,
 } from '@hypha-platform/core/client';
-import { LoadingBackdrop } from '@hypha-platform/ui/server';
+import { SpaceLoadingBackdrop } from '../../spaces/components/space-loading-backdrop';
 import { useForm } from 'react-hook-form';
 import { useConfig } from 'wagmi';
 import { z } from 'zod';
@@ -192,7 +192,7 @@ export const CreateProposalChangeEntryMethodForm = ({
   };
 
   return (
-    <LoadingBackdrop
+    <SpaceLoadingBackdrop
       showKeepWindowOpenMessage={true}
       keepWindowOpenMessage={tAgreementFlow('loadingBackdrop.keepWindowOpen')}
       fullHeight={true}
@@ -237,6 +237,6 @@ export const CreateProposalChangeEntryMethodForm = ({
           </div>
         </form>
       </Form>
-    </LoadingBackdrop>
+    </SpaceLoadingBackdrop>
   );
 };

--- a/packages/epics/src/governance/components/create-proposal-change-space-transparency-settings-form.tsx
+++ b/packages/epics/src/governance/components/create-proposal-change-space-transparency-settings-form.tsx
@@ -6,7 +6,7 @@ import {
   useChangeSpaceTransparencySettingsOrchestrator,
   useJwt,
 } from '@hypha-platform/core/client';
-import { LoadingBackdrop } from '@hypha-platform/ui/server';
+import { SpaceLoadingBackdrop } from '../../spaces/components/space-loading-backdrop';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import { Button, Form } from '@hypha-platform/ui';
@@ -138,7 +138,7 @@ export const CreateProposalChangeSpaceTransparencySettingsForm = ({
   };
 
   return (
-    <LoadingBackdrop
+    <SpaceLoadingBackdrop
       showKeepWindowOpenMessage={true}
       keepWindowOpenMessage={tAgreementFlow('loadingBackdrop.keepWindowOpen')}
       fullHeight={true}
@@ -184,6 +184,6 @@ export const CreateProposalChangeSpaceTransparencySettingsForm = ({
           </div>
         </form>
       </Form>
-    </LoadingBackdrop>
+    </SpaceLoadingBackdrop>
   );
 };

--- a/packages/epics/src/governance/components/create-proposal-change-voting-method-form.tsx
+++ b/packages/epics/src/governance/components/create-proposal-change-voting-method-form.tsx
@@ -14,7 +14,7 @@ import { z } from 'zod';
 import { Button, Form, Separator } from '@hypha-platform/ui';
 import React from 'react';
 import { useConfig } from 'wagmi';
-import { LoadingBackdrop } from '@hypha-platform/ui/server';
+import { SpaceLoadingBackdrop } from '../../spaces/components/space-loading-backdrop';
 import { VOTING_METHOD_TYPES } from '../hooks';
 import {
   useClearResubmitOnSuccess,
@@ -178,7 +178,7 @@ export const CreateProposalChangeVotingMethodForm = ({
   const isButtonDisabled = quorum === 0 && unity === 0;
 
   return (
-    <LoadingBackdrop
+    <SpaceLoadingBackdrop
       showKeepWindowOpenMessage={true}
       keepWindowOpenMessage={tAgreementFlow('loadingBackdrop.keepWindowOpen')}
       fullHeight={true}
@@ -230,6 +230,6 @@ export const CreateProposalChangeVotingMethodForm = ({
           </div>
         </form>
       </Form>
-    </LoadingBackdrop>
+    </SpaceLoadingBackdrop>
   );
 };

--- a/packages/epics/src/governance/components/create-proposal-token-backing-vault-form.tsx
+++ b/packages/epics/src/governance/components/create-proposal-token-backing-vault-form.tsx
@@ -12,7 +12,7 @@ import {
 import { z } from 'zod';
 import { Button, Form, Separator } from '@hypha-platform/ui';
 import React from 'react';
-import { LoadingBackdrop } from '@hypha-platform/ui/server';
+import { SpaceLoadingBackdrop } from '../../spaces/components/space-loading-backdrop';
 import { useConfig } from 'wagmi';
 import {
   useClearResubmitOnSuccess,
@@ -120,7 +120,7 @@ export const CreateProposalTokenBackingVaultForm = ({
   };
 
   return (
-    <LoadingBackdrop
+    <SpaceLoadingBackdrop
       showKeepWindowOpenMessage={true}
       keepWindowOpenMessage={tAgreementFlow('loadingBackdrop.keepWindowOpen')}
       fullHeight={true}
@@ -177,6 +177,6 @@ export const CreateProposalTokenBackingVaultForm = ({
           </div>
         </form>
       </Form>
-    </LoadingBackdrop>
+    </SpaceLoadingBackdrop>
   );
 };

--- a/packages/epics/src/governance/components/create-propose-a-contribution-form.tsx
+++ b/packages/epics/src/governance/components/create-propose-a-contribution-form.tsx
@@ -12,7 +12,7 @@ import { z } from 'zod';
 import { Button, Form, Separator } from '@hypha-platform/ui';
 import React from 'react';
 import { useRouter } from 'next/navigation';
-import { LoadingBackdrop } from '@hypha-platform/ui/server';
+import { SpaceLoadingBackdrop } from '../../spaces/components/space-loading-backdrop';
 import { useConfig } from 'wagmi';
 import {
   clearResubmitProposalSessionStorage,
@@ -122,7 +122,7 @@ export const CreateProposeAContributionForm = ({
   };
 
   return (
-    <LoadingBackdrop
+    <SpaceLoadingBackdrop
       showKeepWindowOpenMessage={true}
       keepWindowOpenMessage={tAgreementFlow('loadingBackdrop.keepWindowOpen')}
       fullHeight={true}
@@ -166,6 +166,6 @@ export const CreateProposeAContributionForm = ({
           </div>
         </form>
       </Form>
-    </LoadingBackdrop>
+    </SpaceLoadingBackdrop>
   );
 };

--- a/packages/epics/src/governance/components/create-redeem-tokens-form.tsx
+++ b/packages/epics/src/governance/components/create-redeem-tokens-form.tsx
@@ -14,7 +14,7 @@ import { Button, Form, Separator } from '@hypha-platform/ui';
 import React from 'react';
 import { useCreateRedeemTokensOrchestrator } from '@hypha-platform/core/client';
 import { useRouter } from 'next/navigation';
-import { LoadingBackdrop } from '@hypha-platform/ui/server';
+import { SpaceLoadingBackdrop } from '../../spaces/components/space-loading-backdrop';
 import { useTranslations } from 'next-intl';
 import { useConfig } from 'wagmi';
 import {
@@ -188,7 +188,7 @@ const CreateRedeemTokensFormInner = ({
   console.log('form errors:', form.formState.errors);
 
   return (
-    <LoadingBackdrop
+    <SpaceLoadingBackdrop
       showKeepWindowOpenMessage={true}
       keepWindowOpenMessage={tAgreementFlow('loadingBackdrop.keepWindowOpen')}
       fullHeight={true}
@@ -242,7 +242,7 @@ const CreateRedeemTokensFormInner = ({
           </div>
         </form>
       </Form>
-    </LoadingBackdrop>
+    </SpaceLoadingBackdrop>
   );
 };
 

--- a/packages/epics/src/governance/components/create-redeem-tokens-form.tsx
+++ b/packages/epics/src/governance/components/create-redeem-tokens-form.tsx
@@ -185,8 +185,6 @@ const CreateRedeemTokensFormInner = ({
     }
   };
 
-  console.log('form errors:', form.formState.errors);
-
   return (
     <SpaceLoadingBackdrop
       showKeepWindowOpenMessage={true}

--- a/packages/epics/src/governance/components/create-redeem-tokens-form.tsx
+++ b/packages/epics/src/governance/components/create-redeem-tokens-form.tsx
@@ -197,13 +197,15 @@ const CreateRedeemTokensFormInner = ({
       message={
         isError ? (
           <div className="flex flex-col">
-            <div>Ouh Snap. There was an error</div>
+            <div>{tAgreementFlow('loadingBackdrop.errorTitle')}</div>
             {form.formState.errors.root?.message && (
               <div className="text-destructive">
                 {form.formState.errors.root.message}
               </div>
             )}
-            <Button onClick={reset}>Reset</Button>
+            <Button onClick={reset}>
+              {tAgreementFlow('loadingBackdrop.resetButton')}
+            </Button>
           </div>
         ) : (
           <div>{currentAction}</div>

--- a/packages/epics/src/governance/components/issue-new-token-form.tsx
+++ b/packages/epics/src/governance/components/issue-new-token-form.tsx
@@ -16,7 +16,7 @@ import { z } from 'zod';
 import { Button, Form, Separator } from '@hypha-platform/ui';
 import React from 'react';
 import { useConfig } from 'wagmi';
-import { LoadingBackdrop } from '@hypha-platform/ui/server';
+import { SpaceLoadingBackdrop } from '../../spaces/components/space-loading-backdrop';
 import { useRouter } from 'next/navigation';
 import {
   clearResubmitProposalSessionStorage,
@@ -403,7 +403,7 @@ export const IssueNewTokenForm = ({
   };
 
   return (
-    <LoadingBackdrop
+    <SpaceLoadingBackdrop
       showKeepWindowOpenMessage={true}
       keepWindowOpenMessage={tAgreementFlow('loadingBackdrop.keepWindowOpen')}
       fullHeight={true}
@@ -460,6 +460,6 @@ export const IssueNewTokenForm = ({
           </div>
         </form>
       </Form>
-    </LoadingBackdrop>
+    </SpaceLoadingBackdrop>
   );
 };

--- a/packages/epics/src/governance/components/membership-exit-form.tsx
+++ b/packages/epics/src/governance/components/membership-exit-form.tsx
@@ -17,7 +17,8 @@ import {
   useScrollToErrors,
 } from '../../hooks';
 import { useConfig } from 'wagmi';
-import { Button, Form, LoadingBackdrop, Separator } from '@hypha-platform/ui';
+import { Button, Form, Separator } from '@hypha-platform/ui';
+import { SpaceLoadingBackdrop } from '../../spaces/components/space-loading-backdrop';
 import { CreateAgreementBaseFields } from '../../agreements';
 import { useTranslations } from 'next-intl';
 import { useLocalizedProposalResolver } from '../hooks/use-localized-proposal-resolver';
@@ -120,7 +121,7 @@ export const MembershipExitForm = ({
   };
 
   return (
-    <LoadingBackdrop
+    <SpaceLoadingBackdrop
       showKeepWindowOpenMessage={true}
       keepWindowOpenMessage={tAgreementFlow('loadingBackdrop.keepWindowOpen')}
       fullHeight={true}
@@ -167,6 +168,6 @@ export const MembershipExitForm = ({
           </div>
         </form>
       </Form>
-    </LoadingBackdrop>
+    </SpaceLoadingBackdrop>
   );
 };

--- a/packages/epics/src/governance/components/mint-tokens-to-space-treasury-form.tsx
+++ b/packages/epics/src/governance/components/mint-tokens-to-space-treasury-form.tsx
@@ -12,7 +12,7 @@ import { z } from 'zod';
 import { Button, Form, Separator } from '@hypha-platform/ui';
 import React from 'react';
 import { useConfig } from 'wagmi';
-import { LoadingBackdrop } from '@hypha-platform/ui/server';
+import { SpaceLoadingBackdrop } from '../../spaces/components/space-loading-backdrop';
 import {
   useClearResubmitOnSuccess,
   useResubmitProposalData,
@@ -113,7 +113,7 @@ export const MintTokensToSpaceTreasuryForm = ({
   };
 
   return (
-    <LoadingBackdrop
+    <SpaceLoadingBackdrop
       showKeepWindowOpenMessage={true}
       keepWindowOpenMessage={tAgreementFlow('loadingBackdrop.keepWindowOpen')}
       fullHeight={true}
@@ -165,6 +165,6 @@ export const MintTokensToSpaceTreasuryForm = ({
           </div>
         </form>
       </Form>
-    </LoadingBackdrop>
+    </SpaceLoadingBackdrop>
   );
 };

--- a/packages/epics/src/governance/components/space-to-space-membership-form.tsx
+++ b/packages/epics/src/governance/components/space-to-space-membership-form.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { Separator, Form, Button, LoadingBackdrop } from '@hypha-platform/ui';
+import { Separator, Form, Button } from '@hypha-platform/ui';
+import { SpaceLoadingBackdrop } from '../../spaces/components/space-loading-backdrop';
 import { CreateAgreementBaseFields } from '../../agreements';
 import {
   useMe,
@@ -125,7 +126,7 @@ export const SpaceToSpaceMembershipForm = ({
   };
 
   return (
-    <LoadingBackdrop
+    <SpaceLoadingBackdrop
       showKeepWindowOpenMessage={true}
       keepWindowOpenMessage={tAgreementFlow('loadingBackdrop.keepWindowOpen')}
       fullHeight={true}
@@ -181,6 +182,6 @@ export const SpaceToSpaceMembershipForm = ({
           )}
         </form>
       </Form>
-    </LoadingBackdrop>
+    </SpaceLoadingBackdrop>
   );
 };

--- a/packages/epics/src/governance/components/space-token-purchase-form.tsx
+++ b/packages/epics/src/governance/components/space-token-purchase-form.tsx
@@ -12,7 +12,7 @@ import {
 import { z } from 'zod';
 import { Button, Form, Separator } from '@hypha-platform/ui';
 import React from 'react';
-import { LoadingBackdrop } from '@hypha-platform/ui/server';
+import { SpaceLoadingBackdrop } from '../../spaces/components/space-loading-backdrop';
 import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import {
@@ -127,7 +127,7 @@ export const SpaceTokenPurchaseForm = ({
   };
 
   return (
-    <LoadingBackdrop
+    <SpaceLoadingBackdrop
       showKeepWindowOpenMessage={true}
       keepWindowOpenMessage={tAgreementFlow('loadingBackdrop.keepWindowOpen')}
       fullHeight={true}
@@ -184,6 +184,6 @@ export const SpaceTokenPurchaseForm = ({
           </div>
         </form>
       </Form>
-    </LoadingBackdrop>
+    </SpaceLoadingBackdrop>
   );
 };

--- a/packages/epics/src/governance/components/token-burning-form.tsx
+++ b/packages/epics/src/governance/components/token-burning-form.tsx
@@ -13,7 +13,7 @@ import { z } from 'zod';
 import { Button, Form, Separator } from '@hypha-platform/ui';
 import React from 'react';
 import { useConfig } from 'wagmi';
-import { LoadingBackdrop } from '@hypha-platform/ui/server';
+import { SpaceLoadingBackdrop } from '../../spaces/components/space-loading-backdrop';
 import {
   useClearResubmitOnSuccess,
   useResubmitProposalData,
@@ -233,7 +233,7 @@ export const TokenBurningForm = ({
   };
 
   return (
-    <LoadingBackdrop
+    <SpaceLoadingBackdrop
       showKeepWindowOpenMessage={true}
       keepWindowOpenMessage={tAgreementFlow('loadingBackdrop.keepWindowOpen')}
       fullHeight={true}
@@ -284,6 +284,6 @@ export const TokenBurningForm = ({
           </div>
         </form>
       </Form>
-    </LoadingBackdrop>
+    </SpaceLoadingBackdrop>
   );
 };

--- a/packages/epics/src/governance/components/update-issued-token-form.tsx
+++ b/packages/epics/src/governance/components/update-issued-token-form.tsx
@@ -19,7 +19,7 @@ import { z } from 'zod';
 import { Button, Form, Separator } from '@hypha-platform/ui';
 import React from 'react';
 import { useConfig } from 'wagmi';
-import { LoadingBackdrop } from '@hypha-platform/ui/server';
+import { SpaceLoadingBackdrop } from '../../spaces/components/space-loading-backdrop';
 import {
   useDbTokens,
   useScrollToErrors,
@@ -488,7 +488,7 @@ export const UpdateIssuedTokenForm = ({
   };
 
   return (
-    <LoadingBackdrop
+    <SpaceLoadingBackdrop
       showKeepWindowOpenMessage={true}
       keepWindowOpenMessage={tAgreementFlow('loadingBackdrop.keepWindowOpen')}
       fullHeight={true}
@@ -540,6 +540,6 @@ export const UpdateIssuedTokenForm = ({
           </div>
         </form>
       </Form>
-    </LoadingBackdrop>
+    </SpaceLoadingBackdrop>
   );
 };

--- a/packages/epics/src/people/components/button-profile.tsx
+++ b/packages/epics/src/people/components/button-profile.tsx
@@ -69,7 +69,7 @@ export const ButtonProfile = ({
                 avatarSrc={person?.avatarUrl}
                 userName={person?.nickname}
                 size="lg"
-                shape="circle"
+                shape="rounded"
               />
               <p>{person?.nickname}</p>
               {address && (
@@ -153,14 +153,14 @@ export const ButtonProfile = ({
               <DropdownMenuTrigger asChild>
                 <button
                   type="button"
-                  className="rounded-[35%] outline-none"
+                  className="rounded-md outline-none"
                   aria-label={t('openProfileMenu')}
                 >
                   <PersonAvatar
                     size="toolbar"
                     avatarSrc={person?.avatarUrl}
                     userName={person?.nickname}
-                    shape="squircle"
+                    shape="rounded"
                     className="ring-1 ring-border/55"
                   />
                 </button>

--- a/packages/epics/src/people/components/button-profile.tsx
+++ b/packages/epics/src/people/components/button-profile.tsx
@@ -153,14 +153,15 @@ export const ButtonProfile = ({
               <DropdownMenuTrigger asChild>
                 <button
                   type="button"
-                  className="rounded-lg outline-none"
+                  className="rounded-[35%] outline-none"
                   aria-label={t('openProfileMenu')}
                 >
                   <PersonAvatar
                     size="toolbar"
                     avatarSrc={person?.avatarUrl}
                     userName={person?.nickname}
-                    shape="circle"
+                    shape="squircle"
+                    className="ring-1 ring-border/55"
                   />
                 </button>
               </DropdownMenuTrigger>

--- a/packages/epics/src/people/components/button-profile.tsx
+++ b/packages/epics/src/people/components/button-profile.tsx
@@ -157,7 +157,7 @@ export const ButtonProfile = ({
                   aria-label={t('openProfileMenu')}
                 >
                   <PersonAvatar
-                    size="md"
+                    size="toolbar"
                     avatarSrc={person?.avatarUrl}
                     userName={person?.nickname}
                     shape="circle"

--- a/packages/epics/src/people/components/button-profile.tsx
+++ b/packages/epics/src/people/components/button-profile.tsx
@@ -69,6 +69,7 @@ export const ButtonProfile = ({
                 avatarSrc={person?.avatarUrl}
                 userName={person?.nickname}
                 size="lg"
+                shape="circle"
               />
               <p>{person?.nickname}</p>
               {address && (
@@ -159,6 +160,7 @@ export const ButtonProfile = ({
                     size="md"
                     avatarSrc={person?.avatarUrl}
                     userName={person?.nickname}
+                    shape="circle"
                   />
                 </button>
               </DropdownMenuTrigger>

--- a/packages/epics/src/people/components/member-card.tsx
+++ b/packages/epics/src/people/components/member-card.tsx
@@ -204,7 +204,7 @@ export const MemberCard: React.FC<MemberCardProps> = ({
       {localIsDelegate && (
         <div>
           <span className="text-1 text-neutral-11 font-medium">
-            Delegated Voting Member
+            {tCommon('delegatedVotingMemberLabel')}
           </span>
         </div>
       )}

--- a/packages/epics/src/people/components/member-card.tsx
+++ b/packages/epics/src/people/components/member-card.tsx
@@ -112,7 +112,7 @@ export const MemberCard: React.FC<MemberCardProps> = ({
         <div className="flex justify-between items-center w-full">
           <div className="flex flex-col">
             <Badge className="w-fit" variant="outline" colorVariant="accent">
-              Member
+              {tCommon('memberRoleLabel')}
             </Badge>
             {!minimize ? (
               <div className="flex gap-x-1">

--- a/packages/epics/src/people/components/member-card.tsx
+++ b/packages/epics/src/people/components/member-card.tsx
@@ -105,7 +105,7 @@ export const MemberCard: React.FC<MemberCardProps> = ({
           userName={nickname}
           size={minimize ? 'sm' : 'lg'}
           isLoading={isLoading}
-          shape="circle"
+          shape="rounded"
           className="mr-3"
         />
 

--- a/packages/epics/src/people/components/member-card.tsx
+++ b/packages/epics/src/people/components/member-card.tsx
@@ -111,7 +111,7 @@ export const MemberCard: React.FC<MemberCardProps> = ({
 
         <div className="flex justify-between items-center w-full">
           <div className="flex flex-col">
-            <Badge className="w-fit" colorVariant="accent">
+            <Badge className="w-fit" variant="outline" colorVariant="accent">
               Member
             </Badge>
             {!minimize ? (

--- a/packages/epics/src/people/components/member-card.tsx
+++ b/packages/epics/src/people/components/member-card.tsx
@@ -105,6 +105,7 @@ export const MemberCard: React.FC<MemberCardProps> = ({
           userName={nickname}
           size={minimize ? 'sm' : 'lg'}
           isLoading={isLoading}
+          shape="circle"
           className="mr-3"
         />
 

--- a/packages/epics/src/people/components/person-avatar.tsx
+++ b/packages/epics/src/people/components/person-avatar.tsx
@@ -30,7 +30,7 @@ export const PersonAvatar = ({
   className?: string;
   isLoading?: boolean;
   size?: AvatarSize;
-  /** `circle` = full round; `squircle` ≈ Discord; `rounded` = default tile */
+  /** `circle` = full round; `squircle` ≈ superellipse; `rounded` = square + subtle corners */
   shape?: 'rounded' | 'squircle' | 'circle';
 }) => {
   const getFallbackContent = () => {
@@ -52,7 +52,7 @@ export const PersonAvatar = ({
       ? 'rounded-full'
       : shape === 'squircle'
       ? 'rounded-[35%]'
-      : 'rounded-lg';
+      : 'rounded-md';
 
   return (
     <Skeleton

--- a/packages/epics/src/people/components/person-avatar.tsx
+++ b/packages/epics/src/people/components/person-avatar.tsx
@@ -2,7 +2,7 @@ import { Avatar, AvatarImage, AvatarFallback } from '@hypha-platform/ui';
 import { UserIcon } from 'lucide-react';
 import { Skeleton } from '@hypha-platform/ui';
 
-type AvatarSize = 'xs' | 'sm' | 'md' | 'lg' | 'chat' | 'reply';
+type AvatarSize = 'xs' | 'sm' | 'md' | 'lg' | 'chat' | 'reply' | 'toolbar';
 
 const sizeMap: Record<AvatarSize, { avatar: string; skeleton: string }> = {
   xs: { avatar: 'w-[12px] h-[12px]', skeleton: '12px' },
@@ -13,6 +13,8 @@ const sizeMap: Record<AvatarSize, { avatar: string; skeleton: string }> = {
   chat: { avatar: 'h-10 w-10', skeleton: '40px' },
   /** Rich-reply quoted author */
   reply: { avatar: 'h-4 w-4', skeleton: '16px' },
+  /** MenuTop / ghost `Button` row: matches default `min-h-10` (40px) */
+  toolbar: { avatar: 'h-10 w-10 shrink-0', skeleton: '40px' },
 };
 
 export const PersonAvatar = ({

--- a/packages/epics/src/people/components/space-member-card.tsx
+++ b/packages/epics/src/people/components/space-member-card.tsx
@@ -52,10 +52,10 @@ export const SpaceMemberCard: React.FC<{
           width="64px"
           height="64px"
           loading={isLoading}
-          className="rounded-lg"
+          className="rounded-full"
         >
           <Image
-            className="h-[64px] w-[64px] rounded-lg"
+            className="h-[64px] w-[64px] rounded-full object-cover"
             src={space.logoUrl || '/placeholder/default-space.svg'}
             height={64}
             width={64}

--- a/packages/epics/src/proposals/components/proposal-head.tsx
+++ b/packages/epics/src/proposals/components/proposal-head.tsx
@@ -114,7 +114,7 @@ export const ProposalHead = ({
           <div className="grid">
             <div className="flex gap-x-1">
               <Badge
-                variant="solid"
+                variant="outline"
                 colorVariant="accent"
                 isLoading={isLoading}
               >

--- a/packages/epics/src/spaces/components/activate-proposals-banner.tsx
+++ b/packages/epics/src/spaces/components/activate-proposals-banner.tsx
@@ -65,7 +65,7 @@ export const ActivateProposalsBanner = ({
   return (
     <div
       className={cn(
-        'border-1 rounded-[8px] bg-accent-surface bg-center border-accent-6',
+        'border-1 rounded-[8px] bg-center border-accent-6 bg-[color-mix(in_oklab,var(--color-accent-surface)_90%,var(--color-accent-9)_10%)]',
         className,
       )}
     >

--- a/packages/epics/src/spaces/components/compact-space-banner-lead.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner-lead.tsx
@@ -27,7 +27,7 @@ function clampParallaxScrollY(): number {
  */
 export function CompactSpaceBannerLead({ src }: Props) {
   const [ready, setReady] = React.useState(false);
-  const [parallaxY, setParallaxY] = React.useState(clampParallaxScrollY);
+  const [parallaxY, setParallaxY] = React.useState(0);
   const [preferReducedMotion, setPreferReducedMotion] = React.useState(false);
 
   React.useEffect(() => {

--- a/packages/epics/src/spaces/components/compact-space-banner-lead.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner-lead.tsx
@@ -29,20 +29,20 @@ export function CompactSpaceBannerLead({ src }: Props) {
   const [ready, setReady] = React.useState(false);
   const [imageFailed, setImageFailed] = React.useState(false);
   const [parallaxY, setParallaxY] = React.useState(0);
-  const [preferReducedMotion, setPreferReducedMotion] = React.useState(false);
+  const [reduceMotion, setReduceMotion] = React.useState(false);
 
-  React.useEffect(() => {
+  React.useLayoutEffect(() => {
     const mq = window.matchMedia?.('(prefers-reduced-motion: reduce)');
     if (!mq) return;
 
-    const sync = () => setPreferReducedMotion(mq.matches);
+    const sync = () => setReduceMotion(mq.matches);
     sync();
     mq.addEventListener('change', sync);
     return () => mq.removeEventListener('change', sync);
   }, []);
 
   React.useEffect(() => {
-    if (preferReducedMotion) return;
+    if (reduceMotion) return;
 
     let raf = 0;
 
@@ -61,7 +61,7 @@ export function CompactSpaceBannerLead({ src }: Props) {
       window.removeEventListener('scroll', onScroll);
       cancelAnimationFrame(raf);
     };
-  }, [preferReducedMotion]);
+  }, [reduceMotion]);
 
   return (
     <div className="pointer-events-none absolute inset-0 z-0 overflow-hidden rounded-[inherit]">
@@ -74,7 +74,7 @@ export function CompactSpaceBannerLead({ src }: Props) {
       <div
         className="absolute left-0 right-0 top-[-12%] h-[124%] will-change-transform"
         style={
-          preferReducedMotion
+          reduceMotion
             ? undefined
             : { transform: `translate3d(0, ${parallaxY}px, 0)` }
         }

--- a/packages/epics/src/spaces/components/compact-space-banner-lead.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner-lead.tsx
@@ -27,6 +27,7 @@ function clampParallaxScrollY(): number {
  */
 export function CompactSpaceBannerLead({ src }: Props) {
   const [ready, setReady] = React.useState(false);
+  const [imageFailed, setImageFailed] = React.useState(false);
   const [parallaxY, setParallaxY] = React.useState(0);
   const [preferReducedMotion, setPreferReducedMotion] = React.useState(false);
 
@@ -88,9 +89,20 @@ export function CompactSpaceBannerLead({ src }: Props) {
             sizes="(max-width: 1280px) 100vw, min(1280px, 100vw)"
             className={cn(
               'object-cover object-center transition-opacity duration-500 ease-out',
-              ready ? 'opacity-100' : 'opacity-0',
+              imageFailed || ready ? 'opacity-100' : 'opacity-0',
             )}
             onLoad={() => setReady(true)}
+            onError={() => {
+              if (process.env.NODE_ENV !== 'production') {
+                console.warn(
+                  '[CompactSpaceBannerLead] lead image failed to load',
+                  {
+                    src,
+                  },
+                );
+              }
+              setImageFailed(true);
+            }}
           />
         </div>
       </div>

--- a/packages/epics/src/spaces/components/compact-space-banner-lead.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner-lead.tsx
@@ -8,12 +8,55 @@ type Props = {
   src: string;
 };
 
+/** Scroll factor: image moves slower than the page for depth (tuned subtle → noticeable). */
+const PARALLAX_SCROLL_RATE = 0.14;
+const PARALLAX_MAX_SHIFT_PX = 56;
+
 /**
  * Hero lead image with stable branded placeholder + fade-in.
  * Avoids the grey flash from CSS background-image decoding on first paint.
+ * Optional scroll parallax on the photo layer (overlays stay fixed for readable text).
  */
 export function CompactSpaceBannerLead({ src }: Props) {
   const [ready, setReady] = React.useState(false);
+  const [parallaxY, setParallaxY] = React.useState(0);
+  const [preferReducedMotion, setPreferReducedMotion] = React.useState(false);
+
+  React.useEffect(() => {
+    const mq = window.matchMedia?.('(prefers-reduced-motion: reduce)');
+    if (!mq) return;
+
+    const sync = () => setPreferReducedMotion(mq.matches);
+    sync();
+    mq.addEventListener('change', sync);
+    return () => mq.removeEventListener('change', sync);
+  }, []);
+
+  React.useEffect(() => {
+    if (preferReducedMotion) return;
+
+    let raf = 0;
+
+    const tick = () => {
+      const y = Math.min(
+        PARALLAX_MAX_SHIFT_PX,
+        Math.max(-PARALLAX_MAX_SHIFT_PX, window.scrollY * PARALLAX_SCROLL_RATE),
+      );
+      setParallaxY(y);
+    };
+
+    const onScroll = () => {
+      cancelAnimationFrame(raf);
+      raf = requestAnimationFrame(tick);
+    };
+
+    tick();
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => {
+      window.removeEventListener('scroll', onScroll);
+      cancelAnimationFrame(raf);
+    };
+  }, [preferReducedMotion]);
 
   return (
     <div className="pointer-events-none absolute inset-0 z-0 overflow-hidden rounded-[inherit]">
@@ -22,18 +65,31 @@ export function CompactSpaceBannerLead({ src }: Props) {
         className="absolute inset-0 bg-[radial-gradient(ellipse_140%_100%_at_12%_-5%,rgb(41,115,78)_0%,rgb(14,54,38)_42%,rgb(7,38,26)_68%,rgb(2,14,10)_100%)]"
         aria-hidden
       />
-      <Image
-        src={src}
-        alt=""
-        fill
-        priority
-        sizes="(max-width: 1280px) 100vw, min(1280px, 100vw)"
-        className={cn(
-          'object-cover object-center transition-opacity duration-500 ease-out',
-          ready ? 'opacity-100' : 'opacity-0',
-        )}
-        onLoadingComplete={() => setReady(true)}
-      />
+      {/* Taller layer + parallax translate so edges never show during scroll */}
+      <div
+        className="absolute left-0 right-0 top-[-12%] h-[124%] will-change-transform"
+        style={
+          preferReducedMotion
+            ? undefined
+            : { transform: `translate3d(0, ${parallaxY}px, 0)` }
+        }
+        aria-hidden
+      >
+        <div className="relative h-full w-full min-h-[12rem]">
+          <Image
+            src={src}
+            alt=""
+            fill
+            priority
+            sizes="(max-width: 1280px) 100vw, min(1280px, 100vw)"
+            className={cn(
+              'object-cover object-center transition-opacity duration-500 ease-out',
+              ready ? 'opacity-100' : 'opacity-0',
+            )}
+            onLoadingComplete={() => setReady(true)}
+          />
+        </div>
+      </div>
     </div>
   );
 }

--- a/packages/epics/src/spaces/components/compact-space-banner-lead.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner-lead.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import * as React from 'react';
+import Image from 'next/image';
+import { cn } from '@hypha-platform/ui-utils';
+
+type Props = {
+  src: string;
+};
+
+/**
+ * Hero lead image with stable branded placeholder + fade-in.
+ * Avoids the grey flash from CSS background-image decoding on first paint.
+ */
+export function CompactSpaceBannerLead({ src }: Props) {
+  const [ready, setReady] = React.useState(false);
+
+  return (
+    <div className="pointer-events-none absolute inset-0 z-0 overflow-hidden rounded-[inherit]">
+      {/* Same atmosphere as no-lead fallback — visible until decode */}
+      <div
+        className="absolute inset-0 bg-[radial-gradient(ellipse_140%_100%_at_12%_-5%,rgb(41,115,78)_0%,rgb(14,54,38)_42%,rgb(7,38,26)_68%,rgb(2,14,10)_100%)]"
+        aria-hidden
+      />
+      <Image
+        src={src}
+        alt=""
+        fill
+        priority
+        sizes="(max-width: 1280px) 100vw, min(1280px, 100vw)"
+        className={cn(
+          'object-cover object-center transition-opacity duration-500 ease-out',
+          ready ? 'opacity-100' : 'opacity-0',
+        )}
+        onLoadingComplete={() => setReady(true)}
+      />
+    </div>
+  );
+}

--- a/packages/epics/src/spaces/components/compact-space-banner-lead.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner-lead.tsx
@@ -12,6 +12,14 @@ type Props = {
 const PARALLAX_SCROLL_RATE = 0.14;
 const PARALLAX_MAX_SHIFT_PX = 56;
 
+function clampParallaxScrollY(): number {
+  if (typeof window === 'undefined') return 0;
+  return Math.min(
+    PARALLAX_MAX_SHIFT_PX,
+    Math.max(-PARALLAX_MAX_SHIFT_PX, window.scrollY * PARALLAX_SCROLL_RATE),
+  );
+}
+
 /**
  * Hero lead image with stable branded placeholder + fade-in.
  * Avoids the grey flash from CSS background-image decoding on first paint.
@@ -19,7 +27,7 @@ const PARALLAX_MAX_SHIFT_PX = 56;
  */
 export function CompactSpaceBannerLead({ src }: Props) {
   const [ready, setReady] = React.useState(false);
-  const [parallaxY, setParallaxY] = React.useState(0);
+  const [parallaxY, setParallaxY] = React.useState(clampParallaxScrollY);
   const [preferReducedMotion, setPreferReducedMotion] = React.useState(false);
 
   React.useEffect(() => {
@@ -38,11 +46,7 @@ export function CompactSpaceBannerLead({ src }: Props) {
     let raf = 0;
 
     const tick = () => {
-      const y = Math.min(
-        PARALLAX_MAX_SHIFT_PX,
-        Math.max(-PARALLAX_MAX_SHIFT_PX, window.scrollY * PARALLAX_SCROLL_RATE),
-      );
-      setParallaxY(y);
+      setParallaxY(clampParallaxScrollY());
     };
 
     const onScroll = () => {

--- a/packages/epics/src/spaces/components/compact-space-banner-lead.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner-lead.tsx
@@ -90,7 +90,7 @@ export function CompactSpaceBannerLead({ src }: Props) {
               'object-cover object-center transition-opacity duration-500 ease-out',
               ready ? 'opacity-100' : 'opacity-0',
             )}
-            onLoadingComplete={() => setReady(true)}
+            onLoad={() => setReady(true)}
           />
         </div>
       </div>

--- a/packages/epics/src/spaces/components/compact-space-banner-lead.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner-lead.tsx
@@ -89,7 +89,11 @@ export function CompactSpaceBannerLead({ src }: Props) {
             sizes="(max-width: 1280px) 100vw, min(1280px, 100vw)"
             className={cn(
               'object-cover object-center transition-opacity duration-500 ease-out',
-              imageFailed || ready ? 'opacity-100' : 'opacity-0',
+              imageFailed
+                ? 'pointer-events-none opacity-0'
+                : ready
+                ? 'opacity-100'
+                : 'opacity-0',
             )}
             onLoad={() => setReady(true)}
             onError={() => {

--- a/packages/epics/src/spaces/components/compact-space-banner.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner.tsx
@@ -4,18 +4,7 @@ import { LinkLabel } from '../../common/link-label';
 import { Avatar, AvatarImage } from '@hypha-platform/ui';
 import { cn } from '@hypha-platform/ui-utils';
 import { CompactSpaceBannerLead } from './compact-space-banner-lead';
-import { isSafeImageUrl } from '../utils/safe-image-url';
-
-function isSafeLinkHref(url: string): boolean {
-  const t = url.trim();
-  if (!t) return false;
-  try {
-    const u = new URL(t);
-    return u.protocol === 'https:' || u.protocol === 'http:';
-  } catch {
-    return false;
-  }
-}
+import { isSafeExternalUrl, isSafeImageUrl } from '../utils/safe-image-url';
 
 /** Matches PR #2165 `SpaceHeaderInsetAvatar` footprint — shared with DHO sticky chrome row */
 export const COMPACT_SPACE_BANNER_AVATAR_CLASSNAME = cn(
@@ -86,7 +75,13 @@ export function CompactSpaceBanner({
   })();
 
   const safeLinks =
-    links?.filter((l) => typeof l === 'string' && isSafeLinkHref(l)) ?? [];
+    links?.filter((l) => typeof l === 'string' && isSafeExternalUrl(l)) ?? [];
+
+  const safeLogoSrc = (() => {
+    const candidate = logoUrl?.trim();
+    if (candidate && isSafeImageUrl(candidate)) return candidate;
+    return isSafeImageUrl(defaultLogoSrc) ? defaultLogoSrc : '';
+  })();
 
   return (
     <section
@@ -191,7 +186,7 @@ export function CompactSpaceBanner({
         <div className="flex items-start gap-6">
           <Avatar className={COMPACT_SPACE_BANNER_AVATAR_CLASSNAME}>
             <AvatarImage
-              src={logoUrl || defaultLogoSrc}
+              src={safeLogoSrc}
               alt={logoAlt}
               className="object-cover"
             />

--- a/packages/epics/src/spaces/components/compact-space-banner.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner.tsx
@@ -107,9 +107,9 @@ export function CompactSpaceBanner({
         />
       )}
 
-      {/* Readability veil — keeps text crisp over photo */}
+      {/* Readability veil — darken foliage under typography (neutral-* tokens are for light surfaces) */}
       <div
-        className="pointer-events-none absolute inset-0 bg-gradient-to-br from-black/35 via-transparent to-emerald-950/55"
+        className="pointer-events-none absolute inset-0 bg-gradient-to-br from-black/45 via-black/25 to-emerald-950/65"
         aria-hidden
       />
 
@@ -151,7 +151,7 @@ export function CompactSpaceBanner({
         {/* Body — scroll when copy exceeds max height (same interaction model as #2165 hero purpose) */}
         {description ? (
           <div className={DESCRIPTION_SCROLL_BOX}>
-            <p className="text-pretty text-2 leading-[1.5] text-white">
+            <p className="text-pretty text-2 leading-[1.5] text-white/95 [text-shadow:0_1px_2px_rgba(0,0,0,0.55)]">
               {description}
             </p>
           </div>
@@ -160,22 +160,26 @@ export function CompactSpaceBanner({
         <div className="h-px w-full bg-white/12" role="presentation" />
 
         <div className="flex flex-col gap-4 gap-x-6 sm:flex-row sm:items-center sm:justify-between">
-          <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-1 text-neutral-11">
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-1 text-white/88 [text-shadow:0_1px_2px_rgba(0,0,0,0.45)]">
             <span>
-              <span className="font-bold text-white">{memberCount}</span>{' '}
-              {membersLabel}
+              <span className="font-bold tabular-nums text-white">
+                {memberCount}
+              </span>{' '}
+              <span className="text-white/92">{membersLabel}</span>
             </span>
-            <span className="text-neutral-10" aria-hidden>
+            <span className="text-white/45" aria-hidden>
               ·
             </span>
             <span>
-              <span className="font-bold text-white">{agreementCount}</span>{' '}
-              {agreementsLabel}
+              <span className="font-bold tabular-nums text-white">
+                {agreementCount}
+              </span>{' '}
+              <span className="text-white/92">{agreementsLabel}</span>
             </span>
-            <span className="text-neutral-10" aria-hidden>
+            <span className="text-white/45" aria-hidden>
               ·
             </span>
-            <span>{createdOnText}</span>
+            <span className="text-white/88">{createdOnText}</span>
           </div>
 
           {footerTrailing ? (

--- a/packages/epics/src/spaces/components/compact-space-banner.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner.tsx
@@ -9,7 +9,7 @@ function isSafeLinkHref(url: string): boolean {
   const t = url.trim();
   if (!t) return false;
   try {
-    const u = new URL(t, 'https://example.com');
+    const u = new URL(t);
     return u.protocol === 'https:' || u.protocol === 'http:';
   } catch {
     return false;

--- a/packages/epics/src/spaces/components/compact-space-banner.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner.tsx
@@ -40,9 +40,10 @@ export const COMPACT_SPACE_BANNER_TITLE_CLASSNAME = cn(
   'text-balance text-6 font-semibold tracking-tight sm:text-7',
 );
 
-/** Purpose column — narrow on sm+; left edge aligns with avatar (full-width column below header row). */
+/** Purpose column — max four lines on narrow viewports (scroll); sm+ wider column + taller cap. */
 const DESCRIPTION_SCROLL_BOX = cn(
-  'max-h-[min(45vh,280px)] w-full max-w-full min-h-0 overflow-y-auto overscroll-y-contain touch-pan-y sm:max-w-[50%]',
+  'w-full max-w-full min-h-0 max-h-[4lh] overflow-y-auto overscroll-y-contain touch-pan-y',
+  'text-2 leading-[1.5] sm:max-h-[min(45vh,280px)] sm:max-w-[50%]',
   '[scrollbar-gutter:stable]',
   '[scrollbar-color:rgba(255,255,255,0.35)_transparent] [scrollbar-width:thin]',
   '[&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-white/30 [&::-webkit-scrollbar-track]:bg-transparent',

--- a/packages/epics/src/spaces/components/compact-space-banner.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner.tsx
@@ -99,7 +99,8 @@ export function CompactSpaceBanner({
       className={cn(
         'relative overflow-hidden rounded-xl border border-[#30363d]',
         'shadow-[0_24px_48px_-12px_rgba(5,33,22,0.55)]',
-        'px-8 pt-8 pb-5',
+        /* Bottom breathing room lives on the footer strip so metadata + badges center between hairline and card edge */
+        'px-8 pt-8 pb-0',
         className,
       )}
       aria-label={title}
@@ -260,7 +261,7 @@ export function CompactSpaceBanner({
             className="h-px w-full shrink-0 bg-white/12"
             role="presentation"
           />
-          <div className="flex flex-col gap-3 gap-x-5 pt-3.5 pb-3.5 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex flex-col gap-3 gap-x-5 py-5 sm:flex-row sm:items-center sm:justify-between">
             <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-1 text-white/88 [text-shadow:0_1px_2px_rgba(0,0,0,0.45)]">
               <span>
                 <span className="font-bold tabular-nums text-white">

--- a/packages/epics/src/spaces/components/compact-space-banner.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner.tsx
@@ -124,7 +124,7 @@ export function CompactSpaceBanner({
             className="pointer-events-none absolute inset-0"
             style={{
               backgroundImage:
-                'linear-gradient(to bottom right, color-mix(in srgb, var(--accent-11, #4f46e5) calc(var(--banner-ov-accent-wash, 0.18) * 100%), transparent), transparent, transparent)',
+                'linear-gradient(to bottom right, color-mix(in srgb, var(--color-accent-11, var(--space-accent, #4f46e5)) calc(var(--banner-ov-accent-wash, 0.18) * 100%), transparent), transparent, transparent)',
             }}
             aria-hidden
           />

--- a/packages/epics/src/spaces/components/compact-space-banner.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner.tsx
@@ -54,7 +54,7 @@ export function CompactSpaceBanner({
   return (
     <section
       className={cn(
-        'relative overflow-hidden rounded-3xl',
+        'relative overflow-hidden rounded-xl',
         'shadow-[0_24px_48px_-12px_rgba(5,33,22,0.55)]',
         'p-8',
         className,
@@ -203,7 +203,7 @@ export function CompactSpaceBanner({
           </div>
 
           {footerTrailing ? (
-            <div className="flex flex-wrap items-center justify-start gap-2 sm:justify-end [&_.rounded-lg]:rounded-full [&_button]:rounded-full">
+            <div className="flex flex-wrap items-center justify-start gap-2 sm:justify-end [&_.rounded-lg]:rounded-md [&_button]:rounded-md">
               {footerTrailing}
             </div>
           ) : null}

--- a/packages/epics/src/spaces/components/compact-space-banner.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner.tsx
@@ -98,41 +98,69 @@ export function CompactSpaceBanner({
       {textureSrc ? (
         <>
           <CompactSpaceBannerLead src={textureSrc} />
-          {/* Exact overlay stack from PR #2165 SpaceHeaderHeroCard */}
+          {/* PR #2165 stack + depth pass — alphas modulated via inherited CSS vars from SpaceAccentFromImages */}
           <div
-            className="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/88 via-black/42 via-[52%] to-black/22"
-            aria-hidden
-          />
-          <div
-            className="pointer-events-none absolute inset-0 bg-gradient-to-r from-black/58 via-transparent to-black/40"
-            aria-hidden
-          />
-          <div
-            className="pointer-events-none absolute inset-0 bg-gradient-to-br from-accent-11/18 via-transparent to-transparent"
-            aria-hidden
-          />
-          {/* Depth pass — cinematic WOW without fighting hero readability */}
-          <div
-            className="pointer-events-none absolute inset-0 mix-blend-soft-light opacity-90 bg-[radial-gradient(ellipse_55%_45%_at_82%_8%,rgba(209,250,229,0.38),transparent_62%)]"
-            aria-hidden
-          />
-          <div
-            className="pointer-events-none absolute inset-0 bg-gradient-to-br from-white/[0.07] from-[-10%] via-transparent via-40% to-transparent to-55%"
-            aria-hidden
-          />
-          <div
-            className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_115%_95%_at_50%_72%,transparent_22%,rgba(0,18,12,0.62)_88%,rgba(0,8,5,0.92)_100%)]"
-            aria-hidden
-          />
-          <div
-            className="pointer-events-none absolute inset-0 rounded-[inherit] opacity-[0.055] mix-blend-overlay"
+            className="pointer-events-none absolute inset-0"
             style={{
+              backgroundImage:
+                'linear-gradient(to top, rgba(0,0,0,var(--banner-ov-v-bottom, 0.88)) 0%, rgba(0,0,0,var(--banner-ov-v-mid, 0.42)) var(--banner-ov-v-mid-at, 52%), rgba(0,0,0,var(--banner-ov-v-top, 0.22)) 100%)',
+            }}
+            aria-hidden
+          />
+          <div
+            className="pointer-events-none absolute inset-0"
+            style={{
+              backgroundImage:
+                'linear-gradient(to right, rgba(0,0,0,var(--banner-ov-h-from, 0.58)), transparent, rgba(0,0,0,var(--banner-ov-h-to, 0.4)))',
+            }}
+            aria-hidden
+          />
+          <div
+            className="pointer-events-none absolute inset-0"
+            style={{
+              backgroundImage:
+                'linear-gradient(to bottom right, color-mix(in srgb, var(--accent-11, #4f46e5) calc(var(--banner-ov-accent-wash, 0.18) * 100%), transparent), transparent, transparent)',
+            }}
+            aria-hidden
+          />
+          <div
+            className="pointer-events-none absolute inset-0 mix-blend-soft-light"
+            style={{
+              backgroundImage:
+                'radial-gradient(ellipse 55% 45% at 82% 8%, rgba(209,250,229,calc(0.38 * var(--banner-ov-skylight-op, 0.9))), transparent 62%)',
+            }}
+            aria-hidden
+          />
+          <div
+            className="pointer-events-none absolute inset-0"
+            style={{
+              backgroundImage:
+                'linear-gradient(to bottom right, rgba(255,255,255,var(--banner-ov-sheen-op, 0.07)) -10%, transparent 40%, transparent 55%)',
+            }}
+            aria-hidden
+          />
+          <div
+            className="pointer-events-none absolute inset-0"
+            style={{
+              backgroundImage:
+                'radial-gradient(ellipse 115% 95% at 50% 72%, transparent 22%, rgba(0,18,12,calc(0.62 * var(--banner-ov-vignette-strength, 1))) 88%, rgba(0,8,5,calc(0.92 * var(--banner-ov-vignette-strength, 1))) 100%)',
+            }}
+            aria-hidden
+          />
+          <div
+            className="pointer-events-none absolute inset-0 rounded-[inherit] mix-blend-overlay"
+            style={{
+              opacity: 'var(--banner-ov-grain-op, 0.055)',
               backgroundImage: `url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.78' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E")`,
             }}
             aria-hidden
           />
           <div
-            className="pointer-events-none absolute inset-0 rounded-[inherit] shadow-[inset_0_1px_0_rgba(255,255,255,0.09),inset_0_-1px_0_rgba(0,0,0,0.18)]"
+            className="pointer-events-none absolute inset-0 rounded-[inherit]"
+            style={{
+              boxShadow:
+                'inset 0 1px 0 rgba(255,255,255,var(--banner-ov-inner-top, 0.09)), inset 0 -1px 0 rgba(0,0,0,var(--banner-ov-inner-bot, 0.18))',
+            }}
             aria-hidden
           />
         </>

--- a/packages/epics/src/spaces/components/compact-space-banner.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner.tsx
@@ -4,6 +4,17 @@ import { LinkLabel } from '../../common/link-label';
 import { Avatar, AvatarImage } from '@hypha-platform/ui';
 import { cn } from '@hypha-platform/ui-utils';
 
+function isSafeLinkHref(url: string): boolean {
+  const t = url.trim();
+  if (!t) return false;
+  try {
+    const u = new URL(t, 'https://example.com');
+    return u.protocol === 'https:' || u.protocol === 'http:';
+  } catch {
+    return false;
+  }
+}
+
 /** Scrollable purpose block — mirrors #2165 hero (`overflow-y-auto`, thin scrollbar). */
 const DESCRIPTION_SCROLL_BOX = cn(
   'max-h-[min(45vh,280px)] w-full min-h-0 overflow-y-auto overscroll-y-contain pr-1 touch-pan-y',
@@ -50,6 +61,9 @@ export function CompactSpaceBanner({
   className,
 }: CompactSpaceBannerProps) {
   const textureSrc = leadImageUrl || defaultLeadImageSrc || undefined;
+
+  const safeLinks =
+    links?.filter((l) => typeof l === 'string' && isSafeLinkHref(l)) ?? [];
 
   return (
     <section
@@ -145,9 +159,9 @@ export function CompactSpaceBanner({
             <h1 className="text-7 font-bold leading-tight tracking-tight text-white">
               {title}
             </h1>
-            {links && links.length > 0 ? (
+            {safeLinks.length > 0 ? (
               <div className="flex flex-wrap gap-x-5 gap-y-2">
-                {links.map((link, index) => (
+                {safeLinks.map((link, index) => (
                   <a
                     key={`${link}_${index}`}
                     href={link}

--- a/packages/epics/src/spaces/components/compact-space-banner.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner.tsx
@@ -15,7 +15,6 @@ function isSafeLinkHref(url: string): boolean {
   }
 }
 
-/** Same-origin paths or absolute http(s) — safe for CSS url() without injection. */
 function isSafeTextureUrl(raw: string): boolean {
   const t = raw.trim();
   if (!t) return false;
@@ -32,7 +31,13 @@ function cssUrlQuoted(url: string): string {
   return JSON.stringify(url);
 }
 
-/** Scrollable purpose block — narrow column (~50% on sm+) so copy wraps like design ref. */
+/** Matches PR #2165 `SpaceHeaderInsetAvatar` footprint */
+const AVATAR_CLASS = cn(
+  'h-16 w-16 shrink-0 rounded-full sm:h-[72px] sm:w-[72px]',
+  'shadow-[0_18px_40px_-12px_rgba(0,0,0,0.55)] ring-1 ring-white/15',
+);
+
+/** Purpose column — narrow on sm+; left edge aligns with avatar (full-width column below header row). */
 const DESCRIPTION_SCROLL_BOX = cn(
   'max-h-[min(45vh,280px)] w-full max-w-full min-h-0 overflow-y-auto overscroll-y-contain touch-pan-y sm:max-w-[50%]',
   '[scrollbar-gutter:stable]',
@@ -47,16 +52,13 @@ export type CompactSpaceBannerProps = {
   logoAlt: string;
   defaultLogoSrc: string;
   links?: string[] | null;
-  /** Shown faintly on the right; reinforces the space visual identity */
   leadImageUrl?: string | null;
   defaultLeadImageSrc?: string;
   memberCount: number;
   agreementCount: number;
-  /** Pre-formatted created date string (locale-aware) */
   createdOnText: string;
   membersLabel: string;
   agreementsLabel: string;
-  /** Trial / sandbox badges — typically `SubscriptionBadge` + `SpaceModeLabel` */
   footerTrailing?: React.ReactNode;
   className?: string;
 };
@@ -88,7 +90,6 @@ export function CompactSpaceBanner({
   return (
     <section
       className={cn(
-        /* Card chrome: ~12–16px radius, subtle blue-gray rim (design ref image 1) */
         'relative overflow-hidden rounded-xl border border-[#30363d]',
         'shadow-[0_24px_48px_-12px_rgba(5,33,22,0.55)]',
         'px-8 pt-8 pb-5',
@@ -96,87 +97,48 @@ export function CompactSpaceBanner({
       )}
       aria-label={title}
     >
-      {/* Atmosphere — deep forest base + spotlight (distinct from flat single gradient) */}
-      <div
-        className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_140%_100%_at_12%_-5%,rgb(41,115,78)_0%,rgb(18,72,52)_38%,rgb(7,38,26)_68%,rgb(2,14,10)_100%)]"
-        aria-hidden
-      />
-      <div
-        className="pointer-events-none absolute inset-0 mix-blend-overlay opacity-90 bg-[radial-gradient(ellipse_60%_45%_at_85%_20%,rgba(52,211,153,0.28),transparent_65%)]"
-        aria-hidden
-      />
-
-      {/* Fine grain — film texture */}
-      <div
-        className="pointer-events-none absolute inset-0 opacity-[0.07] mix-blend-overlay"
-        style={{
-          backgroundImage: `url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E")`,
-        }}
-        aria-hidden
-      />
-
-      {/* Hero image — richer bokeh + color pop, then a cool grade for “studio” depth */}
+      {/* Lead image fill — PR #2165 hero-style base */}
       {textureSrc ? (
         <>
           <div
-            className="pointer-events-none absolute inset-0 bg-cover bg-center opacity-[0.48]"
-            style={{
-              backgroundImage: `url(${cssUrlQuoted(textureSrc)})`,
-              filter: 'blur(32px) saturate(1.35) contrast(1.08)',
-              transform: 'scale(1.12)',
-            }}
-            aria-hidden
-          />
-          <div
-            className="pointer-events-none absolute inset-0 bg-cover bg-[center_28%] bg-no-repeat opacity-[0.38] mix-blend-soft-light"
+            className="pointer-events-none absolute inset-0 bg-cover bg-center"
             style={{ backgroundImage: `url(${cssUrlQuoted(textureSrc)})` }}
             aria-hidden
           />
+          {/* Exact overlay stack from PR #2165 SpaceHeaderHeroCard */}
           <div
-            className="pointer-events-none absolute inset-0 mix-blend-color opacity-[0.22] bg-gradient-to-br from-teal-600/80 via-emerald-900/40 to-slate-950/90"
+            className="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/88 via-black/42 via-[52%] to-black/22"
+            aria-hidden
+          />
+          <div
+            className="pointer-events-none absolute inset-0 bg-gradient-to-r from-black/58 via-transparent to-black/40"
+            aria-hidden
+          />
+          <div
+            className="pointer-events-none absolute inset-0 bg-gradient-to-br from-accent-11/18 via-transparent to-transparent"
             aria-hidden
           />
         </>
       ) : (
         <div
-          className="pointer-events-none absolute inset-0 opacity-[0.1]"
-          style={{
-            backgroundImage: `
-              radial-gradient(ellipse 70% 55% at 85% 35%, rgba(52, 211, 153, 0.4), transparent 60%),
-              radial-gradient(circle at 25% 75%, rgba(16, 185, 129, 0.25), transparent 50%)
-            `,
-          }}
+          className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_140%_100%_at_12%_-5%,rgb(41,115,78)_0%,rgb(14,54,38)_42%,rgb(7,38,26)_68%,rgb(2,14,10)_100%)]"
           aria-hidden
         />
       )}
 
-      {/* Cinematic stack: vignette + rim light + footer anchor (replaces single flat veil) */}
-      <div
-        className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_95%_80%_at_50%_42%,transparent_0%,rgba(0,12,8,0.55)_78%,rgba(0,8,5,0.88)_100%)]"
-        aria-hidden
-      />
-      <div
-        className="pointer-events-none absolute inset-0 bg-gradient-to-b from-emerald-300/14 from-0% via-transparent via-35% to-transparent to-55%"
-        aria-hidden
-      />
-      <div
-        className="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/45 from-0% via-black/12 via-38% to-transparent to-58%"
-        aria-hidden
-      />
-      <div
-        className="pointer-events-none absolute inset-0 bg-gradient-to-r from-black/35 from-[-5%] via-transparent via-50% to-black/30 to-[105%]"
-        aria-hidden
-      />
+      <div className="relative z-10 flex flex-col gap-5">
+        {/* Row 1: avatar + title/links — avatar size matches PR #2165 */}
+        <div className="flex items-start gap-6">
+          <Avatar className={AVATAR_CLASS}>
+            <AvatarImage
+              src={logoUrl || defaultLogoSrc}
+              alt={logoAlt}
+              className="object-cover"
+            />
+          </Avatar>
 
-      <div className="relative z-10 flex items-start gap-6">
-        <Avatar className="h-20 w-20 shrink-0 rounded-full">
-          <AvatarImage src={logoUrl || defaultLogoSrc} alt={logoAlt} />
-        </Avatar>
-
-        {/* Title, purpose, divider, footer share one column so left edges align pixel-true */}
-        <div className="flex min-w-0 flex-1 flex-col gap-5">
-          <div className="space-y-2">
-            <h1 className="text-7 font-bold leading-tight tracking-tight text-white">
+          <div className="min-w-0 flex-1 space-y-2">
+            <h1 className="text-balance text-6 font-semibold tracking-tight text-white drop-shadow-sm sm:text-7">
               {title}
             </h1>
             {safeLinks.length > 0 ? (
@@ -201,46 +163,47 @@ export function CompactSpaceBanner({
               </div>
             ) : null}
           </div>
+        </div>
 
-          {description ? (
-            <div className={DESCRIPTION_SCROLL_BOX}>
-              <p className="text-pretty text-2 leading-[1.5] text-white/95 [text-shadow:0_1px_2px_rgba(0,0,0,0.55)]">
-                {description}
-              </p>
+        {/* Below header: same horizontal origin as avatar — not nested in title column */}
+        {description ? (
+          <div className={DESCRIPTION_SCROLL_BOX}>
+            <p className="text-pretty text-2 leading-[1.5] text-white/95 [text-shadow:0_1px_2px_rgba(0,0,0,0.55)]">
+              {description}
+            </p>
+          </div>
+        ) : null}
+
+        <div className="h-px w-full bg-white/12" role="presentation" />
+
+        <div className="flex flex-col gap-3 gap-x-5 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-1 text-white/88 [text-shadow:0_1px_2px_rgba(0,0,0,0.45)]">
+            <span>
+              <span className="font-bold tabular-nums text-white">
+                {memberCount}
+              </span>{' '}
+              <span className="text-white/92">{membersLabel}</span>
+            </span>
+            <span className="text-white/45" aria-hidden>
+              ·
+            </span>
+            <span>
+              <span className="font-bold tabular-nums text-white">
+                {agreementCount}
+              </span>{' '}
+              <span className="text-white/92">{agreementsLabel}</span>
+            </span>
+            <span className="text-white/45" aria-hidden>
+              ·
+            </span>
+            <span className="text-white/88">{createdOnText}</span>
+          </div>
+
+          {footerTrailing ? (
+            <div className="flex flex-wrap items-center justify-start gap-2 sm:justify-end [&_.rounded-lg]:rounded-md [&_a]:inline-flex [&_a]:items-center [&_button]:rounded-md [&_div]:inline-flex [&_div]:items-center">
+              {footerTrailing}
             </div>
           ) : null}
-
-          <div className="h-px w-full bg-white/12" role="presentation" />
-
-          <div className="flex flex-col gap-3 gap-x-5 sm:flex-row sm:items-center sm:justify-between">
-            <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-1 text-white/88 [text-shadow:0_1px_2px_rgba(0,0,0,0.45)]">
-              <span>
-                <span className="font-bold tabular-nums text-white">
-                  {memberCount}
-                </span>{' '}
-                <span className="text-white/92">{membersLabel}</span>
-              </span>
-              <span className="text-white/45" aria-hidden>
-                ·
-              </span>
-              <span>
-                <span className="font-bold tabular-nums text-white">
-                  {agreementCount}
-                </span>{' '}
-                <span className="text-white/92">{agreementsLabel}</span>
-              </span>
-              <span className="text-white/45" aria-hidden>
-                ·
-              </span>
-              <span className="text-white/88">{createdOnText}</span>
-            </div>
-
-            {footerTrailing ? (
-              <div className="flex flex-wrap items-center justify-start gap-2 sm:justify-end [&_.rounded-lg]:rounded-md [&_a]:inline-flex [&_a]:items-center [&_button]:rounded-md [&_div]:inline-flex [&_div]:items-center">
-                {footerTrailing}
-              </div>
-            ) : null}
-          </div>
         </div>
       </div>
     </section>

--- a/packages/epics/src/spaces/components/compact-space-banner.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner.tsx
@@ -4,6 +4,7 @@ import { LinkLabel } from '../../common/link-label';
 import { Avatar, AvatarImage } from '@hypha-platform/ui';
 import { cn } from '@hypha-platform/ui-utils';
 import { CompactSpaceBannerLead } from './compact-space-banner-lead';
+import { isSafeImageUrl } from '../utils/safe-image-url';
 
 function isSafeLinkHref(url: string): boolean {
   const t = url.trim();
@@ -11,19 +12,6 @@ function isSafeLinkHref(url: string): boolean {
   try {
     const u = new URL(t);
     return u.protocol === 'https:' || u.protocol === 'http:';
-  } catch {
-    return false;
-  }
-}
-
-function isSafeTextureUrl(raw: string): boolean {
-  const t = raw.trim();
-  if (!t) return false;
-  /** Same-origin path only — reject protocol-relative `//evil` */
-  if (t.startsWith('/') && !t.startsWith('//')) return true;
-  try {
-    const u = new URL(t);
-    return u.protocol === 'http:' || u.protocol === 'https:';
   } catch {
     return false;
   }
@@ -89,8 +77,8 @@ export function CompactSpaceBanner({
   const textureSrc = (() => {
     const lead = leadImageUrl?.trim();
     const fallback = defaultLeadImageSrc?.trim() ?? '';
-    if (lead && isSafeTextureUrl(lead)) return lead;
-    if (fallback && isSafeTextureUrl(fallback)) return fallback;
+    if (lead && isSafeImageUrl(lead)) return lead;
+    if (fallback && isSafeImageUrl(fallback)) return fallback;
     return '';
   })();
 

--- a/packages/epics/src/spaces/components/compact-space-banner.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner.tsx
@@ -54,7 +54,7 @@ export function CompactSpaceBanner({
   return (
     <section
       className={cn(
-        'relative overflow-hidden rounded-3xl border border-white/25',
+        'relative overflow-hidden rounded-3xl',
         'shadow-[0_24px_48px_-12px_rgba(5,33,22,0.55)]',
         'p-8',
         className,

--- a/packages/epics/src/spaces/components/compact-space-banner.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner.tsx
@@ -54,7 +54,8 @@ export function CompactSpaceBanner({
   return (
     <section
       className={cn(
-        'relative overflow-hidden rounded-xl',
+        /* Production-style corner: large smooth radius + hairline dark rim (ref image 1) */
+        'relative overflow-hidden rounded-[40px] border border-[#1a1a1a]',
         'shadow-[0_24px_48px_-12px_rgba(5,33,22,0.55)]',
         'p-8',
         className,

--- a/packages/epics/src/spaces/components/compact-space-banner.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner.tsx
@@ -227,7 +227,17 @@ export function CompactSpaceBanner({
 
         {/* Below header: same horizontal origin as avatar — not nested in title column */}
         {description ? (
-          <div className={DESCRIPTION_SCROLL_BOX}>
+          <div
+            role="region"
+            aria-label={
+              logoAlt ? `${logoAlt}: description` : 'Space description'
+            }
+            tabIndex={0}
+            className={cn(
+              DESCRIPTION_SCROLL_BOX,
+              'outline-none focus-visible:ring-2 focus-visible:ring-white/70 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent',
+            )}
+          >
             <p className="text-pretty text-2 leading-[1.5] text-white/95 [text-shadow:0_1px_2px_rgba(0,0,0,0.55)]">
               {description}
             </p>

--- a/packages/epics/src/spaces/components/compact-space-banner.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner.tsx
@@ -109,7 +109,7 @@ export function CompactSpaceBanner({
       <div className="relative z-10 flex flex-col gap-6">
         {/* Header row: avatar + title stack only (Image 2) */}
         <div className="flex items-start gap-6">
-          <Avatar className="h-20 w-20 shrink-0 rounded-full ring-2 ring-emerald-400/90 ring-offset-[3px] ring-offset-[#0a2818]">
+          <Avatar className="h-20 w-20 shrink-0 rounded-full">
             <AvatarImage src={logoUrl || defaultLogoSrc} alt={logoAlt} />
           </Avatar>
 

--- a/packages/epics/src/spaces/components/compact-space-banner.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner.tsx
@@ -3,6 +3,7 @@ import { LinkIcon } from '../../common/link-icon';
 import { LinkLabel } from '../../common/link-label';
 import { Avatar, AvatarImage } from '@hypha-platform/ui';
 import { cn } from '@hypha-platform/ui-utils';
+import { CompactSpaceBannerLead } from './compact-space-banner-lead';
 
 function isSafeLinkHref(url: string): boolean {
   const t = url.trim();
@@ -25,10 +26,6 @@ function isSafeTextureUrl(raw: string): boolean {
   } catch {
     return false;
   }
-}
-
-function cssUrlQuoted(url: string): string {
-  return JSON.stringify(url);
 }
 
 /** Matches PR #2165 `SpaceHeaderInsetAvatar` footprint */
@@ -97,14 +94,10 @@ export function CompactSpaceBanner({
       )}
       aria-label={title}
     >
-      {/* Lead image fill — PR #2165 hero-style base */}
+      {/* Lead image — Image + preload avoids grey decode flash; overlays unchanged */}
       {textureSrc ? (
         <>
-          <div
-            className="pointer-events-none absolute inset-0 bg-cover bg-center"
-            style={{ backgroundImage: `url(${cssUrlQuoted(textureSrc)})` }}
-            aria-hidden
-          />
+          <CompactSpaceBannerLead src={textureSrc} />
           {/* Exact overlay stack from PR #2165 SpaceHeaderHeroCard */}
           <div
             className="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/88 via-black/42 via-[52%] to-black/22"

--- a/packages/epics/src/spaces/components/compact-space-banner.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner.tsx
@@ -45,7 +45,8 @@ export const COMPACT_SPACE_BANNER_TITLE_CLASSNAME = cn(
 /** Purpose column — max four lines on narrow viewports (scroll); sm+ wider column + taller cap. */
 const DESCRIPTION_SCROLL_BOX = cn(
   'w-full max-w-full min-h-0 max-h-[4lh] overflow-y-auto overscroll-y-contain touch-pan-y',
-  'text-2 leading-[1.5] sm:max-h-[min(45vh,280px)] sm:max-w-[50%]',
+  /* Slightly under text-2 (14px) for calmer purpose copy vs title */
+  'text-[13px] leading-[1.45] sm:max-h-[min(45vh,280px)] sm:max-w-[50%]',
   '[scrollbar-gutter:stable]',
   '[scrollbar-color:rgba(255,255,255,0.35)_transparent] [scrollbar-width:thin]',
   '[&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-white/30 [&::-webkit-scrollbar-track]:bg-transparent',
@@ -252,7 +253,7 @@ export function CompactSpaceBanner({
               'outline-none focus-visible:ring-2 focus-visible:ring-white/70 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent',
             )}
           >
-            <p className="text-pretty text-2 leading-[1.5] text-white/95 [text-shadow:0_1px_2px_rgba(0,0,0,0.55)]">
+            <p className="text-pretty text-white/95 [text-shadow:0_1px_2px_rgba(0,0,0,0.55)]">
               {description}
             </p>
           </div>

--- a/packages/epics/src/spaces/components/compact-space-banner.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner.tsx
@@ -78,9 +78,13 @@ export function CompactSpaceBanner({
   footerTrailing,
   className,
 }: CompactSpaceBannerProps) {
-  const rawTexture = leadImageUrl || defaultLeadImageSrc || '';
-  const textureSrc =
-    rawTexture && isSafeTextureUrl(rawTexture) ? rawTexture.trim() : '';
+  const textureSrc = (() => {
+    const lead = leadImageUrl?.trim();
+    const fallback = defaultLeadImageSrc?.trim() ?? '';
+    if (lead && isSafeTextureUrl(lead)) return lead;
+    if (fallback && isSafeTextureUrl(fallback)) return fallback;
+    return '';
+  })();
 
   const safeLinks =
     links?.filter((l) => typeof l === 'string' && isSafeLinkHref(l)) ?? [];

--- a/packages/epics/src/spaces/components/compact-space-banner.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner.tsx
@@ -1,0 +1,159 @@
+import * as React from 'react';
+import { LinkIcon } from '../../common/link-icon';
+import { LinkLabel } from '../../common/link-label';
+import { Avatar, AvatarImage } from '@hypha-platform/ui';
+import { cn } from '@hypha-platform/ui-utils';
+
+export type CompactSpaceBannerProps = {
+  title: string;
+  description: string | null | undefined;
+  logoUrl: string | null | undefined;
+  logoAlt: string;
+  defaultLogoSrc: string;
+  links?: string[] | null;
+  /** Shown faintly on the right; reinforces the space visual identity */
+  leadImageUrl?: string | null;
+  defaultLeadImageSrc?: string;
+  memberCount: number;
+  agreementCount: number;
+  /** Pre-formatted created date string (locale-aware) */
+  createdOnText: string;
+  membersLabel: string;
+  agreementsLabel: string;
+  /** Trial / sandbox badges — typically `SubscriptionBadge` + `SpaceModeLabel` */
+  footerTrailing?: React.ReactNode;
+  className?: string;
+};
+
+export function CompactSpaceBanner({
+  title,
+  description,
+  logoUrl,
+  logoAlt,
+  defaultLogoSrc,
+  links,
+  leadImageUrl,
+  defaultLeadImageSrc,
+  memberCount,
+  agreementCount,
+  createdOnText,
+  membersLabel,
+  agreementsLabel,
+  footerTrailing,
+  className,
+}: CompactSpaceBannerProps) {
+  const textureSrc = leadImageUrl || defaultLeadImageSrc || undefined;
+
+  return (
+    <section
+      className={cn(
+        'relative overflow-hidden rounded-2xl border border-white/10',
+        'bg-gradient-to-br from-[#0b2214] via-[#143d28] to-[#0d2818]',
+        'p-6 sm:p-8 shadow-lg',
+        className,
+      )}
+      aria-label={title}
+    >
+      {/* Foliage-like noise + lead image texture */}
+      <div
+        className="pointer-events-none absolute inset-0 opacity-[0.12]"
+        style={{
+          backgroundImage: `
+            radial-gradient(ellipse 80% 60% at 90% 40%, rgba(34, 197, 94, 0.35), transparent 55%),
+            radial-gradient(circle at 20% 80%, rgba(16, 185, 129, 0.2), transparent 45%),
+            repeating-linear-gradient(
+              -18deg,
+              transparent,
+              transparent 2px,
+              rgba(0, 0, 0, 0.08) 2px,
+              rgba(0, 0, 0, 0.08) 4px
+            )
+          `,
+        }}
+        aria-hidden
+      />
+      {textureSrc ? (
+        <div
+          className="pointer-events-none absolute inset-0 bg-cover bg-right bg-no-repeat opacity-[0.18] mix-blend-overlay"
+          style={{ backgroundImage: `url(${textureSrc})` }}
+          aria-hidden
+        />
+      ) : null}
+      <div
+        className="pointer-events-none absolute inset-0 bg-gradient-to-r from-black/25 via-transparent to-emerald-950/40"
+        aria-hidden
+      />
+
+      <div className="relative z-10 flex flex-col gap-5">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:gap-6">
+          <Avatar className="h-20 w-20 shrink-0 rounded-full ring-2 ring-white/25 ring-offset-2 ring-offset-[#0f331f]">
+            <AvatarImage src={logoUrl || defaultLogoSrc} alt={logoAlt} />
+          </Avatar>
+
+          <div className="min-w-0 flex-1 space-y-3">
+            <h1 className="text-7 font-semibold leading-tight tracking-tight text-white">
+              {title}
+            </h1>
+            {links && links.length > 0 ? (
+              <div className="flex flex-wrap gap-x-5 gap-y-2">
+                {links.map((link, index) => (
+                  <a
+                    key={`${link}_${index}`}
+                    href={link}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1.5 text-1 text-white/95 hover:text-white"
+                  >
+                    <span className="text-white/90 [&_svg]:h-4 [&_svg]:w-4">
+                      <LinkIcon url={link} />
+                    </span>
+                    <LinkLabel
+                      url={link}
+                      className="underline-offset-4 hover:underline"
+                    />
+                  </a>
+                ))}
+              </div>
+            ) : null}
+
+            {description ? (
+              <p className="max-w-full text-2 leading-relaxed text-white/90 sm:max-w-[52%]">
+                {description}
+              </p>
+            ) : null}
+          </div>
+        </div>
+
+        <div className="h-px w-full bg-white/15" role="presentation" />
+
+        <div className="flex flex-col gap-4 gap-x-6 md:flex-row md:items-center md:justify-between">
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-1 text-white/75">
+            <span>
+              <span className="font-semibold text-white/95">{memberCount}</span>{' '}
+              {membersLabel}
+            </span>
+            <span className="text-white/40" aria-hidden>
+              ·
+            </span>
+            <span>
+              <span className="font-semibold text-white/95">
+                {agreementCount}
+              </span>{' '}
+              {agreementsLabel}
+            </span>
+            <span className="text-white/40" aria-hidden>
+              ·
+            </span>
+            <span>{createdOnText}</span>
+          </div>
+
+          {footerTrailing ? (
+            <div className="flex flex-wrap items-center justify-start gap-2 md:justify-end">
+              {footerTrailing}
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/packages/epics/src/spaces/components/compact-space-banner.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner.tsx
@@ -37,8 +37,8 @@ export type CompactSpaceBannerProps = {
   links?: string[] | null;
   leadImageUrl?: string | null;
   defaultLeadImageSrc?: string;
-  memberCount: number;
-  agreementCount: number;
+  memberCount: number | null;
+  agreementCount: number | null;
   createdOnText: string;
   membersLabel: string;
   agreementsLabel: string;
@@ -252,7 +252,7 @@ export function CompactSpaceBanner({
             <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-1 text-white/88 [text-shadow:0_1px_2px_rgba(0,0,0,0.45)]">
               <span>
                 <span className="font-bold tabular-nums text-white">
-                  {memberCount}
+                  {memberCount ?? '—'}
                 </span>{' '}
                 <span className="text-white/92">{membersLabel}</span>
               </span>
@@ -261,7 +261,7 @@ export function CompactSpaceBanner({
               </span>
               <span>
                 <span className="font-bold tabular-nums text-white">
-                  {agreementCount}
+                  {agreementCount ?? '—'}
                 </span>{' '}
                 <span className="text-white/92">{agreementsLabel}</span>
               </span>

--- a/packages/epics/src/spaces/components/compact-space-banner.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner.tsx
@@ -237,7 +237,7 @@ export function CompactSpaceBanner({
           </div>
 
           {footerTrailing ? (
-            <div className="flex flex-wrap items-center justify-start gap-2 sm:justify-end [&_.rounded-lg]:rounded-md [&_button]:rounded-md">
+            <div className="flex flex-wrap items-center justify-start gap-2 sm:justify-end [&_.rounded-lg]:rounded-md [&_a]:inline-flex [&_a]:items-center [&_button]:rounded-md [&_div]:inline-flex [&_div]:items-center">
               {footerTrailing}
             </div>
           ) : null}

--- a/packages/epics/src/spaces/components/compact-space-banner.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner.tsx
@@ -47,51 +47,74 @@ export function CompactSpaceBanner({
   return (
     <section
       className={cn(
-        'relative overflow-hidden rounded-2xl border border-white/10',
-        'bg-gradient-to-br from-[#0b2214] via-[#143d28] to-[#0d2818]',
-        'p-6 sm:p-8 shadow-lg',
+        'relative overflow-hidden rounded-3xl border border-white/25',
+        'shadow-[0_24px_48px_-12px_rgba(5,33,22,0.55)]',
+        'p-8',
         className,
       )}
       aria-label={title}
     >
-      {/* Foliage-like noise + lead image texture */}
+      {/* Base gradient — lighter top-left (Image 2), darker bottom-right */}
       <div
-        className="pointer-events-none absolute inset-0 opacity-[0.12]"
+        className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_120%_90%_at_10%_-10%,rgb(34,94,62)_0%,rgb(14,54,38)_42%,rgb(5,33,22)_72%,rgb(2,18,12)_100%)]"
+        aria-hidden
+      />
+
+      {/* Fine grain */}
+      <div
+        className="pointer-events-none absolute inset-0 opacity-[0.06]"
         style={{
-          backgroundImage: `
-            radial-gradient(ellipse 80% 60% at 90% 40%, rgba(34, 197, 94, 0.35), transparent 55%),
-            radial-gradient(circle at 20% 80%, rgba(16, 185, 129, 0.2), transparent 45%),
-            repeating-linear-gradient(
-              -18deg,
-              transparent,
-              transparent 2px,
-              rgba(0, 0, 0, 0.08) 2px,
-              rgba(0, 0, 0, 0.08) 4px
-            )
-          `,
+          backgroundImage: `url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E")`,
         }}
         aria-hidden
       />
+
+      {/* Bokeh foliage — full-bleed, visibly layered like Image 2 */}
       {textureSrc ? (
+        <>
+          <div
+            className="pointer-events-none absolute inset-0 bg-cover bg-center opacity-[0.42]"
+            style={{
+              backgroundImage: `url(${textureSrc})`,
+              filter: 'blur(28px) saturate(1.15)',
+              transform: 'scale(1.08)',
+            }}
+            aria-hidden
+          />
+          <div
+            className="pointer-events-none absolute inset-0 bg-cover bg-[center_30%] bg-no-repeat opacity-[0.35] mix-blend-soft-light"
+            style={{ backgroundImage: `url(${textureSrc})` }}
+            aria-hidden
+          />
+        </>
+      ) : (
         <div
-          className="pointer-events-none absolute inset-0 bg-cover bg-right bg-no-repeat opacity-[0.18] mix-blend-overlay"
-          style={{ backgroundImage: `url(${textureSrc})` }}
+          className="pointer-events-none absolute inset-0 opacity-[0.08]"
+          style={{
+            backgroundImage: `
+              radial-gradient(ellipse 70% 55% at 85% 35%, rgba(34, 197, 94, 0.35), transparent 60%),
+              radial-gradient(circle at 25% 75%, rgba(16, 185, 129, 0.22), transparent 50%)
+            `,
+          }}
           aria-hidden
         />
-      ) : null}
+      )}
+
+      {/* Readability veil — keeps text crisp over photo */}
       <div
-        className="pointer-events-none absolute inset-0 bg-gradient-to-r from-black/25 via-transparent to-emerald-950/40"
+        className="pointer-events-none absolute inset-0 bg-gradient-to-br from-black/35 via-transparent to-emerald-950/55"
         aria-hidden
       />
 
-      <div className="relative z-10 flex flex-col gap-5">
-        <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:gap-6">
-          <Avatar className="h-20 w-20 shrink-0 rounded-full ring-2 ring-white/25 ring-offset-2 ring-offset-[#0f331f]">
+      <div className="relative z-10 flex flex-col gap-6">
+        {/* Header row: avatar + title stack only (Image 2) */}
+        <div className="flex items-start gap-6">
+          <Avatar className="h-20 w-20 shrink-0 rounded-full ring-2 ring-emerald-400/90 ring-offset-[3px] ring-offset-[#0a2818]">
             <AvatarImage src={logoUrl || defaultLogoSrc} alt={logoAlt} />
           </Avatar>
 
-          <div className="min-w-0 flex-1 space-y-3">
-            <h1 className="text-7 font-semibold leading-tight tracking-tight text-white">
+          <div className="min-w-0 flex-1 space-y-2">
+            <h1 className="text-7 font-bold leading-tight tracking-tight text-white">
               {title}
             </h1>
             {links && links.length > 0 ? (
@@ -102,9 +125,9 @@ export function CompactSpaceBanner({
                     href={link}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="inline-flex items-center gap-1.5 text-1 text-white/95 hover:text-white"
+                    className="inline-flex items-center gap-1.5 text-1 text-white/80 hover:text-white"
                   >
-                    <span className="text-white/90 [&_svg]:h-4 [&_svg]:w-4">
+                    <span className="text-white/80 [&_svg]:h-4 [&_svg]:w-4">
                       <LinkIcon url={link} />
                     </span>
                     <LinkLabel
@@ -115,40 +138,39 @@ export function CompactSpaceBanner({
                 ))}
               </div>
             ) : null}
-
-            {description ? (
-              <p className="max-w-full text-2 leading-relaxed text-white/90 sm:max-w-[52%]">
-                {description}
-              </p>
-            ) : null}
           </div>
         </div>
 
-        <div className="h-px w-full bg-white/15" role="presentation" />
+        {/* Body — full width under header (Image 2); not constrained to half column */}
+        {description ? (
+          <p className="max-w-none text-2 leading-[1.5] text-white">
+            {description}
+          </p>
+        ) : null}
 
-        <div className="flex flex-col gap-4 gap-x-6 md:flex-row md:items-center md:justify-between">
-          <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-1 text-white/75">
+        <div className="h-px w-full bg-white/12" role="presentation" />
+
+        <div className="flex flex-col gap-4 gap-x-6 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-1 text-neutral-11">
             <span>
-              <span className="font-semibold text-white/95">{memberCount}</span>{' '}
+              <span className="font-bold text-white">{memberCount}</span>{' '}
               {membersLabel}
             </span>
-            <span className="text-white/40" aria-hidden>
+            <span className="text-neutral-10" aria-hidden>
               ·
             </span>
             <span>
-              <span className="font-semibold text-white/95">
-                {agreementCount}
-              </span>{' '}
+              <span className="font-bold text-white">{agreementCount}</span>{' '}
               {agreementsLabel}
             </span>
-            <span className="text-white/40" aria-hidden>
+            <span className="text-neutral-10" aria-hidden>
               ·
             </span>
             <span>{createdOnText}</span>
           </div>
 
           {footerTrailing ? (
-            <div className="flex flex-wrap items-center justify-start gap-2 md:justify-end">
+            <div className="flex flex-wrap items-center justify-start gap-2 sm:justify-end [&_.rounded-lg]:rounded-full [&_button]:rounded-full">
               {footerTrailing}
             </div>
           ) : null}

--- a/packages/epics/src/spaces/components/compact-space-banner.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner.tsx
@@ -29,10 +29,15 @@ function isSafeTextureUrl(raw: string): boolean {
   }
 }
 
-/** Matches PR #2165 `SpaceHeaderInsetAvatar` footprint */
-const AVATAR_CLASS = cn(
+/** Matches PR #2165 `SpaceHeaderInsetAvatar` footprint — shared with DHO sticky chrome row */
+export const COMPACT_SPACE_BANNER_AVATAR_CLASSNAME = cn(
   'h-16 w-16 shrink-0 rounded-full sm:h-[72px] sm:w-[72px]',
   'shadow-[0_18px_40px_-12px_rgba(0,0,0,0.55)] ring-1 ring-white/15',
+);
+
+/** Title size/weight on the banner — reuse on sticky for horizontal alignment */
+export const COMPACT_SPACE_BANNER_TITLE_CLASSNAME = cn(
+  'text-balance text-6 font-semibold tracking-tight sm:text-7',
 );
 
 /** Purpose column — narrow on sm+; left edge aligns with avatar (full-width column below header row). */
@@ -189,7 +194,7 @@ export function CompactSpaceBanner({
       <div className="relative z-10 flex flex-col gap-5">
         {/* Row 1: avatar + title/links — avatar size matches PR #2165 */}
         <div className="flex items-start gap-6">
-          <Avatar className={AVATAR_CLASS}>
+          <Avatar className={COMPACT_SPACE_BANNER_AVATAR_CLASSNAME}>
             <AvatarImage
               src={logoUrl || defaultLogoSrc}
               alt={logoAlt}
@@ -198,7 +203,12 @@ export function CompactSpaceBanner({
           </Avatar>
 
           <div className="min-w-0 flex-1 space-y-2">
-            <h1 className="text-balance text-6 font-semibold tracking-tight text-white drop-shadow-sm sm:text-7">
+            <h1
+              className={cn(
+                COMPACT_SPACE_BANNER_TITLE_CLASSNAME,
+                'text-white drop-shadow-sm',
+              )}
+            >
               {title}
             </h1>
             {safeLinks.length > 0 ? (

--- a/packages/epics/src/spaces/components/compact-space-banner.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner.tsx
@@ -15,6 +15,23 @@ function isSafeLinkHref(url: string): boolean {
   }
 }
 
+/** Same-origin paths or absolute http(s) — safe for CSS url() without injection. */
+function isSafeTextureUrl(raw: string): boolean {
+  const t = raw.trim();
+  if (!t) return false;
+  if (t.startsWith('/')) return true;
+  try {
+    const u = new URL(t);
+    return u.protocol === 'http:' || u.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+function cssUrlQuoted(url: string): string {
+  return JSON.stringify(url);
+}
+
 /** Scrollable purpose block — mirrors #2165 hero (`overflow-y-auto`, thin scrollbar). */
 const DESCRIPTION_SCROLL_BOX = cn(
   'max-h-[min(45vh,280px)] w-full min-h-0 overflow-y-auto overscroll-y-contain pr-1 touch-pan-y',
@@ -60,7 +77,9 @@ export function CompactSpaceBanner({
   footerTrailing,
   className,
 }: CompactSpaceBannerProps) {
-  const textureSrc = leadImageUrl || defaultLeadImageSrc || undefined;
+  const rawTexture = leadImageUrl || defaultLeadImageSrc || '';
+  const textureSrc =
+    rawTexture && isSafeTextureUrl(rawTexture) ? rawTexture.trim() : '';
 
   const safeLinks =
     links?.filter((l) => typeof l === 'string' && isSafeLinkHref(l)) ?? [];
@@ -101,7 +120,7 @@ export function CompactSpaceBanner({
           <div
             className="pointer-events-none absolute inset-0 bg-cover bg-center opacity-[0.48]"
             style={{
-              backgroundImage: `url(${textureSrc})`,
+              backgroundImage: `url(${cssUrlQuoted(textureSrc)})`,
               filter: 'blur(32px) saturate(1.35) contrast(1.08)',
               transform: 'scale(1.12)',
             }}
@@ -109,7 +128,7 @@ export function CompactSpaceBanner({
           />
           <div
             className="pointer-events-none absolute inset-0 bg-cover bg-[center_28%] bg-no-repeat opacity-[0.38] mix-blend-soft-light"
-            style={{ backgroundImage: `url(${textureSrc})` }}
+            style={{ backgroundImage: `url(${cssUrlQuoted(textureSrc)})` }}
             aria-hidden
           />
           <div

--- a/packages/epics/src/spaces/components/compact-space-banner.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner.tsx
@@ -61,55 +61,75 @@ export function CompactSpaceBanner({
       )}
       aria-label={title}
     >
-      {/* Base gradient — lighter top-left (Image 2), darker bottom-right */}
+      {/* Atmosphere — deep forest base + spotlight (distinct from flat single gradient) */}
       <div
-        className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_120%_90%_at_10%_-10%,rgb(34,94,62)_0%,rgb(14,54,38)_42%,rgb(5,33,22)_72%,rgb(2,18,12)_100%)]"
+        className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_140%_100%_at_12%_-5%,rgb(41,115,78)_0%,rgb(18,72,52)_38%,rgb(7,38,26)_68%,rgb(2,14,10)_100%)]"
+        aria-hidden
+      />
+      <div
+        className="pointer-events-none absolute inset-0 mix-blend-overlay opacity-90 bg-[radial-gradient(ellipse_60%_45%_at_85%_20%,rgba(52,211,153,0.28),transparent_65%)]"
         aria-hidden
       />
 
-      {/* Fine grain */}
+      {/* Fine grain — film texture */}
       <div
-        className="pointer-events-none absolute inset-0 opacity-[0.06]"
+        className="pointer-events-none absolute inset-0 opacity-[0.07] mix-blend-overlay"
         style={{
           backgroundImage: `url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E")`,
         }}
         aria-hidden
       />
 
-      {/* Bokeh foliage — full-bleed, visibly layered like Image 2 */}
+      {/* Hero image — richer bokeh + color pop, then a cool grade for “studio” depth */}
       {textureSrc ? (
         <>
           <div
-            className="pointer-events-none absolute inset-0 bg-cover bg-center opacity-[0.42]"
+            className="pointer-events-none absolute inset-0 bg-cover bg-center opacity-[0.48]"
             style={{
               backgroundImage: `url(${textureSrc})`,
-              filter: 'blur(28px) saturate(1.15)',
-              transform: 'scale(1.08)',
+              filter: 'blur(32px) saturate(1.35) contrast(1.08)',
+              transform: 'scale(1.12)',
             }}
             aria-hidden
           />
           <div
-            className="pointer-events-none absolute inset-0 bg-cover bg-[center_30%] bg-no-repeat opacity-[0.35] mix-blend-soft-light"
+            className="pointer-events-none absolute inset-0 bg-cover bg-[center_28%] bg-no-repeat opacity-[0.38] mix-blend-soft-light"
             style={{ backgroundImage: `url(${textureSrc})` }}
+            aria-hidden
+          />
+          <div
+            className="pointer-events-none absolute inset-0 mix-blend-color opacity-[0.22] bg-gradient-to-br from-teal-600/80 via-emerald-900/40 to-slate-950/90"
             aria-hidden
           />
         </>
       ) : (
         <div
-          className="pointer-events-none absolute inset-0 opacity-[0.08]"
+          className="pointer-events-none absolute inset-0 opacity-[0.1]"
           style={{
             backgroundImage: `
-              radial-gradient(ellipse 70% 55% at 85% 35%, rgba(34, 197, 94, 0.35), transparent 60%),
-              radial-gradient(circle at 25% 75%, rgba(16, 185, 129, 0.22), transparent 50%)
+              radial-gradient(ellipse 70% 55% at 85% 35%, rgba(52, 211, 153, 0.4), transparent 60%),
+              radial-gradient(circle at 25% 75%, rgba(16, 185, 129, 0.25), transparent 50%)
             `,
           }}
           aria-hidden
         />
       )}
 
-      {/* Readability veil — darken foliage under typography (neutral-* tokens are for light surfaces) */}
+      {/* Cinematic stack: vignette + rim light + footer anchor (replaces single flat veil) */}
       <div
-        className="pointer-events-none absolute inset-0 bg-gradient-to-br from-black/45 via-black/25 to-emerald-950/65"
+        className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_95%_80%_at_50%_42%,transparent_0%,rgba(0,12,8,0.55)_78%,rgba(0,8,5,0.88)_100%)]"
+        aria-hidden
+      />
+      <div
+        className="pointer-events-none absolute inset-0 bg-gradient-to-b from-emerald-300/14 from-0% via-transparent via-35% to-transparent to-55%"
+        aria-hidden
+      />
+      <div
+        className="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/60 from-0% via-black/18 via-45% to-transparent to-72%"
+        aria-hidden
+      />
+      <div
+        className="pointer-events-none absolute inset-0 bg-gradient-to-r from-black/35 from-[-5%] via-transparent via-50% to-black/30 to-[105%]"
         aria-hidden
       />
 

--- a/packages/epics/src/spaces/components/compact-space-banner.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner.tsx
@@ -38,6 +38,8 @@ export const COMPACT_SPACE_BANNER_AVATAR_CLASSNAME = cn(
 /** Title size/weight on the banner — reuse on sticky for horizontal alignment */
 export const COMPACT_SPACE_BANNER_TITLE_CLASSNAME = cn(
   'text-balance text-6 font-semibold tracking-tight sm:text-7',
+  /* Use design-token text stack from packages/ui-utils @theme (--font-family-text) */
+  '[font-family:var(--font-family-text),ui-sans-serif,system-ui,sans-serif]',
 );
 
 /** Purpose column — max four lines on narrow viewports (scroll); sm+ wider column + taller cap. */

--- a/packages/epics/src/spaces/components/compact-space-banner.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner.tsx
@@ -34,7 +34,8 @@ function cssUrlQuoted(url: string): string {
 
 /** Scrollable purpose block — narrow column (~50% on sm+) so copy wraps like design ref. */
 const DESCRIPTION_SCROLL_BOX = cn(
-  'max-h-[min(45vh,280px)] w-full max-w-full min-h-0 overflow-y-auto overscroll-y-contain pr-1 touch-pan-y sm:max-w-[50%]',
+  'max-h-[min(45vh,280px)] w-full max-w-full min-h-0 overflow-y-auto overscroll-y-contain touch-pan-y sm:max-w-[50%]',
+  '[scrollbar-gutter:stable]',
   '[scrollbar-color:rgba(255,255,255,0.35)_transparent] [scrollbar-width:thin]',
   '[&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-white/30 [&::-webkit-scrollbar-track]:bg-transparent',
 );
@@ -167,14 +168,14 @@ export function CompactSpaceBanner({
         aria-hidden
       />
 
-      <div className="relative z-10 flex flex-col gap-5">
-        {/* Header row: avatar + title stack only (Image 2) */}
-        <div className="flex items-start gap-6">
-          <Avatar className="h-20 w-20 shrink-0 rounded-full">
-            <AvatarImage src={logoUrl || defaultLogoSrc} alt={logoAlt} />
-          </Avatar>
+      <div className="relative z-10 flex items-start gap-6">
+        <Avatar className="h-20 w-20 shrink-0 rounded-full">
+          <AvatarImage src={logoUrl || defaultLogoSrc} alt={logoAlt} />
+        </Avatar>
 
-          <div className="min-w-0 flex-1 space-y-2">
+        {/* Title, purpose, divider, footer share one column so left edges align pixel-true */}
+        <div className="flex min-w-0 flex-1 flex-col gap-5">
+          <div className="space-y-2">
             <h1 className="text-7 font-bold leading-tight tracking-tight text-white">
               {title}
             </h1>
@@ -200,47 +201,46 @@ export function CompactSpaceBanner({
               </div>
             ) : null}
           </div>
-        </div>
 
-        {/* Body — scroll when copy exceeds max height (same interaction model as #2165 hero purpose) */}
-        {description ? (
-          <div className={DESCRIPTION_SCROLL_BOX}>
-            <p className="text-pretty text-2 leading-[1.5] text-white/95 [text-shadow:0_1px_2px_rgba(0,0,0,0.55)]">
-              {description}
-            </p>
-          </div>
-        ) : null}
-
-        <div className="h-px w-full bg-white/12" role="presentation" />
-
-        <div className="flex flex-col gap-3 gap-x-5 sm:flex-row sm:items-center sm:justify-between">
-          <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-1 text-white/88 [text-shadow:0_1px_2px_rgba(0,0,0,0.45)]">
-            <span>
-              <span className="font-bold tabular-nums text-white">
-                {memberCount}
-              </span>{' '}
-              <span className="text-white/92">{membersLabel}</span>
-            </span>
-            <span className="text-white/45" aria-hidden>
-              ·
-            </span>
-            <span>
-              <span className="font-bold tabular-nums text-white">
-                {agreementCount}
-              </span>{' '}
-              <span className="text-white/92">{agreementsLabel}</span>
-            </span>
-            <span className="text-white/45" aria-hidden>
-              ·
-            </span>
-            <span className="text-white/88">{createdOnText}</span>
-          </div>
-
-          {footerTrailing ? (
-            <div className="flex flex-wrap items-center justify-start gap-2 sm:justify-end [&_.rounded-lg]:rounded-md [&_a]:inline-flex [&_a]:items-center [&_button]:rounded-md [&_div]:inline-flex [&_div]:items-center">
-              {footerTrailing}
+          {description ? (
+            <div className={DESCRIPTION_SCROLL_BOX}>
+              <p className="text-pretty text-2 leading-[1.5] text-white/95 [text-shadow:0_1px_2px_rgba(0,0,0,0.55)]">
+                {description}
+              </p>
             </div>
           ) : null}
+
+          <div className="h-px w-full bg-white/12" role="presentation" />
+
+          <div className="flex flex-col gap-3 gap-x-5 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-1 text-white/88 [text-shadow:0_1px_2px_rgba(0,0,0,0.45)]">
+              <span>
+                <span className="font-bold tabular-nums text-white">
+                  {memberCount}
+                </span>{' '}
+                <span className="text-white/92">{membersLabel}</span>
+              </span>
+              <span className="text-white/45" aria-hidden>
+                ·
+              </span>
+              <span>
+                <span className="font-bold tabular-nums text-white">
+                  {agreementCount}
+                </span>{' '}
+                <span className="text-white/92">{agreementsLabel}</span>
+              </span>
+              <span className="text-white/45" aria-hidden>
+                ·
+              </span>
+              <span className="text-white/88">{createdOnText}</span>
+            </div>
+
+            {footerTrailing ? (
+              <div className="flex flex-wrap items-center justify-start gap-2 sm:justify-end [&_.rounded-lg]:rounded-md [&_a]:inline-flex [&_a]:items-center [&_button]:rounded-md [&_div]:inline-flex [&_div]:items-center">
+                {footerTrailing}
+              </div>
+            ) : null}
+          </div>
         </div>
       </div>
     </section>

--- a/packages/epics/src/spaces/components/compact-space-banner.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner.tsx
@@ -53,6 +53,8 @@ export type CompactSpaceBannerProps = {
   createdOnText: string;
   membersLabel: string;
   agreementsLabel: string;
+  /** Localized accessible name for the description region (screen readers). */
+  descriptionLabel: string;
   footerTrailing?: React.ReactNode;
   className?: string;
 };
@@ -71,6 +73,7 @@ export function CompactSpaceBanner({
   createdOnText,
   membersLabel,
   agreementsLabel,
+  descriptionLabel,
   footerTrailing,
   className,
 }: CompactSpaceBannerProps) {
@@ -231,9 +234,7 @@ export function CompactSpaceBanner({
         {description ? (
           <div
             role="region"
-            aria-label={
-              logoAlt ? `${logoAlt}: description` : 'Space description'
-            }
+            aria-label={descriptionLabel}
             tabIndex={0}
             className={cn(
               DESCRIPTION_SCROLL_BOX,

--- a/packages/epics/src/spaces/components/compact-space-banner.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner.tsx
@@ -35,9 +35,9 @@ export const COMPACT_SPACE_BANNER_AVATAR_CLASSNAME = cn(
   'shadow-[0_18px_40px_-12px_rgba(0,0,0,0.55)] ring-1 ring-white/15',
 );
 
-/** Title size/weight on the banner — reuse on sticky for horizontal alignment */
+/** Title size on the banner — reuse on sticky; regular weight (no semibold) for calmer hero + chrome */
 export const COMPACT_SPACE_BANNER_TITLE_CLASSNAME = cn(
-  'text-balance text-6 font-semibold tracking-tight sm:text-7',
+  'text-balance text-6 font-normal tracking-tight sm:text-7',
   /* Use design-token text stack from packages/ui-utils @theme (--font-family-text) */
   '[font-family:var(--font-family-text),ui-sans-serif,system-ui,sans-serif]',
 );

--- a/packages/epics/src/spaces/components/compact-space-banner.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner.tsx
@@ -118,12 +118,46 @@ export function CompactSpaceBanner({
             className="pointer-events-none absolute inset-0 bg-gradient-to-br from-accent-11/18 via-transparent to-transparent"
             aria-hidden
           />
+          {/* Depth pass — cinematic WOW without fighting hero readability */}
+          <div
+            className="pointer-events-none absolute inset-0 mix-blend-soft-light opacity-90 bg-[radial-gradient(ellipse_55%_45%_at_82%_8%,rgba(209,250,229,0.38),transparent_62%)]"
+            aria-hidden
+          />
+          <div
+            className="pointer-events-none absolute inset-0 bg-gradient-to-br from-white/[0.07] from-[-10%] via-transparent via-40% to-transparent to-55%"
+            aria-hidden
+          />
+          <div
+            className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_115%_95%_at_50%_72%,transparent_22%,rgba(0,18,12,0.62)_88%,rgba(0,8,5,0.92)_100%)]"
+            aria-hidden
+          />
+          <div
+            className="pointer-events-none absolute inset-0 rounded-[inherit] opacity-[0.055] mix-blend-overlay"
+            style={{
+              backgroundImage: `url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.78' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E")`,
+            }}
+            aria-hidden
+          />
+          <div
+            className="pointer-events-none absolute inset-0 rounded-[inherit] shadow-[inset_0_1px_0_rgba(255,255,255,0.09),inset_0_-1px_0_rgba(0,0,0,0.18)]"
+            aria-hidden
+          />
         </>
       ) : (
-        <div
-          className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_140%_100%_at_12%_-5%,rgb(41,115,78)_0%,rgb(14,54,38)_42%,rgb(7,38,26)_68%,rgb(2,14,10)_100%)]"
-          aria-hidden
-        />
+        <>
+          <div
+            className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_140%_100%_at_12%_-5%,rgb(41,115,78)_0%,rgb(14,54,38)_42%,rgb(7,38,26)_68%,rgb(2,14,10)_100%)]"
+            aria-hidden
+          />
+          <div
+            className="pointer-events-none absolute inset-0 mix-blend-soft-light opacity-80 bg-[radial-gradient(ellipse_50%_40%_at_80%_5%,rgba(52,211,153,0.2),transparent_60%)]"
+            aria-hidden
+          />
+          <div
+            className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_110%_90%_at_50%_78%,transparent_35%,rgba(0,14,10,0.72)_92%)]"
+            aria-hidden
+          />
+        </>
       )}
 
       <div className="relative z-10 flex flex-col gap-5">

--- a/packages/epics/src/spaces/components/compact-space-banner.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner.tsx
@@ -87,8 +87,8 @@ export function CompactSpaceBanner({
   return (
     <section
       className={cn(
-        /* Production-style corner: large smooth radius + hairline dark rim (ref image 1) */
-        'relative overflow-hidden rounded-[40px] border border-[#1a1a1a]',
+        /* Card chrome: ~12–16px radius, subtle blue-gray rim (design ref image 1) */
+        'relative overflow-hidden rounded-xl border border-[#30363d]',
         'shadow-[0_24px_48px_-12px_rgba(5,33,22,0.55)]',
         'p-8',
         className,

--- a/packages/epics/src/spaces/components/compact-space-banner.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner.tsx
@@ -19,7 +19,8 @@ function isSafeLinkHref(url: string): boolean {
 function isSafeTextureUrl(raw: string): boolean {
   const t = raw.trim();
   if (!t) return false;
-  if (t.startsWith('/')) return true;
+  /** Same-origin path only — reject protocol-relative `//evil` */
+  if (t.startsWith('/') && !t.startsWith('//')) return true;
   try {
     const u = new URL(t);
     return u.protocol === 'http:' || u.protocol === 'https:';

--- a/packages/epics/src/spaces/components/compact-space-banner.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner.tsx
@@ -234,36 +234,41 @@ export function CompactSpaceBanner({
           </div>
         ) : null}
 
-        <div className="h-px w-full bg-white/12" role="presentation" />
-
-        <div className="flex flex-col gap-3 gap-x-5 sm:flex-row sm:items-center sm:justify-between">
-          <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-1 text-white/88 [text-shadow:0_1px_2px_rgba(0,0,0,0.45)]">
-            <span>
-              <span className="font-bold tabular-nums text-white">
-                {memberCount}
-              </span>{' '}
-              <span className="text-white/92">{membersLabel}</span>
-            </span>
-            <span className="text-white/45" aria-hidden>
-              ·
-            </span>
-            <span>
-              <span className="font-bold tabular-nums text-white">
-                {agreementCount}
-              </span>{' '}
-              <span className="text-white/92">{agreementsLabel}</span>
-            </span>
-            <span className="text-white/45" aria-hidden>
-              ·
-            </span>
-            <span className="text-white/88">{createdOnText}</span>
-          </div>
-
-          {footerTrailing ? (
-            <div className="flex flex-wrap items-center justify-start gap-2 sm:justify-end [&_.rounded-lg]:rounded-md [&_a]:inline-flex [&_a]:items-center [&_button]:rounded-md [&_div]:inline-flex [&_div]:items-center">
-              {footerTrailing}
+        {/* Hairline + metadata: one flex item so gap-5 does not double-space above the strip */}
+        <div className="flex flex-col">
+          <div
+            className="h-px w-full shrink-0 bg-white/12"
+            role="presentation"
+          />
+          <div className="flex flex-col gap-3 gap-x-5 pt-3.5 pb-3.5 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-1 text-white/88 [text-shadow:0_1px_2px_rgba(0,0,0,0.45)]">
+              <span>
+                <span className="font-bold tabular-nums text-white">
+                  {memberCount}
+                </span>{' '}
+                <span className="text-white/92">{membersLabel}</span>
+              </span>
+              <span className="text-white/45" aria-hidden>
+                ·
+              </span>
+              <span>
+                <span className="font-bold tabular-nums text-white">
+                  {agreementCount}
+                </span>{' '}
+                <span className="text-white/92">{agreementsLabel}</span>
+              </span>
+              <span className="text-white/45" aria-hidden>
+                ·
+              </span>
+              <span className="text-white/88">{createdOnText}</span>
             </div>
-          ) : null}
+
+            {footerTrailing ? (
+              <div className="flex flex-wrap items-center justify-start gap-2 sm:justify-end [&_.rounded-lg]:rounded-md [&_a]:inline-flex [&_a]:items-center [&_button]:rounded-md [&_div]:inline-flex [&_div]:items-center">
+                {footerTrailing}
+              </div>
+            ) : null}
+          </div>
         </div>
       </div>
     </section>

--- a/packages/epics/src/spaces/components/compact-space-banner.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner.tsx
@@ -90,7 +90,7 @@ export function CompactSpaceBanner({
         /* Card chrome: ~12–16px radius, subtle blue-gray rim (design ref image 1) */
         'relative overflow-hidden rounded-xl border border-[#30363d]',
         'shadow-[0_24px_48px_-12px_rgba(5,33,22,0.55)]',
-        'p-8',
+        'px-8 pt-8 pb-5',
         className,
       )}
       aria-label={title}
@@ -159,7 +159,7 @@ export function CompactSpaceBanner({
         aria-hidden
       />
       <div
-        className="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/60 from-0% via-black/18 via-45% to-transparent to-72%"
+        className="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/45 from-0% via-black/12 via-38% to-transparent to-58%"
         aria-hidden
       />
       <div
@@ -167,7 +167,7 @@ export function CompactSpaceBanner({
         aria-hidden
       />
 
-      <div className="relative z-10 flex flex-col gap-6">
+      <div className="relative z-10 flex flex-col gap-5">
         {/* Header row: avatar + title stack only (Image 2) */}
         <div className="flex items-start gap-6">
           <Avatar className="h-20 w-20 shrink-0 rounded-full">
@@ -213,7 +213,7 @@ export function CompactSpaceBanner({
 
         <div className="h-px w-full bg-white/12" role="presentation" />
 
-        <div className="flex flex-col gap-4 gap-x-6 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex flex-col gap-3 gap-x-5 sm:flex-row sm:items-center sm:justify-between">
           <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-1 text-white/88 [text-shadow:0_1px_2px_rgba(0,0,0,0.45)]">
             <span>
               <span className="font-bold tabular-nums text-white">

--- a/packages/epics/src/spaces/components/compact-space-banner.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner.tsx
@@ -45,8 +45,7 @@ export const COMPACT_SPACE_BANNER_TITLE_CLASSNAME = cn(
 /** Purpose column — max four lines on narrow viewports (scroll); sm+ wider column + taller cap. */
 const DESCRIPTION_SCROLL_BOX = cn(
   'w-full max-w-full min-h-0 max-h-[4lh] overflow-y-auto overscroll-y-contain touch-pan-y',
-  /* Slightly under text-2 (14px) for calmer purpose copy vs title */
-  'text-[13px] leading-[1.45] sm:max-h-[min(45vh,280px)] sm:max-w-[50%]',
+  'text-2 leading-[1.5] sm:max-h-[min(45vh,280px)] sm:max-w-[50%]',
   '[scrollbar-gutter:stable]',
   '[scrollbar-color:rgba(255,255,255,0.35)_transparent] [scrollbar-width:thin]',
   '[&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-white/30 [&::-webkit-scrollbar-track]:bg-transparent',
@@ -253,7 +252,7 @@ export function CompactSpaceBanner({
               'outline-none focus-visible:ring-2 focus-visible:ring-white/70 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent',
             )}
           >
-            <p className="text-pretty text-white/95 [text-shadow:0_1px_2px_rgba(0,0,0,0.55)]">
+            <p className="text-pretty text-2 leading-[1.5] text-white/95 [text-shadow:0_1px_2px_rgba(0,0,0,0.55)]">
               {description}
             </p>
           </div>

--- a/packages/epics/src/spaces/components/compact-space-banner.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner.tsx
@@ -4,6 +4,13 @@ import { LinkLabel } from '../../common/link-label';
 import { Avatar, AvatarImage } from '@hypha-platform/ui';
 import { cn } from '@hypha-platform/ui-utils';
 
+/** Scrollable purpose block — mirrors #2165 hero (`overflow-y-auto`, thin scrollbar). */
+const DESCRIPTION_SCROLL_BOX = cn(
+  'max-h-[min(45vh,280px)] w-full min-h-0 overflow-y-auto overscroll-y-contain pr-1 touch-pan-y',
+  '[scrollbar-color:rgba(255,255,255,0.35)_transparent] [scrollbar-width:thin]',
+  '[&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-white/30 [&::-webkit-scrollbar-track]:bg-transparent',
+);
+
 export type CompactSpaceBannerProps = {
   title: string;
   description: string | null | undefined;
@@ -141,11 +148,13 @@ export function CompactSpaceBanner({
           </div>
         </div>
 
-        {/* Body — full width under header (Image 2); not constrained to half column */}
+        {/* Body — scroll when copy exceeds max height (same interaction model as #2165 hero purpose) */}
         {description ? (
-          <p className="max-w-none text-2 leading-[1.5] text-white">
-            {description}
-          </p>
+          <div className={DESCRIPTION_SCROLL_BOX}>
+            <p className="text-pretty text-2 leading-[1.5] text-white">
+              {description}
+            </p>
+          </div>
         ) : null}
 
         <div className="h-px w-full bg-white/12" role="presentation" />

--- a/packages/epics/src/spaces/components/compact-space-banner.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner.tsx
@@ -32,9 +32,9 @@ function cssUrlQuoted(url: string): string {
   return JSON.stringify(url);
 }
 
-/** Scrollable purpose block — mirrors #2165 hero (`overflow-y-auto`, thin scrollbar). */
+/** Scrollable purpose block — narrow column (~50% on sm+) so copy wraps like design ref. */
 const DESCRIPTION_SCROLL_BOX = cn(
-  'max-h-[min(45vh,280px)] w-full min-h-0 overflow-y-auto overscroll-y-contain pr-1 touch-pan-y',
+  'max-h-[min(45vh,280px)] w-full max-w-full min-h-0 overflow-y-auto overscroll-y-contain pr-1 touch-pan-y sm:max-w-[50%]',
   '[scrollbar-color:rgba(255,255,255,0.35)_transparent] [scrollbar-width:thin]',
   '[&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-white/30 [&::-webkit-scrollbar-track]:bg-transparent',
 );

--- a/packages/epics/src/spaces/components/create-subspace-form.tsx
+++ b/packages/epics/src/spaces/components/create-subspace-form.tsx
@@ -6,7 +6,7 @@ import { useParams, useRouter } from 'next/navigation';
 import { useJwt } from '@hypha-platform/core/client';
 import { useCreateSpaceOrchestrator } from '@hypha-platform/core/client';
 import React from 'react';
-import { LoadingBackdrop } from '@hypha-platform/ui/server';
+import { SpaceLoadingBackdrop } from './space-loading-backdrop';
 import { Button } from '@hypha-platform/ui';
 import { useMe } from '@hypha-platform/core/client';
 import { Locale } from '@hypha-platform/i18n';
@@ -50,7 +50,7 @@ export const CreateSubspaceForm = ({
   }, [progress, spaceSlug]);
 
   return (
-    <LoadingBackdrop
+    <SpaceLoadingBackdrop
       showKeepWindowOpenMessage={true}
       keepWindowOpenMessage={tAgreementFlow('loadingBackdrop.keepWindowOpen')}
       fullHeight={true}
@@ -79,6 +79,6 @@ export const CreateSubspaceForm = ({
         label="add"
         slugIncorrectMessage={t('slugAlreadyExistsLong')}
       />
-    </LoadingBackdrop>
+    </SpaceLoadingBackdrop>
   );
 };

--- a/packages/epics/src/spaces/components/index.ts
+++ b/packages/epics/src/spaces/components/index.ts
@@ -1,4 +1,5 @@
 export * from './activate-proposals-banner';
+export * from './compact-space-banner';
 export * from './category-search';
 export * from './category-spaces';
 export * from './create-space-form';

--- a/packages/epics/src/spaces/components/index.ts
+++ b/packages/epics/src/spaces/components/index.ts
@@ -1,5 +1,6 @@
 export * from './activate-proposals-banner';
 export * from './compact-space-banner';
+export * from './space-accent-from-images';
 export * from './category-search';
 export * from './category-spaces';
 export * from './create-space-form';

--- a/packages/epics/src/spaces/components/index.ts
+++ b/packages/epics/src/spaces/components/index.ts
@@ -1,6 +1,7 @@
 export * from './activate-proposals-banner';
 export * from './compact-space-banner';
 export * from './space-accent-from-images';
+export * from './space-accent-portal-context';
 export * from './category-search';
 export * from './category-spaces';
 export * from './create-space-form';

--- a/packages/epics/src/spaces/components/index.ts
+++ b/packages/epics/src/spaces/components/index.ts
@@ -35,3 +35,4 @@ export * from './space-discoverability-field';
 export * from './space-activity-access-field';
 export * from './space-access-denied';
 export * from './space-tab-access-wrapper';
+export * from './space-loading-backdrop';

--- a/packages/epics/src/spaces/components/join-space.tsx
+++ b/packages/epics/src/spaces/components/join-space.tsx
@@ -205,7 +205,7 @@ export const JoinSpace = ({ spaceId, web3SpaceId }: JoinSpaceProps) => {
       <Button
         disabled={isButtonDisabled || !isAuthenticated}
         onClick={handleJoinSpace}
-        className="rounded-lg min-w-[120px]"
+        className="min-w-[120px]"
         colorVariant={isMember || justJoined ? 'neutral' : 'accent'}
         variant={isMember || justJoined ? 'outline' : 'default'}
         title={!isAuthenticated ? t('signIn') : buttonTitle}

--- a/packages/epics/src/spaces/components/sales-banner.tsx
+++ b/packages/epics/src/spaces/components/sales-banner.tsx
@@ -101,9 +101,13 @@ export const SalesBanner = ({ web3SpaceId }: SalesBannerProps) => {
         <Button
           onClick={onClose}
           variant="ghost"
-          className="rounded-full w-fit text-foreground flex-shrink-0"
+          className="group rounded-full w-fit flex-shrink-0 text-foreground"
         >
-          <Cross1Icon width={16} height={16} />
+          <Cross1Icon
+            width={16}
+            height={16}
+            className="transition-colors group-hover:text-white dark:group-hover:text-foreground"
+          />
         </Button>
       </div>
     </div>

--- a/packages/epics/src/spaces/components/sales-banner.tsx
+++ b/packages/epics/src/spaces/components/sales-banner.tsx
@@ -69,7 +69,7 @@ export const SalesBanner = ({ web3SpaceId }: SalesBannerProps) => {
   const { title, subtitle, actionText } = bannerStates[status];
 
   return (
-    <div className="rounded-[8px] p-5 border-1 bg-accent-surface border-accent-6 bg-center flex flex-col md:flex-row gap-4 md:gap-5 items-start md:items-center justify-between">
+    <div className="rounded-[8px] border-1 border-accent-6 bg-center p-5 flex flex-col md:flex-row gap-4 md:gap-5 items-start md:items-center justify-between bg-[color-mix(in_oklab,var(--color-accent-surface)_90%,var(--color-accent-9)_10%)]">
       <div className="flex items-center gap-3 md:gap-5 w-full md:w-auto">
         <ExclamationTriangleIcon
           width={16}

--- a/packages/epics/src/spaces/components/space-accent-from-images.tsx
+++ b/packages/epics/src/spaces/components/space-accent-from-images.tsx
@@ -140,6 +140,12 @@ export function SpaceAccentFromImages({
     if (scopeElInit) {
       for (const [k, v] of Object.entries(DEFAULT_SPACE_SCOPE_STYLE)) {
         if (v === undefined || v === null) continue;
+        if (process.env.NODE_ENV !== 'production') {
+          console.assert(
+            k.startsWith('--'),
+            `Invalid CSS custom property: ${k}`,
+          );
+        }
         scopeElInit.style.setProperty(k, String(v));
       }
     }
@@ -164,6 +170,12 @@ export function SpaceAccentFromImages({
 
       for (const [k, v] of Object.entries(scopeStyle)) {
         if (v === undefined || v === null) continue;
+        if (process.env.NODE_ENV !== 'production') {
+          console.assert(
+            k.startsWith('--'),
+            `Invalid CSS custom property: ${k}`,
+          );
+        }
         scopeEl.style.setProperty(k, String(v));
       }
 

--- a/packages/epics/src/spaces/components/space-accent-from-images.tsx
+++ b/packages/epics/src/spaces/components/space-accent-from-images.tsx
@@ -25,13 +25,16 @@ export type SpaceAccentFromImagesProps = {
 
 /**
  * Same-origin image URL so canvas readPixels works for remote hosts without CORS
- * (Next.js Image Optimization proxies the bytes).
+ * (Next.js Image Optimization proxies the bytes). Null for unsupported URLs.
  */
-function canvasFriendlyImageSrc(src: string): string {
+function canvasFriendlyImageSrc(src: string): string | null {
   const t = src.trim();
-  if (t.startsWith('/') || typeof window === 'undefined') {
-    return t;
+  if (!t) return null;
+  /** Same-origin path — reject protocol-relative `//evil` */
+  if (t.startsWith('/')) {
+    return t.startsWith('//') ? null : t;
   }
+  if (typeof window === 'undefined') return null;
   try {
     const u = new URL(t);
     if (u.protocol === 'http:' || u.protocol === 'https:') {
@@ -40,11 +43,16 @@ function canvasFriendlyImageSrc(src: string): string {
   } catch {
     /* ignore */
   }
-  return t;
+  return null;
 }
 
 async function sampleImageToAccent(src: string): Promise<string | null> {
   return new Promise((resolve) => {
+    const friendlySrc = canvasFriendlyImageSrc(src);
+    if (!friendlySrc) {
+      resolve(null);
+      return;
+    }
     const img = new Image();
     img.crossOrigin = 'anonymous';
     img.onload = () => {
@@ -69,7 +77,7 @@ async function sampleImageToAccent(src: string): Promise<string | null> {
       }
     };
     img.onerror = () => resolve(null);
-    img.src = canvasFriendlyImageSrc(src);
+    img.src = friendlySrc;
   });
 }
 
@@ -78,6 +86,11 @@ async function sampleBannerToneOverlayVars(
   src: string,
 ): Promise<Record<string, string> | null> {
   return new Promise((resolve) => {
+    const friendlySrc = canvasFriendlyImageSrc(src);
+    if (!friendlySrc) {
+      resolve(null);
+      return;
+    }
     const img = new Image();
     img.crossOrigin = 'anonymous';
     img.onload = () => {
@@ -103,7 +116,7 @@ async function sampleBannerToneOverlayVars(
       }
     };
     img.onerror = () => resolve(null);
-    img.src = canvasFriendlyImageSrc(src);
+    img.src = friendlySrc;
   });
 }
 

--- a/packages/epics/src/spaces/components/space-accent-from-images.tsx
+++ b/packages/epics/src/spaces/components/space-accent-from-images.tsx
@@ -7,6 +7,11 @@ import {
   mixHexColors,
   SPACE_ACCENT_FALLBACK,
 } from '../utils/extract-space-accent';
+import {
+  analyzeBannerToneFromImageData,
+  DEFAULT_BANNER_OVERLAY_CSS_VARS,
+  overlayCssVarsFromTone,
+} from '../utils/banner-overlay-tone';
 
 export type SpaceAccentFromImagesProps = {
   bannerSrc: string;
@@ -60,6 +65,42 @@ async function sampleImageToAccent(src: string): Promise<string | null> {
   });
 }
 
+/** Larger sample grid for luminance / contrast / edge analysis (banner only). */
+async function sampleBannerToneOverlayVars(
+  src: string,
+): Promise<Record<string, string> | null> {
+  return new Promise((resolve) => {
+    const img = new Image();
+    if (!src.startsWith('/')) {
+      img.crossOrigin = 'anonymous';
+    }
+    img.onload = () => {
+      try {
+        const maxSide = 112;
+        const scale = Math.min(maxSide / img.width, maxSide / img.height, 1);
+        const w = Math.max(16, Math.round(img.width * scale));
+        const h = Math.max(16, Math.round(img.height * scale));
+        const canvas = document.createElement('canvas');
+        canvas.width = w;
+        canvas.height = h;
+        const ctx = canvas.getContext('2d');
+        if (!ctx) {
+          resolve(null);
+          return;
+        }
+        ctx.drawImage(img, 0, 0, w, h);
+        const data = ctx.getImageData(0, 0, w, h);
+        const tone = analyzeBannerToneFromImageData(data);
+        resolve(overlayCssVarsFromTone(tone));
+      } catch {
+        resolve(null);
+      }
+    };
+    img.onerror = () => resolve(null);
+    img.src = src;
+  });
+}
+
 /**
  * Computes a dominant saturated accent from banner + logo imagery and exposes
  * `--space-accent`, `--space-accent-foreground`, `--space-accent-muted` on the wrapper.
@@ -76,9 +117,10 @@ export function SpaceAccentFromImages({
     let cancelled = false;
 
     (async () => {
-      const [bannerAccent, logoAccent] = await Promise.all([
+      const [bannerAccent, logoAccent, overlayVars] = await Promise.all([
         sampleImageToAccent(bannerSrc),
         sampleImageToAccent(logoSrc),
+        sampleBannerToneOverlayVars(bannerSrc),
       ]);
       if (cancelled || !ref.current) return;
 
@@ -98,10 +140,16 @@ export function SpaceAccentFromImages({
         0.45,
       );
 
-      ref.current.style.setProperty('--space-accent', accent);
-      ref.current.style.setProperty('--space-accent-foreground', fg);
-      ref.current.style.setProperty('--space-accent-muted', subtle);
-      ref.current.style.setProperty('--space-accent-contrast', fg);
+      const el = ref.current;
+      el.style.setProperty('--space-accent', accent);
+      el.style.setProperty('--space-accent-foreground', fg);
+      el.style.setProperty('--space-accent-muted', subtle);
+      el.style.setProperty('--space-accent-contrast', fg);
+
+      const ov = overlayVars ?? DEFAULT_BANNER_OVERLAY_CSS_VARS;
+      for (const [k, v] of Object.entries(ov)) {
+        el.style.setProperty(k, v);
+      }
     })();
 
     return () => {
@@ -110,7 +158,12 @@ export function SpaceAccentFromImages({
   }, [bannerSrc, logoSrc]);
 
   return (
-    <div ref={ref} data-space-accent-scope className={cn(className)}>
+    <div
+      ref={ref}
+      data-space-accent-scope
+      className={cn(className)}
+      style={DEFAULT_BANNER_OVERLAY_CSS_VARS as React.CSSProperties}
+    >
       {children}
     </div>
   );

--- a/packages/epics/src/spaces/components/space-accent-from-images.tsx
+++ b/packages/epics/src/spaces/components/space-accent-from-images.tsx
@@ -2,17 +2,17 @@
 
 import * as React from 'react';
 import { cn } from '@hypha-platform/ui-utils';
-import {
-  buildAccentPaletteFromHex,
-  extractAccentHexFromImageData,
-  mixHexColors,
-  SPACE_ACCENT_FALLBACK,
-} from '../utils/extract-space-accent';
+import { extractAccentHexFromImageData } from '../utils/extract-space-accent';
 import {
   analyzeBannerToneFromImageData,
   DEFAULT_BANNER_OVERLAY_CSS_VARS,
   overlayCssVarsFromTone,
 } from '../utils/banner-overlay-tone';
+import {
+  buildSpaceScopeStyleFromSampledAccents,
+  getDefaultSpaceScopeStyle,
+} from '../utils/space-accent-scope-style';
+import { useSetSpaceAccentPortalStyles } from './space-accent-portal-context';
 
 export type SpaceAccentFromImagesProps = {
   bannerSrc: string;
@@ -21,18 +21,6 @@ export type SpaceAccentFromImagesProps = {
   /** Optional class on the wrapping element that receives CSS variables */
   className?: string;
 };
-
-/** Perceived brightness 0–255 */
-function brightness(hex: string): number {
-  const r = parseInt(hex.slice(1, 3), 16);
-  const g = parseInt(hex.slice(3, 5), 16);
-  const b = parseInt(hex.slice(5, 7), 16);
-  return (r * 299 + g * 587 + b * 114) / 1000;
-}
-
-function contrastingForeground(hex: string): string {
-  return brightness(hex) > 186 ? '#0f172a' : '#f8fafc';
-}
 
 /**
  * Same-origin image URL so canvas readPixels works for remote hosts without CORS
@@ -129,62 +117,47 @@ export function SpaceAccentFromImages({
   className,
 }: SpaceAccentFromImagesProps) {
   const ref = React.useRef<HTMLDivElement>(null);
+  const setPortalStyles = useSetSpaceAccentPortalStyles();
 
   React.useEffect(() => {
     let cancelled = false;
 
     (async () => {
-      const [bannerAccent, logoAccent, overlayVars] = await Promise.all([
+      const [bannerAccent, logoAccent, overlayRecord] = await Promise.all([
         sampleImageToAccent(bannerSrc),
         sampleImageToAccent(logoSrc),
         sampleBannerToneOverlayVars(bannerSrc),
       ]);
       if (cancelled || !ref.current) return;
 
-      let accent = SPACE_ACCENT_FALLBACK;
-      if (bannerAccent && logoAccent) {
-        accent = mixHexColors(bannerAccent, logoAccent, 0.55);
-      } else if (bannerAccent) {
-        accent = bannerAccent;
-      } else if (logoAccent) {
-        accent = logoAccent;
-      }
-
-      const fg = contrastingForeground(accent);
-      const subtle = mixHexColors(
-        accent,
-        brightness(accent) > 186 ? '#0f172a' : '#ffffff',
-        0.45,
-      );
-
       const el = ref.current;
-      el.style.setProperty('--space-accent', accent);
-      el.style.setProperty('--space-accent-foreground', fg);
-      el.style.setProperty('--space-accent-muted', subtle);
-      el.style.setProperty('--space-accent-contrast', fg);
+      const overlayVars = overlayRecord ?? DEFAULT_BANNER_OVERLAY_CSS_VARS;
 
-      const palette = buildAccentPaletteFromHex(accent);
-      for (const [key, value] of Object.entries(palette)) {
-        el.style.setProperty(key, value);
+      const scopeStyle = buildSpaceScopeStyleFromSampledAccents({
+        bannerAccent,
+        logoAccent,
+        overlayVars,
+      });
+
+      for (const [k, v] of Object.entries(scopeStyle)) {
+        if (v === undefined || v === null) continue;
+        el.style.setProperty(k, String(v));
       }
 
-      const ov = overlayVars ?? DEFAULT_BANNER_OVERLAY_CSS_VARS;
-      for (const [k, v] of Object.entries(ov)) {
-        el.style.setProperty(k, v);
-      }
+      setPortalStyles?.(scopeStyle);
     })();
 
     return () => {
       cancelled = true;
     };
-  }, [bannerSrc, logoSrc]);
+  }, [bannerSrc, logoSrc, setPortalStyles]);
 
   return (
     <div
       ref={ref}
       data-space-accent-scope
       className={cn(className)}
-      style={DEFAULT_BANNER_OVERLAY_CSS_VARS as React.CSSProperties}
+      style={getDefaultSpaceScopeStyle()}
     >
       {children}
     </div>

--- a/packages/epics/src/spaces/components/space-accent-from-images.tsx
+++ b/packages/epics/src/spaces/components/space-accent-from-images.tsx
@@ -10,7 +10,7 @@ import {
 } from '../utils/banner-overlay-tone';
 import {
   buildSpaceScopeStyleFromSampledAccents,
-  getDefaultSpaceScopeStyle,
+  DEFAULT_SPACE_SCOPE_STYLE,
 } from '../utils/space-accent-scope-style';
 import { useSetSpaceAccentPortalStyles } from './space-accent-portal-context';
 
@@ -157,7 +157,7 @@ export function SpaceAccentFromImages({
       ref={ref}
       data-space-accent-scope
       className={cn(className)}
-      style={getDefaultSpaceScopeStyle()}
+      style={DEFAULT_SPACE_SCOPE_STYLE}
     >
       {children}
     </div>

--- a/packages/epics/src/spaces/components/space-accent-from-images.tsx
+++ b/packages/epics/src/spaces/components/space-accent-from-images.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react';
 import { cn } from '@hypha-platform/ui-utils';
 import {
+  buildAccentPaletteFromHex,
   extractAccentHexFromImageData,
   mixHexColors,
   SPACE_ACCENT_FALLBACK,
@@ -33,15 +34,33 @@ function contrastingForeground(hex: string): string {
   return brightness(hex) > 186 ? '#0f172a' : '#f8fafc';
 }
 
+/**
+ * Same-origin image URL so canvas readPixels works for remote hosts without CORS
+ * (Next.js Image Optimization proxies the bytes).
+ */
+function canvasFriendlyImageSrc(src: string): string {
+  const t = src.trim();
+  if (t.startsWith('/') || typeof window === 'undefined') {
+    return t;
+  }
+  try {
+    const u = new URL(t);
+    if (u.protocol === 'http:' || u.protocol === 'https:') {
+      return `/_next/image?url=${encodeURIComponent(t)}&w=96&q=75`;
+    }
+  } catch {
+    /* ignore */
+  }
+  return t;
+}
+
 async function sampleImageToAccent(src: string): Promise<string | null> {
   return new Promise((resolve) => {
     const img = new Image();
-    if (!src.startsWith('/')) {
-      img.crossOrigin = 'anonymous';
-    }
+    img.crossOrigin = 'anonymous';
     img.onload = () => {
       try {
-        const maxSide = 56;
+        const maxSide = 96;
         const scale = Math.min(maxSide / img.width, maxSide / img.height, 1);
         const w = Math.max(8, Math.round(img.width * scale));
         const h = Math.max(8, Math.round(img.height * scale));
@@ -61,7 +80,7 @@ async function sampleImageToAccent(src: string): Promise<string | null> {
       }
     };
     img.onerror = () => resolve(null);
-    img.src = src;
+    img.src = canvasFriendlyImageSrc(src);
   });
 }
 
@@ -71,9 +90,7 @@ async function sampleBannerToneOverlayVars(
 ): Promise<Record<string, string> | null> {
   return new Promise((resolve) => {
     const img = new Image();
-    if (!src.startsWith('/')) {
-      img.crossOrigin = 'anonymous';
-    }
+    img.crossOrigin = 'anonymous';
     img.onload = () => {
       try {
         const maxSide = 112;
@@ -97,7 +114,7 @@ async function sampleBannerToneOverlayVars(
       }
     };
     img.onerror = () => resolve(null);
-    img.src = src;
+    img.src = canvasFriendlyImageSrc(src);
   });
 }
 
@@ -145,6 +162,11 @@ export function SpaceAccentFromImages({
       el.style.setProperty('--space-accent-foreground', fg);
       el.style.setProperty('--space-accent-muted', subtle);
       el.style.setProperty('--space-accent-contrast', fg);
+
+      const palette = buildAccentPaletteFromHex(accent);
+      for (const [key, value] of Object.entries(palette)) {
+        el.style.setProperty(key, value);
+      }
 
       const ov = overlayVars ?? DEFAULT_BANNER_OVERLAY_CSS_VARS;
       for (const [k, v] of Object.entries(ov)) {

--- a/packages/epics/src/spaces/components/space-accent-from-images.tsx
+++ b/packages/epics/src/spaces/components/space-accent-from-images.tsx
@@ -12,6 +12,7 @@ import {
   buildSpaceScopeStyleFromSampledAccents,
   DEFAULT_SPACE_SCOPE_STYLE,
 } from '../utils/space-accent-scope-style';
+import { defaultSpacePortalStyles } from '../utils/space-accent-portal-styles';
 import { useSetSpaceAccentPortalStyles } from './space-accent-portal-context';
 
 export type SpaceAccentFromImagesProps = {
@@ -122,6 +123,15 @@ export function SpaceAccentFromImages({
   React.useEffect(() => {
     let cancelled = false;
 
+    const scopeElInit = ref.current;
+    if (scopeElInit) {
+      for (const [k, v] of Object.entries(DEFAULT_SPACE_SCOPE_STYLE)) {
+        if (v === undefined || v === null) continue;
+        scopeElInit.style.setProperty(k, String(v));
+      }
+    }
+    setPortalStyles?.(defaultSpacePortalStyles);
+
     (async () => {
       const [bannerAccent, logoAccent, overlayRecord] = await Promise.all([
         sampleImageToAccent(bannerSrc),
@@ -130,7 +140,7 @@ export function SpaceAccentFromImages({
       ]);
       if (cancelled || !ref.current) return;
 
-      const el = ref.current;
+      const scopeEl = ref.current;
       const overlayVars = overlayRecord ?? DEFAULT_BANNER_OVERLAY_CSS_VARS;
 
       const scopeStyle = buildSpaceScopeStyleFromSampledAccents({
@@ -141,7 +151,7 @@ export function SpaceAccentFromImages({
 
       for (const [k, v] of Object.entries(scopeStyle)) {
         if (v === undefined || v === null) continue;
-        el.style.setProperty(k, String(v));
+        scopeEl.style.setProperty(k, String(v));
       }
 
       setPortalStyles?.(scopeStyle);

--- a/packages/epics/src/spaces/components/space-accent-from-images.tsx
+++ b/packages/epics/src/spaces/components/space-accent-from-images.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import * as React from 'react';
+import { cn } from '@hypha-platform/ui-utils';
+import {
+  extractAccentHexFromImageData,
+  mixHexColors,
+  SPACE_ACCENT_FALLBACK,
+} from '../utils/extract-space-accent';
+
+export type SpaceAccentFromImagesProps = {
+  bannerSrc: string;
+  logoSrc: string;
+  children: React.ReactNode;
+  /** Optional class on the wrapping element that receives CSS variables */
+  className?: string;
+};
+
+/** Perceived brightness 0–255 */
+function brightness(hex: string): number {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  return (r * 299 + g * 587 + b * 114) / 1000;
+}
+
+function contrastingForeground(hex: string): string {
+  return brightness(hex) > 186 ? '#0f172a' : '#f8fafc';
+}
+
+async function sampleImageToAccent(src: string): Promise<string | null> {
+  return new Promise((resolve) => {
+    const img = new Image();
+    if (!src.startsWith('/')) {
+      img.crossOrigin = 'anonymous';
+    }
+    img.onload = () => {
+      try {
+        const maxSide = 56;
+        const scale = Math.min(maxSide / img.width, maxSide / img.height, 1);
+        const w = Math.max(8, Math.round(img.width * scale));
+        const h = Math.max(8, Math.round(img.height * scale));
+        const canvas = document.createElement('canvas');
+        canvas.width = w;
+        canvas.height = h;
+        const ctx = canvas.getContext('2d');
+        if (!ctx) {
+          resolve(null);
+          return;
+        }
+        ctx.drawImage(img, 0, 0, w, h);
+        const data = ctx.getImageData(0, 0, w, h);
+        resolve(extractAccentHexFromImageData(data));
+      } catch {
+        resolve(null);
+      }
+    };
+    img.onerror = () => resolve(null);
+    img.src = src;
+  });
+}
+
+/**
+ * Computes a dominant saturated accent from banner + logo imagery and exposes
+ * `--space-accent`, `--space-accent-foreground`, `--space-accent-muted` on the wrapper.
+ */
+export function SpaceAccentFromImages({
+  bannerSrc,
+  logoSrc,
+  children,
+  className,
+}: SpaceAccentFromImagesProps) {
+  const ref = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    let cancelled = false;
+
+    (async () => {
+      const [bannerAccent, logoAccent] = await Promise.all([
+        sampleImageToAccent(bannerSrc),
+        sampleImageToAccent(logoSrc),
+      ]);
+      if (cancelled || !ref.current) return;
+
+      let accent = SPACE_ACCENT_FALLBACK;
+      if (bannerAccent && logoAccent) {
+        accent = mixHexColors(bannerAccent, logoAccent, 0.55);
+      } else if (bannerAccent) {
+        accent = bannerAccent;
+      } else if (logoAccent) {
+        accent = logoAccent;
+      }
+
+      const fg = contrastingForeground(accent);
+      const subtle = mixHexColors(
+        accent,
+        brightness(accent) > 186 ? '#0f172a' : '#ffffff',
+        0.45,
+      );
+
+      ref.current.style.setProperty('--space-accent', accent);
+      ref.current.style.setProperty('--space-accent-foreground', fg);
+      ref.current.style.setProperty('--space-accent-muted', subtle);
+      ref.current.style.setProperty('--space-accent-contrast', fg);
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [bannerSrc, logoSrc]);
+
+  return (
+    <div ref={ref} data-space-accent-scope className={cn(className)}>
+      {children}
+    </div>
+  );
+}

--- a/packages/epics/src/spaces/components/space-accent-portal-context.tsx
+++ b/packages/epics/src/spaces/components/space-accent-portal-context.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import * as React from 'react';
+import type { SpaceAccentPortalStyles } from '../utils/space-accent-portal-styles';
+import { defaultSpacePortalStyles } from '../utils/space-accent-portal-styles';
+
+export type { SpaceAccentPortalStyles };
+
+const SpaceAccentPortalStylesContext =
+  React.createContext<SpaceAccentPortalStyles>(defaultSpacePortalStyles);
+
+const SpaceAccentPortalSetterContext = React.createContext<
+  ((s: SpaceAccentPortalStyles) => void) | null
+>(null);
+
+export function SpaceAccentPortalBridge({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [styles, setStyles] = React.useState<SpaceAccentPortalStyles>(
+    defaultSpacePortalStyles,
+  );
+
+  return (
+    <SpaceAccentPortalStylesContext.Provider value={styles}>
+      <SpaceAccentPortalSetterContext.Provider value={setStyles}>
+        {children}
+      </SpaceAccentPortalSetterContext.Provider>
+    </SpaceAccentPortalStylesContext.Provider>
+  );
+}
+
+export function useSpaceAccentPortalStyles(): SpaceAccentPortalStyles {
+  return React.useContext(SpaceAccentPortalStylesContext);
+}
+
+export function useSetSpaceAccentPortalStyles():
+  | ((s: SpaceAccentPortalStyles) => void)
+  | null {
+  return React.useContext(SpaceAccentPortalSetterContext);
+}

--- a/packages/epics/src/spaces/components/space-loading-backdrop.tsx
+++ b/packages/epics/src/spaces/components/space-loading-backdrop.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import * as React from 'react';
+import { LoadingBackdrop, type LoadingBackdropProps } from '@hypha-platform/ui';
+import { useSpaceAccentPortalStyles } from './space-accent-portal-context';
+
+/**
+ * Same as {@link LoadingBackdrop}, but when the overlay is portaled to `document.body`
+ * it re-applies the current space accent CSS variables so `bg-accent-9` (progress bar)
+ * matches the DHO space palette.
+ */
+export function SpaceLoadingBackdrop(props: LoadingBackdropProps) {
+  const portalScopeStyle = useSpaceAccentPortalStyles();
+  return <LoadingBackdrop {...props} portalScopeStyle={portalScopeStyle} />;
+}

--- a/packages/epics/src/spaces/components/space-loading-backdrop.tsx
+++ b/packages/epics/src/spaces/components/space-loading-backdrop.tsx
@@ -10,6 +10,10 @@ import { useSpaceAccentPortalStyles } from './space-accent-portal-context';
  * matches the DHO space palette.
  */
 export function SpaceLoadingBackdrop(props: LoadingBackdropProps) {
-  const portalScopeStyle = useSpaceAccentPortalStyles();
+  const accentScopeStyle = useSpaceAccentPortalStyles();
+  const portalScopeStyle = {
+    ...accentScopeStyle,
+    ...props.portalScopeStyle,
+  };
   return <LoadingBackdrop {...props} portalScopeStyle={portalScopeStyle} />;
 }

--- a/packages/epics/src/spaces/components/space-mode-label.tsx
+++ b/packages/epics/src/spaces/components/space-mode-label.tsx
@@ -32,6 +32,7 @@ const LabelButton = ({
       className="flex cursor-pointer"
       colorVariant={colorVariant}
       variant="outline"
+      size={1}
       role="link"
       title={t('changeSpaceConfiguration')}
       onClick={(e) => {
@@ -59,7 +60,12 @@ const LabelBadge = ({
   caption: string;
   colorVariant?: 'accent' | 'error';
 }) => (
-  <Badge className="flex" colorVariant={colorVariant} variant="outline">
+  <Badge
+    className="flex"
+    colorVariant={colorVariant}
+    variant="outline"
+    size={1}
+  >
     {caption}
   </Badge>
 );

--- a/packages/epics/src/spaces/index.ts
+++ b/packages/epics/src/spaces/index.ts
@@ -1,3 +1,4 @@
 export * from './components';
 export * from './hooks';
 export * from './utils/transparency-access';
+export { isSafeImageUrl } from './utils/safe-image-url';

--- a/packages/epics/src/spaces/index.ts
+++ b/packages/epics/src/spaces/index.ts
@@ -1,4 +1,4 @@
 export * from './components';
 export * from './hooks';
 export * from './utils/transparency-access';
-export { isSafeImageUrl } from './utils/safe-image-url';
+export { isSafeImageUrl, isSafeExternalUrl } from './utils/safe-image-url';

--- a/packages/epics/src/spaces/utils/banner-overlay-tone.ts
+++ b/packages/epics/src/spaces/utils/banner-overlay-tone.ts
@@ -49,7 +49,7 @@ function populationStdDev(values: number[], mean: number): number {
  * Sobel magnitude on grayscale grid; returns mean normalized gradient [0,1].
  */
 function meanEdgeEnergy(
-  gray: number[][],
+  gray: Float32Array,
   width: number,
   height: number,
 ): number {
@@ -58,19 +58,18 @@ function meanEdgeEnergy(
   let sum = 0;
   let count = 0;
 
+  const at = (yy: number, xx: number) => gray[yy * width + xx] ?? 0;
+
   for (let y = 1; y < height - 1; y++) {
     for (let x = 1; x < width - 1; x++) {
-      const rowUp = gray[y - 1];
-      const rowMid = gray[y];
-      const rowDn = gray[y + 1];
-      const tl = rowUp?.[x - 1] ?? 0;
-      const t = rowUp?.[x] ?? 0;
-      const tr = rowUp?.[x + 1] ?? 0;
-      const l = rowMid?.[x - 1] ?? 0;
-      const r = rowMid?.[x + 1] ?? 0;
-      const bl = rowDn?.[x - 1] ?? 0;
-      const b = rowDn?.[x] ?? 0;
-      const br = rowDn?.[x + 1] ?? 0;
+      const tl = at(y - 1, x - 1);
+      const t = at(y - 1, x);
+      const tr = at(y - 1, x + 1);
+      const l = at(y, x - 1);
+      const r = at(y, x + 1);
+      const bl = at(y + 1, x - 1);
+      const b = at(y + 1, x);
+      const br = at(y + 1, x + 1);
 
       const gx = -tl + tr - 2 * l + 2 * r - bl + br;
       const gy = -tl - 2 * t - tr + bl + 2 * b + br;
@@ -94,12 +93,9 @@ export function analyzeBannerToneFromImageData(
   let satSum = 0;
   let satN = 0;
 
-  const gray: number[][] = Array.from({ length: height }, () =>
-    Array.from({ length: width }, () => 0),
-  );
-  const sampled: boolean[][] = Array.from({ length: height }, () =>
-    Array.from({ length: width }, () => false),
-  );
+  const nPx = width * height;
+  const gray = new Float32Array(nPx);
+  const sampled = new Uint8Array(nPx);
 
   for (let y = 0; y < height; y++) {
     for (let x = 0; x < width; x++) {
@@ -114,8 +110,9 @@ export function analyzeBannerToneFromImageData(
       const l = luminance(r, g, b);
       lumas.push(l);
 
-      gray[y]![x] = l;
-      sampled[y]![x] = true;
+      const gi = y * width + x;
+      gray[gi] = l;
+      sampled[gi] = 1;
 
       const max = Math.max(r, g, b) / 255;
       const min = Math.min(r, g, b) / 255;
@@ -134,11 +131,9 @@ export function analyzeBannerToneFromImageData(
   meanL /= lumas.length;
 
   /** Avoid fake edges at transparent corners (e.g. logo PNG): fill gaps with mean luma */
-  for (let y = 0; y < height; y++) {
-    for (let x = 0; x < width; x++) {
-      if (!sampled[y]?.[x]) {
-        gray[y]![x] = meanL;
-      }
+  for (let i = 0; i < nPx; i++) {
+    if (!sampled[i]) {
+      gray[i] = meanL;
     }
   }
 

--- a/packages/epics/src/spaces/utils/banner-overlay-tone.ts
+++ b/packages/epics/src/spaces/utils/banner-overlay-tone.ts
@@ -24,6 +24,14 @@ export type BannerToneMetrics = {
   edgeEnergy: number;
 };
 
+/** Neutral metrics → static PR #2165–style reference (single source of truth) */
+export const BANNER_OVERLAY_FALLBACK_METRICS: BannerToneMetrics = {
+  luminanceMean: 0.42,
+  luminanceStd: 0.12,
+  saturationMean: 0.35,
+  edgeEnergy: 0.25,
+};
+
 /**
  * Population variance (divide by n, not n-1) for stable small samples.
  */
@@ -118,12 +126,7 @@ export function analyzeBannerToneFromImageData(
   }
 
   if (lumas.length < 16) {
-    return {
-      luminanceMean: 0.42,
-      luminanceStd: 0.12,
-      saturationMean: 0.35,
-      edgeEnergy: 0.25,
-    };
+    return { ...BANNER_OVERLAY_FALLBACK_METRICS };
   }
 
   let meanL = 0;
@@ -152,14 +155,6 @@ export function analyzeBannerToneFromImageData(
 }
 
 export type BannerOverlayCssVars = Record<string, string>;
-
-/** Neutral metrics → static PR #2165–style reference (used for baseline blend) */
-export const BANNER_OVERLAY_FALLBACK_METRICS: BannerToneMetrics = {
-  luminanceMean: 0.42,
-  luminanceStd: 0.12,
-  saturationMean: 0.35,
-  edgeEnergy: 0.25,
-};
 
 /** Portion of image-driven deviation from baseline we apply (lower = truer hero colour). */
 const OVERLAY_DYNAMIC_STRENGTH = 0.42;

--- a/packages/epics/src/spaces/utils/banner-overlay-tone.ts
+++ b/packages/epics/src/spaces/utils/banner-overlay-tone.ts
@@ -153,13 +153,18 @@ export function analyzeBannerToneFromImageData(
 
 export type BannerOverlayCssVars = Record<string, string>;
 
-/**
- * Maps tone metrics to CSS variables consumed by `CompactSpaceBanner` overlays.
- * Defaults are tuned to match the previous static PR #2165 stack when metrics are neutral.
- */
-export function overlayCssVarsFromTone(
-  m: BannerToneMetrics,
-): BannerOverlayCssVars {
+/** Neutral metrics → static PR #2165–style reference (used for baseline blend) */
+export const BANNER_OVERLAY_FALLBACK_METRICS: BannerToneMetrics = {
+  luminanceMean: 0.42,
+  luminanceStd: 0.12,
+  saturationMean: 0.35,
+  edgeEnergy: 0.25,
+};
+
+/** Portion of image-driven deviation from baseline we apply (lower = truer hero colour). */
+const OVERLAY_DYNAMIC_STRENGTH = 0.42;
+
+function overlayCssVarsFromToneRaw(m: BannerToneMetrics): BannerOverlayCssVars {
   const {
     luminanceMean: L,
     luminanceStd: spread,
@@ -168,44 +173,40 @@ export function overlayCssVarsFromTone(
   } = m;
 
   /**
-   * brighter image → stronger scrim for text legibility
-   * (anchor around mid-photographic tone ~0.38)
+   * brighter image → slightly stronger scrim (subtle; was overpowering photos)
    */
-  const brightNeed = clamp01((L - 0.36) / 0.46);
+  const brightNeed = clamp01((L - 0.38) / 0.52) * 0.72;
   /**
-   * very dark hero → ease the bottom crush so mud doesn't swallow midtones
+   * very dark hero → ease the bottom crush
    */
-  const darkEase = clamp01((0.22 - L) / 0.22) * 0.55;
+  const darkEase = clamp01((0.22 - L) / 0.22) * 0.42;
   /**
-   * Radiance: colorful + luminous + micro-contrast → lift the WOW sheen slightly
+   * Radiance — keep light touches only so overlays don’t dominate the plate
    */
   const radiance = clamp01(0.35 * S + 0.35 * L + 0.3 * E);
   /**
-   * Busy / high-frequency → soften film grain & glow so overlays don't shimmer
+   * Busy / high-frequency → soften film grain & glow
    */
   const calmGrain = clamp01(0.55 * spread + 0.45 * E);
 
-  /** Vertical gradient stops (bottom → mid → top), PR #2165 baseline embedded */
-  const vBottom = clamp01(0.88 + brightNeed * 0.09 - darkEase * 0.14);
-  const vMid = clamp01(0.42 + brightNeed * 0.11 - darkEase * 0.08);
-  const vTop = clamp01(0.22 + brightNeed * 0.09 - darkEase * 0.06);
+  /** Vertical gradient — smaller deltas than before */
+  const vBottom = clamp01(0.88 + brightNeed * 0.05 - darkEase * 0.09);
+  const vMid = clamp01(0.42 + brightNeed * 0.06 - darkEase * 0.05);
+  const vTop = clamp01(0.22 + brightNeed * 0.05 - darkEase * 0.04);
 
-  /** Horizontal vignette sides */
-  const hFrom = clamp01(0.58 + brightNeed * 0.12 - darkEase * 0.06);
-  const hTo = clamp01(0.4 + brightNeed * 0.08);
+  const hFrom = clamp01(0.58 + brightNeed * 0.07 - darkEase * 0.04);
+  const hTo = clamp01(0.4 + brightNeed * 0.05);
 
-  /** Accent tint wash (was accent-11/18) — scales slightly with saturation radiance */
-  const accentWash = clamp01(0.14 + radiance * 0.12);
+  /** Tint wash — cap so original image chroma reads through */
+  const accentWash = clamp01(0.1 + radiance * 0.05);
 
-  /** Depth pass layers */
-  const skylightOpacity = clamp01(0.78 + radiance * 0.14 - calmGrain * 0.12);
-  const sheenOpacity = clamp01(0.06 + radiance * 0.06);
-  /** Scales alphas inside the bottom vignette radial (brighter heroes need a touch more) */
-  const vignetteStrength = clamp01(0.92 + brightNeed * 0.14 - darkEase * 0.1);
-  const grainOpacity = clamp01(0.055 + radiance * 0.025 - calmGrain * 0.028);
+  const skylightOpacity = clamp01(0.78 + radiance * 0.06 - calmGrain * 0.08);
+  const sheenOpacity = clamp01(0.05 + radiance * 0.025);
+  const vignetteStrength = clamp01(0.92 + brightNeed * 0.08 - darkEase * 0.07);
+  const grainOpacity = clamp01(0.048 + radiance * 0.015 - calmGrain * 0.02);
 
-  const innerTop = clamp01(0.09 + radiance * 0.04);
-  const innerBot = clamp01(0.18 + brightNeed * 0.04);
+  const innerTop = clamp01(0.085 + radiance * 0.022);
+  const innerBot = clamp01(0.17 + brightNeed * 0.025);
 
   return {
     '--banner-ov-v-bottom': String(vBottom),
@@ -224,13 +225,41 @@ export function overlayCssVarsFromTone(
   };
 }
 
-/** Neutral metrics → static overlay tuning (SSR / before client analysis) */
-export const BANNER_OVERLAY_FALLBACK_METRICS: BannerToneMetrics = {
-  luminanceMean: 0.42,
-  luminanceStd: 0.12,
-  saturationMean: 0.35,
-  edgeEnergy: 0.25,
-};
+/**
+ * Blend dynamic overlay toward neutral baseline so the hero keeps more of its
+ * native colour; `OVERLAY_DYNAMIC_STRENGTH` controls how much image tone may move the stack.
+ */
+function blendOverlayTowardBaseline(
+  dynamic: BannerOverlayCssVars,
+  baseline: BannerOverlayCssVars,
+  strength: number,
+): BannerOverlayCssVars {
+  const out: BannerOverlayCssVars = { ...baseline };
+  for (const key of Object.keys(dynamic)) {
+    if (key === '--banner-ov-v-mid-at') {
+      out[key] = dynamic[key] ?? baseline[key] ?? '52%';
+      continue;
+    }
+    const d = parseFloat(dynamic[key] ?? '');
+    const b = parseFloat(baseline[key] ?? '');
+    if (!Number.isFinite(d) || !Number.isFinite(b)) continue;
+    const v = b + (d - b) * strength;
+    out[key] = String(clamp01(v));
+  }
+  return out;
+}
+
+/**
+ * Maps tone metrics to CSS variables consumed by `CompactSpaceBanner` overlays.
+ * Neutral metrics match the classic PR #2165 static stack; real images get a gentle nudge only.
+ */
+export function overlayCssVarsFromTone(
+  m: BannerToneMetrics,
+): BannerOverlayCssVars {
+  const baseline = overlayCssVarsFromToneRaw(BANNER_OVERLAY_FALLBACK_METRICS);
+  const raw = overlayCssVarsFromToneRaw(m);
+  return blendOverlayTowardBaseline(raw, baseline, OVERLAY_DYNAMIC_STRENGTH);
+}
 
 export const DEFAULT_BANNER_OVERLAY_CSS_VARS: BannerOverlayCssVars =
   overlayCssVarsFromTone(BANNER_OVERLAY_FALLBACK_METRICS);

--- a/packages/epics/src/spaces/utils/banner-overlay-tone.ts
+++ b/packages/epics/src/spaces/utils/banner-overlay-tone.ts
@@ -1,0 +1,236 @@
+/**
+ * Derive tone metrics from RGBA image data for dynamic hero overlay modulation.
+ * Focus: perceived luminance (intensity), spread (local contrast / "texture"),
+ * and saturation (color radiance).
+ */
+
+function clamp01(n: number): number {
+  return Math.min(1, Math.max(0, n));
+}
+
+/** Perceived luminance in [0, 1] (standard sRGB approximation) */
+function luminance(r: number, g: number, b: number): number {
+  return (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+}
+
+export type BannerToneMetrics = {
+  /** Mean perceived brightness [0, 1] */
+  luminanceMean: number;
+  /** Std. dev. of luminance — higher = busier / more contrast (edges, texture) */
+  luminanceStd: number;
+  /** Mean HSL saturation [0, 1] on reasonably opaque pixels */
+  saturationMean: number;
+  /** Mean gradient magnitude on a downscaled luma grid [0, ~1], normalized */
+  edgeEnergy: number;
+};
+
+/**
+ * Population variance (divide by n, not n-1) for stable small samples.
+ */
+function populationStdDev(values: number[], mean: number): number {
+  if (values.length === 0) return 0;
+  let acc = 0;
+  for (const v of values) {
+    const d = v - mean;
+    acc += d * d;
+  }
+  return Math.sqrt(acc / values.length);
+}
+
+/**
+ * Sobel magnitude on grayscale grid; returns mean normalized gradient [0,1].
+ */
+function meanEdgeEnergy(
+  gray: number[][],
+  width: number,
+  height: number,
+): number {
+  if (width < 3 || height < 3) return 0;
+
+  let sum = 0;
+  let count = 0;
+
+  for (let y = 1; y < height - 1; y++) {
+    for (let x = 1; x < width - 1; x++) {
+      const rowUp = gray[y - 1];
+      const rowMid = gray[y];
+      const rowDn = gray[y + 1];
+      const tl = rowUp?.[x - 1] ?? 0;
+      const t = rowUp?.[x] ?? 0;
+      const tr = rowUp?.[x + 1] ?? 0;
+      const l = rowMid?.[x - 1] ?? 0;
+      const r = rowMid?.[x + 1] ?? 0;
+      const bl = rowDn?.[x - 1] ?? 0;
+      const b = rowDn?.[x] ?? 0;
+      const br = rowDn?.[x + 1] ?? 0;
+
+      const gx = -tl + tr - 2 * l + 2 * r - bl + br;
+      const gy = -tl - 2 * t - tr + bl + 2 * b + br;
+
+      sum += Math.hypot(gx, gy);
+      count++;
+    }
+  }
+
+  if (count === 0) return 0;
+  /** Typical max Sobel magnitude for 0–1 luma grid is ~4; soften with sqrt for spread */
+  return clamp01(Math.sqrt(sum / count / 4));
+}
+
+export function analyzeBannerToneFromImageData(
+  data: ImageData,
+): BannerToneMetrics {
+  const px = data.data;
+  const { width, height } = data;
+  const lumas: number[] = [];
+  let satSum = 0;
+  let satN = 0;
+
+  const gray: number[][] = Array.from({ length: height }, () =>
+    Array.from({ length: width }, () => 0),
+  );
+  const sampled: boolean[][] = Array.from({ length: height }, () =>
+    Array.from({ length: width }, () => false),
+  );
+
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const i = (y * width + x) * 4;
+      const a = px[i + 3] ?? 0;
+      if (a < 24) continue;
+
+      const r = px[i] ?? 0;
+      const g = px[i + 1] ?? 0;
+      const b = px[i + 2] ?? 0;
+
+      const l = luminance(r, g, b);
+      lumas.push(l);
+
+      gray[y]![x] = l;
+      sampled[y]![x] = true;
+
+      const max = Math.max(r, g, b) / 255;
+      const min = Math.min(r, g, b) / 255;
+      const sat = max === 0 ? 0 : (max - min) / max;
+      satSum += sat;
+      satN++;
+    }
+  }
+
+  if (lumas.length < 16) {
+    return {
+      luminanceMean: 0.42,
+      luminanceStd: 0.12,
+      saturationMean: 0.35,
+      edgeEnergy: 0.25,
+    };
+  }
+
+  let meanL = 0;
+  for (const v of lumas) meanL += v;
+  meanL /= lumas.length;
+
+  /** Avoid fake edges at transparent corners (e.g. logo PNG): fill gaps with mean luma */
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      if (!sampled[y]?.[x]) {
+        gray[y]![x] = meanL;
+      }
+    }
+  }
+
+  const stdL = populationStdDev(lumas, meanL);
+  const edgeEnergy = meanEdgeEnergy(gray, width, height);
+  const saturationMean = satN > 0 ? satSum / satN : 0.35;
+
+  return {
+    luminanceMean: clamp01(meanL),
+    luminanceStd: clamp01(stdL * 2),
+    saturationMean: clamp01(saturationMean),
+    edgeEnergy: clamp01(edgeEnergy),
+  };
+}
+
+export type BannerOverlayCssVars = Record<string, string>;
+
+/**
+ * Maps tone metrics to CSS variables consumed by `CompactSpaceBanner` overlays.
+ * Defaults are tuned to match the previous static PR #2165 stack when metrics are neutral.
+ */
+export function overlayCssVarsFromTone(
+  m: BannerToneMetrics,
+): BannerOverlayCssVars {
+  const {
+    luminanceMean: L,
+    luminanceStd: spread,
+    saturationMean: S,
+    edgeEnergy: E,
+  } = m;
+
+  /**
+   * brighter image → stronger scrim for text legibility
+   * (anchor around mid-photographic tone ~0.38)
+   */
+  const brightNeed = clamp01((L - 0.36) / 0.46);
+  /**
+   * very dark hero → ease the bottom crush so mud doesn't swallow midtones
+   */
+  const darkEase = clamp01((0.22 - L) / 0.22) * 0.55;
+  /**
+   * Radiance: colorful + luminous + micro-contrast → lift the WOW sheen slightly
+   */
+  const radiance = clamp01(0.35 * S + 0.35 * L + 0.3 * E);
+  /**
+   * Busy / high-frequency → soften film grain & glow so overlays don't shimmer
+   */
+  const calmGrain = clamp01(0.55 * spread + 0.45 * E);
+
+  /** Vertical gradient stops (bottom → mid → top), PR #2165 baseline embedded */
+  const vBottom = clamp01(0.88 + brightNeed * 0.09 - darkEase * 0.14);
+  const vMid = clamp01(0.42 + brightNeed * 0.11 - darkEase * 0.08);
+  const vTop = clamp01(0.22 + brightNeed * 0.09 - darkEase * 0.06);
+
+  /** Horizontal vignette sides */
+  const hFrom = clamp01(0.58 + brightNeed * 0.12 - darkEase * 0.06);
+  const hTo = clamp01(0.4 + brightNeed * 0.08);
+
+  /** Accent tint wash (was accent-11/18) — scales slightly with saturation radiance */
+  const accentWash = clamp01(0.14 + radiance * 0.12);
+
+  /** Depth pass layers */
+  const skylightOpacity = clamp01(0.78 + radiance * 0.14 - calmGrain * 0.12);
+  const sheenOpacity = clamp01(0.06 + radiance * 0.06);
+  /** Scales alphas inside the bottom vignette radial (brighter heroes need a touch more) */
+  const vignetteStrength = clamp01(0.92 + brightNeed * 0.14 - darkEase * 0.1);
+  const grainOpacity = clamp01(0.055 + radiance * 0.025 - calmGrain * 0.028);
+
+  const innerTop = clamp01(0.09 + radiance * 0.04);
+  const innerBot = clamp01(0.18 + brightNeed * 0.04);
+
+  return {
+    '--banner-ov-v-bottom': String(vBottom),
+    '--banner-ov-v-mid': String(vMid),
+    '--banner-ov-v-top': String(vTop),
+    '--banner-ov-v-mid-at': '52%',
+    '--banner-ov-h-from': String(hFrom),
+    '--banner-ov-h-to': String(hTo),
+    '--banner-ov-accent-wash': String(accentWash),
+    '--banner-ov-skylight-op': String(skylightOpacity),
+    '--banner-ov-sheen-op': String(sheenOpacity),
+    '--banner-ov-vignette-strength': String(vignetteStrength),
+    '--banner-ov-grain-op': String(grainOpacity),
+    '--banner-ov-inner-top': String(innerTop),
+    '--banner-ov-inner-bot': String(innerBot),
+  };
+}
+
+/** Neutral metrics → static overlay tuning (SSR / before client analysis) */
+export const BANNER_OVERLAY_FALLBACK_METRICS: BannerToneMetrics = {
+  luminanceMean: 0.42,
+  luminanceStd: 0.12,
+  saturationMean: 0.35,
+  edgeEnergy: 0.25,
+};
+
+export const DEFAULT_BANNER_OVERLAY_CSS_VARS: BannerOverlayCssVars =
+  overlayCssVarsFromTone(BANNER_OVERLAY_FALLBACK_METRICS);

--- a/packages/epics/src/spaces/utils/extract-space-accent.ts
+++ b/packages/epics/src/spaces/utils/extract-space-accent.ts
@@ -145,7 +145,7 @@ export function buildAccentPaletteFromHex(
   const out: Record<string, string> = {};
   for (let i = 0; i < 12; i++) {
     const step = i + 1;
-    let l = ACCENT_LIGHTNESS_CURVE[i]!;
+    let l: number = ACCENT_LIGHTNESS_CURVE[i]!;
     /** Softly tie ladder to extracted luminance so dark banners don’t wash out mid-tones. */
     l = clamp(l * (1 - 0.11) + l0 * 0.11, 0.06, 0.992);
 

--- a/packages/epics/src/spaces/utils/extract-space-accent.ts
+++ b/packages/epics/src/spaces/utils/extract-space-accent.ts
@@ -49,6 +49,86 @@ export function rgbToHsl(
   return { h, s, l };
 }
 
+/**
+ * HSL [0,1] → RGB 0–255. Used to build Radix-style accent ramps from one hex.
+ */
+export function hslToRgb(
+  h: number,
+  s: number,
+  l: number,
+): [number, number, number] {
+  let r: number;
+  let g: number;
+  let b: number;
+
+  if (s === 0) {
+    r = g = b = l;
+  } else {
+    const hue2rgb = (p: number, q: number, t: number) => {
+      let tt = t;
+      if (tt < 0) tt += 1;
+      if (tt > 1) tt -= 1;
+      if (tt < 1 / 6) return p + (q - p) * 6 * tt;
+      if (tt < 1 / 2) return q;
+      if (tt < 2 / 3) return p + (q - p) * (2 / 3 - tt) * 6;
+      return p;
+    };
+
+    const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+    const p = 2 * l - q;
+    r = hue2rgb(p, q, h + 1 / 3);
+    g = hue2rgb(p, q, h);
+    b = hue2rgb(p, q, h - 1 / 3);
+  }
+
+  return [Math.round(r * 255), Math.round(g * 255), Math.round(b * 255)];
+}
+
+/** 12-step Radix-style accent ramp (sufficient for Tailwind accent-1…12 bindings). */
+export function buildAccentPaletteFromHex(
+  baseHex: string,
+): Record<string, string> {
+  const r0 = parseInt(baseHex.slice(1, 3), 16);
+  const g0 = parseInt(baseHex.slice(3, 5), 16);
+  const b0 = parseInt(baseHex.slice(5, 7), 16);
+  const { h } = rgbToHsl(r0, g0, b0);
+
+  const steps = [
+    { step: 1, l: 0.99, s: 0.02 },
+    { step: 2, l: 0.97, s: 0.04 },
+    { step: 3, l: 0.93, s: 0.08 },
+    { step: 4, l: 0.88, s: 0.12 },
+    { step: 5, l: 0.78, s: 0.18 },
+    { step: 6, l: 0.62, s: 0.24 },
+    { step: 7, l: 0.52, s: 0.32 },
+    { step: 8, l: 0.45, s: 0.38 },
+    { step: 9, l: 0.52, s: 0.5 },
+    { step: 10, l: 0.48, s: 0.48 },
+    { step: 11, l: 0.42, s: 0.42 },
+    { step: 12, l: 0.2, s: 0.08 },
+  ];
+
+  const out: Record<string, string> = {};
+  for (const { step, l, s } of steps) {
+    const [r, g, b] = hslToRgb(h, clamp(s, 0, 1), clamp(l, 0, 1));
+    out[`--color-accent-${step}`] = rgbToHex(r, g, b);
+  }
+
+  const solid = out['--color-accent-9'] ?? baseHex;
+  const sr = parseInt(solid.slice(1, 3), 16);
+  const sg = parseInt(solid.slice(3, 5), 16);
+  const sb = parseInt(solid.slice(5, 7), 16);
+  const lum = (sr * 299 + sg * 587 + sb * 114) / 1000;
+  const onSolid = lum > 186 ? '#0f172a' : '#ffffff';
+
+  /** Semantic slots used by buttons (bg-accent-9, text-accent-contrast, etc.) */
+  out['--color-accent'] = solid;
+  out['--color-accent-foreground'] = out['--color-accent-12'] ?? '#ffffff';
+  out['--color-accent-contrast'] = onSolid;
+
+  return out;
+}
+
 export function extractAccentHexFromImageData(data: ImageData): string {
   const px = data.data;
   const { width, height } = data;
@@ -56,6 +136,12 @@ export function extractAccentHexFromImageData(data: ImageData): string {
   let gSum = 0;
   let bSum = 0;
   let n = 0;
+
+  /** Weighted fallback when strict filter yields few samples (dark overlays, grading). */
+  let wrSum = 0;
+  let wgSum = 0;
+  let wbSum = 0;
+  let wSum = 0;
 
   for (let y = 0; y < height; y++) {
     for (let x = 0; x < width; x++) {
@@ -68,6 +154,13 @@ export function extractAccentHexFromImageData(data: ImageData): string {
       const b = px[i + 2] ?? 0;
       const { s, l } = rgbToHsl(r, g, b);
 
+      /** Prefer chromatic mid-tones; weight all opaque pixels by saturation for fallback */
+      const chromaWeight = clamp(s * (1 - Math.abs(l - 0.48) * 1.35), 0.02, 1);
+      wrSum += r * chromaWeight;
+      wgSum += g * chromaWeight;
+      wbSum += b * chromaWeight;
+      wSum += chromaWeight;
+
       if (s < 0.12) continue;
       if (l < 0.06 || l > 0.94) continue;
 
@@ -78,11 +171,15 @@ export function extractAccentHexFromImageData(data: ImageData): string {
     }
   }
 
-  if (n < 8) {
-    return SPACE_ACCENT_FALLBACK;
+  if (n >= 8) {
+    return rgbToHex(rSum / n, gSum / n, bSum / n);
   }
 
-  return rgbToHex(rSum / n, gSum / n, bSum / n);
+  if (wSum >= 8) {
+    return rgbToHex(wrSum / wSum, wgSum / wSum, wbSum / wSum);
+  }
+
+  return SPACE_ACCENT_FALLBACK;
 }
 
 export function mixHexColors(a: string, b: string, weightA: number): string {

--- a/packages/epics/src/spaces/utils/extract-space-accent.ts
+++ b/packages/epics/src/spaces/utils/extract-space-accent.ts
@@ -1,0 +1,101 @@
+/**
+ * Derive a single accent hex from RGBA image data by averaging saturated,
+ * mid-tone pixels (skips near-gray / near-black / near-white).
+ */
+
+export const SPACE_ACCENT_FALLBACK = '#4a65d8';
+
+function clamp(n: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, n));
+}
+
+export function rgbToHex(r: number, g: number, b: number): string {
+  const to = (x: number) =>
+    clamp(Math.round(x), 0, 255).toString(16).padStart(2, '0');
+  return `#${to(r)}${to(g)}${to(b)}`;
+}
+
+/** HSL in [0,1] ranges */
+export function rgbToHsl(
+  r: number,
+  g: number,
+  b: number,
+): { h: number; s: number; l: number } {
+  r /= 255;
+  g /= 255;
+  b /= 255;
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  let h = 0;
+  let s = 0;
+  const l = (max + min) / 2;
+
+  if (max !== min) {
+    const d = max - min;
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    switch (max) {
+      case r:
+        h = ((g - b) / d + (g < b ? 6 : 0)) / 6;
+        break;
+      case g:
+        h = ((b - r) / d + 2) / 6;
+        break;
+      default:
+        h = ((r - g) / d + 4) / 6;
+        break;
+    }
+  }
+
+  return { h, s, l };
+}
+
+export function extractAccentHexFromImageData(data: ImageData): string {
+  const px = data.data;
+  const { width, height } = data;
+  let rSum = 0;
+  let gSum = 0;
+  let bSum = 0;
+  let n = 0;
+
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const i = (y * width + x) * 4;
+      const a = px[i + 3] ?? 0;
+      if (a < 40) continue;
+
+      const r = px[i] ?? 0;
+      const g = px[i + 1] ?? 0;
+      const b = px[i + 2] ?? 0;
+      const { s, l } = rgbToHsl(r, g, b);
+
+      if (s < 0.12) continue;
+      if (l < 0.06 || l > 0.94) continue;
+
+      rSum += r;
+      gSum += g;
+      bSum += b;
+      n++;
+    }
+  }
+
+  if (n < 8) {
+    return SPACE_ACCENT_FALLBACK;
+  }
+
+  return rgbToHex(rSum / n, gSum / n, bSum / n);
+}
+
+export function mixHexColors(a: string, b: string, weightA: number): string {
+  const pa = parseInt(a.slice(1, 3), 16);
+  const ga = parseInt(a.slice(3, 5), 16);
+  const ba = parseInt(a.slice(5, 7), 16);
+  const pb = parseInt(b.slice(1, 3), 16);
+  const gb = parseInt(b.slice(3, 5), 16);
+  const bb = parseInt(b.slice(5, 7), 16);
+  const w = clamp(weightA, 0, 1);
+  return rgbToHex(
+    pa * w + pb * (1 - w),
+    ga * w + gb * (1 - w),
+    ba * w + bb * (1 - w),
+  );
+}

--- a/packages/epics/src/spaces/utils/extract-space-accent.ts
+++ b/packages/epics/src/spaces/utils/extract-space-accent.ts
@@ -95,33 +95,81 @@ export function hslToRgb(
   return [Math.round(r * 255), Math.round(g * 255), Math.round(b * 255)];
 }
 
+/**
+ * Canonical lightness ladder (approx. Radix-style spread). Peaks mid-ramp then
+ * darkens for hover / solid text slots — avoids duplicate L at steps 9–10.
+ */
+const ACCENT_LIGHTNESS_CURVE = [
+  0.987, 0.971, 0.943, 0.898, 0.798, 0.648, 0.538, 0.472, 0.492, 0.438, 0.382,
+  0.172,
+] as const;
+
+/**
+ * Intrinsic chroma weights per step (0–1). Peaks around interactive steps so
+ * primary CTAs feel vivid; tints steps 1–6 without going neon.
+ */
+const ACCENT_CHROMA_WEIGHT_CURVE = [
+  0.06, 0.11, 0.18, 0.28, 0.42, 0.58, 0.72, 0.84, 0.92, 0.88, 0.76, 0.22,
+] as const;
+
+/** Tiny hue drift so steps feel nuanced without shifting away from sampled hue. */
+function accentHueForStep(baseH: number, stepIndex: number): number {
+  const i = stepIndex + 1;
+  const drift = (i - 6.5) * 0.004 + Math.sin((i / 13) * Math.PI) * 0.006;
+  let nh = baseH + drift;
+  nh -= Math.floor(nh);
+  return nh;
+}
+
+/** Blend toward extracted accent RGB so ramps stay tethered at high saturation. */
+function softenTowardAccent(
+  sample: string,
+  baseHex: string,
+  ratio: number,
+): string {
+  return mixHexColors(sample, baseHex, clamp(ratio, 0, 1));
+}
+
 /** 12-step Radix-style accent ramp (sufficient for Tailwind accent-1…12 bindings). */
 export function buildAccentPaletteFromHex(
   baseHex: string,
 ): Record<string, string> {
   const fb = parseRgbFromHex(SPACE_ACCENT_FALLBACK)!;
   const [r0, g0, b0] = parseRgbFromHex(baseHex) ?? fb;
-  const { h } = rgbToHsl(r0, g0, b0);
+  const { h, s: s0, l: l0 } = rgbToHsl(r0, g0, b0);
 
-  const steps = [
-    { step: 1, l: 0.99, s: 0.02 },
-    { step: 2, l: 0.97, s: 0.04 },
-    { step: 3, l: 0.93, s: 0.08 },
-    { step: 4, l: 0.88, s: 0.12 },
-    { step: 5, l: 0.78, s: 0.18 },
-    { step: 6, l: 0.62, s: 0.24 },
-    { step: 7, l: 0.52, s: 0.32 },
-    { step: 8, l: 0.45, s: 0.38 },
-    { step: 9, l: 0.52, s: 0.5 },
-    { step: 10, l: 0.48, s: 0.48 },
-    { step: 11, l: 0.42, s: 0.42 },
-    { step: 12, l: 0.2, s: 0.08 },
-  ];
+  /** Greys need injected chroma or buttons read as neutral; cap so vivid sources stay controlled. */
+  const chromaAnchor = clamp(0.14 + s0 * 0.92, 0.16, 0.62);
+  const chromaCeil = clamp(chromaAnchor * 1.08 + 0.06, 0.22, 0.78);
 
   const out: Record<string, string> = {};
-  for (const { step, l, s } of steps) {
-    const [r, g, b] = hslToRgb(h, clamp(s, 0, 1), clamp(l, 0, 1));
-    out[`--color-accent-${step}`] = rgbToHex(r, g, b);
+  for (let i = 0; i < 12; i++) {
+    const step = i + 1;
+    let l = ACCENT_LIGHTNESS_CURVE[i]!;
+    /** Softly tie ladder to extracted luminance so dark banners don’t wash out mid-tones. */
+    l = clamp(l * (1 - 0.11) + l0 * 0.11, 0.06, 0.992);
+
+    const w = ACCENT_CHROMA_WEIGHT_CURVE[i]!;
+    let s = chromaAnchor + (chromaCeil - chromaAnchor) * w;
+
+    /** Extra chroma on primary/hover slots — capped so solids stay nuanced vs neon. */
+    if (step === 9) s = clamp(s * 1.045 + 0.015, 0, 0.74);
+    if (step === 10) s = clamp(s * 1.025, 0, 0.72);
+
+    const hh = accentHueForStep(h, i);
+    const [r, g, b] = hslToRgb(hh, clamp(s, 0, 1), clamp(l, 0, 1));
+    const candidate = rgbToHex(r, g, b);
+
+    /** Stronger tether on mid-ramp/interactive steps where HSL blows past brand hue */
+    let tether = 0.07 + w * 0.16;
+    if (step >= 8 && step <= 11) tether += 0.12;
+    if (step === 9 || step === 10) tether += 0.06;
+
+    out[`--color-accent-${step}`] = softenTowardAccent(
+      candidate,
+      baseHex,
+      tether,
+    );
   }
 
   const solid = out['--color-accent-9'] ?? baseHex;

--- a/packages/epics/src/spaces/utils/extract-space-accent.ts
+++ b/packages/epics/src/spaces/utils/extract-space-accent.ts
@@ -5,6 +5,17 @@
 
 export const SPACE_ACCENT_FALLBACK = '#4a65d8';
 
+/** Validates `#RRGGBB` for palette and mixHexColors callers. */
+export function parseRgbFromHex(hex: string): [number, number, number] | null {
+  const t = hex.trim();
+  if (!/^#[0-9a-fA-F]{6}$/.test(t)) return null;
+  const r = parseInt(t.slice(1, 3), 16);
+  const g = parseInt(t.slice(3, 5), 16);
+  const b = parseInt(t.slice(5, 7), 16);
+  if ([r, g, b].some((n) => Number.isNaN(n))) return null;
+  return [r, g, b];
+}
+
 function clamp(n: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, n));
 }
@@ -88,9 +99,8 @@ export function hslToRgb(
 export function buildAccentPaletteFromHex(
   baseHex: string,
 ): Record<string, string> {
-  const r0 = parseInt(baseHex.slice(1, 3), 16);
-  const g0 = parseInt(baseHex.slice(3, 5), 16);
-  const b0 = parseInt(baseHex.slice(5, 7), 16);
+  const fb = parseRgbFromHex(SPACE_ACCENT_FALLBACK)!;
+  const [r0, g0, b0] = parseRgbFromHex(baseHex) ?? fb;
   const { h } = rgbToHsl(r0, g0, b0);
 
   const steps = [
@@ -115,9 +125,8 @@ export function buildAccentPaletteFromHex(
   }
 
   const solid = out['--color-accent-9'] ?? baseHex;
-  const sr = parseInt(solid.slice(1, 3), 16);
-  const sg = parseInt(solid.slice(3, 5), 16);
-  const sb = parseInt(solid.slice(5, 7), 16);
+  const solidRgb = parseRgbFromHex(solid) ?? fb;
+  const [sr, sg, sb] = solidRgb;
   const lum = (sr * 299 + sg * 587 + sb * 114) / 1000;
   const onSolid = lum > 186 ? '#0f172a' : '#ffffff';
 
@@ -183,12 +192,11 @@ export function extractAccentHexFromImageData(data: ImageData): string {
 }
 
 export function mixHexColors(a: string, b: string, weightA: number): string {
-  const pa = parseInt(a.slice(1, 3), 16);
-  const ga = parseInt(a.slice(3, 5), 16);
-  const ba = parseInt(a.slice(5, 7), 16);
-  const pb = parseInt(b.slice(1, 3), 16);
-  const gb = parseInt(b.slice(3, 5), 16);
-  const bb = parseInt(b.slice(5, 7), 16);
+  const fb = parseRgbFromHex(SPACE_ACCENT_FALLBACK)!;
+  const ca = parseRgbFromHex(a) ?? fb;
+  const cb = parseRgbFromHex(b) ?? fb;
+  const [pa, ga, ba] = ca;
+  const [pb, gb, bb] = cb;
   const w = clamp(weightA, 0, 1);
   return rgbToHex(
     pa * w + pb * (1 - w),

--- a/packages/epics/src/spaces/utils/safe-image-url.ts
+++ b/packages/epics/src/spaces/utils/safe-image-url.ts
@@ -13,3 +13,16 @@ export function isSafeImageUrl(raw: string | null | undefined): boolean {
     return false;
   }
 }
+
+/** External link target: absolute http(s) only (no relative or protocol-relative URLs). */
+export function isSafeExternalUrl(raw: string | null | undefined): boolean {
+  if (raw == null) return false;
+  const t = raw.trim();
+  if (!t) return false;
+  try {
+    const u = new URL(t);
+    return u.protocol === 'http:' || u.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}

--- a/packages/epics/src/spaces/utils/safe-image-url.ts
+++ b/packages/epics/src/spaces/utils/safe-image-url.ts
@@ -1,0 +1,15 @@
+/**
+ * Safe URL for lead / logo images: same-origin path (not protocol-relative) or http(s) absolute.
+ */
+export function isSafeImageUrl(raw: string | null | undefined): boolean {
+  if (raw == null) return false;
+  const t = raw.trim();
+  if (!t) return false;
+  if (t.startsWith('/') && !t.startsWith('//')) return true;
+  try {
+    const u = new URL(t);
+    return u.protocol === 'http:' || u.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}

--- a/packages/epics/src/spaces/utils/space-accent-portal-styles.ts
+++ b/packages/epics/src/spaces/utils/space-accent-portal-styles.ts
@@ -1,0 +1,36 @@
+import type * as React from 'react';
+import { mixHexColors, SPACE_ACCENT_FALLBACK } from './extract-space-accent';
+import { DEFAULT_BANNER_OVERLAY_CSS_VARS } from './banner-overlay-tone';
+import { buildSpaceScopeStyle } from './space-accent-scope-style';
+
+function brightness(hex: string): number {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  return (r * 299 + g * 587 + b * 114) / 1000;
+}
+
+function contrastingForeground(hex: string): string {
+  return brightness(hex) > 186 ? '#0f172a' : '#f8fafc';
+}
+
+export type SpaceAccentPortalStyles = React.CSSProperties;
+
+/** Baseline portal styles (SSR + bridge init) until client canvas updates */
+export function getDefaultSpacePortalStyles(): SpaceAccentPortalStyles {
+  const accent = SPACE_ACCENT_FALLBACK;
+  const fg = contrastingForeground(accent);
+  const muted = mixHexColors(
+    accent,
+    brightness(accent) > 186 ? '#0f172a' : '#ffffff',
+    0.45,
+  );
+  return buildSpaceScopeStyle({
+    accent,
+    foreground: fg,
+    muted,
+    overlayVars: DEFAULT_BANNER_OVERLAY_CSS_VARS,
+  });
+}
+
+export const defaultSpacePortalStyles = getDefaultSpacePortalStyles();

--- a/packages/epics/src/spaces/utils/space-accent-portal-styles.ts
+++ b/packages/epics/src/spaces/utils/space-accent-portal-styles.ts
@@ -1,36 +1,15 @@
 import type * as React from 'react';
-import { mixHexColors, SPACE_ACCENT_FALLBACK } from './extract-space-accent';
-import { DEFAULT_BANNER_OVERLAY_CSS_VARS } from './banner-overlay-tone';
-import { buildSpaceScopeStyle } from './space-accent-scope-style';
-
-function brightness(hex: string): number {
-  const r = parseInt(hex.slice(1, 3), 16);
-  const g = parseInt(hex.slice(3, 5), 16);
-  const b = parseInt(hex.slice(5, 7), 16);
-  return (r * 299 + g * 587 + b * 114) / 1000;
-}
-
-function contrastingForeground(hex: string): string {
-  return brightness(hex) > 186 ? '#0f172a' : '#f8fafc';
-}
+import {
+  DEFAULT_SPACE_SCOPE_STYLE,
+  getDefaultSpaceScopeStyle,
+} from './space-accent-scope-style';
 
 export type SpaceAccentPortalStyles = React.CSSProperties;
 
-/** Baseline portal styles (SSR + bridge init) until client canvas updates */
+/** Delegates to scope defaults so portal bridge stays in sync with page accent wrapper */
 export function getDefaultSpacePortalStyles(): SpaceAccentPortalStyles {
-  const accent = SPACE_ACCENT_FALLBACK;
-  const fg = contrastingForeground(accent);
-  const muted = mixHexColors(
-    accent,
-    brightness(accent) > 186 ? '#0f172a' : '#ffffff',
-    0.45,
-  );
-  return buildSpaceScopeStyle({
-    accent,
-    foreground: fg,
-    muted,
-    overlayVars: DEFAULT_BANNER_OVERLAY_CSS_VARS,
-  });
+  return getDefaultSpaceScopeStyle();
 }
 
-export const defaultSpacePortalStyles = getDefaultSpacePortalStyles();
+export const defaultSpacePortalStyles: SpaceAccentPortalStyles =
+  DEFAULT_SPACE_SCOPE_STYLE;

--- a/packages/epics/src/spaces/utils/space-accent-scope-style.ts
+++ b/packages/epics/src/spaces/utils/space-accent-scope-style.ts
@@ -2,6 +2,7 @@ import type * as React from 'react';
 import {
   buildAccentPaletteFromHex,
   mixHexColors,
+  parseRgbFromHex,
   SPACE_ACCENT_FALLBACK,
 } from './extract-space-accent';
 import {
@@ -12,10 +13,16 @@ import {
 /** W3C-style luminance cutoff for choosing dark vs light foreground on accent */
 const BRIGHTNESS_DARK_FG_THRESHOLD = 186;
 
+function normalizeAccentHex(hex: string | null | undefined): string | null {
+  if (hex == null) return null;
+  const normalized = hex.trim();
+  if (!normalized) return null;
+  return parseRgbFromHex(normalized) ? normalized : null;
+}
+
 function brightness(hex: string): number {
-  const r = parseInt(hex.slice(1, 3), 16);
-  const g = parseInt(hex.slice(3, 5), 16);
-  const b = parseInt(hex.slice(5, 7), 16);
+  const fb = parseRgbFromHex(SPACE_ACCENT_FALLBACK)!;
+  const [r, g, b] = parseRgbFromHex(hex) ?? fb;
   return (r * 299 + g * 587 + b * 114) / 1000;
 }
 
@@ -33,7 +40,8 @@ export function buildSpaceScopeStyle(input: {
   muted: string;
   overlayVars: BannerOverlayCssVars;
 }): React.CSSProperties {
-  const { accent, foreground, muted, overlayVars } = input;
+  const { foreground, muted, overlayVars } = input;
+  const accent = normalizeAccentHex(input.accent) ?? SPACE_ACCENT_FALLBACK;
   const palette = buildAccentPaletteFromHex(accent);
 
   return {
@@ -74,7 +82,8 @@ export function buildSpaceScopeStyleFromSampledAccents(options: {
   overlayVars: BannerOverlayCssVars | null;
 }): React.CSSProperties {
   let accent = SPACE_ACCENT_FALLBACK;
-  const { bannerAccent, logoAccent } = options;
+  const bannerAccent = normalizeAccentHex(options.bannerAccent);
+  const logoAccent = normalizeAccentHex(options.logoAccent);
   if (bannerAccent && logoAccent) {
     accent = mixHexColors(bannerAccent, logoAccent, 0.55);
   } else if (bannerAccent) {

--- a/packages/epics/src/spaces/utils/space-accent-scope-style.ts
+++ b/packages/epics/src/spaces/utils/space-accent-scope-style.ts
@@ -1,0 +1,93 @@
+import type * as React from 'react';
+import {
+  buildAccentPaletteFromHex,
+  mixHexColors,
+  SPACE_ACCENT_FALLBACK,
+} from './extract-space-accent';
+import {
+  DEFAULT_BANNER_OVERLAY_CSS_VARS,
+  type BannerOverlayCssVars,
+} from './banner-overlay-tone';
+
+function brightness(hex: string): number {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  return (r * 299 + g * 587 + b * 114) / 1000;
+}
+
+function contrastingForeground(hex: string): string {
+  return brightness(hex) > 186 ? '#0f172a' : '#f8fafc';
+}
+
+/**
+ * Inline style bag for `[data-space-accent-scope]` and portaled DHO shells
+ * (`ProposalOverlayShell`) so accent matches outside the DOM subtree.
+ */
+export function buildSpaceScopeStyle(input: {
+  accent: string;
+  foreground: string;
+  muted: string;
+  overlayVars: BannerOverlayCssVars;
+}): React.CSSProperties {
+  const { accent, foreground, muted, overlayVars } = input;
+  const palette = buildAccentPaletteFromHex(accent);
+
+  return {
+    ...overlayVars,
+    ...palette,
+    '--space-accent': accent,
+    '--space-accent-foreground': foreground,
+    '--space-accent-muted': muted,
+    '--space-accent-contrast': foreground,
+    '--space-tab-active-border': accent,
+  } as React.CSSProperties;
+}
+
+export function getDefaultSpaceScopeStyle(): React.CSSProperties {
+  const accent = SPACE_ACCENT_FALLBACK;
+  const fg = contrastingForeground(accent);
+  const subtle = mixHexColors(
+    accent,
+    brightness(accent) > 186 ? '#0f172a' : '#ffffff',
+    0.45,
+  );
+
+  return buildSpaceScopeStyle({
+    accent,
+    foreground: fg,
+    muted: subtle,
+    overlayVars: DEFAULT_BANNER_OVERLAY_CSS_VARS,
+  });
+}
+
+/** Canvas sampling results → same inline style bag as `buildSpaceScopeStyle` */
+export function buildSpaceScopeStyleFromSampledAccents(options: {
+  bannerAccent: string | null;
+  logoAccent: string | null;
+  overlayVars: BannerOverlayCssVars | null;
+}): React.CSSProperties {
+  let accent = SPACE_ACCENT_FALLBACK;
+  const { bannerAccent, logoAccent } = options;
+  if (bannerAccent && logoAccent) {
+    accent = mixHexColors(bannerAccent, logoAccent, 0.55);
+  } else if (bannerAccent) {
+    accent = bannerAccent;
+  } else if (logoAccent) {
+    accent = logoAccent;
+  }
+
+  const fg = contrastingForeground(accent);
+  const subtle = mixHexColors(
+    accent,
+    brightness(accent) > 186 ? '#0f172a' : '#ffffff',
+    0.45,
+  );
+
+  return buildSpaceScopeStyle({
+    accent,
+    foreground: fg,
+    muted: subtle,
+    overlayVars: options.overlayVars ?? DEFAULT_BANNER_OVERLAY_CSS_VARS,
+  });
+}

--- a/packages/epics/src/spaces/utils/space-accent-scope-style.ts
+++ b/packages/epics/src/spaces/utils/space-accent-scope-style.ts
@@ -61,6 +61,9 @@ export function getDefaultSpaceScopeStyle(): React.CSSProperties {
   });
 }
 
+/** Module singleton for initial paint and resetting accent scope between samples */
+export const DEFAULT_SPACE_SCOPE_STYLE = getDefaultSpaceScopeStyle();
+
 /** Canvas sampling results → same inline style bag as `buildSpaceScopeStyle` */
 export function buildSpaceScopeStyleFromSampledAccents(options: {
   bannerAccent: string | null;

--- a/packages/epics/src/spaces/utils/space-accent-scope-style.ts
+++ b/packages/epics/src/spaces/utils/space-accent-scope-style.ts
@@ -9,6 +9,9 @@ import {
   type BannerOverlayCssVars,
 } from './banner-overlay-tone';
 
+/** W3C-style luminance cutoff for choosing dark vs light foreground on accent */
+const BRIGHTNESS_DARK_FG_THRESHOLD = 186;
+
 function brightness(hex: string): number {
   const r = parseInt(hex.slice(1, 3), 16);
   const g = parseInt(hex.slice(3, 5), 16);
@@ -17,7 +20,7 @@ function brightness(hex: string): number {
 }
 
 function contrastingForeground(hex: string): string {
-  return brightness(hex) > 186 ? '#0f172a' : '#f8fafc';
+  return brightness(hex) > BRIGHTNESS_DARK_FG_THRESHOLD ? '#0f172a' : '#f8fafc';
 }
 
 /**
@@ -49,7 +52,7 @@ export function getDefaultSpaceScopeStyle(): React.CSSProperties {
   const fg = contrastingForeground(accent);
   const subtle = mixHexColors(
     accent,
-    brightness(accent) > 186 ? '#0f172a' : '#ffffff',
+    brightness(accent) > BRIGHTNESS_DARK_FG_THRESHOLD ? '#0f172a' : '#ffffff',
     0.45,
   );
 
@@ -83,7 +86,7 @@ export function buildSpaceScopeStyleFromSampledAccents(options: {
   const fg = contrastingForeground(accent);
   const subtle = mixHexColors(
     accent,
-    brightness(accent) > 186 ? '#0f172a' : '#ffffff',
+    brightness(accent) > BRIGHTNESS_DARK_FG_THRESHOLD ? '#0f172a' : '#ffffff',
     0.45,
   );
 

--- a/packages/epics/src/treasury/components/requests/transfer-card.tsx
+++ b/packages/epics/src/treasury/components/requests/transfer-card.tsx
@@ -76,18 +76,16 @@ export const TransferCard: React.FC<TransferCardProps> = ({
                 {symbol ? (
                   <Badge
                     isLoading={isLoading}
-                    variant="surface"
+                    variant="outline"
                     colorVariant="accent"
-                    className="text-foreground"
                   >
                     {symbol}
                   </Badge>
                 ) : null}
                 <Badge
                   isLoading={isLoading}
-                  variant="surface"
+                  variant="outline"
                   colorVariant="accent"
-                  className="text-foreground"
                 >
                   {isMint
                     ? tTreasury('transactionCard.type.mint')
@@ -97,7 +95,7 @@ export const TransferCard: React.FC<TransferCardProps> = ({
                 </Badge>
                 <Badge
                   isLoading={isLoading}
-                  variant="surface"
+                  variant="outline"
                   colorVariant={
                     isMint || direction === 'incoming' ? 'success' : 'error'
                   }

--- a/packages/epics/src/treasury/components/requests/transfer-card.tsx
+++ b/packages/epics/src/treasury/components/requests/transfer-card.tsx
@@ -78,6 +78,7 @@ export const TransferCard: React.FC<TransferCardProps> = ({
                     isLoading={isLoading}
                     variant="surface"
                     colorVariant="accent"
+                    className="text-foreground"
                   >
                     {symbol}
                   </Badge>
@@ -86,6 +87,7 @@ export const TransferCard: React.FC<TransferCardProps> = ({
                   isLoading={isLoading}
                   variant="surface"
                   colorVariant="accent"
+                  className="text-foreground"
                 >
                   {isMint
                     ? tTreasury('transactionCard.type.mint')

--- a/packages/i18n/src/messages/de.json
+++ b/packages/i18n/src/messages/de.json
@@ -2,6 +2,7 @@
   "Common": {
     "Assignments": "Zuweisungen",
     "Members": "Mitglieder",
+    "memberRoleLabel": "Mitglied",
     "Treasury": "Schatzkammer",
     "Agreements": "Vereinbarungen",
     "Spaces": "Spaces",

--- a/packages/i18n/src/messages/de.json
+++ b/packages/i18n/src/messages/de.json
@@ -3,6 +3,7 @@
     "Assignments": "Zuweisungen",
     "Members": "Mitglieder",
     "memberRoleLabel": "Mitglied",
+    "delegatedVotingMemberLabel": "Delegiertes Stimmmitglied",
     "Treasury": "Schatzkammer",
     "Agreements": "Vereinbarungen",
     "Spaces": "Spaces",

--- a/packages/i18n/src/messages/de.json
+++ b/packages/i18n/src/messages/de.json
@@ -8,7 +8,7 @@
     "Spaces": "Spaces",
     "loadMore": "Mehr laden",
     "noMore": "Keine weiteren",
-    "spaceBannerDescriptionAria": "{title}: Beschreibung",
+    "spaceBannerDescriptionAria": "Beschreibung von {title}",
     "createdOn": "Erstellt am {date}",
     "acceptedOn": "Angenommen am {date}",
     "rejectedOn": "Abgelehnt am {date}",

--- a/packages/i18n/src/messages/de.json
+++ b/packages/i18n/src/messages/de.json
@@ -1003,7 +1003,9 @@
       }
     },
     "loadingBackdrop": {
-      "keepWindowOpen": "Lassen Sie dieses Fenster geöffnet, bis wir fertig sind."
+      "keepWindowOpen": "Lassen Sie dieses Fenster geöffnet, bis wir fertig sind.",
+      "errorTitle": "Etwas ist schiefgelaufen",
+      "resetButton": "Zurücksetzen"
     },
     "spaceTokenPurchaseProgress": {
       "CREATE_WEB2_AGREEMENT": "Vereinbarung wird erstellt...",

--- a/packages/i18n/src/messages/de.json
+++ b/packages/i18n/src/messages/de.json
@@ -7,6 +7,7 @@
     "Spaces": "Spaces",
     "loadMore": "Mehr laden",
     "noMore": "Keine weiteren",
+    "spaceBannerDescriptionAria": "{title}: Beschreibung",
     "createdOn": "Erstellt am {date}",
     "acceptedOn": "Angenommen am {date}",
     "rejectedOn": "Abgelehnt am {date}",

--- a/packages/i18n/src/messages/en.json
+++ b/packages/i18n/src/messages/en.json
@@ -7,6 +7,7 @@
     "Spaces": "Spaces",
     "loadMore": "Load more",
     "noMore": "No more",
+    "spaceBannerDescriptionAria": "{title}: description",
     "createdOn": "Created on {date}",
     "acceptedOn": "Accepted on {date}",
     "rejectedOn": "Rejected on {date}",

--- a/packages/i18n/src/messages/en.json
+++ b/packages/i18n/src/messages/en.json
@@ -3,6 +3,7 @@
     "Assignments": "Assignments",
     "Members": "Members",
     "memberRoleLabel": "Member",
+    "delegatedVotingMemberLabel": "Delegated voting member",
     "Treasury": "Treasury",
     "Agreements": "Agreements",
     "Spaces": "Spaces",

--- a/packages/i18n/src/messages/en.json
+++ b/packages/i18n/src/messages/en.json
@@ -8,7 +8,7 @@
     "Spaces": "Spaces",
     "loadMore": "Load more",
     "noMore": "No more",
-    "spaceBannerDescriptionAria": "{title}: description",
+    "spaceBannerDescriptionAria": "Description of {title}",
     "createdOn": "Created on {date}",
     "acceptedOn": "Accepted on {date}",
     "rejectedOn": "Rejected on {date}",

--- a/packages/i18n/src/messages/en.json
+++ b/packages/i18n/src/messages/en.json
@@ -1004,7 +1004,9 @@
       }
     },
     "loadingBackdrop": {
-      "keepWindowOpen": "Keep this window open until we're finished."
+      "keepWindowOpen": "Keep this window open until we're finished.",
+      "errorTitle": "Something went wrong",
+      "resetButton": "Reset"
     },
     "spaceTokenPurchaseProgress": {
       "CREATE_WEB2_AGREEMENT": "Creating agreement...",

--- a/packages/i18n/src/messages/en.json
+++ b/packages/i18n/src/messages/en.json
@@ -2,6 +2,7 @@
   "Common": {
     "Assignments": "Assignments",
     "Members": "Members",
+    "memberRoleLabel": "Member",
     "Treasury": "Treasury",
     "Agreements": "Agreements",
     "Spaces": "Spaces",

--- a/packages/i18n/src/messages/es.json
+++ b/packages/i18n/src/messages/es.json
@@ -1,7 +1,7 @@
 {
   "Common": {
     "createdOn": "Creado el {date}",
-    "spaceBannerDescriptionAria": "{title}: descripción",
+    "spaceBannerDescriptionAria": "Descripción de {title}",
     "acceptedOn": "Aceptado el {date}",
     "rejectedOn": "Rechazado el {date}",
     "joinedSpaceOn": "Se unió al espacio el {date}",

--- a/packages/i18n/src/messages/es.json
+++ b/packages/i18n/src/messages/es.json
@@ -7,6 +7,7 @@
     "joinedSpaceOn": "Se unió al espacio el {date}",
     "Assignments": "Asignaciones",
     "Members": "Miembros",
+    "memberRoleLabel": "Miembro",
     "Treasury": "Tesorería",
     "Agreements": "Acuerdos",
     "Spaces": "Espacios",

--- a/packages/i18n/src/messages/es.json
+++ b/packages/i18n/src/messages/es.json
@@ -683,7 +683,9 @@
       }
     },
     "loadingBackdrop": {
-      "keepWindowOpen": "Mantén esta ventana abierta hasta que terminemos."
+      "keepWindowOpen": "Mantén esta ventana abierta hasta que terminemos.",
+      "errorTitle": "Algo salió mal",
+      "resetButton": "Restablecer"
     },
     "spaceTokenPurchaseProgress": {
       "CREATE_WEB2_AGREEMENT": "Creando acuerdo...",

--- a/packages/i18n/src/messages/es.json
+++ b/packages/i18n/src/messages/es.json
@@ -8,6 +8,7 @@
     "Assignments": "Asignaciones",
     "Members": "Miembros",
     "memberRoleLabel": "Miembro",
+    "delegatedVotingMemberLabel": "Miembro con voto delegado",
     "Treasury": "Tesorería",
     "Agreements": "Acuerdos",
     "Spaces": "Espacios",

--- a/packages/i18n/src/messages/es.json
+++ b/packages/i18n/src/messages/es.json
@@ -1,6 +1,7 @@
 {
   "Common": {
     "createdOn": "Creado el {date}",
+    "spaceBannerDescriptionAria": "{title}: descripción",
     "acceptedOn": "Aceptado el {date}",
     "rejectedOn": "Rechazado el {date}",
     "joinedSpaceOn": "Se unió al espacio el {date}",

--- a/packages/i18n/src/messages/fr.json
+++ b/packages/i18n/src/messages/fr.json
@@ -2,6 +2,7 @@
   "Common": {
     "Assignments": "Affectations",
     "Members": "Membres",
+    "memberRoleLabel": "Membre",
     "Treasury": "Trésorerie",
     "Agreements": "Accords",
     "Spaces": "Espaces",

--- a/packages/i18n/src/messages/fr.json
+++ b/packages/i18n/src/messages/fr.json
@@ -3,6 +3,7 @@
     "Assignments": "Affectations",
     "Members": "Membres",
     "memberRoleLabel": "Membre",
+    "delegatedVotingMemberLabel": "Membre avec vote délégué",
     "Treasury": "Trésorerie",
     "Agreements": "Accords",
     "Spaces": "Espaces",

--- a/packages/i18n/src/messages/fr.json
+++ b/packages/i18n/src/messages/fr.json
@@ -7,6 +7,7 @@
     "Spaces": "Espaces",
     "loadMore": "Charger plus",
     "noMore": "Plus aucun",
+    "spaceBannerDescriptionAria": "{title} : description",
     "createdOn": "Créé le {date}",
     "acceptedOn": "Accepté le {date}",
     "rejectedOn": "Rejeté le {date}",

--- a/packages/i18n/src/messages/fr.json
+++ b/packages/i18n/src/messages/fr.json
@@ -1003,7 +1003,9 @@
       }
     },
     "loadingBackdrop": {
-      "keepWindowOpen": "Gardez cette fenêtre ouverte jusqu’à la fin."
+      "keepWindowOpen": "Gardez cette fenêtre ouverte jusqu’à la fin.",
+      "errorTitle": "Une erreur s’est produite",
+      "resetButton": "Réinitialiser"
     },
     "spaceTokenPurchaseProgress": {
       "CREATE_WEB2_AGREEMENT": "Création de l'accord...",

--- a/packages/i18n/src/messages/fr.json
+++ b/packages/i18n/src/messages/fr.json
@@ -8,7 +8,7 @@
     "Spaces": "Espaces",
     "loadMore": "Charger plus",
     "noMore": "Plus aucun",
-    "spaceBannerDescriptionAria": "{title} : description",
+    "spaceBannerDescriptionAria": "Description de {title}",
     "createdOn": "Créé le {date}",
     "acceptedOn": "Accepté le {date}",
     "rejectedOn": "Rejeté le {date}",

--- a/packages/i18n/src/messages/pt.json
+++ b/packages/i18n/src/messages/pt.json
@@ -683,7 +683,9 @@
       }
     },
     "loadingBackdrop": {
-      "keepWindowOpen": "Mantenha esta janela aberta até terminarmos."
+      "keepWindowOpen": "Mantenha esta janela aberta até terminarmos.",
+      "errorTitle": "Algo correu mal",
+      "resetButton": "Repor"
     },
     "spaceTokenPurchaseProgress": {
       "CREATE_WEB2_AGREEMENT": "A criar acordo...",

--- a/packages/i18n/src/messages/pt.json
+++ b/packages/i18n/src/messages/pt.json
@@ -8,6 +8,7 @@
     "Assignments": "Tarefas",
     "Members": "Membros",
     "memberRoleLabel": "Membro",
+    "delegatedVotingMemberLabel": "Membro com voto delegado",
     "Treasury": "Tesouraria",
     "Agreements": "Acordos",
     "Spaces": "Espaços",

--- a/packages/i18n/src/messages/pt.json
+++ b/packages/i18n/src/messages/pt.json
@@ -1,6 +1,7 @@
 {
   "Common": {
     "createdOn": "Criado em {date}",
+    "spaceBannerDescriptionAria": "{title}: descrição",
     "acceptedOn": "Aceito em {date}",
     "rejectedOn": "Rejeitado em {date}",
     "joinedSpaceOn": "Entrou no espaço em {date}",

--- a/packages/i18n/src/messages/pt.json
+++ b/packages/i18n/src/messages/pt.json
@@ -1,7 +1,7 @@
 {
   "Common": {
     "createdOn": "Criado em {date}",
-    "spaceBannerDescriptionAria": "{title}: descrição",
+    "spaceBannerDescriptionAria": "Descrição de {title}",
     "acceptedOn": "Aceito em {date}",
     "rejectedOn": "Rejeitado em {date}",
     "joinedSpaceOn": "Entrou no espaço em {date}",

--- a/packages/i18n/src/messages/pt.json
+++ b/packages/i18n/src/messages/pt.json
@@ -7,6 +7,7 @@
     "joinedSpaceOn": "Entrou no espaço em {date}",
     "Assignments": "Tarefas",
     "Members": "Membros",
+    "memberRoleLabel": "Membro",
     "Treasury": "Tesouraria",
     "Agreements": "Acordos",
     "Spaces": "Espaços",

--- a/packages/ui/src/badge.tsx
+++ b/packages/ui/src/badge.tsx
@@ -31,7 +31,7 @@ const parameters = {
 };
 
 const badgeVariants = cva(
-  'inline-flex items-center rounded-lg border focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 font-medium transition-colors',
+  'inline-flex items-center rounded-lg border focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 font-medium transition-[color,background-color,border-color,box-shadow,ring-color]',
   {
     variants: {
       size: {
@@ -59,7 +59,7 @@ const badgeVariants = cva(
       variant: {
         solid: 'border-transparent',
         soft: 'border-transparent',
-        outline: 'bg-transparent',
+        outline: 'bg-transparent ring-2 ring-transparent',
         surface: '',
       },
       colorVariant: {
@@ -128,31 +128,31 @@ const badgeVariants = cva(
         variant: 'outline',
         colorVariant: 'accent',
         className:
-          'border-accent-8 text-accent-11 hover:border-accent-9 hover:bg-accent-2 hover:text-foreground',
+          'border-accent-8 text-accent-11 hover:border-accent-10 hover:text-foreground hover:ring-accent-10/70',
       },
       {
         variant: 'outline',
         colorVariant: 'success',
         className:
-          'border-success-8 text-success-11 hover:border-success-9 hover:bg-success-2 hover:text-foreground',
+          'border-success-8 text-success-11 hover:border-success-10 hover:text-foreground hover:ring-success-10/70',
       },
       {
         variant: 'outline',
         colorVariant: 'error',
         className:
-          'border-error-8 text-error-11 hover:border-error-9 hover:bg-error-2 hover:text-foreground',
+          'border-error-8 text-error-11 hover:border-error-10 hover:text-foreground hover:ring-error-10/70',
       },
       {
         variant: 'outline',
         colorVariant: 'warn',
         className:
-          'border-warning-8 text-warning-11 hover:border-warning-9 hover:bg-warning-2 hover:text-foreground',
+          'border-warning-8 text-warning-11 hover:border-warning-10 hover:text-foreground hover:ring-warning-10/70',
       },
       {
         variant: 'outline',
         colorVariant: 'neutral',
         className:
-          'border-neutral-8 text-neutral-11 hover:border-neutral-9 hover:bg-neutral-2',
+          'border-neutral-8 text-neutral-11 hover:border-neutral-10 hover:text-foreground hover:ring-neutral-10/65',
       },
       // Surface variants
       {

--- a/packages/ui/src/badge.tsx
+++ b/packages/ui/src/badge.tsx
@@ -31,7 +31,7 @@ const parameters = {
 };
 
 const badgeVariants = cva(
-  'inline-flex items-center rounded-lg border focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 font-medium transition-[color,background-color,border-color,box-shadow,ring-color]',
+  'inline-flex items-center rounded-lg border focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 font-medium transition-[color,background-color,border-color,box-shadow]',
   {
     variants: {
       size: {

--- a/packages/ui/src/badge.tsx
+++ b/packages/ui/src/badge.tsx
@@ -152,7 +152,7 @@ const badgeVariants = cva(
         variant: 'outline',
         colorVariant: 'neutral',
         className:
-          'border-neutral-8 text-neutral-11 hover:border-neutral-10 hover:text-foreground hover:ring-neutral-10/65',
+          'border-neutral-8 text-neutral-11 hover:border-neutral-10 hover:text-foreground hover:ring-neutral-10/70',
       },
       // Surface variants
       {

--- a/packages/ui/src/badge.tsx
+++ b/packages/ui/src/badge.tsx
@@ -123,30 +123,30 @@ const badgeVariants = cva(
         colorVariant: 'neutral',
         className: 'bg-neutral-3 text-neutral-11 hover:bg-neutral-4',
       },
-      // Outline variants
+      // Outline variants — hover tint needs high-contrast text (accent-11 on accent-2 is illegible on strong themes)
       {
         variant: 'outline',
         colorVariant: 'accent',
         className:
-          'border-accent-8 text-accent-11 hover:border-accent-9 hover:bg-accent-2',
+          'border-accent-8 text-accent-11 hover:border-accent-9 hover:bg-accent-2 hover:text-foreground',
       },
       {
         variant: 'outline',
         colorVariant: 'success',
         className:
-          'border-success-8 text-success-11 hover:border-success-9 hover:bg-success-2',
+          'border-success-8 text-success-11 hover:border-success-9 hover:bg-success-2 hover:text-foreground',
       },
       {
         variant: 'outline',
         colorVariant: 'error',
         className:
-          'border-error-8 text-error-11 hover:border-error-9 hover:bg-error-2',
+          'border-error-8 text-error-11 hover:border-error-9 hover:bg-error-2 hover:text-foreground',
       },
       {
         variant: 'outline',
         colorVariant: 'warn',
         className:
-          'border-warning-8 text-warning-11 hover:border-warning-9 hover:bg-warning-2',
+          'border-warning-8 text-warning-11 hover:border-warning-9 hover:bg-warning-2 hover:text-foreground',
       },
       {
         variant: 'outline',

--- a/packages/ui/src/badge.tsx
+++ b/packages/ui/src/badge.tsx
@@ -31,7 +31,7 @@ const parameters = {
 };
 
 const badgeVariants = cva(
-  'inline-flex items-center rounded-lg border focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 font-medium transition-[color,background-color,border-color,box-shadow]',
+  'inline-flex items-center rounded-lg border focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 font-medium transition-[color,background-color,border-color,box-shadow,--tw-ring-color]',
   {
     variants: {
       size: {

--- a/packages/ui/src/breadcrumb.tsx
+++ b/packages/ui/src/breadcrumb.tsx
@@ -43,7 +43,10 @@ function BreadcrumbLink({
   return (
     <Comp
       data-slot="breadcrumb-link"
-      className={cn('hover:text-foreground transition-colors', className)}
+      className={cn(
+        'underline-offset-4 transition-colors hover:text-foreground hover:underline',
+        className,
+      )}
       {...props}
     />
   );

--- a/packages/ui/src/button.tsx
+++ b/packages/ui/src/button.tsx
@@ -5,13 +5,14 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@hypha-platform/ui-utils';
 
 const buttonVariants = cva(
-  'cursor-pointer rounded-lg inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-semibold ring-offset-background transition-[color,box-shadow,transform,background-color] duration-200 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
+  'cursor-pointer rounded-lg inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-semibold ring-offset-background transition-[color,box-shadow,transform,background-color,ring-color] duration-200 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
   {
     variants: {
       variant: {
         default: '',
         outline:
-          'border bg-transparent shadow-sm hover:shadow-md active:shadow-sm',
+          /* ring-2 reserved so hover highlight does not shift layout */
+          'border bg-transparent shadow-sm ring-2 ring-transparent hover:shadow-md active:shadow-sm',
         link: 'underline-offset-4 hover:underline bg-transparent font-medium',
         ghost: 'bg-transparent font-medium',
       },
@@ -62,26 +63,26 @@ const buttonVariants = cva(
         variant: 'outline',
         colorVariant: 'accent',
         className:
-          /* accent-12 on accent-3 wash reads as colour-on-colour; foreground stays legible on the tint */
-          'border-accent-8 text-accent-11 hover:bg-accent-3 hover:text-foreground hover:border-accent-9 active:scale-[0.99]',
+          /* Outline hover: emphasize border + ring — no solid fill (matches status chips) */
+          'border-accent-8 text-accent-11 hover:border-accent-10 hover:text-foreground hover:ring-accent-10/75 active:scale-[0.99]',
       },
       {
         variant: 'outline',
         colorVariant: 'neutral',
         className:
-          'border-neutral-9 bg-neutral-1 text-neutral-12 hover:bg-neutral-3 hover:text-foreground hover:border-neutral-10',
+          'border-neutral-9 bg-neutral-1 text-neutral-12 hover:border-neutral-11 hover:text-foreground hover:ring-neutral-10/70',
       },
       {
         variant: 'outline',
         colorVariant: 'error',
         className:
-          'border-error-9 text-error-9 hover:bg-error-2 hover:text-foreground',
+          'border-error-9 text-error-9 hover:border-error-10 hover:text-foreground hover:ring-error-10/75',
       },
       {
         variant: 'outline',
         colorVariant: 'success',
         className:
-          'border-success-10 text-success-11 hover:bg-success-2 hover:text-foreground',
+          'border-success-10 text-success-11 hover:border-success-11 hover:text-foreground hover:ring-success-10/75',
       },
       {
         variant: 'link',

--- a/packages/ui/src/button.tsx
+++ b/packages/ui/src/button.tsx
@@ -69,19 +69,19 @@ const buttonVariants = cva(
         variant: 'outline',
         colorVariant: 'neutral',
         className:
-          'border-neutral-9 text-secondary-foreground bg-neutral-1 hover:text-neutral-12',
+          'border-neutral-9 bg-neutral-1 text-neutral-12 hover:bg-neutral-3 hover:text-foreground hover:border-neutral-10',
       },
       {
         variant: 'outline',
         colorVariant: 'error',
         className:
-          'border-error-9 text-error-9 hover:bg-error-2 hover:text-error-11',
+          'border-error-9 text-error-9 hover:bg-error-2 hover:text-foreground',
       },
       {
         variant: 'outline',
         colorVariant: 'success',
         className:
-          'border-success-10 text-success-11 hover:bg-success-2 hover:text-success-12',
+          'border-success-10 text-success-11 hover:bg-success-2 hover:text-foreground',
       },
       {
         variant: 'link',
@@ -111,17 +111,17 @@ const buttonVariants = cva(
       {
         variant: 'ghost',
         colorVariant: 'neutral',
-        className: 'text-neutral-11 hover:bg-neutral-3 hover:text-neutral-12',
+        className: 'text-neutral-11 hover:bg-neutral-3 hover:text-foreground',
       },
       {
         variant: 'ghost',
         colorVariant: 'error',
-        className: 'text-error-11 hover:bg-error-3 hover:text-error-12',
+        className: 'text-error-11 hover:bg-error-3 hover:text-foreground',
       },
       {
         variant: 'ghost',
         colorVariant: 'success',
-        className: 'text-success-11 hover:bg-success-3 hover:text-success-12',
+        className: 'text-success-11 hover:bg-success-3 hover:text-foreground',
       },
     ],
   },

--- a/packages/ui/src/button.tsx
+++ b/packages/ui/src/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@hypha-platform/ui-utils';
 
 const buttonVariants = cva(
-  'cursor-pointer rounded-md inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-semibold ring-offset-background transition-[color,box-shadow,transform,background-color] duration-200 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
+  'cursor-pointer rounded-lg inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-semibold ring-offset-background transition-[color,box-shadow,transform,background-color] duration-200 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
   {
     variants: {
       variant: {

--- a/packages/ui/src/button.tsx
+++ b/packages/ui/src/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@hypha-platform/ui-utils';
 
 const buttonVariants = cva(
-  'cursor-pointer rounded-lg inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-semibold ring-offset-background transition-[color,box-shadow,transform,background-color] duration-200 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
+  'cursor-pointer rounded-lg inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-semibold ring-offset-background transition-[color,box-shadow,transform,background-color,--tw-ring-color] duration-200 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
   {
     variants: {
       variant: {

--- a/packages/ui/src/button.tsx
+++ b/packages/ui/src/button.tsx
@@ -62,7 +62,8 @@ const buttonVariants = cva(
         variant: 'outline',
         colorVariant: 'accent',
         className:
-          'border-accent-8 text-accent-11 hover:bg-accent-3 hover:text-accent-12 hover:border-accent-9 active:scale-[0.99]',
+          /* accent-12 on accent-3 wash reads as colour-on-colour; foreground stays legible on the tint */
+          'border-accent-8 text-accent-11 hover:bg-accent-3 hover:text-foreground hover:border-accent-9 active:scale-[0.99]',
       },
       {
         variant: 'outline',
@@ -105,7 +106,7 @@ const buttonVariants = cva(
       {
         variant: 'ghost',
         colorVariant: 'accent',
-        className: 'text-accent-11 hover:bg-accent-3 hover:text-accent-12',
+        className: 'text-accent-11 hover:bg-accent-3 hover:text-foreground',
       },
       {
         variant: 'ghost',

--- a/packages/ui/src/button.tsx
+++ b/packages/ui/src/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@hypha-platform/ui-utils';
 
 const buttonVariants = cva(
-  'cursor-pointer rounded-lg inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-semibold ring-offset-background transition-[color,box-shadow,transform,background-color,ring-color] duration-200 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
+  'cursor-pointer rounded-lg inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-semibold ring-offset-background transition-[color,box-shadow,transform,background-color] duration-200 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
   {
     variants: {
       variant: {

--- a/packages/ui/src/molecules/loading-backdrop-inner.tsx
+++ b/packages/ui/src/molecules/loading-backdrop-inner.tsx
@@ -16,6 +16,11 @@ type LoadingBackdropInnerPropsBase = {
   fullHeight?: boolean;
   /** `auto`: follow Aside overlay context (modal shell vs side panel). */
   fullHeightVariant?: 'auto' | 'docked-panel' | 'responsive-modal-shell';
+  /**
+   * When the overlay is portaled to `document.body`, host CSS variables here
+   * (e.g. space-derived `--color-accent-9`) so `bg-accent-9` on the progress bar resolves.
+   */
+  portalScopeStyle?: React.CSSProperties;
 };
 
 /** When `showKeepWindowOpenMessage` is true, localized `keepWindowOpenMessage` is required (no English default in this component). */
@@ -117,6 +122,7 @@ export function LoadingBackdropInner({
   keepWindowOpenMessage,
   fullHeight = false,
   fullHeightVariant = 'auto',
+  portalScopeStyle,
 }: LoadingBackdropInnerProps) {
   const asideLayout = useAsideOverlayLayout();
   const resolvedFullHeightVariant =
@@ -142,6 +148,8 @@ export function LoadingBackdropInner({
         'max-md:top-[var(--menu-top-height,65px)] max-md:right-[var(--sidebar-right-width,0px)]',
         className,
       )}
+      style={portalScopeStyle}
+      data-space-accent-scope={portalScopeStyle ? '' : undefined}
       aria-live="polite"
       aria-busy="true"
     >
@@ -166,7 +174,9 @@ export function LoadingBackdropInner({
         style={{
           top: 'var(--menu-top-height, 65px)',
           right: 'var(--sidebar-right-width, 0px)',
+          ...portalScopeStyle,
         }}
+        data-space-accent-scope={portalScopeStyle ? '' : undefined}
         aria-live="polite"
         aria-busy="true"
       >
@@ -183,6 +193,8 @@ export function LoadingBackdropInner({
           'absolute inset-0 z-10 flex min-h-full flex-col items-center justify-center space-y-2 bg-background/75',
           className,
         )}
+        style={portalScopeStyle}
+        data-space-accent-scope={portalScopeStyle ? '' : undefined}
         aria-live="polite"
         aria-busy="true"
       >

--- a/packages/ui/src/organisms/menu-top.tsx
+++ b/packages/ui/src/organisms/menu-top.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Logo } from '../atoms';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { Menu } from 'lucide-react';
 import { RxCross1 } from 'react-icons/rx';
 import { usePathname } from 'next/navigation';
@@ -35,10 +35,29 @@ export const MenuTop = ({
     setIsMobileMenuOpen(false);
   }, [pathname]);
 
+  useLayoutEffect(() => {
+    const el = headerRef.current;
+    if (!el || typeof document === 'undefined') return;
+
+    const sync = () => {
+      const h = el.offsetHeight;
+      setHeaderHeight(h);
+      document.documentElement.style.setProperty('--menu-top-height', `${h}px`);
+    };
+
+    sync();
+    const ro = new ResizeObserver(sync);
+    ro.observe(el);
+    return () => {
+      ro.disconnect();
+      document.documentElement.style.removeProperty('--menu-top-height');
+    };
+  }, []);
+
   return (
     <header
       ref={headerRef}
-      className="flex min-h-[65px] min-w-0 flex-shrink-0 items-center justify-between gap-x-2 gap-y-2 border-b border-border bg-background-2 px-4 py-3 z-30"
+      className="flex min-h-[70px] min-w-0 flex-shrink-0 items-center justify-between gap-x-2 gap-y-2 border-b border-border bg-background-2 px-4 py-4 z-30"
     >
       <div
         className={clsx(

--- a/packages/ui/src/upload/add-attachment.tsx
+++ b/packages/ui/src/upload/add-attachment.tsx
@@ -126,7 +126,13 @@ export const AddAttachment: React.FC<AddAttachmentProps> = ({
 
   return (
     <div className="flex flex-col items-end w-full">
-      <Button variant="ghost" onClick={handleClick} type="button">
+      <Button
+        variant="ghost"
+        colorVariant="accent"
+        type="button"
+        onClick={handleClick}
+        className="w-full justify-start text-accent-11 hover:bg-accent-3 hover:text-neutral-12 [&_svg]:text-accent-11 hover:[&_svg]:text-neutral-12"
+      >
         <Link2Icon />
         {label}
         <input

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1043,6 +1043,9 @@ importers:
       '@hypha-platform/config-typescript':
         specifier: workspace:*
         version: link:../../config/typescript
+      next:
+        specifier: ^15.1.6
+        version: 15.4.8(@babel/core@7.26.10)(@opentelemetry/api@1.9.0)(@playwright/test@1.52.0)(babel-plugin-macros@3.1.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(sass@1.86.3)
 
   packages/evm:
     devDependencies:
@@ -11695,10 +11698,6 @@ packages:
     resolution: {integrity: sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==}
     engines: {node: '>=0.10'}
     hasBin: true
-
-  detect-libc@2.0.3:
-    resolution: {integrity: sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==}
-    engines: {node: '>=8'}
 
   detect-libc@2.0.4:
     resolution: {integrity: sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==}
@@ -35100,9 +35099,6 @@ snapshots:
 
   detect-libc@1.0.3: {}
 
-  detect-libc@2.0.3:
-    optional: true
-
   detect-libc@2.0.4: {}
 
   detect-newline@3.1.0: {}
@@ -43586,7 +43582,7 @@ snapshots:
   sharp@0.33.5:
     dependencies:
       color: 4.2.3
-      detect-libc: 2.0.3
+      detect-libc: 2.0.4
       semver: 7.7.2
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.33.5


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Latest

**Third CodeRabbit autofix pass (one commit per actionable thread, `8fdc5eac2` … `444154229`):**

- **DHO counts:** Pass nullable `memberCount` / `agreementCount` into `CompactSpaceBanner`; show **—** when enrichment failed (no more `?? 0`).
- **i18n:** Clearer **`spaceBannerDescriptionAria`** phrasing in all locales (e.g. “Description of {title}”).
- **Ring transitions:** **`--tw-ring-color`** on `Button` base CVA; **`SelectAction`** card/icon; **`Badge`** base CVA (split from neutral opacity tweak).
- **Badge:** Neutral outline hover ring **`/70`** to match other variants.
- **Member card:** **`delegatedVotingMemberLabel`** + locale keys (CodeRabbit follow-up on delegate row).

Earlier passes on this branch: sticky/nav/theme/outline fixes, shared URL helpers, theme storage normalize, etc.

**Checks:** `pnpm check-types` in `apps/web` and `packages/epics`.

**Preview:** Vercel check on this PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a7d004de-8e00-4583-8aab-2261e0203d77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a7d004de-8e00-4583-8aab-2261e0203d77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sticky space header, new compact space banner with parallax & reduced-motion support, dynamic space-accent theming (banner/logo-derived) and portal-scoped styling; SpaceLoadingBackdrop and theme storage normalization added
  * Safer image/link handling and new localized strings for banner aria text, member label, and loading error/reset UI

* **Bug Fixes**
  * Pinned repository change-detection action to an immutable version

* **Style**
  * Refined buttons, badges, avatars, spacing, tabs, and header sizing; improved tab scrolling behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->