### PR TITLE
feat(ui): polish language picker dropdown

### DIFF
--- a/apps/web/src/components/connected-language-select.tsx
+++ b/apps/web/src/components/connected-language-select.tsx
@@ -31,6 +31,7 @@ export function ConnectedLanguageSelect() {
       locales={locales}
       onLocaleChange={handleLocaleChange}
       ariaLabel={tNav('selectLanguage')}
+      menuHeading={tNav('interfaceLanguage')}
     />
   );
 }

--- a/packages/i18n/src/messages/de.json
+++ b/packages/i18n/src/messages/de.json
@@ -78,6 +78,7 @@
     "openProfileMenu": "Profilmenü öffnen",
     "closeMenu": "Menü schließen",
     "selectLanguage": "Sprache auswählen",
+    "interfaceLanguage": "Oberflächensprache",
     "myProfile": "Mein Profil",
     "notificationCentre": "Benachrichtigungszentrale",
     "switchToLightMode": "Zum hellen Modus wechseln",

--- a/packages/i18n/src/messages/en.json
+++ b/packages/i18n/src/messages/en.json
@@ -78,6 +78,7 @@
     "openProfileMenu": "Open profile menu",
     "closeMenu": "Close menu",
     "selectLanguage": "Select language",
+    "interfaceLanguage": "Interface language",
     "myProfile": "My Profile",
     "notificationCentre": "Notification Centre",
     "switchToLightMode": "Switch to light mode",

--- a/packages/i18n/src/messages/es.json
+++ b/packages/i18n/src/messages/es.json
@@ -731,6 +731,7 @@
     "openProfileMenu": "Abrir menú de perfil",
     "closeMenu": "Cerrar menú",
     "selectLanguage": "Seleccionar idioma",
+    "interfaceLanguage": "Idioma de la interfaz",
     "myProfile": "Mi perfil",
     "notificationCentre": "Centro de notificaciones",
     "switchToLightMode": "Cambiar al modo de luz",

--- a/packages/i18n/src/messages/fr.json
+++ b/packages/i18n/src/messages/fr.json
@@ -78,6 +78,7 @@
     "openProfileMenu": "Ouvrir le menu du profil",
     "closeMenu": "Fermer le menu",
     "selectLanguage": "Choisir la langue",
+    "interfaceLanguage": "Langue de l’interface",
     "myProfile": "Mon profil",
     "notificationCentre": "Centre de notifications",
     "switchToLightMode": "Passer en mode clair",

--- a/packages/i18n/src/messages/pt.json
+++ b/packages/i18n/src/messages/pt.json
@@ -731,6 +731,7 @@
     "openProfileMenu": "Abrir menu do perfil",
     "closeMenu": "Fechar menu",
     "selectLanguage": "Selecione o idioma",
+    "interfaceLanguage": "Idioma da interface",
     "myProfile": "Meu perfil",
     "notificationCentre": "Central de Notificações",
     "switchToLightMode": "Mudar para o modo claro",

--- a/packages/ui/src/language-select.tsx
+++ b/packages/ui/src/language-select.tsx
@@ -1,11 +1,16 @@
 'use client';
 
-import { Globe } from 'lucide-react';
+import { Check, Globe } from 'lucide-react';
+
+import { cn } from '@hypha-platform/ui-utils';
+
 import { Button } from './button';
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from './dropdown-menu';
 
