### PR TITLE
fix(layout): sync DHO parallax and sticky chrome with main column scroll

### DIFF
--- a/apps/web/src/app/[lang]/dho/[id]/_components/dho-sticky-space-chrome.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/dho-sticky-space-chrome.tsx
@@ -5,6 +5,7 @@ import { createPortal } from 'react-dom';
 import {
   COMPACT_SPACE_BANNER_AVATAR_CLASSNAME,
   COMPACT_SPACE_BANNER_TITLE_CLASSNAME,
+  subscribeMainColumnScroll,
 } from '@hypha-platform/epics';
 import { Avatar, AvatarImage } from '@hypha-platform/ui';
 import { cn } from '@hypha-platform/ui-utils';
@@ -126,11 +127,11 @@ export function DhoStickySpaceChrome({
 
     tick();
     mq.addEventListener('change', onScroll);
-    window.addEventListener('scroll', onScroll, { passive: true });
+    const unsubscribeScroll = subscribeMainColumnScroll(onScroll);
     window.addEventListener('resize', onScroll);
     return () => {
       mq.removeEventListener('change', onScroll);
-      window.removeEventListener('scroll', onScroll);
+      unsubscribeScroll();
       window.removeEventListener('resize', onScroll);
       if (raf) cancelAnimationFrame(raf);
     };

--- a/apps/web/src/app/[lang]/dho/[id]/_components/navigation-tabs.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/navigation-tabs.tsx
@@ -11,21 +11,20 @@ import { getDhoPathMembers } from '../@tab/members/constants';
 import { getDhoPathTreasury } from '../@tab/treasury/constants';
 // import { getDhoPathOverview } from '../@tab/overview/constants'; // Overview tab removed
 import { cn } from '@hypha-platform/ui-utils';
-import { getEffectiveDhoTab } from '@hypha-platform/epics';
+import {
+  getEffectiveDhoTab,
+  useMainColumnScrollY,
+} from '@hypha-platform/epics';
 import { getDhoPathCoherence } from '../@tab/coherence/constants';
 
 /** Subtle scroll parallax: tab strip drifts slightly vs page for depth (see CompactSpaceBannerLead). */
 const TAB_PARALLAX_SCROLL_RATE = 0.07;
 const TAB_PARALLAX_MAX_SHIFT_PX = 18;
 
-function clampTabParallaxScrollY(): number {
-  if (typeof window === 'undefined') return 0;
+function clampTabParallaxScrollY(scrollY: number): number {
   return Math.min(
     TAB_PARALLAX_MAX_SHIFT_PX,
-    Math.max(
-      -TAB_PARALLAX_MAX_SHIFT_PX,
-      window.scrollY * TAB_PARALLAX_SCROLL_RATE,
-    ),
+    Math.max(-TAB_PARALLAX_MAX_SHIFT_PX, scrollY * TAB_PARALLAX_SCROLL_RATE),
   );
 }
 
@@ -49,7 +48,7 @@ export function NavigationTabs({
   const pathname = usePathname();
   const activeTab = getEffectiveDhoTab(pathname, { coherenceEnabled });
 
-  const [tabParallaxY, setTabParallaxY] = React.useState(0);
+  const mainScrollY = useMainColumnScrollY();
   const [preferReducedMotion, setPreferReducedMotion] = React.useState(false);
 
   React.useEffect(() => {
@@ -58,37 +57,16 @@ export function NavigationTabs({
 
     const sync = () => {
       setPreferReducedMotion(mq.matches);
-      if (mq.matches) setTabParallaxY(0);
     };
     sync();
     mq.addEventListener('change', sync);
     return () => mq.removeEventListener('change', sync);
   }, []);
 
-  React.useEffect(() => {
-    if (preferReducedMotion || isReducedMotionPreferred()) {
-      setTabParallaxY(0);
-      return;
-    }
-
-    let raf = 0;
-
-    const tick = () => {
-      setTabParallaxY(clampTabParallaxScrollY());
-    };
-
-    const onScroll = () => {
-      cancelAnimationFrame(raf);
-      raf = requestAnimationFrame(tick);
-    };
-
-    tick();
-    window.addEventListener('scroll', onScroll, { passive: true });
-    return () => {
-      window.removeEventListener('scroll', onScroll);
-      cancelAnimationFrame(raf);
-    };
-  }, [preferReducedMotion]);
+  const tabParallaxY =
+    preferReducedMotion || isReducedMotionPreferred()
+      ? 0
+      : clampTabParallaxScrollY(mainScrollY);
 
   const tabs = [
     // Overview tab removed - functionality replaced by space-visualization

--- a/packages/epics/src/common/index.ts
+++ b/packages/epics/src/common/index.ts
@@ -23,6 +23,11 @@ export {
   HumanSidebarTrigger,
 } from './panel-wrap-layout';
 export {
+  useMainColumnScrollY,
+  getMainColumnScrollY,
+  subscribeMainColumnScroll,
+} from './main-column-scroll';
+export {
   HumanChatPanelHeader,
   HumanChatPanelMessageBubble,
   HumanChatPanelChatBar,

--- a/packages/epics/src/common/main-column-scroll.ts
+++ b/packages/epics/src/common/main-column-scroll.ts
@@ -1,0 +1,76 @@
+'use client';
+
+import { useSyncExternalStore } from 'react';
+
+/**
+ * Scroll position for the primary app column. When space side panels wrap content in
+ * `SidebarInset` with `overflow-y-auto`, the document does not scroll — this module
+ * tracks whichever element is the current scroll root (inset or window).
+ */
+
+let scrollRoot: HTMLElement | null = null;
+const listeners = new Set<() => void>();
+
+function readScrollY(): number {
+  if (typeof window === 'undefined') return 0;
+  if (scrollRoot) return scrollRoot.scrollTop;
+  return window.scrollY;
+}
+
+function onScroll() {
+  listeners.forEach((l) => l());
+}
+
+function detachScrollTarget() {
+  if (scrollRoot) {
+    scrollRoot.removeEventListener('scroll', onScroll);
+  }
+  if (typeof window !== 'undefined') {
+    window.removeEventListener('scroll', onScroll);
+  }
+}
+
+function attachScrollTarget() {
+  detachScrollTarget();
+  if (listeners.size === 0) return;
+  if (scrollRoot) {
+    scrollRoot.addEventListener('scroll', onScroll, { passive: true });
+  } else if (typeof window !== 'undefined') {
+    window.addEventListener('scroll', onScroll, { passive: true });
+  }
+}
+
+/**
+ * Called from the scrollable `SidebarInset` ref (or `null` on unmount).
+ * When panels are off, root stays `null` and we fall back to `window`.
+ */
+export function setMainColumnScrollRoot(el: HTMLElement | null) {
+  if (scrollRoot === el) return;
+  scrollRoot = el;
+  attachScrollTarget();
+  listeners.forEach((l) => l());
+}
+
+/** Subscribe to scroll on the main column (inset or window). Safe for non-React listeners. */
+export function subscribeMainColumnScroll(onStoreChange: () => void) {
+  const wasEmpty = listeners.size === 0;
+  listeners.add(onStoreChange);
+  if (wasEmpty) attachScrollTarget();
+  return () => {
+    listeners.delete(onStoreChange);
+    if (listeners.size === 0) detachScrollTarget();
+  };
+}
+
+/** Current vertical scroll of the main column (inset or window). */
+export function getMainColumnScrollY(): number {
+  return readScrollY();
+}
+
+export function useMainColumnScrollY(): number {
+  return useSyncExternalStore(
+    subscribeMainColumnScroll,
+    getMainColumnScrollY,
+    () => 0,
+  );
+}

--- a/packages/epics/src/common/panel-main-column-scroll-bridge.tsx
+++ b/packages/epics/src/common/panel-main-column-scroll-bridge.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import * as React from 'react';
+import {
+  SidebarProvider,
+  Sidebar,
+  SidebarInset,
+  SidebarResizeHandle,
+} from '@hypha-platform/ui';
+import { setMainColumnScrollRoot } from './main-column-scroll';
+
+type Props = {
+  leftOpen: boolean;
+  onLeftOpenChange: (open: boolean) => void;
+  rightOpen: boolean;
+  onRightOpenChange: (open: boolean) => void;
+  leftContent: React.ReactNode;
+  rightContent: React.ReactNode;
+  children: React.ReactNode;
+};
+
+/**
+ * Single scroll container when both AI and Human panels are enabled, so parallax and
+ * sticky DHO chrome see one scroll root instead of nested `overflow-y-auto` insets.
+ */
+export function PanelDualSidebarScrollBridge({
+  leftOpen,
+  onLeftOpenChange,
+  rightOpen,
+  onRightOpenChange,
+  leftContent,
+  rightContent,
+  children,
+}: Props) {
+  const bindScrollRoot = React.useCallback((node: HTMLElement | null) => {
+    setMainColumnScrollRoot(node);
+  }, []);
+
+  return (
+    <SidebarProvider
+      open={leftOpen}
+      onOpenChange={onLeftOpenChange}
+      style={
+        {
+          '--sidebar-width': '320px',
+        } as React.CSSProperties
+      }
+    >
+      <Sidebar side="left" variant="sidebar" collapsible="offcanvas">
+        {leftContent}
+        <SidebarResizeHandle />
+      </Sidebar>
+      <SidebarInset ref={bindScrollRoot} className="overflow-y-auto">
+        <SidebarProvider
+          open={rightOpen}
+          onOpenChange={onRightOpenChange}
+          style={
+            {
+              '--sidebar-width': '320px',
+            } as React.CSSProperties
+          }
+        >
+          {children}
+          <Sidebar side="right" variant="sidebar" collapsible="offcanvas">
+            <SidebarResizeHandle />
+            {rightContent}
+          </Sidebar>
+        </SidebarProvider>
+      </SidebarInset>
+    </SidebarProvider>
+  );
+}

--- a/packages/epics/src/common/panel-scroll-inset.tsx
+++ b/packages/epics/src/common/panel-scroll-inset.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import * as React from 'react';
+import { SidebarInset } from '@hypha-platform/ui';
+import { setMainColumnScrollRoot } from './main-column-scroll';
+
+type Props = React.ComponentProps<typeof SidebarInset>;
+
+/**
+ * `SidebarInset` that registers itself as the main column scroll root for parallax /
+ * sticky chrome when this inset is the scrollport (`overflow-y-auto`).
+ */
+export function PanelScrollInset({ className, ...props }: Props) {
+  const bind = React.useCallback((node: HTMLElement | null) => {
+    setMainColumnScrollRoot(node);
+  }, []);
+
+  return <SidebarInset ref={bind} className={className} {...props} />;
+}

--- a/packages/epics/src/common/panel-wrap-layout.tsx
+++ b/packages/epics/src/common/panel-wrap-layout.tsx
@@ -5,7 +5,6 @@ import { MessageCircle, Sparkles } from 'lucide-react';
 import {
   SidebarProvider,
   Sidebar,
-  SidebarInset,
   SidebarResizeHandle,
 } from '@hypha-platform/ui';
 import { useTranslations } from 'next-intl';
@@ -16,6 +15,8 @@ import {
   useHumanChatPanel,
 } from './human-chat-panel-context';
 import { useIsSpaceContext } from './use-is-space-context';
+import { PanelDualSidebarScrollBridge } from './panel-main-column-scroll-bridge';
+import { PanelScrollInset } from './panel-scroll-inset';
 
 // ─── Panel Providers ─────────────────────────────────────────────────────────
 // Owns the open/close state for both panels and wraps children with the
@@ -122,11 +123,27 @@ export function PanelWrapLayout({
   const effectiveLeft = isSpace ? left : undefined;
   const effectiveRight = isSpace ? right : undefined;
 
-  // Core content that goes inside the innermost SidebarInset
+  // Core content that goes inside the scrollable SidebarInset (when panels wrap layout)
   let content = <>{children}</>;
 
-  // Wrap with right panel if provided and in space context
-  if (effectiveRight) {
+  if (effectiveLeft && effectiveRight) {
+    content = (
+      <PanelDualSidebarScrollBridge
+        leftOpen={leftOpen}
+        onLeftOpenChange={(open) => {
+          if (open !== leftOpen) toggleLeft();
+        }}
+        rightOpen={rightOpen}
+        onRightOpenChange={(open) => {
+          if (open !== rightOpen) toggleRight();
+        }}
+        leftContent={effectiveLeft.content}
+        rightContent={effectiveRight.content}
+      >
+        {content}
+      </PanelDualSidebarScrollBridge>
+    );
+  } else if (effectiveRight) {
     content = (
       <SidebarProvider
         open={rightOpen}
@@ -139,17 +156,16 @@ export function PanelWrapLayout({
           } as React.CSSProperties
         }
       >
-        <SidebarInset className="overflow-y-auto">{content}</SidebarInset>
+        <PanelScrollInset className="overflow-y-auto">
+          {content}
+        </PanelScrollInset>
         <Sidebar side="right" variant="sidebar" collapsible="offcanvas">
           <SidebarResizeHandle />
           {effectiveRight.content}
         </Sidebar>
       </SidebarProvider>
     );
-  }
-
-  // Wrap with left panel if provided and in space context
-  if (effectiveLeft) {
+  } else if (effectiveLeft) {
     content = (
       <SidebarProvider
         open={leftOpen}
@@ -166,7 +182,9 @@ export function PanelWrapLayout({
           {effectiveLeft.content}
           <SidebarResizeHandle />
         </Sidebar>
-        <SidebarInset className="overflow-y-auto">{content}</SidebarInset>
+        <PanelScrollInset className="overflow-y-auto">
+          {content}
+        </PanelScrollInset>
       </SidebarProvider>
     );
   }

--- a/packages/epics/src/spaces/components/compact-space-banner-lead.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner-lead.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react';
 import Image from 'next/image';
 import { cn } from '@hypha-platform/ui-utils';
+import { useMainColumnScrollY } from '../../common/main-column-scroll';
 
 type Props = {
   src: string;
@@ -12,11 +13,10 @@ type Props = {
 const PARALLAX_SCROLL_RATE = 0.14;
 const PARALLAX_MAX_SHIFT_PX = 56;
 
-function clampParallaxScrollY(): number {
-  if (typeof window === 'undefined') return 0;
+function clampParallaxScrollY(scrollY: number): number {
   return Math.min(
     PARALLAX_MAX_SHIFT_PX,
-    Math.max(-PARALLAX_MAX_SHIFT_PX, window.scrollY * PARALLAX_SCROLL_RATE),
+    Math.max(-PARALLAX_MAX_SHIFT_PX, scrollY * PARALLAX_SCROLL_RATE),
   );
 }
 
@@ -28,7 +28,7 @@ function clampParallaxScrollY(): number {
 export function CompactSpaceBannerLead({ src }: Props) {
   const [ready, setReady] = React.useState(false);
   const [imageFailed, setImageFailed] = React.useState(false);
-  const [parallaxY, setParallaxY] = React.useState(0);
+  const mainScrollY = useMainColumnScrollY();
   const [reduceMotion, setReduceMotion] = React.useState(false);
 
   React.useLayoutEffect(() => {
@@ -41,27 +41,7 @@ export function CompactSpaceBannerLead({ src }: Props) {
     return () => mq.removeEventListener('change', sync);
   }, []);
 
-  React.useEffect(() => {
-    if (reduceMotion) return;
-
-    let raf = 0;
-
-    const tick = () => {
-      setParallaxY(clampParallaxScrollY());
-    };
-
-    const onScroll = () => {
-      cancelAnimationFrame(raf);
-      raf = requestAnimationFrame(tick);
-    };
-
-    tick();
-    window.addEventListener('scroll', onScroll, { passive: true });
-    return () => {
-      window.removeEventListener('scroll', onScroll);
-      cancelAnimationFrame(raf);
-    };
-  }, [reduceMotion]);
+  const parallaxY = reduceMotion ? 0 : clampParallaxScrollY(mainScrollY);
 
   return (
     <div className="pointer-events-none absolute inset-0 z-0 overflow-hidden rounded-[inherit]">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On space routes (`/[lang]/dho/[id]/...`), `PanelWrapLayout` wraps the main column in `SidebarInset` with `overflow-y-auto`. The document does not scroll, so `window.scrollY` stays near zero and `window` `scroll` events do not fire for that scrollport.

That broke:

- Hero parallax in `CompactSpaceBannerLead` (was driven by `window.scrollY`).
- Tab strip parallax in `NavigationTabs` (same).
- `DhoStickySpaceChrome` sticky state (listened only to `window` scroll).

## Solution

1. **`main-column-scroll.ts`** — module-level scroll root (`HTMLElement | null`) with `subscribeMainColumnScroll` / `getMainColumnScrollY` / `useMainColumnScrollY` (`useSyncExternalStore`). Listeners attach to the inset or `window` only when subscribed.

2. **`PanelScrollInset`** — registers the scrollable `SidebarInset` as the main column root when only one panel wraps layout.

3. **`PanelDualSidebarScrollBridge`** — when **both** AI and Human panels are enabled, a **single** `SidebarInset` scrolls the center column (avoids nested `overflow-y-auto` insets). Left and right sidebars each keep their own `SidebarProvider` + `open` state.

4. **Consumers** — `CompactSpaceBannerLead` and `NavigationTabs` use `useMainColumnScrollY()`; `DhoStickySpaceChrome` uses `subscribeMainColumnScroll` instead of `window.addEventListener('scroll', ...)`.

## QA notes

- Verify on a DHO space with Human chat (and optionally AI) enabled: scroll the main column and confirm hero image drift, tab strip drift, and sticky space chrome after scrolling past the banner.
- With **Reduce motion** enabled, parallax should still be disabled (unchanged behavior).

## Branch

`cursor/fix-main-column-scroll-parallax-8073` → `main`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-82c9ec29-6eb0-4d1a-a1fa-bde9fdde8073"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-82c9ec29-6eb0-4d1a-a1fa-bde9fdde8073"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

