### PR TITLE
fix(web): language picker left of profile in header

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -164,6 +164,9 @@ export default async function RootLayout({
                               ) : undefined
                             }
                           >
+                            {isLanguageSelectVisible && (
+                              <ConnectedLanguageSelect />
+                            )}
                             <ConnectedButtonProfile
                               useAuthentication={useAuthentication}
                               useMe={useMe}
@@ -180,9 +183,6 @@ export default async function RootLayout({
                                 },
                               ]}
                             />
-                            {isLanguageSelectVisible && (
-                              <ConnectedLanguageSelect />
-                            )}
                           </MenuTop>
                         </div>
                         {/* Scrollable content area */}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reorders `MenuTop` children in the root layout so the language control appears **to the left** of the profile menu on desktop (`flex` + `gap-2`).

## Notes

- **Mobile:** The full-screen menu lists children in the same order, so language appears **above** the profile block, which matches “language before profile” in reading order.
- No `MenuTop` API change; only DOM order in `apps/web/src/app/layout.tsx`.

## Testing

- `pnpm --filter web run lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-96eb6bfb-45ce-4f8e-b86e-168a89a8f1bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-96eb6bfb-45ce-4f8e-b86e-168a89a8f1bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

