### PR TITLE
fix(i18n): navigation and notification copy (de, es, pt)

### DIFF
--- a/packages/i18n/src/messages/de.json
+++ b/packages/i18n/src/messages/de.json
@@ -82,7 +82,7 @@
     "notificationCentre": "Benachrichtigungszentrale",
     "switchToLightMode": "Zum hellen Modus wechseln",
     "switchToDarkMode": "Zum dunklen Modus wechseln",
-    "updateMfa": "Fondschutz aktualisieren (MFA)",
+    "updateMfa": "Fondsschutz aktualisieren (MFA)",
     "protectMfa": "Fonds schützen (MFA)",
     "logout": "Abmelden",
     "viewProfile": "Profil anzeigen",
@@ -91,7 +91,7 @@
     "getStarted": "Loslegen"
   },
   "NotificationCentre": {
-    "title": "Benachrichtigungszentrum",
+    "title": "Benachrichtigungszentrale",
     "loading": {
       "keepWindowOpen": "Lassen Sie dieses Fenster geöffnet, bis wir fertig sind."
     },

--- a/packages/i18n/src/messages/es.json
+++ b/packages/i18n/src/messages/es.json
@@ -733,7 +733,7 @@
     "selectLanguage": "Seleccionar idioma",
     "myProfile": "Mi perfil",
     "notificationCentre": "Centro de notificaciones",
-    "switchToLightMode": "Cambiar al modo de luz",
+    "switchToLightMode": "Cambiar al modo claro",
     "switchToDarkMode": "Cambiar al modo oscuro",
     "updateMfa": "Actualizar la protección de fondos (MFA)",
     "protectMfa": "Proteger fondos (MFA)",

--- a/packages/i18n/src/messages/pt.json
+++ b/packages/i18n/src/messages/pt.json
@@ -730,7 +730,7 @@
     "openMenu": "Abrir menu",
     "openProfileMenu": "Abrir menu do perfil",
     "closeMenu": "Fechar menu",
-    "selectLanguage": "Selecione o idioma",
+    "selectLanguage": "Selecionar idioma",
     "myProfile": "Meu perfil",
     "notificationCentre": "Central de Notificações",
     "switchToLightMode": "Mudar para o modo claro",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Targeted copy fixes after a pass over `Navigation` and related German notification hub strings.

## Changes

- **de:** `Fondschutz` → `Fondsschutz` (correct compound for *funds protection*). `NotificationCentre.title` now matches `Navigation.notificationCentre` (`Benachrichtigungszentrale`) for consistency with English and the rest of the app.
- **es:** Light mode string uses **modo claro** (standard for light/dark UI in Spanish; *modo de luz* reads unnaturally).
- **pt:** `selectLanguage` uses imperative **Selecionar idioma**, aligned with *Abrir menu*, *Fechar menu*, etc.

## Testing

- `pnpm run verify:messages`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-96eb6bfb-45ce-4f8e-b86e-168a89a8f1bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-96eb6bfb-45ce-4f8e-b86e-168a89a8f1bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