@@ -20,6 +25,8 @@ type LanguageSelectProps = {
   locales: LocaleOption[];
   onLocaleChange: (locale: string) => void;
   ariaLabel?: string;
+  /** Optional heading shown above the locale list (e.g. translated "Interface language"). */
+  menuHeading?: string;
 };
 
 export function LanguageSelect({
@@ -27,6 +34,7 @@ export function LanguageSelect({
   locales,
   onLocaleChange,
   ariaLabel = 'Select language',
+  menuHeading,
 }: LanguageSelectProps) {
   const currentMeta = locales.find((l) => l.code === currentLocale);
 
@@ -35,13 +43,15 @@ export function LanguageSelect({
       <DropdownMenuTrigger asChild>
         <Button
           variant="outline"
-          size="default"
+          colorVariant="neutral"
+          size="sm"
           aria-label={ariaLabel}
-          className="gap-1.5"
+          aria-haspopup="menu"
+          className="min-w-9 gap-1.5 px-3"
         >
-          <Globe className="size-4" />
+          <Globe className="size-4 shrink-0" aria-hidden />
           <span className="sr-only">{currentMeta?.label ?? currentLocale}</span>
-          <span className="text-xs font-semibold" aria-hidden>
+          <span className="text-xs font-semibold tabular-nums" aria-hidden>
             {currentMeta?.shortLabel ?? currentLocale.toUpperCase()}
           </span>
         </Button>
@@ -49,19 +59,58 @@ export function LanguageSelect({
       <DropdownMenuContent
         align="end"
         side="bottom"
-        className="bg-neutral-2 rounded-[6px] min-w-[185px] flex flex-col"
+        sideOffset={6}
+        collisionPadding={12}
+        className={cn(
+          'w-[var(--radix-dropdown-menu-trigger-width)] min-w-[11.5rem] border border-border/90',
+          'bg-popover p-1 text-popover-foreground shadow-xl',
+        )}
       >
-        {locales
-          .filter((locale) => locale.code !== currentLocale)
-          .map((locale) => (
+        {menuHeading ? (
+          <>
+            <DropdownMenuLabel className="px-2 py-1.5 text-1 font-medium leading-tight text-muted-foreground">
+              {menuHeading}
+            </DropdownMenuLabel>
+            <DropdownMenuSeparator className="-mx-1 my-0.5" />
+          </>
+        ) : null}
+        {locales.map((locale) => {
+          const active = locale.code === currentLocale;
+          return (
             <DropdownMenuItem
               key={locale.code}
-              onClick={() => onLocaleChange(locale.code)}
-              className="px-0 text-1"
+              textValue={`${locale.label} ${locale.shortLabel}`}
+              onSelect={(event) => {
+                if (active) {
+                  event.preventDefault();
+                  return;
+                }
+                onLocaleChange(locale.code);
+              }}
+              className={cn(
+                'min-h-9 gap-2 px-2 py-2 text-2',
+                active &&
+                  'cursor-default bg-neutral-3/90 text-foreground focus:bg-neutral-3/90 focus:text-foreground data-[highlighted]:bg-neutral-3/90',
+              )}
+              aria-current={active ? 'true' : undefined}
             >
-              {locale.label}
+              <span
+                className="flex size-5 shrink-0 items-center justify-center text-accent-11"
+                aria-hidden
+              >
+                {active ? <Check className="size-4" strokeWidth={2.5} /> : null}
+              </span>
+              <span className="flex min-w-0 flex-1 flex-col gap-0.5 text-left">
+                <span className="truncate font-medium leading-snug">
+                  {locale.label}
+                </span>
+                <span className="text-1 font-mono font-semibold uppercase tracking-wide text-muted-foreground">
+                  {locale.shortLabel}
+                </span>
+              </span>
             </DropdownMenuItem>
-          ))}
+          );
+        })}
       </DropdownMenuContent>
     </DropdownMenu>
   );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Refines the header language menu for clearer hierarchy, stronger surface separation from the page, and an explicit “current language” state.

## What changed

- **Panel:** Uses `bg-popover` / `text-popover-foreground` with `border-border`, `shadow-xl`, and `sideOffset` so the menu reads as a floating surface and lines up under the trigger. Width follows the trigger (`w-[var(--radix-dropdown-menu-trigger-width)]`) with a sensible `min-w` floor.
- **List:** Shows **all** locales (not only “other” languages). The active row shows a **check** in a reserved column, subtle **neutral** background, and `aria-current="true"`. Other rows stay interactive for switching.
- **Copy:** Optional `menuHeading` prop; web passes `Navigation.interfaceLanguage` (new key in all 5 locale files).
- **Trigger:** Compact `outline` + `neutral` `sm` button so the control matches toolbar density.

## Testing

- `pnpm --filter @hypha-platform/ui run lint` (no new errors)
- `pnpm run verify:messages`
- `pnpm run format:fix`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-96eb6bfb-45ce-4f8e-b86e-168a89a8f1bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-96eb6bfb-45ce-4f8e-b86e-168a89a8f1bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added menu heading label to the language selector dropdown
  * Language dropdown now displays all available languages with a checkmark indicator for the currently selected language

* **Style**
  * Improved language selector button styling and layout

* **Documentation**
  * Added interface language translations in German, English, Spanish, French, and Portuguese

<!-- end of auto-generated comment: release notes by coderabbit.ai -->