### PR TITLE
feat(feature-flags): enable language picker for all users

### DIFF
--- a/packages/feature-flags/src/index.ts
+++ b/packages/feature-flags/src/index.ts
@@ -31,7 +31,7 @@ export const flagDefinitionsForDiscovery = {
   },
   showLanguageSelect: {
     key: 'show-language-select',
-    defaultValue: false,
+    defaultValue: true,
     description: 'Show the i18n language select button in the menu bar',
     origin: 'hypha' as const,
     options: undefined as undefined,
@@ -75,7 +75,9 @@ export async function getShowLanguageSelect(): Promise<boolean> {
   if (o !== undefined) return o;
 
   const store = await cookies();
-  return store.get(HYPHA_SHOW_LANGUAGE_SELECT)?.value === 'true';
+  const cookieValue = store.get(HYPHA_SHOW_LANGUAGE_SELECT)?.value;
+  if (cookieValue === 'false') return false;
+  return true;
 }
 
 async function getBooleanFlagFromToolbarCookieOrEnv(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Releases the header language picker to everyone by default.

## Changes

- **`show-language-select` Vercel Flags discovery:** `defaultValue` is now `true` so new evaluations align with production behavior.
- **`getShowLanguageSelect()`:** Returns `true` unless explicitly turned off via the Vercel toolbar override or `HYPHA_SHOW_LANGUAGE_SELECT=false` (cookie).

## Testing

- `pnpm --filter @hypha-platform/feature-flags run lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-96eb6bfb-45ce-4f8e-b86e-168a89a8f1bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-96eb6bfb-45ce-4f8e-b86e-168a89a8f1bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Language selection is now enabled by default, allowing users to easily access language preferences without requiring additional setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->