### PR TITLE
feat(spaces): language picker outline uses space accent

### DIFF
--- a/apps/web/src/app/[lang]/dho/[id]/space-accent.css
+++ b/apps/web/src/app/[lang]/dho/[id]/space-accent.css
@@ -18,3 +18,15 @@
 [data-space-accent-scope] [data-space-nav]:hover {
   opacity: 0.92;
 }
+
+/**
+ * Header language picker lives outside `[data-space-accent-scope]`; accent is
+ * mirrored to `html` by `SpaceAccentFromImages` while a space layout is mounted.
+ */
+html[data-space-chrome-accent='true'] [data-language-select-trigger] {
+  border-color: color-mix(in srgb, var(--space-accent) 78%, transparent);
+}
+
+html[data-space-chrome-accent='true'] [data-language-select-trigger]:hover {
+  border-color: color-mix(in srgb, var(--space-accent) 92%, transparent);
+}

--- a/packages/epics/src/spaces/components/space-accent-from-images.tsx
+++ b/packages/epics/src/spaces/components/space-accent-from-images.tsx
@@ -82,6 +82,29 @@ async function sampleImageToAccent(src: string): Promise<string | null> {
 }
 
 /** Larger sample grid for luminance / contrast / edge analysis (banner only). */
+/**
+ * Mirrors `--space-accent` from the in-page accent scope to `documentElement`
+ * so fixed chrome (e.g. header language picker) can use the same token.
+ */
+function syncSpaceChromeAccentToRoot(scopeEl: HTMLElement | null) {
+  const root = document.documentElement;
+  if (!scopeEl) {
+    root.removeAttribute('data-space-chrome-accent');
+    root.style.removeProperty('--space-accent');
+    return;
+  }
+  const accent = getComputedStyle(scopeEl)
+    .getPropertyValue('--space-accent')
+    .trim();
+  if (!accent) {
+    root.removeAttribute('data-space-chrome-accent');
+    root.style.removeProperty('--space-accent');
+    return;
+  }
+  root.style.setProperty('--space-accent', accent);
+  root.setAttribute('data-space-chrome-accent', 'true');
+}
+
 async function sampleBannerToneOverlayVars(
   src: string,
 ): Promise<Record<string, string> | null> {
@@ -148,6 +171,7 @@ export function SpaceAccentFromImages({
         }
         scopeElInit.style.setProperty(k, String(v));
       }
+      syncSpaceChromeAccentToRoot(scopeElInit);
     }
     setPortalStyles?.(defaultSpacePortalStyles);
 
@@ -179,11 +203,13 @@ export function SpaceAccentFromImages({
         scopeEl.style.setProperty(k, String(v));
       }
 
+      syncSpaceChromeAccentToRoot(scopeEl);
       setPortalStyles?.(scopeStyle);
     })();
 
     return () => {
       cancelled = true;
+      syncSpaceChromeAccentToRoot(null);
     };
   }, [bannerSrc, logoSrc, setPortalStyles]);
 

--- a/packages/ui/src/language-select.tsx
+++ b/packages/ui/src/language-select.tsx
@@ -37,6 +37,7 @@ export function LanguageSelect({
           variant="outline"
           size="default"
           aria-label={ariaLabel}
+          data-language-select-trigger
           className="gap-1.5"
         >
           <Globe className="size-4" />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The language picker lives in the global `MenuTop` (root layout), outside `[data-space-accent-scope]`, so it could not read the sampled space accent from layout DOM.

## Approach

1. **`SpaceAccentFromImages`** — After applying accent CSS to the in-page scope element, read resolved `--space-accent` with `getComputedStyle` and set it on `document.documentElement`, plus `data-space-chrome-accent="true"`. Clear both on effect cleanup (leaving a space route).
2. **`space-accent.css`** — When `html[data-space-chrome-accent]`, override **border** on `[data-language-select-trigger]` using `color-mix` with `var(--space-accent)` (slightly stronger on hover).
3. **`LanguageSelect`** — Add `data-language-select-trigger` on the outline button for the selector hook.

## Testing

- `pnpm --filter @hypha-platform/epics run lint` (no new errors)
- `pnpm --filter @hypha-platform/ui run lint`
- `pnpm run format:fix`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-96eb6bfb-45ce-4f8e-b86e-168a89a8f1bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-96eb6bfb-45ce-4f8e-b86e-168a89a8f1bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

