### PR TITLE
Multi lingual

### DIFF
--- a/packages/epics/src/people/components/button-profile.tsx
+++ b/packages/epics/src/people/components/button-profile.tsx
@@ -4,21 +4,31 @@ import {
   Button,
   DropdownMenu,
   DropdownMenuContent,
+  DropdownMenuGroup,
   DropdownMenuItem,
+  DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@hypha-platform/ui';
 import { PersonAvatar } from './person-avatar';
 import { EthAddress } from './eth-address';
-import { TrashIcon, LogOutIcon, Repeat, Shield } from 'lucide-react';
+import {
+  Bell,
+  ChevronRight,
+  LogOutIcon,
+  Repeat,
+  Shield,
+  TrashIcon,
+  UserRound,
+} from 'lucide-react';
 import { ButtonNavItem, ButtonNavItemProps } from '@hypha-platform/ui';
 import Link from 'next/link';
 import { Person } from '@hypha-platform/core/client';
-import { Text } from '@radix-ui/themes';
 import { usePrivy, useMfaEnrollment } from '@privy-io/react-auth';
 import { useTranslations } from 'next-intl';
 import { usePathname } from 'next/navigation';
 import { useEffect, useState } from 'react';
+import { cn } from '@hypha-platform/ui-utils';
 
 export type ButtonProfileProps = {
   address?: string;
@@ -33,6 +43,9 @@ export type ButtonProfileProps = {
   person?: Person;
   resolvedTheme?: string;
 };
+
+const menuItemClass =
+  'gap-2 px-2 py-2 text-2 [&_svg]:text-muted-foreground data-[highlighted]:[&_svg]:text-foreground';
 
 export const ButtonProfile = ({
   person,
@@ -54,6 +67,9 @@ export const ButtonProfile = ({
   const { showMfaEnrollmentModal } = useMfaEnrollment();
   const hasMfaMethods = user && user.mfaMethods && user.mfaMethods.length > 0;
 
+  const displayName = [person?.name, person?.surname].filter(Boolean).join(' ');
+  const primaryLine = displayName.trim() || person?.nickname || t('myProfile');
+
   useEffect(() => {
     setProfileMenuOpen(false);
   }, [pathname]);
@@ -63,20 +79,34 @@ export const ButtonProfile = ({
       {isConnected ? (
         <>
           {/* Mobile */}
-          <div className="flex flex-col justify-center gap-8 md:hidden">
-            <div className="flex flex-col items-center gap-2">
+          <div className="flex flex-col justify-center gap-6 md:hidden">
+            <div
+              className={cn(
+                'flex flex-col items-center gap-3 rounded-xl border border-border/80',
+                'bg-popover px-4 py-5 text-popover-foreground shadow-sm',
+              )}
+            >
               <PersonAvatar
                 avatarSrc={person?.avatarUrl}
                 userName={person?.nickname}
                 size="lg"
                 shape="rounded"
               />
-              <p>{person?.nickname}</p>
-              {address && (
-                <div>
+              <div className="flex flex-col items-center gap-0.5 text-center">
+                <p className="text-2 font-semibold leading-snug text-foreground">
+                  {primaryLine}
+                </p>
+                {displayName.trim() && person?.nickname ? (
+                  <p className="text-1 text-muted-foreground">
+                    {person.nickname}
+                  </p>
+                ) : null}
+              </div>
+              {address ? (
+                <div className="w-full max-w-[16rem] rounded-lg border border-border/60 bg-muted/40 px-3 py-2">
                   <EthAddress address={address} />
                 </div>
-              )}
+              ) : null}
             </div>
 
             {navItems.map((item) => (
@@ -97,15 +127,6 @@ export const ButtonProfile = ({
                 href={notificationCentrePath}
               />
             )}
-
-            {/* TODO: It is necessary to implement profile deletion as part of a separate task */}
-            {/* {onDelete && (
-              <ButtonNavItem
-                onClick={onDelete}
-                classNames="text-error-11"
-                label="Delete"
-              />
-            )} */}
 
             <ButtonNavItem
               onClick={onChangeThemeMode}
@@ -149,104 +170,164 @@ export const ButtonProfile = ({
             <DropdownMenu
               open={profileMenuOpen}
               onOpenChange={setProfileMenuOpen}
+              modal={false}
             >
               <DropdownMenuTrigger asChild>
                 <button
                   type="button"
-                  className="rounded-md outline-none"
+                  className={cn(
+                    'rounded-lg border border-neutral-9 bg-neutral-1 text-neutral-12 outline-none',
+                    'shadow-sm ring-2 ring-transparent transition-[color,box-shadow,border-color,background-color]',
+                    'hover:border-neutral-11 hover:text-foreground hover:ring-neutral-10/50',
+                    'focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+                    'data-[state=open]:border-neutral-11 data-[state=open]:shadow-md',
+                  )}
                   aria-label={t('openProfileMenu')}
+                  aria-haspopup="menu"
                 >
                   <PersonAvatar
                     size="toolbar"
                     avatarSrc={person?.avatarUrl}
                     userName={person?.nickname}
                     shape="rounded"
-                    className="ring-1 ring-border/55"
+                    className="ring-0"
                   />
                 </button>
               </DropdownMenuTrigger>
-              <DropdownMenuContent className="bg-neutral-2 rounded-[6px] min-w-[185px] flex flex-col">
-                <Text className="text-2 font-medium text-foreground">
-                  {person?.name} {person?.surname}
-                </Text>
-                {address && (
-                  <DropdownMenuItem className="px-0 text-1 flex justify-between">
-                    <EthAddress address={address} />
-                  </DropdownMenuItem>
+              <DropdownMenuContent
+                align="end"
+                side="bottom"
+                sideOffset={6}
+                collisionPadding={12}
+                className={cn(
+                  'w-[min(17.5rem,calc(100vw-1.5rem))] border border-border/90 p-1',
+                  'bg-popover text-popover-foreground shadow-xl',
                 )}
-                {profileUrl && (
-                  <DropdownMenuItem className="px-0 text-1" asChild>
-                    <Link className="text-accent-11" href={profileUrl}>
-                      {t('viewProfile')}
-                    </Link>
-                  </DropdownMenuItem>
-                )}
-                {notificationCentrePath && (
+              >
+                <DropdownMenuLabel className="cursor-default px-2 pb-0 pt-1.5 font-normal">
+                  <div className="flex gap-3">
+                    <PersonAvatar
+                      size="md"
+                      avatarSrc={person?.avatarUrl}
+                      userName={person?.nickname}
+                      shape="rounded"
+                      className="ring-1 ring-border/60"
+                    />
+                    <div className="flex min-w-0 flex-1 flex-col gap-1">
+                      <span className="truncate text-2 font-semibold leading-snug text-foreground">
+                        {primaryLine}
+                      </span>
+                      {displayName.trim() && person?.nickname ? (
+                        <span className="truncate text-1 text-muted-foreground">
+                          {person.nickname}
+                        </span>
+                      ) : null}
+                      {address ? (
+                        <div
+                          className={cn(
+                            'mt-1 rounded-md border border-border/50 bg-muted/35 px-2 py-1.5',
+                            'text-1 text-muted-foreground',
+                          )}
+                        >
+                          <EthAddress address={address} />
+                        </div>
+                      ) : null}
+                    </div>
+                  </div>
+                </DropdownMenuLabel>
+
+                {(profileUrl || notificationCentrePath) && (
                   <>
-                    <DropdownMenuSeparator />
-                    <DropdownMenuItem className="px-0 text-1" asChild>
-                      <Link
-                        className="text-accent-11"
-                        href={notificationCentrePath}
-                      >
-                        {t('notificationCentre')}
-                      </Link>
-                    </DropdownMenuItem>
+                    <DropdownMenuSeparator className="-mx-0 my-1" />
+                    <DropdownMenuGroup className="space-y-0.5">
+                      {profileUrl ? (
+                        <DropdownMenuItem className={menuItemClass} asChild>
+                          <Link href={profileUrl}>
+                            <UserRound
+                              className="size-4 shrink-0"
+                              aria-hidden
+                            />
+                            <span className="flex-1">{t('viewProfile')}</span>
+                            <ChevronRight
+                              className="ml-auto size-4 opacity-60"
+                              aria-hidden
+                            />
+                          </Link>
+                        </DropdownMenuItem>
+                      ) : null}
+                      {notificationCentrePath ? (
+                        <DropdownMenuItem className={menuItemClass} asChild>
+                          <Link href={notificationCentrePath}>
+                            <Bell className="size-4 shrink-0" aria-hidden />
+                            <span className="flex-1">
+                              {t('notificationCentre')}
+                            </span>
+                            <ChevronRight
+                              className="ml-auto size-4 opacity-60"
+                              aria-hidden
+                            />
+                          </Link>
+                        </DropdownMenuItem>
+                      ) : null}
+                    </DropdownMenuGroup>
                   </>
                 )}
-                <DropdownMenuSeparator />
-                {onChangeThemeMode && (
-                  <DropdownMenuItem
-                    onClick={onChangeThemeMode}
-                    className="px-0 text-1 flex justify-between"
-                  >
-                    {resolvedTheme === 'dark'
-                      ? t('switchToLightMode')
-                      : t('switchToDarkMode')}
-                    <Repeat className="icon-sm" />
-                  </DropdownMenuItem>
-                )}
-                {hasMfaMethods ? (
-                  <>
-                    <DropdownMenuSeparator />
+
+                <DropdownMenuSeparator className="-mx-0 my-1" />
+
+                <DropdownMenuGroup className="space-y-0.5">
+                  {onChangeThemeMode ? (
                     <DropdownMenuItem
-                      onClick={showMfaEnrollmentModal}
-                      className="px-0 text-1"
+                      className={menuItemClass}
+                      onClick={onChangeThemeMode}
                     >
-                      {t('updateMfa')}
-                      <Shield className="icon-sm" />
+                      <span className="flex-1">
+                        {resolvedTheme === 'dark'
+                          ? t('switchToLightMode')
+                          : t('switchToDarkMode')}
+                      </span>
+                      <Repeat className="size-4 shrink-0" aria-hidden />
                     </DropdownMenuItem>
-                  </>
-                ) : (
-                  <>
-                    <DropdownMenuSeparator />
-                    <DropdownMenuItem
-                      onClick={showMfaEnrollmentModal}
-                      className="px-0 text-1 flex justify-between"
-                    >
-                      {t('protectMfa')}
-                      <Shield className="icon-sm" />
-                    </DropdownMenuItem>
-                  </>
-                )}
-                <DropdownMenuSeparator />
-                {onDelete && (
+                  ) : null}
                   <DropdownMenuItem
-                    onClick={onDelete}
-                    className="px-0 text-1 flex justify-between"
-                    disabled
+                    className={menuItemClass}
+                    onClick={showMfaEnrollmentModal}
                   >
-                    {t('delete')}
-                    <TrashIcon className="icon-sm" />
+                    <span className="flex-1">
+                      {hasMfaMethods ? t('updateMfa') : t('protectMfa')}
+                    </span>
+                    <Shield className="size-4 shrink-0" aria-hidden />
                   </DropdownMenuItem>
-                )}
-                <DropdownMenuSeparator />
+                </DropdownMenuGroup>
+
+                {onDelete ? (
+                  <>
+                    <DropdownMenuSeparator className="-mx-0 my-1" />
+                    <DropdownMenuItem
+                      onClick={onDelete}
+                      className={cn(
+                        menuItemClass,
+                        'text-error-11 focus:text-error-11',
+                      )}
+                      disabled
+                    >
+                      <span className="flex-1">{t('delete')}</span>
+                      <TrashIcon className="size-4 shrink-0" aria-hidden />
+                    </DropdownMenuItem>
+                  </>
+                ) : null}
+
+                <DropdownMenuSeparator className="-mx-0 my-1" />
+
                 <DropdownMenuItem
                   onClick={onLogout}
-                  className="px-0 text-1 text-error-11 flex justify-between"
+                  className={cn(
+                    menuItemClass,
+                    'text-error-11 focus:bg-error-3 focus:text-error-12 data-[highlighted]:bg-error-3',
+                  )}
                 >
-                  {t('logout')}
-                  <LogOutIcon className="icon-sm" />
+                  <span className="flex-1">{t('logout')}</span>
+                  <LogOutIcon className="size-4 shrink-0" aria-hidden />
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reworks the signed-in profile menu so it matches the rest of the app: shared `DropdownMenu` surface tokens, clearer hierarchy, and a header trigger that reads as part of the top bar.

## Desktop

- **Trigger:** Neutral outline frame (border, shadow, focus ring, open state) so it sits visually with other chrome controls instead of a bare avatar.
- **Panel:** `bg-popover`, `border-border`, `shadow-xl`, `sideOffset` / `collisionPadding` — same family as other menus.
- **Header:** `DropdownMenuLabel` with avatar + display name (name + surname, else nickname / fallback) + optional nickname line + address in a muted chip.
- **Actions:** Icons + labels + trailing chevrons for profile and notification links; theme + MFA grouped; logout uses error styling with a subtle error-tinted focus surface. `modal={false}` to avoid stacking issues with other dropdowns.
- **Removed** `@radix-ui/themes` `Text` in favor of token-based typography.

## Mobile (full-screen menu)

- Identity block uses the same popover/border language as the rest of the UI; optional nickname under the title; address in a compact chip.

## Testing

- `pnpm --filter @hypha-platform/epics run lint` (no new errors)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-96eb6bfb-45ce-4f8e-b86e-168a89a8f1bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-96eb6bfb-45ce-4f8e-b86e-168a89a8f1bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

