### PR TITLE
fix(members): unsaved delegate changes as modal on member aside

### DIFF
--- a/apps/web/src/app/[lang]/dho/[id]/@aside/members/person/[personSlug]/page.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@aside/members/person/[personSlug]/page.tsx
@@ -1,9 +1,11 @@
 'use client';
 
-import { useParams } from 'next/navigation';
+import { useCallback, useRef, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
 
 import {
   DelegateVotingSection,
+  type DelegateVotingSectionHandle,
   MemberDetail,
   MemberPageParams,
   SidePanel,
@@ -19,8 +21,21 @@ import {
 } from '@hypha-platform/core/client';
 import { useMembers } from '@web/hooks/use-members';
 import { tryDecodeUriPart } from '@hypha-platform/ui-utils';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  Button,
+} from '@hypha-platform/ui';
+import { useTranslations } from 'next-intl';
 
 export default function Member() {
+  const router = useRouter();
   const { id, lang, personSlug: personSlugRaw } = useParams<MemberPageParams>();
   const personSlug = tryDecodeUriPart(personSlugRaw);
   const { person, isLoading: isLoadingPersons } = useMemberBySlug(personSlug);
@@ -33,12 +48,57 @@ export default function Member() {
     spaceId: space?.web3SpaceId as number,
     userAddress: person?.address as `0x${string}`,
   });
+  const tMembersTab = useTranslations('MembersTab');
+
+  const membersListPath = getDhoPathMembers(lang, id);
+  const delegateSectionRef = useRef<DelegateVotingSectionHandle>(null);
+  const [unsavedOpen, setUnsavedOpen] = useState(false);
+  const [pendingLeavePath, setPendingLeavePath] = useState<string | null>(null);
+  const [isSavingAndLeaving, setIsSavingAndLeaving] = useState(false);
+
+  const navigateToMembersList = useCallback(() => {
+    router.push(membersListPath);
+  }, [router, membersListPath]);
+
+  const handleCloseRequest = useCallback(() => {
+    if (delegateSectionRef.current?.getIsDirty() === true) {
+      setPendingLeavePath(membersListPath);
+      setUnsavedOpen(true);
+      return;
+    }
+    navigateToMembersList();
+  }, [membersListPath, navigateToMembersList]);
+
+  const handleDiscardAndLeave = useCallback(() => {
+    delegateSectionRef.current?.resetDirtyBaseline();
+    setUnsavedOpen(false);
+    setPendingLeavePath(null);
+    if (pendingLeavePath) {
+      router.push(pendingLeavePath);
+    }
+  }, [pendingLeavePath, router]);
+
+  const handleSaveAndLeave = useCallback(async () => {
+    setIsSavingAndLeaving(true);
+    try {
+      const ok = await delegateSectionRef.current?.submitPersist();
+      if (ok === true && pendingLeavePath) {
+        setUnsavedOpen(false);
+        router.push(pendingLeavePath);
+        setPendingLeavePath(null);
+      }
+    } finally {
+      setIsSavingAndLeaving(false);
+    }
+  }, [pendingLeavePath, router]);
 
   return (
     <SidePanel>
       <div className="flex flex-col gap-5">
         <MemberDetail
-          closeUrl={getDhoPathMembers(lang, id)}
+          closeUrl={membersListPath}
+          onCloseRequest={handleCloseRequest}
+          closeDisabled={isSavingAndLeaving}
           member={{
             avatarUrl: person?.avatarUrl,
             name: person?.name,
@@ -55,12 +115,63 @@ export default function Member() {
         />
         {!isDelegate && (
           <DelegateVotingSection
+            ref={delegateSectionRef}
             web3SpaceId={space?.web3SpaceId as number}
             useMembers={useMembers}
             spaceSlug={id}
           />
         )}
       </div>
+
+      <AlertDialog
+        open={unsavedOpen}
+        onOpenChange={(open) => {
+          if (!open && !isSavingAndLeaving) {
+            setUnsavedOpen(false);
+            setPendingLeavePath(null);
+          }
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle className="m-0 text-[17px] font-medium text-mauve12 text-card-foreground">
+              {tMembersTab('memberDetail.unsavedChangesModal.title')}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {tMembersTab('memberDetail.unsavedChangesModal.description')}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter className="flex flex-row justify-end gap-[25px] sm:space-x-0">
+            <AlertDialogCancel asChild>
+              <Button
+                type="button"
+                variant="outline"
+                colorVariant="neutral"
+                disabled={isSavingAndLeaving}
+                onClick={handleDiscardAndLeave}
+              >
+                {tMembersTab('memberDetail.unsavedChangesModal.discard')}
+              </Button>
+            </AlertDialogCancel>
+            <AlertDialogAction asChild>
+              <Button
+                type="button"
+                variant="outline"
+                colorVariant="neutral"
+                disabled={isSavingAndLeaving}
+                onClick={(e) => {
+                  e.preventDefault();
+                  void handleSaveAndLeave();
+                }}
+              >
+                {isSavingAndLeaving
+                  ? tMembersTab('memberDetail.unsavedChangesModal.saving')
+                  : tMembersTab('memberDetail.unsavedChangesModal.save')}
+              </Button>
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </SidePanel>
   );
 }

--- a/packages/epics/src/people/components/delegate-voting-section.tsx
+++ b/packages/epics/src/people/components/delegate-voting-section.tsx
@@ -1,11 +1,19 @@
 'use client';
 
-import { useEffect, useRef, useState, useMemo } from 'react';
+import {
+  useEffect,
+  useRef,
+  useState,
+  useMemo,
+  useCallback,
+  forwardRef,
+  useImperativeHandle,
+} from 'react';
 import { Separator, Label, Button } from '@hypha-platform/ui';
 import { DelegatedMemberSelector } from './delegated-member-selector';
 // import { DelegatedSpaceSelector } from './delegated-space-selector';
 import { UseMembers } from '../../spaces';
-import { useForm } from 'react-hook-form';
+import { useForm, useFormState } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Form, FormField, FormMessage, FormItem } from '@hypha-platform/ui';
 import { z } from 'zod';
@@ -29,6 +37,13 @@ interface DelegateVotingSectionProps {
   useMembers: UseMembers;
 }
 
+export type DelegateVotingSectionHandle = {
+  getIsDirty: () => boolean;
+  /** Programmatic submit; resolves true when validation passes and persist finished. */
+  submitPersist: () => Promise<boolean>;
+  resetDirtyBaseline: () => void;
+};
+
 type DelegateToMemberForm = {
   delegatedSpace: number;
   delegatedMember: string;
@@ -45,11 +60,10 @@ const passOnDelegatedVoiceSchema = z.object({
 type PassOnDelegatedVoiceForm = z.infer<typeof passOnDelegatedVoiceSchema>;
 */
 
-export const DelegateVotingSection = ({
-  web3SpaceId,
-  spaceSlug,
-  useMembers,
-}: DelegateVotingSectionProps) => {
+export const DelegateVotingSection = forwardRef<
+  DelegateVotingSectionHandle,
+  DelegateVotingSectionProps
+>(function DelegateVotingSection({ web3SpaceId, spaceSlug, useMembers }, ref) {
   const tMembersTab = useTranslations('MembersTab');
   const { personSlug: personSlugRaw } = useParams<ProfileComponentParams>();
   const personSlug = tryDecodeUriPart(personSlugRaw);
@@ -63,6 +77,32 @@ export const DelegateVotingSection = ({
   const filteredMembers =
     persons?.data?.filter((member) => member.address !== person?.address) ?? [];
   const isMember = person?.slug === personSlug;
+
+  const delegateToMemberSchema = useMemo(
+    () =>
+      z.object({
+        delegatedSpace: z.number({
+          required_error: tMembersTab('delegateSection.errors.selectSpace'),
+          invalid_type_error: tMembersTab('delegateSection.errors.selectSpace'),
+        }),
+        delegatedMember: z
+          .string()
+          .min(1, tMembersTab('delegateSection.errors.selectMember')),
+      }),
+    [tMembersTab],
+  );
+
+  const delegateToMemberFormRef = useRef<HTMLFormElement>(null);
+  const delegateToMemberForm = useForm<DelegateToMemberForm>({
+    resolver: zodResolver(delegateToMemberSchema),
+    defaultValues: {
+      delegatedMember: '',
+      delegatedSpace: effectiveSpaceId as number,
+    },
+  });
+  const { isDirty: delegateFormIsDirty } = useFormState({
+    control: delegateToMemberForm.control,
+  });
 
   const {
     delegate: delegateToMember,
@@ -110,27 +150,6 @@ export const DelegateVotingSection = ({
     }
   }, [delegateHashSpace, resetDelegateSpace]);
   */
-
-  if (!isMember) return null;
-
-  const delegateToMemberSchema = z.object({
-    delegatedSpace: z.number({
-      required_error: tMembersTab('delegateSection.errors.selectSpace'),
-      invalid_type_error: tMembersTab('delegateSection.errors.selectSpace'),
-    }),
-    delegatedMember: z
-      .string()
-      .min(1, tMembersTab('delegateSection.errors.selectMember')),
-  });
-
-  const delegateToMemberFormRef = useRef<HTMLFormElement>(null);
-  const delegateToMemberForm = useForm<DelegateToMemberForm>({
-    resolver: zodResolver(delegateToMemberSchema),
-    defaultValues: {
-      delegatedMember: '',
-      delegatedSpace: effectiveSpaceId as number,
-    },
-  });
 
   const viewerAddress = person?.address?.toLowerCase();
 
@@ -198,19 +217,23 @@ export const DelegateVotingSection = ({
     ];
   }, [effectiveSpaceId, person?.address]);
 
-  const handleDelegateToMember = async (data: DelegateToMemberForm) => {
-    await delegateToMember({
-      address: data.delegatedMember as `0x${string}`,
-      spaceId: data.delegatedSpace,
-    });
-    delegateToMemberForm.setValue('delegatedMember', data.delegatedMember);
-    if (delegateCacheKey) {
-      await mutateCache(delegateCacheKey);
-    }
-    await updateMembers?.();
-  };
+  const handleDelegateToMember = useCallback(
+    async (data: DelegateToMemberForm) => {
+      await delegateToMember({
+        address: data.delegatedMember as `0x${string}`,
+        spaceId: data.delegatedSpace,
+      });
+      delegateToMemberForm.setValue('delegatedMember', data.delegatedMember);
+      if (delegateCacheKey) {
+        await mutateCache(delegateCacheKey);
+      }
+      await updateMembers?.();
+      delegateToMemberForm.reset(delegateToMemberForm.getValues());
+    },
+    [delegateCacheKey, delegateToMember, delegateToMemberForm, updateMembers],
+  );
 
-  const handleUndelegate = async () => {
+  const handleUndelegate = useCallback(async () => {
     if (!effectiveSpaceId || !hasConfirmedDelegate) return;
     await undelegate({
       spaceId: effectiveSpaceId,
@@ -220,7 +243,40 @@ export const DelegateVotingSection = ({
       await mutateCache(delegateCacheKey);
     }
     await updateMembers?.();
-  };
+    delegateToMemberForm.reset(delegateToMemberForm.getValues());
+  }, [
+    delegateCacheKey,
+    delegateToMemberForm,
+    effectiveSpaceId,
+    hasConfirmedDelegate,
+    undelegate,
+    updateMembers,
+  ]);
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      getIsDirty: () => delegateFormIsDirty,
+      submitPersist: () =>
+        new Promise<boolean>((resolve) => {
+          void delegateToMemberForm.handleSubmit(
+            async (data) => {
+              try {
+                await handleDelegateToMember(data);
+                resolve(true);
+              } catch {
+                resolve(false);
+              }
+            },
+            () => resolve(false),
+          )();
+        }),
+      resetDirtyBaseline: () => {
+        delegateToMemberForm.reset(delegateToMemberForm.getValues());
+      },
+    }),
+    [delegateFormIsDirty, delegateToMemberForm, handleDelegateToMember],
+  );
 
   /*
   const handleDelegateSpace = async (data: PassOnDelegatedVoiceForm) => {
@@ -230,6 +286,9 @@ export const DelegateVotingSection = ({
     });
   };
   */
+
+  if (!isMember) return null;
+
   return (
     <div className="flex flex-col gap-5">
       <Form {...delegateToMemberForm}>
@@ -384,4 +443,4 @@ export const DelegateVotingSection = ({
       {/* <Separator /> */}
     </div>
   );
-};
+});

--- a/packages/epics/src/people/components/index.ts
+++ b/packages/epics/src/people/components/index.ts
@@ -21,7 +21,10 @@ export * from './space-with-number-of-months';
 export * from './space-with-number-of-months-array';
 export * from './activate-spaces-form';
 export * from './space-member-card';
-export * from './delegate-voting-section';
+export {
+  DelegateVotingSection,
+  type DelegateVotingSectionHandle,
+} from './delegate-voting-section';
 export * from './mfa-banner';
 export * from './escrow-deposit-banner';
 export * from './escrow-deposit-banners';

--- a/packages/epics/src/people/components/member-detail.tsx
+++ b/packages/epics/src/people/components/member-detail.tsx
@@ -26,6 +26,9 @@ export type MemberDetailProps = {
   member: MemberType;
   isLoading: boolean;
   spaces: Space[];
+  /** When set, invoked instead of navigating to `closeUrl` (e.g. unsaved-changes guard). */
+  onCloseRequest?: () => void;
+  closeDisabled?: boolean;
 };
 
 export const MemberDetail = ({
@@ -34,23 +37,42 @@ export const MemberDetail = ({
   closeUrl,
   member,
   spaces,
+  onCloseRequest,
+  closeDisabled = false,
 }: MemberDetailProps) => {
   const tCommon = useTranslations('Common');
+  const showClose = Boolean(closeUrl) || Boolean(onCloseRequest);
 
   return (
     <div className="flex flex-col gap-5">
       <div className="flex gap-5 justify-between">
         <MemberHead {...member} lang={lang} isLoading={isLoading} />
-        <Link href={closeUrl} scroll={false}>
-          <Button
-            variant="ghost"
-            colorVariant="neutral"
-            className="flex items-center"
-          >
-            {tCommon('close')}
-            <RxCross1 className="ml-2" />
-          </Button>
-        </Link>
+        {showClose ? (
+          onCloseRequest ? (
+            <Button
+              type="button"
+              variant="ghost"
+              colorVariant="neutral"
+              className="flex items-center"
+              disabled={closeDisabled}
+              onClick={onCloseRequest}
+            >
+              {tCommon('close')}
+              <RxCross1 className="ml-2" />
+            </Button>
+          ) : (
+            <Link href={closeUrl} scroll={false}>
+              <Button
+                variant="ghost"
+                colorVariant="neutral"
+                className="flex items-center"
+              >
+                {tCommon('close')}
+                <RxCross1 className="ml-2" />
+              </Button>
+            </Link>
+          )
+        ) : null}
       </div>
       <Separator />
       <Skeleton

--- a/packages/i18n/src/messages/de.json
+++ b/packages/i18n/src/messages/de.json
@@ -338,6 +338,13 @@
         "inactive": "Inaktiv",
         "applicant": "Bewerber",
         "unknown": "Unbekannt"
+      },
+      "unsavedChangesModal": {
+        "title": "Ungespeicherte Änderungen",
+        "description": "Sie haben ungespeicherte Änderungen. Wenn Sie die Seite verlassen, gehen sie verloren.",
+        "discard": "Änderungen verwerfen",
+        "save": "Änderungen speichern",
+        "saving": "Wird gespeichert..."
       }
     },
     "delegateSection": {

--- a/packages/i18n/src/messages/en.json
+++ b/packages/i18n/src/messages/en.json
@@ -338,6 +338,13 @@
         "inactive": "Inactive",
         "applicant": "Applicant",
         "unknown": "Unknown"
+      },
+      "unsavedChangesModal": {
+        "title": "Unsaved changes",
+        "description": "You have unsaved changes. If you navigate away, you will lose them.",
+        "discard": "Discard changes",
+        "save": "Save changes",
+        "saving": "Saving..."
       }
     },
     "delegateSection": {

--- a/packages/i18n/src/messages/es.json
+++ b/packages/i18n/src/messages/es.json
@@ -991,6 +991,13 @@
         "inactive": "Inactivo",
         "applicant": "Candidato",
         "unknown": "Desconocido"
+      },
+      "unsavedChangesModal": {
+        "title": "Cambios sin guardar",
+        "description": "Tienes cambios sin guardar. Si sales, los perderás.",
+        "discard": "Descartar cambios",
+        "save": "Guardar cambios",
+        "saving": "Guardando..."
       }
     },
     "delegateSection": {

--- a/packages/i18n/src/messages/fr.json
+++ b/packages/i18n/src/messages/fr.json
@@ -338,6 +338,13 @@
         "inactive": "Inactif",
         "applicant": "Candidat",
         "unknown": "Inconnu"
+      },
+      "unsavedChangesModal": {
+        "title": "Modifications non enregistrées",
+        "description": "Vous avez des modifications non enregistrées. Si vous quittez la page, elles seront perdues.",
+        "discard": "Abandonner les modifications",
+        "save": "Enregistrer les modifications",
+        "saving": "Enregistrement..."
       }
     },
     "delegateSection": {

--- a/packages/i18n/src/messages/pt.json
+++ b/packages/i18n/src/messages/pt.json
@@ -991,6 +991,13 @@
         "inactive": "Inativo",
         "applicant": "Candidato",
         "unknown": "Desconhecido"
+      },
+      "unsavedChangesModal": {
+        "title": "Alterações não salvas",
+        "description": "Você tem alterações não salvas. Se sair, elas serão perdidas.",
+        "discard": "Descartar alterações",
+        "save": "Salvar alterações",
+        "saving": "Salvando..."
       }
     },
     "delegateSection": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When viewing your own member profile in the DHO members aside, changing the **Delegate to Member** form and tapping **Close** previously navigated away without the production-style **Unsaved changes** confirmation.

This change intercepts close when the delegate form is dirty, opens a centered **AlertDialog** (same typography and neutral outline button pairing as `ConfirmDialog`), and offers **Discard changes** or **Save changes** (with a saving state). Successful save resets the form dirty baseline before leaving.

## Additional fixes

- **DelegateVotingSection** now registers `useForm` before the `isMember` early return so hook order stays valid for all viewers.
- After successful delegate or undelegate, the form calls **`reset`** with current values so the dirty state clears without losing displayed data.

## i18n

Added `MembersTab.memberDetail.unsavedChangesModal.*` strings in **en**, **de**, **es**, **fr**, and **pt**.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bbee0be7-c6bf-4d98-92b0-839be6759fa4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bbee0be7-c6bf-4d98-92b0-839be6759fa4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

