### PR TITLE
fix(governance): validate token-backing vault preconditions client-side

### DIFF
--- a/packages/core/src/generated.ts
+++ b/packages/core/src/generated.ts
@@ -23,7 +23,7 @@ export const aggregatorV3InterfaceAbi = [
     ],
     stateMutability: 'view',
   },
-] as const;
+] as const
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // AgreementsImplementation
@@ -235,14 +235,14 @@ export const agreementsImplementationAbi = [
     outputs: [],
     stateMutability: 'payable',
   },
-] as const;
+] as const
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0x83B5d4F555A68126bB302685e67767Bb7a2985F0)
  */
 export const agreementsImplementationAddress = {
   8453: '0x83B5d4F555A68126bB302685e67767Bb7a2985F0',
-} as const;
+} as const
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0x83B5d4F555A68126bB302685e67767Bb7a2985F0)
@@ -250,7 +250,7 @@ export const agreementsImplementationAddress = {
 export const agreementsImplementationConfig = {
   address: agreementsImplementationAddress,
   abi: agreementsImplementationAbi,
-} as const;
+} as const
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // DAOProposalsImplementation
@@ -959,14 +959,14 @@ export const daoProposalsImplementationAbi = [
     outputs: [],
     stateMutability: 'nonpayable',
   },
-] as const;
+] as const
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0x001bA7a00a259Fb12d7936455e292a60FC2bef14)
  */
 export const daoProposalsImplementationAddress = {
   8453: '0x001bA7a00a259Fb12d7936455e292a60FC2bef14',
-} as const;
+} as const
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0x001bA7a00a259Fb12d7936455e292a60FC2bef14)
@@ -974,7 +974,7 @@ export const daoProposalsImplementationAddress = {
 export const daoProposalsImplementationConfig = {
   address: daoProposalsImplementationAddress,
   abi: daoProposalsImplementationAbi,
-} as const;
+} as const
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // DAOSpaceFactoryImplementation
@@ -1673,14 +1673,14 @@ export const daoSpaceFactoryImplementationAbi = [
     outputs: [],
     stateMutability: 'payable',
   },
-] as const;
+] as const
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0xc8B8454D2F9192FeCAbc2C6F5d88F6434A2a9cd9)
  */
 export const daoSpaceFactoryImplementationAddress = {
   8453: '0xc8B8454D2F9192FeCAbc2C6F5d88F6434A2a9cd9',
-} as const;
+} as const
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0xc8B8454D2F9192FeCAbc2C6F5d88F6434A2a9cd9)
@@ -1688,7 +1688,7 @@ export const daoSpaceFactoryImplementationAddress = {
 export const daoSpaceFactoryImplementationConfig = {
   address: daoSpaceFactoryImplementationAddress,
   abi: daoSpaceFactoryImplementationAbi,
-} as const;
+} as const
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // DecayingSpaceToken
@@ -3206,14 +3206,14 @@ export const decayingSpaceTokenAbi = [
     outputs: [{ name: '', internalType: 'bool', type: 'bool' }],
     stateMutability: 'view',
   },
-] as const;
+] as const
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0xc8995514f8c76b9d9a509b4fdba0d06eb732907e)
  */
 export const decayingSpaceTokenAddress = {
   8453: '0xC8995514f8C76b9D9A509b4fDbA0D06eB732907e',
-} as const;
+} as const
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0xc8995514f8c76b9d9a509b4fdba0d06eb732907e)
@@ -3221,7 +3221,7 @@ export const decayingSpaceTokenAddress = {
 export const decayingSpaceTokenConfig = {
   address: decayingSpaceTokenAddress,
   abi: decayingSpaceTokenAbi,
-} as const;
+} as const
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // DecayingTokenFactory
@@ -3609,14 +3609,14 @@ export const decayingTokenFactoryAbi = [
     outputs: [],
     stateMutability: 'payable',
   },
-] as const;
+] as const
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0x299f4D2327933c1f363301dbd2a28379ccD5539b)
  */
 export const decayingTokenFactoryAddress = {
   8453: '0x299f4D2327933c1f363301dbd2a28379ccD5539b',
-} as const;
+} as const
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0x299f4D2327933c1f363301dbd2a28379ccD5539b)
@@ -3624,7 +3624,7 @@ export const decayingTokenFactoryAddress = {
 export const decayingTokenFactoryConfig = {
   address: decayingTokenFactoryAddress,
   abi: decayingTokenFactoryAbi,
-} as const;
+} as const
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // EnergyDistributionImplementation
@@ -4366,14 +4366,14 @@ export const energyDistributionImplementationAbi = [
     ],
     stateMutability: 'view',
   },
-] as const;
+] as const
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0x02d88b0C4CC3A4AE86482056c25d65916Dd6DD95)
  */
 export const energyDistributionImplementationAddress = {
   8453: '0x02d88b0C4CC3A4AE86482056c25d65916Dd6DD95',
-} as const;
+} as const
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0x02d88b0C4CC3A4AE86482056c25d65916Dd6DD95)
@@ -4381,7 +4381,7 @@ export const energyDistributionImplementationAddress = {
 export const energyDistributionImplementationConfig = {
   address: energyDistributionImplementationAddress,
   abi: energyDistributionImplementationAbi,
-} as const;
+} as const
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // EscrowImplementation
@@ -4756,14 +4756,14 @@ export const escrowImplementationAbi = [
     outputs: [{ name: '', internalType: 'bool', type: 'bool' }],
     stateMutability: 'nonpayable',
   },
-] as const;
+] as const
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0x447A317cA5516933264Cdd6aeee0633Fa954B576)
  */
 export const escrowImplementationAddress = {
   8453: '0x447A317cA5516933264Cdd6aeee0633Fa954B576',
-} as const;
+} as const
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0x447A317cA5516933264Cdd6aeee0633Fa954B576)
@@ -4771,7 +4771,7 @@ export const escrowImplementationAddress = {
 export const escrowImplementationConfig = {
   address: escrowImplementationAddress,
   abi: escrowImplementationAbi,
-} as const;
+} as const
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // HyphaToken
@@ -5603,14 +5603,14 @@ export const hyphaTokenAbi = [
     outputs: [{ name: '', internalType: 'uint256', type: 'uint256' }],
     stateMutability: 'view',
   },
-] as const;
+] as const
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0x8b93862835C36e9689E9bb1Ab21De3982e266CD3)
  */
 export const hyphaTokenAddress = {
   8453: '0x8b93862835C36e9689E9bb1Ab21De3982e266CD3',
-} as const;
+} as const
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0x8b93862835C36e9689E9bb1Ab21De3982e266CD3)
@@ -5618,7 +5618,7 @@ export const hyphaTokenAddress = {
 export const hyphaTokenConfig = {
   address: hyphaTokenAddress,
   abi: hyphaTokenAbi,
-} as const;
+} as const
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // ISpaceTokenPrice
@@ -5639,7 +5639,7 @@ export const iSpaceTokenPriceAbi = [
     outputs: [{ name: '', internalType: 'uint256', type: 'uint256' }],
     stateMutability: 'view',
   },
-] as const;
+] as const
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // ITokenBackingBurnableERC20
@@ -5656,7 +5656,7 @@ export const iTokenBackingBurnableErc20Abi = [
     outputs: [],
     stateMutability: 'nonpayable',
   },
-] as const;
+] as const
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // OwnershipTokenFactory
@@ -6016,14 +6016,14 @@ export const ownershipTokenFactoryAbi = [
     outputs: [{ name: '', internalType: 'address', type: 'address' }],
     stateMutability: 'view',
   },
-] as const;
+] as const
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0xA1eDf096B72226ae2f7BDEb12E9c9C82152BccB6)
  */
 export const ownershipTokenFactoryAddress = {
   8453: '0xA1eDf096B72226ae2f7BDEb12E9c9C82152BccB6',
-} as const;
+} as const
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0xA1eDf096B72226ae2f7BDEb12E9c9C82152BccB6)
@@ -6031,7 +6031,7 @@ export const ownershipTokenFactoryAddress = {
 export const ownershipTokenFactoryConfig = {
   address: ownershipTokenFactoryAddress,
   abi: ownershipTokenFactoryAbi,
-} as const;
+} as const
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // OwnershipTokenVotingPowerImplementation
@@ -6286,14 +6286,14 @@ export const ownershipTokenVotingPowerImplementationAbi = [
     outputs: [],
     stateMutability: 'payable',
   },
-] as const;
+] as const
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0x255c7b5DaC3696199fEF7A8CC6Cc87190bc36eFd)
  */
 export const ownershipTokenVotingPowerImplementationAddress = {
   8453: '0x255c7b5DaC3696199fEF7A8CC6Cc87190bc36eFd',
-} as const;
+} as const
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0x255c7b5DaC3696199fEF7A8CC6Cc87190bc36eFd)
@@ -6301,7 +6301,7 @@ export const ownershipTokenVotingPowerImplementationAddress = {
 export const ownershipTokenVotingPowerImplementationConfig = {
   address: ownershipTokenVotingPowerImplementationAddress,
   abi: ownershipTokenVotingPowerImplementationAbi,
-} as const;
+} as const
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // RegularTokenFactory
@@ -6668,14 +6668,14 @@ export const regularTokenFactoryAbi = [
     outputs: [{ name: '', internalType: 'address', type: 'address' }],
     stateMutability: 'view',
   },
-] as const;
+] as const
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0x95A33EC94de2189893884DaD63eAa19f7390144a)
  */
 export const regularTokenFactoryAddress = {
   8453: '0x95A33EC94de2189893884DaD63eAa19f7390144a',
-} as const;
+} as const
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0x95A33EC94de2189893884DaD63eAa19f7390144a)
@@ -6683,7 +6683,7 @@ export const regularTokenFactoryAddress = {
 export const regularTokenFactoryConfig = {
   address: regularTokenFactoryAddress,
   abi: regularTokenFactoryAbi,
-} as const;
+} as const
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // SpacePaymentTracker
@@ -6985,14 +6985,14 @@ export const spacePaymentTrackerAbi = [
     outputs: [],
     stateMutability: 'payable',
   },
-] as const;
+] as const
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0x4B61250c8F19BA96C473c65022453E95176b0139)
  */
 export const spacePaymentTrackerAddress = {
   8453: '0x4B61250c8F19BA96C473c65022453E95176b0139',
-} as const;
+} as const
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0x4B61250c8F19BA96C473c65022453E95176b0139)
@@ -7000,7 +7000,7 @@ export const spacePaymentTrackerAddress = {
 export const spacePaymentTrackerConfig = {
   address: spacePaymentTrackerAddress,
   abi: spacePaymentTrackerAbi,
-} as const;
+} as const
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // TokenBackingVaultImplementation
@@ -7587,6 +7587,29 @@ export const tokenBackingVaultImplementationAbi = [
     inputs: [
       { name: 'spaceId', internalType: 'uint256', type: 'uint256' },
       { name: 'spaceToken', internalType: 'address', type: 'address' },
+      { name: 'minimumBackingBps', internalType: 'uint256', type: 'uint256' },
+      { name: 'redemptionPrice', internalType: 'uint256', type: 'uint256' },
+      {
+        name: 'redemptionPriceCurrencyFeed',
+        internalType: 'address',
+        type: 'address',
+      },
+      { name: 'maxRedemptionBps', internalType: 'uint256', type: 'uint256' },
+      {
+        name: 'maxRedemptionPeriodDays',
+        internalType: 'uint256',
+        type: 'uint256',
+      },
+    ],
+    name: 'createVault',
+    outputs: [{ name: 'vaultId', internalType: 'uint256', type: 'uint256' }],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    inputs: [
+      { name: 'spaceId', internalType: 'uint256', type: 'uint256' },
+      { name: 'spaceToken', internalType: 'address', type: 'address' },
       { name: 'backingToken', internalType: 'address', type: 'address' },
     ],
     name: 'getBackingBalance',
@@ -7970,14 +7993,14 @@ export const tokenBackingVaultImplementationAbi = [
     outputs: [],
     stateMutability: 'nonpayable',
   },
-] as const;
+] as const
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0x9997C22f06F0aC67dF07C8Cb2A08562C53dD4E9f)
  */
 export const tokenBackingVaultImplementationAddress = {
   8453: '0x9997C22f06F0aC67dF07C8Cb2A08562C53dD4E9f',
-} as const;
+} as const
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0x9997C22f06F0aC67dF07C8Cb2A08562C53dD4E9f)
@@ -7985,7 +8008,7 @@ export const tokenBackingVaultImplementationAddress = {
 export const tokenBackingVaultImplementationConfig = {
   address: tokenBackingVaultImplementationAddress,
   abi: tokenBackingVaultImplementationAbi,
-} as const;
+} as const
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // TokenBalanceJoinImplementation
@@ -8214,14 +8237,14 @@ export const tokenBalanceJoinImplementationAbi = [
     outputs: [],
     stateMutability: 'payable',
   },
-] as const;
+] as const
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0x41cD69A3a3715B16598415df336a8Cc533CCAF76)
  */
 export const tokenBalanceJoinImplementationAddress = {
   8453: '0x41cD69A3a3715B16598415df336a8Cc533CCAF76',
-} as const;
+} as const
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0x41cD69A3a3715B16598415df336a8Cc533CCAF76)
@@ -8229,7 +8252,7 @@ export const tokenBalanceJoinImplementationAddress = {
 export const tokenBalanceJoinImplementationConfig = {
   address: tokenBalanceJoinImplementationAddress,
   abi: tokenBalanceJoinImplementationAbi,
-} as const;
+} as const
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // TokenVotingPowerImplementation
@@ -8529,14 +8552,14 @@ export const tokenVotingPowerImplementationAbi = [
     outputs: [],
     stateMutability: 'payable',
   },
-] as const;
+] as const
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0x3214DE1Eb858799Db626Bd9699e78c2E6E33D2BE)
  */
 export const tokenVotingPowerImplementationAddress = {
   8453: '0x3214DE1Eb858799Db626Bd9699e78c2E6E33D2BE',
-} as const;
+} as const
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0x3214DE1Eb858799Db626Bd9699e78c2E6E33D2BE)
@@ -8544,7 +8567,7 @@ export const tokenVotingPowerImplementationAddress = {
 export const tokenVotingPowerImplementationConfig = {
   address: tokenVotingPowerImplementationAddress,
   abi: tokenVotingPowerImplementationAbi,
-} as const;
+} as const
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // TransferHelper
@@ -8703,14 +8726,14 @@ export const transferHelperAbi = [
     outputs: [],
     stateMutability: 'nonpayable',
   },
-] as const;
+] as const
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0x479002F7602579203ffba3eE84ACC1BC5b0d6785)
  */
 export const transferHelperAddress = {
   8453: '0x479002F7602579203ffba3eE84ACC1BC5b0d6785',
-} as const;
+} as const
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0x479002F7602579203ffba3eE84ACC1BC5b0d6785)
@@ -8718,7 +8741,7 @@ export const transferHelperAddress = {
 export const transferHelperConfig = {
   address: transferHelperAddress,
   abi: transferHelperAbi,
-} as const;
+} as const
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // VoteDecayTokenVotingPowerImplementation
@@ -9029,14 +9052,14 @@ export const voteDecayTokenVotingPowerImplementationAbi = [
     outputs: [],
     stateMutability: 'payable',
   },
-] as const;
+] as const
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0x6dB5E05B21c68550B63a7404a3B68F81c159DAee)
  */
 export const voteDecayTokenVotingPowerImplementationAddress = {
   8453: '0x6dB5E05B21c68550B63a7404a3B68F81c159DAee',
-} as const;
+} as const
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0x6dB5E05B21c68550B63a7404a3B68F81c159DAee)
@@ -9044,7 +9067,7 @@ export const voteDecayTokenVotingPowerImplementationAddress = {
 export const voteDecayTokenVotingPowerImplementationConfig = {
   address: voteDecayTokenVotingPowerImplementationAddress,
   abi: voteDecayTokenVotingPowerImplementationAbi,
-} as const;
+} as const
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // VotingPowerDelegationImplementation
@@ -9391,14 +9414,14 @@ export const votingPowerDelegationImplementationAbi = [
     outputs: [{ name: '', internalType: 'bool', type: 'bool' }],
     stateMutability: 'view',
   },
-] as const;
+] as const
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0xc87546357EeFF8653cF058Be2BA850813e39cda0)
  */
 export const votingPowerDelegationImplementationAddress = {
   8453: '0xc87546357EeFF8653cF058Be2BA850813e39cda0',
-} as const;
+} as const
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0xc87546357EeFF8653cF058Be2BA850813e39cda0)
@@ -9406,4 +9429,4 @@ export const votingPowerDelegationImplementationAddress = {
 export const votingPowerDelegationImplementationConfig = {
   address: votingPowerDelegationImplementationAddress,
   abi: votingPowerDelegationImplementationAbi,
-} as const;
+} as const

--- a/packages/core/src/generated.ts
+++ b/packages/core/src/generated.ts
@@ -23,7 +23,7 @@ export const aggregatorV3InterfaceAbi = [
     ],
     stateMutability: 'view',
   },
-] as const
+] as const;
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // AgreementsImplementation
@@ -235,14 +235,14 @@ export const agreementsImplementationAbi = [
     outputs: [],
     stateMutability: 'payable',
   },
-] as const
+] as const;
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0x83B5d4F555A68126bB302685e67767Bb7a2985F0)
  */
 export const agreementsImplementationAddress = {
   8453: '0x83B5d4F555A68126bB302685e67767Bb7a2985F0',
-} as const
+} as const;
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0x83B5d4F555A68126bB302685e67767Bb7a2985F0)
@@ -250,7 +250,7 @@ export const agreementsImplementationAddress = {
 export const agreementsImplementationConfig = {
   address: agreementsImplementationAddress,
   abi: agreementsImplementationAbi,
-} as const
+} as const;
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // DAOProposalsImplementation
@@ -959,14 +959,14 @@ export const daoProposalsImplementationAbi = [
     outputs: [],
     stateMutability: 'nonpayable',
   },
-] as const
+] as const;
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0x001bA7a00a259Fb12d7936455e292a60FC2bef14)
  */
 export const daoProposalsImplementationAddress = {
   8453: '0x001bA7a00a259Fb12d7936455e292a60FC2bef14',
-} as const
+} as const;
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0x001bA7a00a259Fb12d7936455e292a60FC2bef14)
@@ -974,7 +974,7 @@ export const daoProposalsImplementationAddress = {
 export const daoProposalsImplementationConfig = {
   address: daoProposalsImplementationAddress,
   abi: daoProposalsImplementationAbi,
-} as const
+} as const;
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // DAOSpaceFactoryImplementation
@@ -1673,14 +1673,14 @@ export const daoSpaceFactoryImplementationAbi = [
     outputs: [],
     stateMutability: 'payable',
   },
-] as const
+] as const;
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0xc8B8454D2F9192FeCAbc2C6F5d88F6434A2a9cd9)
  */
 export const daoSpaceFactoryImplementationAddress = {
   8453: '0xc8B8454D2F9192FeCAbc2C6F5d88F6434A2a9cd9',
-} as const
+} as const;
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0xc8B8454D2F9192FeCAbc2C6F5d88F6434A2a9cd9)
@@ -1688,7 +1688,7 @@ export const daoSpaceFactoryImplementationAddress = {
 export const daoSpaceFactoryImplementationConfig = {
   address: daoSpaceFactoryImplementationAddress,
   abi: daoSpaceFactoryImplementationAbi,
-} as const
+} as const;
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // DecayingSpaceToken
@@ -3206,14 +3206,14 @@ export const decayingSpaceTokenAbi = [
     outputs: [{ name: '', internalType: 'bool', type: 'bool' }],
     stateMutability: 'view',
   },
-] as const
+] as const;
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0xc8995514f8c76b9d9a509b4fdba0d06eb732907e)
  */
 export const decayingSpaceTokenAddress = {
   8453: '0xC8995514f8C76b9D9A509b4fDbA0D06eB732907e',
-} as const
+} as const;
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0xc8995514f8c76b9d9a509b4fdba0d06eb732907e)
@@ -3221,7 +3221,7 @@ export const decayingSpaceTokenAddress = {
 export const decayingSpaceTokenConfig = {
   address: decayingSpaceTokenAddress,
   abi: decayingSpaceTokenAbi,
-} as const
+} as const;
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // DecayingTokenFactory
@@ -3609,14 +3609,14 @@ export const decayingTokenFactoryAbi = [
     outputs: [],
     stateMutability: 'payable',
   },
-] as const
+] as const;
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0x299f4D2327933c1f363301dbd2a28379ccD5539b)
  */
 export const decayingTokenFactoryAddress = {
   8453: '0x299f4D2327933c1f363301dbd2a28379ccD5539b',
-} as const
+} as const;
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0x299f4D2327933c1f363301dbd2a28379ccD5539b)
@@ -3624,7 +3624,7 @@ export const decayingTokenFactoryAddress = {
 export const decayingTokenFactoryConfig = {
   address: decayingTokenFactoryAddress,
   abi: decayingTokenFactoryAbi,
-} as const
+} as const;
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // EnergyDistributionImplementation
@@ -4366,14 +4366,14 @@ export const energyDistributionImplementationAbi = [
     ],
     stateMutability: 'view',
   },
-] as const
+] as const;
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0x02d88b0C4CC3A4AE86482056c25d65916Dd6DD95)
  */
 export const energyDistributionImplementationAddress = {
   8453: '0x02d88b0C4CC3A4AE86482056c25d65916Dd6DD95',
-} as const
+} as const;
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0x02d88b0C4CC3A4AE86482056c25d65916Dd6DD95)
@@ -4381,7 +4381,7 @@ export const energyDistributionImplementationAddress = {
 export const energyDistributionImplementationConfig = {
   address: energyDistributionImplementationAddress,
   abi: energyDistributionImplementationAbi,
-} as const
+} as const;
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // EscrowImplementation
@@ -4756,14 +4756,14 @@ export const escrowImplementationAbi = [
     outputs: [{ name: '', internalType: 'bool', type: 'bool' }],
     stateMutability: 'nonpayable',
   },
-] as const
+] as const;
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0x447A317cA5516933264Cdd6aeee0633Fa954B576)
  */
 export const escrowImplementationAddress = {
   8453: '0x447A317cA5516933264Cdd6aeee0633Fa954B576',
-} as const
+} as const;
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0x447A317cA5516933264Cdd6aeee0633Fa954B576)
@@ -4771,7 +4771,7 @@ export const escrowImplementationAddress = {
 export const escrowImplementationConfig = {
   address: escrowImplementationAddress,
   abi: escrowImplementationAbi,
-} as const
+} as const;
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // HyphaToken
@@ -5603,14 +5603,14 @@ export const hyphaTokenAbi = [
     outputs: [{ name: '', internalType: 'uint256', type: 'uint256' }],
     stateMutability: 'view',
   },
-] as const
+] as const;
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0x8b93862835C36e9689E9bb1Ab21De3982e266CD3)
  */
 export const hyphaTokenAddress = {
   8453: '0x8b93862835C36e9689E9bb1Ab21De3982e266CD3',
-} as const
+} as const;
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0x8b93862835C36e9689E9bb1Ab21De3982e266CD3)
@@ -5618,7 +5618,7 @@ export const hyphaTokenAddress = {
 export const hyphaTokenConfig = {
   address: hyphaTokenAddress,
   abi: hyphaTokenAbi,
-} as const
+} as const;
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // ISpaceTokenPrice
@@ -5639,7 +5639,7 @@ export const iSpaceTokenPriceAbi = [
     outputs: [{ name: '', internalType: 'uint256', type: 'uint256' }],
     stateMutability: 'view',
   },
-] as const
+] as const;
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // ITokenBackingBurnableERC20
@@ -5656,7 +5656,7 @@ export const iTokenBackingBurnableErc20Abi = [
     outputs: [],
     stateMutability: 'nonpayable',
   },
-] as const
+] as const;
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // OwnershipTokenFactory
@@ -6016,14 +6016,14 @@ export const ownershipTokenFactoryAbi = [
     outputs: [{ name: '', internalType: 'address', type: 'address' }],
     stateMutability: 'view',
   },
-] as const
+] as const;
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0xA1eDf096B72226ae2f7BDEb12E9c9C82152BccB6)
  */
 export const ownershipTokenFactoryAddress = {
   8453: '0xA1eDf096B72226ae2f7BDEb12E9c9C82152BccB6',
-} as const
+} as const;
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0xA1eDf096B72226ae2f7BDEb12E9c9C82152BccB6)
@@ -6031,7 +6031,7 @@ export const ownershipTokenFactoryAddress = {
 export const ownershipTokenFactoryConfig = {
   address: ownershipTokenFactoryAddress,
   abi: ownershipTokenFactoryAbi,
-} as const
+} as const;
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // OwnershipTokenVotingPowerImplementation
@@ -6286,14 +6286,14 @@ export const ownershipTokenVotingPowerImplementationAbi = [
     outputs: [],
     stateMutability: 'payable',
   },
-] as const
+] as const;
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0x255c7b5DaC3696199fEF7A8CC6Cc87190bc36eFd)
  */
 export const ownershipTokenVotingPowerImplementationAddress = {
   8453: '0x255c7b5DaC3696199fEF7A8CC6Cc87190bc36eFd',
-} as const
+} as const;
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0x255c7b5DaC3696199fEF7A8CC6Cc87190bc36eFd)
@@ -6301,7 +6301,7 @@ export const ownershipTokenVotingPowerImplementationAddress = {
 export const ownershipTokenVotingPowerImplementationConfig = {
   address: ownershipTokenVotingPowerImplementationAddress,
   abi: ownershipTokenVotingPowerImplementationAbi,
-} as const
+} as const;
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // RegularTokenFactory
@@ -6668,14 +6668,14 @@ export const regularTokenFactoryAbi = [
     outputs: [{ name: '', internalType: 'address', type: 'address' }],
     stateMutability: 'view',
   },
-] as const
+] as const;
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0x95A33EC94de2189893884DaD63eAa19f7390144a)
  */
 export const regularTokenFactoryAddress = {
   8453: '0x95A33EC94de2189893884DaD63eAa19f7390144a',
-} as const
+} as const;
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0x95A33EC94de2189893884DaD63eAa19f7390144a)
@@ -6683,7 +6683,7 @@ export const regularTokenFactoryAddress = {
 export const regularTokenFactoryConfig = {
   address: regularTokenFactoryAddress,
   abi: regularTokenFactoryAbi,
-} as const
+} as const;
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // SpacePaymentTracker
@@ -6985,14 +6985,14 @@ export const spacePaymentTrackerAbi = [
     outputs: [],
     stateMutability: 'payable',
   },
-] as const
+] as const;
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0x4B61250c8F19BA96C473c65022453E95176b0139)
  */
 export const spacePaymentTrackerAddress = {
   8453: '0x4B61250c8F19BA96C473c65022453E95176b0139',
-} as const
+} as const;
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0x4B61250c8F19BA96C473c65022453E95176b0139)
@@ -7000,7 +7000,7 @@ export const spacePaymentTrackerAddress = {
 export const spacePaymentTrackerConfig = {
   address: spacePaymentTrackerAddress,
   abi: spacePaymentTrackerAbi,
-} as const
+} as const;
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // TokenBackingVaultImplementation
@@ -7993,14 +7993,14 @@ export const tokenBackingVaultImplementationAbi = [
     outputs: [],
     stateMutability: 'nonpayable',
   },
-] as const
+] as const;
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0x9997C22f06F0aC67dF07C8Cb2A08562C53dD4E9f)
  */
 export const tokenBackingVaultImplementationAddress = {
   8453: '0x9997C22f06F0aC67dF07C8Cb2A08562C53dD4E9f',
-} as const
+} as const;
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0x9997C22f06F0aC67dF07C8Cb2A08562C53dD4E9f)
@@ -8008,7 +8008,7 @@ export const tokenBackingVaultImplementationAddress = {
 export const tokenBackingVaultImplementationConfig = {
   address: tokenBackingVaultImplementationAddress,
   abi: tokenBackingVaultImplementationAbi,
-} as const
+} as const;
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // TokenBalanceJoinImplementation
@@ -8237,14 +8237,14 @@ export const tokenBalanceJoinImplementationAbi = [
     outputs: [],
     stateMutability: 'payable',
   },
-] as const
+] as const;
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0x41cD69A3a3715B16598415df336a8Cc533CCAF76)
  */
 export const tokenBalanceJoinImplementationAddress = {
   8453: '0x41cD69A3a3715B16598415df336a8Cc533CCAF76',
-} as const
+} as const;
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0x41cD69A3a3715B16598415df336a8Cc533CCAF76)
@@ -8252,7 +8252,7 @@ export const tokenBalanceJoinImplementationAddress = {
 export const tokenBalanceJoinImplementationConfig = {
   address: tokenBalanceJoinImplementationAddress,
   abi: tokenBalanceJoinImplementationAbi,
-} as const
+} as const;
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // TokenVotingPowerImplementation
@@ -8552,14 +8552,14 @@ export const tokenVotingPowerImplementationAbi = [
     outputs: [],
     stateMutability: 'payable',
   },
-] as const
+] as const;
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0x3214DE1Eb858799Db626Bd9699e78c2E6E33D2BE)
  */
 export const tokenVotingPowerImplementationAddress = {
   8453: '0x3214DE1Eb858799Db626Bd9699e78c2E6E33D2BE',
-} as const
+} as const;
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0x3214DE1Eb858799Db626Bd9699e78c2E6E33D2BE)
@@ -8567,7 +8567,7 @@ export const tokenVotingPowerImplementationAddress = {
 export const tokenVotingPowerImplementationConfig = {
   address: tokenVotingPowerImplementationAddress,
   abi: tokenVotingPowerImplementationAbi,
-} as const
+} as const;
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // TransferHelper
@@ -8726,14 +8726,14 @@ export const transferHelperAbi = [
     outputs: [],
     stateMutability: 'nonpayable',
   },
-] as const
+] as const;
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0x479002F7602579203ffba3eE84ACC1BC5b0d6785)
  */
 export const transferHelperAddress = {
   8453: '0x479002F7602579203ffba3eE84ACC1BC5b0d6785',
-} as const
+} as const;
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0x479002F7602579203ffba3eE84ACC1BC5b0d6785)
@@ -8741,7 +8741,7 @@ export const transferHelperAddress = {
 export const transferHelperConfig = {
   address: transferHelperAddress,
   abi: transferHelperAbi,
-} as const
+} as const;
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // VoteDecayTokenVotingPowerImplementation
@@ -9052,14 +9052,14 @@ export const voteDecayTokenVotingPowerImplementationAbi = [
     outputs: [],
     stateMutability: 'payable',
   },
-] as const
+] as const;
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0x6dB5E05B21c68550B63a7404a3B68F81c159DAee)
  */
 export const voteDecayTokenVotingPowerImplementationAddress = {
   8453: '0x6dB5E05B21c68550B63a7404a3B68F81c159DAee',
-} as const
+} as const;
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0x6dB5E05B21c68550B63a7404a3B68F81c159DAee)
@@ -9067,7 +9067,7 @@ export const voteDecayTokenVotingPowerImplementationAddress = {
 export const voteDecayTokenVotingPowerImplementationConfig = {
   address: voteDecayTokenVotingPowerImplementationAddress,
   abi: voteDecayTokenVotingPowerImplementationAbi,
-} as const
+} as const;
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // VotingPowerDelegationImplementation
@@ -9414,14 +9414,14 @@ export const votingPowerDelegationImplementationAbi = [
     outputs: [{ name: '', internalType: 'bool', type: 'bool' }],
     stateMutability: 'view',
   },
-] as const
+] as const;
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0xc87546357EeFF8653cF058Be2BA850813e39cda0)
  */
 export const votingPowerDelegationImplementationAddress = {
   8453: '0xc87546357EeFF8653cF058Be2BA850813e39cda0',
-} as const
+} as const;
 
 /**
  * [__View Contract on Base Basescan__](https://basescan.org/address/0xc87546357EeFF8653cF058Be2BA850813e39cda0)
@@ -9429,4 +9429,4 @@ export const votingPowerDelegationImplementationAddress = {
 export const votingPowerDelegationImplementationConfig = {
   address: votingPowerDelegationImplementationAddress,
   abi: votingPowerDelegationImplementationAbi,
-} as const
+} as const;

--- a/packages/core/src/governance/client/hooks/useTokenBackingVaultMutations.web3.rsc.ts
+++ b/packages/core/src/governance/client/hooks/useTokenBackingVaultMutations.web3.rsc.ts
@@ -71,15 +71,8 @@ async function readTokenSymbol(address: `0x${string}`): Promise<string | null> {
   }
 }
 
-function shortAddress(addr: string): string {
-  if (addr.length <= 12) return addr;
-  return `${addr.slice(0, 6)}…${addr.slice(-4)}`;
-}
-
-function tokenLabel(symbol: string | null, address: string): string {
-  return symbol
-    ? `"${symbol}" (${shortAddress(address)})`
-    : `at ${shortAddress(address)}`;
+function tokenLabel(symbol: string | null): string {
+  return symbol ? `"${symbol}"` : 'one of the selected tokens';
 }
 
 interface TokenBackingVaultInput {
@@ -174,11 +167,33 @@ export const useTokenBackingVaultMutationsWeb3Rsc = ({
         ? currentVaultConfig.redeemEnabled
         : false;
 
-      // True when this proposal will create a brand new vault via addBackingToken.
-      // _getOrCreateVault sets minimumBackingBps, redemptionPrice/currencyFeed,
-      // maxRedemptionBps and maxRedemptionPeriodDays during creation, so the
+      // The contract accepts an empty-vault setup via the new createVault()
+      // entry point. Use it when the user wants to spin up a vault now and
+      // register backing collateral later.
+      const willCreateEmptyVault =
+        arg.activateVault && !vaultExists && validAddCollaterals.length === 0;
+
+      // True when this proposal will create a brand new vault.
+      // _getOrCreateVault initializes minimumBackingBps, redemptionPrice/currencyFeed,
+      // maxRedemptionBps and maxRedemptionPeriodDays at creation, so the
       // separate set* calls below would be redundant in that case.
-      const isCreatingNewVault = !vaultExists && willAddBacking;
+      const isCreatingNewVault =
+        !vaultExists && (willAddBacking || willCreateEmptyVault);
+
+      // Hoist the contract-shaped values that need to be visible both to
+      // the preflight (to decide whether tokenPrice() is mandatory) and
+      // the transaction-building block.
+      const redemptionPrice = arg.tokenPrice
+        ? BigInt(
+            Math.round(parseFloat(arg.tokenPrice) * Number(PRICE_PRECISION)),
+          )
+        : 0n;
+      const currencyFeed =
+        (arg.referenceCurrency as `0x${string}`) ??
+        (CURRENCY_FEEDS.USD as `0x${string}`);
+      const minimumBackingBps = BigInt((arg.minimumBackingPercent ?? 0) * 100);
+      const maxRedemptionBps = BigInt((arg.maxRedemptionPercent ?? 0) * 100);
+      const maxRedemptionPeriodDays = BigInt(arg.maxRedemptionPeriodDays ?? 0);
 
       // Read the vault's existing backing tokens once and reuse the resulting
       // Set for both the preflight (to skip already-configured tokens — those
@@ -215,31 +230,22 @@ export const useTokenBackingVaultMutationsWeb3Rsc = ({
       const validationErrors: string[] = [];
       const SUPPORTED_TOKENS_HINT = 'USDC, WETH, cbBTC, or EURC';
 
-      // Contract requires at least one backing token to create a vault.
-      if (
-        arg.activateVault &&
-        !vaultExists &&
-        validAddCollaterals.length === 0
-      ) {
-        validationErrors.push(
-          'Please add at least one backing token before creating the vault.',
-        );
-      }
-
-      // Space token must have tokenPrice() > 0 when creating a new vault.
-      if (isCreatingNewVault) {
+      // Space token must have tokenPrice() > 0 when creating a new vault,
+      // UNLESS a redemption-price override is being set in this proposal.
+      // The contract's _requirePriceableSpaceToken accepts either source.
+      if (isCreatingNewVault && redemptionPrice === 0n) {
         const [spaceTokenSymbol, spaceTokenPrice] = await Promise.all([
           readTokenSymbol(spaceToken),
           readTokenPrice(spaceToken),
         ]);
-        const label = tokenLabel(spaceTokenSymbol, spaceToken);
+        const label = tokenLabel(spaceTokenSymbol);
         if (spaceTokenPrice === null) {
           validationErrors.push(
-            `We couldn't read a price from the space token ${label}. Make sure it's a token issued by your space, then try again.`,
+            `We couldn't read a price from the space token ${label}. Either set a price on it or set a redemption price below, then try again.`,
           );
         } else if (spaceTokenPrice === 0n) {
           validationErrors.push(
-            `The space token ${label} doesn't have a price yet. Open the token settings, set its price, and then come back here to create the vault.`,
+            `The space token ${label} doesn't have a price yet. Either set its price, or set a redemption price below to use that instead.`,
           );
         }
       }
@@ -260,7 +266,7 @@ export const useTokenBackingVaultMutationsWeb3Rsc = ({
               readTokenSymbol(tokenAddr),
               readTokenPrice(tokenAddr),
             ]);
-            const label = tokenLabel(symbol, tokenAddr);
+            const label = tokenLabel(symbol);
             if (price === null) {
               validationErrors.push(
                 `We can't find a price source for the backing token ${label}. Pick a supported token (${SUPPORTED_TOKENS_HINT}) or a token issued by your space that already has a price set.`,
@@ -312,6 +318,28 @@ export const useTokenBackingVaultMutationsWeb3Rsc = ({
         }
       }
 
+      if (willCreateEmptyVault) {
+        // No backing tokens to register — call the dedicated createVault()
+        // entry point to spin up the empty vault with its config.
+        transactions.push({
+          target: vaultAddress,
+          value: 0n,
+          data: encodeFunctionData({
+            abi: tokenBackingVaultImplementationAbi,
+            functionName: 'createVault',
+            args: [
+              spaceId,
+              spaceToken,
+              minimumBackingBps,
+              redemptionPrice,
+              currencyFeed,
+              maxRedemptionBps,
+              maxRedemptionPeriodDays,
+            ],
+          }),
+        });
+      }
+
       if (willAddBacking && validAddCollaterals.length) {
         // Reuses `existingBackingTokens` populated above so the same
         // membership decision drives both preflight validation and the
@@ -359,26 +387,6 @@ export const useTokenBackingVaultMutationsWeb3Rsc = ({
             fundingAmounts.push(parseUnits(c.amount, decimals));
           }
 
-          const minimumBackingBps = BigInt(
-            (arg.minimumBackingPercent ?? 0) * 100,
-          );
-          const redemptionPrice = arg.tokenPrice
-            ? BigInt(
-                Math.round(
-                  parseFloat(arg.tokenPrice) * Number(PRICE_PRECISION),
-                ),
-              )
-            : 0n;
-          const currencyFeed =
-            (arg.referenceCurrency as `0x${string}`) ??
-            (CURRENCY_FEEDS.USD as `0x${string}`);
-          const maxRedemptionBps = BigInt(
-            (arg.maxRedemptionPercent ?? 0) * 100,
-          );
-          const maxRedemptionPeriodDays = BigInt(
-            arg.maxRedemptionPeriodDays ?? 0,
-          );
-
           transactions.push({
             target: vaultAddress,
             value: 0n,
@@ -404,7 +412,7 @@ export const useTokenBackingVaultMutationsWeb3Rsc = ({
       }
 
       if (
-        (willAddBacking || vaultExists) &&
+        (willAddBacking || willCreateEmptyVault || vaultExists) &&
         (!vaultExists || currentRedeemEnabled !== arg.enableRedemption)
       ) {
         transactions.push({
@@ -418,7 +426,10 @@ export const useTokenBackingVaultMutationsWeb3Rsc = ({
         });
       }
 
-      if (arg.redemptionStartDate && (willAddBacking || vaultExists)) {
+      if (
+        arg.redemptionStartDate &&
+        (willAddBacking || willCreateEmptyVault || vaultExists)
+      ) {
         const startDate = BigInt(
           Math.floor(arg.redemptionStartDate.getTime() / 1000),
         );
@@ -434,13 +445,9 @@ export const useTokenBackingVaultMutationsWeb3Rsc = ({
       }
 
       // The next three calls are redundant when creating a new vault —
-      // addBackingToken already passes the same values into _getOrCreateVault.
-      // Only emit them when updating an existing vault.
+      // addBackingToken / createVault already pass the same values into
+      // _getOrCreateVault. Only emit them when updating an existing vault.
       if (!isCreatingNewVault && arg.tokenPrice && arg.referenceCurrency) {
-        const redemptionPrice = BigInt(
-          Math.round(parseFloat(arg.tokenPrice) * Number(PRICE_PRECISION)),
-        );
-        const currencyFeed = arg.referenceCurrency as `0x${string}`;
         transactions.push({
           target: vaultAddress,
           value: 0n,
@@ -454,8 +461,8 @@ export const useTokenBackingVaultMutationsWeb3Rsc = ({
 
       if (
         !isCreatingNewVault &&
-        (arg.maxRedemptionPercent ?? 0) > 0 &&
-        (arg.maxRedemptionPeriodDays ?? 0) > 0
+        maxRedemptionBps > 0n &&
+        maxRedemptionPeriodDays > 0n
       ) {
         transactions.push({
           target: vaultAddress,
@@ -466,25 +473,21 @@ export const useTokenBackingVaultMutationsWeb3Rsc = ({
             args: [
               spaceId,
               spaceToken,
-              BigInt((arg.maxRedemptionPercent ?? 0) * 100),
-              BigInt(arg.maxRedemptionPeriodDays ?? 0),
+              maxRedemptionBps,
+              maxRedemptionPeriodDays,
             ],
           }),
         });
       }
 
-      if (!isCreatingNewVault && (arg.minimumBackingPercent ?? 0) > 0) {
+      if (!isCreatingNewVault && minimumBackingBps > 0n) {
         transactions.push({
           target: vaultAddress,
           value: 0n,
           data: encodeFunctionData({
             abi: tokenBackingVaultImplementationAbi,
             functionName: 'setMinimumBacking',
-            args: [
-              spaceId,
-              spaceToken,
-              BigInt((arg.minimumBackingPercent ?? 0) * 100),
-            ],
+            args: [spaceId, spaceToken, minimumBackingBps],
           }),
         });
       }

--- a/packages/core/src/governance/client/hooks/useTokenBackingVaultMutations.web3.rsc.ts
+++ b/packages/core/src/governance/client/hooks/useTokenBackingVaultMutations.web3.rsc.ts
@@ -37,6 +37,28 @@ interface BackingCollateralEntry {
   amount: string;
 }
 
+const tokenPriceAbi = [
+  {
+    inputs: [],
+    name: 'tokenPrice',
+    outputs: [{ type: 'uint256', name: '' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+] as const;
+
+async function readTokenPrice(address: `0x${string}`): Promise<bigint | null> {
+  try {
+    return (await publicClient.readContract({
+      address,
+      abi: tokenPriceAbi,
+      functionName: 'tokenPrice',
+    })) as bigint;
+  } catch {
+    return null;
+  }
+}
+
 interface TokenBackingVaultInput {
   spaceId: number;
   spaceToken: `0x${string}`;
@@ -128,6 +150,82 @@ export const useTokenBackingVaultMutationsWeb3Rsc = ({
       const currentRedeemEnabled = currentVaultConfig
         ? currentVaultConfig.redeemEnabled
         : false;
+
+      // True when this proposal will create a brand new vault via addBackingToken.
+      // _getOrCreateVault sets minimumBackingBps, redemptionPrice/currencyFeed,
+      // maxRedemptionBps and maxRedemptionPeriodDays during creation, so the
+      // separate set* calls below would be redundant in that case.
+      const isCreatingNewVault = !vaultExists && willAddBacking;
+
+      // ============================================================
+      //  Preflight validation — surfaces the contract-level reverts
+      //  with actionable messages BEFORE the user signs / votes.
+      //  Mirrors the require() checks in TokenBackingVaultImplementation
+      //  so failures don't end up as opaque "Execution failed" reverts
+      //  from the executor (it drops returndata).
+      // ============================================================
+      const validationErrors: string[] = [];
+
+      // Contract requires at least one backing token to create a vault.
+      if (
+        arg.activateVault &&
+        !vaultExists &&
+        validAddCollaterals.length === 0
+      ) {
+        validationErrors.push(
+          'At least one backing collateral is required to create a vault.',
+        );
+      }
+
+      // Space token must have tokenPrice() > 0 when creating a new vault.
+      if (isCreatingNewVault) {
+        const spaceTokenPrice = await readTokenPrice(spaceToken);
+        if (spaceTokenPrice === null) {
+          validationErrors.push(
+            'The selected space token does not expose tokenPrice(). Pick a Hypha-issued space token.',
+          );
+        } else if (spaceTokenPrice === 0n) {
+          validationErrors.push(
+            'The selected space token has no price set. Update the token to set a price greater than 0 before creating a backing vault.',
+          );
+        }
+      }
+
+      // Backing tokens without a Chainlink feed mapping must expose
+      // tokenPrice() > 0 (the contract reads it directly).
+      if (validAddCollaterals.length > 0) {
+        for (const c of validAddCollaterals) {
+          const hasFeed = Boolean(
+            ASSET_PRICE_FEED_BY_TOKEN[c.token.toLowerCase()],
+          );
+          if (hasFeed) continue;
+          const price = await readTokenPrice(c.token as `0x${string}`);
+          if (price === null) {
+            validationErrors.push(
+              `Backing token ${c.token} has no Chainlink price feed mapping and does not expose tokenPrice(). Pick a supported token (e.g. USDC, WETH, cbBTC, EURC) or a Hypha-issued token with a price set.`,
+            );
+          } else if (price === 0n) {
+            validationErrors.push(
+              `Backing token ${c.token} has no price set. Set a tokenPrice greater than 0 on the token, or pick a token with a Chainlink price feed.`,
+            );
+          }
+        }
+      }
+
+      // Maximum-redemption cap requires a non-zero rolling period
+      // (matches `Period must be > 0 when cap is set` in the contract).
+      if (
+        (arg.maxRedemptionPercent ?? 0) > 0 &&
+        (arg.maxRedemptionPeriodDays ?? 0) <= 0
+      ) {
+        validationErrors.push(
+          'Maximum Redemption % is set, but the rolling period (days) is missing. Pick a period or set Maximum Redemption % to 0.',
+        );
+      }
+
+      if (validationErrors.length > 0) {
+        throw new Error(validationErrors.join('\n'));
+      }
 
       // Approve Vault contract to spend tokens on behalf of the Space.
       // Must be the first transactions executed so addBackingToken can transfer tokens.
@@ -285,7 +383,10 @@ export const useTokenBackingVaultMutationsWeb3Rsc = ({
         });
       }
 
-      if (arg.tokenPrice && arg.referenceCurrency) {
+      // The next three calls are redundant when creating a new vault —
+      // addBackingToken already passes the same values into _getOrCreateVault.
+      // Only emit them when updating an existing vault.
+      if (!isCreatingNewVault && arg.tokenPrice && arg.referenceCurrency) {
         const redemptionPrice = BigInt(
           Math.round(parseFloat(arg.tokenPrice) * Number(PRICE_PRECISION)),
         );
@@ -302,6 +403,7 @@ export const useTokenBackingVaultMutationsWeb3Rsc = ({
       }
 
       if (
+        !isCreatingNewVault &&
         (arg.maxRedemptionPercent ?? 0) > 0 &&
         (arg.maxRedemptionPeriodDays ?? 0) > 0
       ) {
@@ -321,7 +423,7 @@ export const useTokenBackingVaultMutationsWeb3Rsc = ({
         });
       }
 
-      if ((arg.minimumBackingPercent ?? 0) > 0) {
+      if (!isCreatingNewVault && (arg.minimumBackingPercent ?? 0) > 0) {
         transactions.push({
           target: vaultAddress,
           value: 0n,

--- a/packages/core/src/governance/client/hooks/useTokenBackingVaultMutations.web3.rsc.ts
+++ b/packages/core/src/governance/client/hooks/useTokenBackingVaultMutations.web3.rsc.ts
@@ -180,6 +180,31 @@ export const useTokenBackingVaultMutationsWeb3Rsc = ({
       // separate set* calls below would be redundant in that case.
       const isCreatingNewVault = !vaultExists && willAddBacking;
 
+      // Read the vault's existing backing tokens once and reuse the resulting
+      // Set for both the preflight (to skip already-configured tokens — those
+      // get added via `addBacking`, which doesn't re-validate token price) and
+      // the transaction-building block below. Empty when the vault doesn't
+      // exist yet, so no RPC call is needed in that case.
+      let existingBackingTokens = new Set<string>();
+      if (vaultExists && validAddCollaterals.length > 0) {
+        const configuredBackingTokens = await publicClient.readContract({
+          address: vaultAddress,
+          abi: tokenBackingVaultImplementationAbi,
+          functionName: 'getBackingTokens',
+          args: [spaceId, spaceToken],
+        });
+        existingBackingTokens = new Set(
+          configuredBackingTokens.map((token) => token.toLowerCase()),
+        );
+      }
+
+      // Only tokens passed to `addBackingToken` go through the contract's
+      // price validation (see TokenBackingVaultImplementation). Tokens added
+      // via `addBacking` already passed validation when first registered.
+      const collateralsBeingRegistered = validAddCollaterals.filter(
+        (c) => !existingBackingTokens.has(c.token.toLowerCase()),
+      );
+
       // ============================================================
       //  Preflight validation — surfaces the contract-level reverts
       //  with actionable messages BEFORE the user signs / votes.
@@ -220,10 +245,12 @@ export const useTokenBackingVaultMutationsWeb3Rsc = ({
       }
 
       // Backing tokens without a Chainlink feed mapping must expose
-      // tokenPrice() > 0 (the contract reads it directly).
-      if (validAddCollaterals.length > 0) {
+      // tokenPrice() > 0 (the contract reads it directly inside
+      // addBackingToken). Skip tokens already configured on the vault —
+      // those go through addBacking and won't re-trigger price validation.
+      if (collateralsBeingRegistered.length > 0) {
         await Promise.all(
-          validAddCollaterals.map(async (c) => {
+          collateralsBeingRegistered.map(async (c) => {
             const hasFeed = Boolean(
               ASSET_PRICE_FEED_BY_TOKEN[c.token.toLowerCase()],
             );
@@ -286,25 +313,13 @@ export const useTokenBackingVaultMutationsWeb3Rsc = ({
       }
 
       if (willAddBacking && validAddCollaterals.length) {
-        let existingBackingTokens = new Set<string>();
-        if (vaultExists) {
-          const configuredBackingTokens = await publicClient.readContract({
-            address: vaultAddress,
-            abi: tokenBackingVaultImplementationAbi,
-            functionName: 'getBackingTokens',
-            args: [spaceId, spaceToken],
-          });
-          existingBackingTokens = new Set(
-            configuredBackingTokens.map((token) => token.toLowerCase()),
-          );
-        }
-
+        // Reuses `existingBackingTokens` populated above so the same
+        // membership decision drives both preflight validation and the
+        // addBacking-vs-addBackingToken split below.
         const collateralsForAddBacking = validAddCollaterals.filter((c) =>
           existingBackingTokens.has(c.token.toLowerCase()),
         );
-        const collateralsForAddBackingToken = validAddCollaterals.filter(
-          (c) => !existingBackingTokens.has(c.token.toLowerCase()),
-        );
+        const collateralsForAddBackingToken = collateralsBeingRegistered;
 
         if (collateralsForAddBacking.length > 0) {
           const backingTokens = collateralsForAddBacking.map(

--- a/packages/core/src/governance/client/hooks/useTokenBackingVaultMutations.web3.rsc.ts
+++ b/packages/core/src/governance/client/hooks/useTokenBackingVaultMutations.web3.rsc.ts
@@ -59,6 +59,29 @@ async function readTokenPrice(address: `0x${string}`): Promise<bigint | null> {
   }
 }
 
+async function readTokenSymbol(address: `0x${string}`): Promise<string | null> {
+  try {
+    return (await publicClient.readContract({
+      address,
+      abi: erc20Abi,
+      functionName: 'symbol',
+    })) as string;
+  } catch {
+    return null;
+  }
+}
+
+function shortAddress(addr: string): string {
+  if (addr.length <= 12) return addr;
+  return `${addr.slice(0, 6)}…${addr.slice(-4)}`;
+}
+
+function tokenLabel(symbol: string | null, address: string): string {
+  return symbol
+    ? `"${symbol}" (${shortAddress(address)})`
+    : `at ${shortAddress(address)}`;
+}
+
 interface TokenBackingVaultInput {
   spaceId: number;
   spaceToken: `0x${string}`;
@@ -165,6 +188,7 @@ export const useTokenBackingVaultMutationsWeb3Rsc = ({
       //  from the executor (it drops returndata).
       // ============================================================
       const validationErrors: string[] = [];
+      const SUPPORTED_TOKENS_HINT = 'USDC, WETH, cbBTC, or EURC';
 
       // Contract requires at least one backing token to create a vault.
       if (
@@ -173,20 +197,24 @@ export const useTokenBackingVaultMutationsWeb3Rsc = ({
         validAddCollaterals.length === 0
       ) {
         validationErrors.push(
-          'At least one backing collateral is required to create a vault.',
+          'Please add at least one backing token before creating the vault.',
         );
       }
 
       // Space token must have tokenPrice() > 0 when creating a new vault.
       if (isCreatingNewVault) {
-        const spaceTokenPrice = await readTokenPrice(spaceToken);
+        const [spaceTokenSymbol, spaceTokenPrice] = await Promise.all([
+          readTokenSymbol(spaceToken),
+          readTokenPrice(spaceToken),
+        ]);
+        const label = tokenLabel(spaceTokenSymbol, spaceToken);
         if (spaceTokenPrice === null) {
           validationErrors.push(
-            'The selected space token does not expose tokenPrice(). Pick a Hypha-issued space token.',
+            `We couldn't read a price from the space token ${label}. Make sure it's a token issued by your space, then try again.`,
           );
         } else if (spaceTokenPrice === 0n) {
           validationErrors.push(
-            'The selected space token has no price set. Update the token to set a price greater than 0 before creating a backing vault.',
+            `The space token ${label} doesn't have a price yet. Open the token settings, set its price, and then come back here to create the vault.`,
           );
         }
       }
@@ -194,22 +222,29 @@ export const useTokenBackingVaultMutationsWeb3Rsc = ({
       // Backing tokens without a Chainlink feed mapping must expose
       // tokenPrice() > 0 (the contract reads it directly).
       if (validAddCollaterals.length > 0) {
-        for (const c of validAddCollaterals) {
-          const hasFeed = Boolean(
-            ASSET_PRICE_FEED_BY_TOKEN[c.token.toLowerCase()],
-          );
-          if (hasFeed) continue;
-          const price = await readTokenPrice(c.token as `0x${string}`);
-          if (price === null) {
-            validationErrors.push(
-              `Backing token ${c.token} has no Chainlink price feed mapping and does not expose tokenPrice(). Pick a supported token (e.g. USDC, WETH, cbBTC, EURC) or a Hypha-issued token with a price set.`,
+        await Promise.all(
+          validAddCollaterals.map(async (c) => {
+            const hasFeed = Boolean(
+              ASSET_PRICE_FEED_BY_TOKEN[c.token.toLowerCase()],
             );
-          } else if (price === 0n) {
-            validationErrors.push(
-              `Backing token ${c.token} has no price set. Set a tokenPrice greater than 0 on the token, or pick a token with a Chainlink price feed.`,
-            );
-          }
-        }
+            if (hasFeed) return;
+            const tokenAddr = c.token as `0x${string}`;
+            const [symbol, price] = await Promise.all([
+              readTokenSymbol(tokenAddr),
+              readTokenPrice(tokenAddr),
+            ]);
+            const label = tokenLabel(symbol, tokenAddr);
+            if (price === null) {
+              validationErrors.push(
+                `We can't find a price source for the backing token ${label}. Pick a supported token (${SUPPORTED_TOKENS_HINT}) or a token issued by your space that already has a price set.`,
+              );
+            } else if (price === 0n) {
+              validationErrors.push(
+                `The backing token ${label} doesn't have a price yet. Set its price first, or pick a supported token (${SUPPORTED_TOKENS_HINT}) instead.`,
+              );
+            }
+          }),
+        );
       }
 
       // Maximum-redemption cap requires a non-zero rolling period
@@ -219,7 +254,7 @@ export const useTokenBackingVaultMutationsWeb3Rsc = ({
         (arg.maxRedemptionPeriodDays ?? 0) <= 0
       ) {
         validationErrors.push(
-          'Maximum Redemption % is set, but the rolling period (days) is missing. Pick a period or set Maximum Redemption % to 0.',
+          'Please choose a redemption period to go with the maximum redemption percentage, or set the percentage to 0 to remove the limit.',
         );
       }
 

--- a/packages/core/src/governance/client/hooks/useTokenBackingVaultMutations.web3.rsc.ts
+++ b/packages/core/src/governance/client/hooks/useTokenBackingVaultMutations.web3.rsc.ts
@@ -105,6 +105,138 @@ function parseUnits(value: string, decimals: number): bigint {
   return BigInt(padded || '0');
 }
 
+/**
+ * Pure preflight validation. Mirrors the require() checks in
+ * TokenBackingVaultImplementation so failures don't end up as opaque
+ * "Execution failed" reverts from the executor (which drops returndata).
+ *
+ * Exported so the form layer can run the validation BEFORE the
+ * orchestrator starts any task — that way a validation failure does not
+ * pop the loading-backdrop modal; it just surfaces inline on the form.
+ *
+ * Throws an Error whose message is a `\n`-joined list of human-readable
+ * problems when one or more checks fail. Resolves with `void` otherwise.
+ */
+export async function preflightTokenBackingVault(
+  arg: TokenBackingVaultInput,
+): Promise<void> {
+  const vaultAddress =
+    tokenBackingVaultImplementationAddress[
+      chainId as keyof typeof tokenBackingVaultImplementationAddress
+    ];
+
+  const spaceId = BigInt(arg.spaceId);
+  const spaceToken = arg.spaceToken;
+  const validAddCollaterals =
+    arg.addCollaterals?.filter(
+      (c) => c.token && Number.parseFloat(c.amount) > 0,
+    ) ?? [];
+  const willAddBacking = arg.activateVault && validAddCollaterals.length > 0;
+
+  const vaultExists = await publicClient.readContract({
+    address: vaultAddress,
+    abi: tokenBackingVaultImplementationAbi,
+    functionName: 'vaultExists',
+    args: [spaceId, spaceToken],
+  });
+
+  const willCreateEmptyVault =
+    arg.activateVault && !vaultExists && validAddCollaterals.length === 0;
+  const isCreatingNewVault =
+    !vaultExists && (willAddBacking || willCreateEmptyVault);
+
+  const redemptionPrice = arg.tokenPrice
+    ? BigInt(Math.round(parseFloat(arg.tokenPrice) * Number(PRICE_PRECISION)))
+    : 0n;
+
+  let existingBackingTokens = new Set<string>();
+  if (vaultExists && validAddCollaterals.length > 0) {
+    const configuredBackingTokens = await publicClient.readContract({
+      address: vaultAddress,
+      abi: tokenBackingVaultImplementationAbi,
+      functionName: 'getBackingTokens',
+      args: [spaceId, spaceToken],
+    });
+    existingBackingTokens = new Set(
+      configuredBackingTokens.map((token) => token.toLowerCase()),
+    );
+  }
+
+  // Only tokens passed to `addBackingToken` go through the contract's
+  // price validation. Tokens added via `addBacking` already passed
+  // validation when first registered.
+  const collateralsBeingRegistered = validAddCollaterals.filter(
+    (c) => !existingBackingTokens.has(c.token.toLowerCase()),
+  );
+
+  const validationErrors: string[] = [];
+  const SUPPORTED_TOKENS_HINT = 'USDC, WETH, cbBTC, or EURC';
+
+  // Space token must have tokenPrice() > 0 when creating a new vault,
+  // UNLESS a redemption-price override is being set in this proposal
+  // (the contract's _requirePriceableSpaceToken accepts either source).
+  if (isCreatingNewVault && redemptionPrice === 0n) {
+    const [spaceTokenSymbol, spaceTokenPrice] = await Promise.all([
+      readTokenSymbol(spaceToken),
+      readTokenPrice(spaceToken),
+    ]);
+    const label = tokenLabel(spaceTokenSymbol);
+    if (spaceTokenPrice === null) {
+      validationErrors.push(
+        `We couldn't read a price from the space token ${label}. Either set a price on it or set a redemption price below, then try again.`,
+      );
+    } else if (spaceTokenPrice === 0n) {
+      validationErrors.push(
+        `The space token ${label} doesn't have a price yet. Either set its price, or set a redemption price below to use that instead.`,
+      );
+    }
+  }
+
+  // Backing tokens without a Chainlink feed mapping must expose
+  // tokenPrice() > 0 (the contract reads it directly inside
+  // addBackingToken).
+  if (collateralsBeingRegistered.length > 0) {
+    await Promise.all(
+      collateralsBeingRegistered.map(async (c) => {
+        const hasFeed = Boolean(
+          ASSET_PRICE_FEED_BY_TOKEN[c.token.toLowerCase()],
+        );
+        if (hasFeed) return;
+        const tokenAddr = c.token as `0x${string}`;
+        const [symbol, price] = await Promise.all([
+          readTokenSymbol(tokenAddr),
+          readTokenPrice(tokenAddr),
+        ]);
+        const label = tokenLabel(symbol);
+        if (price === null) {
+          validationErrors.push(
+            `We can't find a price source for the backing token ${label}. Pick a supported token (${SUPPORTED_TOKENS_HINT}) or a token issued by your space that already has a price set.`,
+          );
+        } else if (price === 0n) {
+          validationErrors.push(
+            `The backing token ${label} doesn't have a price yet. Set its price first, or pick a supported token (${SUPPORTED_TOKENS_HINT}) instead.`,
+          );
+        }
+      }),
+    );
+  }
+
+  // Maximum-redemption cap requires a non-zero rolling period
+  // (matches `Period must be > 0 when cap is set` in the contract).
+  if (
+    (arg.maxRedemptionPercent ?? 0) > 0 &&
+    (arg.maxRedemptionPeriodDays ?? 0) <= 0
+  ) {
+    validationErrors.push(
+      'Please choose a redemption period to go with the maximum redemption percentage, or set the percentage to 0 to remove the limit.',
+    );
+  }
+
+  if (validationErrors.length > 0) {
+    throw new Error(validationErrors.join('\n'));
+  }
+}
+
 export const useTokenBackingVaultMutationsWeb3Rsc = ({
   proposalSlug,
 }: {
@@ -220,80 +352,12 @@ export const useTokenBackingVaultMutationsWeb3Rsc = ({
         (c) => !existingBackingTokens.has(c.token.toLowerCase()),
       );
 
-      // ============================================================
-      //  Preflight validation — surfaces the contract-level reverts
-      //  with actionable messages BEFORE the user signs / votes.
-      //  Mirrors the require() checks in TokenBackingVaultImplementation
-      //  so failures don't end up as opaque "Execution failed" reverts
-      //  from the executor (it drops returndata).
-      // ============================================================
-      const validationErrors: string[] = [];
-      const SUPPORTED_TOKENS_HINT = 'USDC, WETH, cbBTC, or EURC';
-
-      // Space token must have tokenPrice() > 0 when creating a new vault,
-      // UNLESS a redemption-price override is being set in this proposal.
-      // The contract's _requirePriceableSpaceToken accepts either source.
-      if (isCreatingNewVault && redemptionPrice === 0n) {
-        const [spaceTokenSymbol, spaceTokenPrice] = await Promise.all([
-          readTokenSymbol(spaceToken),
-          readTokenPrice(spaceToken),
-        ]);
-        const label = tokenLabel(spaceTokenSymbol);
-        if (spaceTokenPrice === null) {
-          validationErrors.push(
-            `We couldn't read a price from the space token ${label}. Either set a price on it or set a redemption price below, then try again.`,
-          );
-        } else if (spaceTokenPrice === 0n) {
-          validationErrors.push(
-            `The space token ${label} doesn't have a price yet. Either set its price, or set a redemption price below to use that instead.`,
-          );
-        }
-      }
-
-      // Backing tokens without a Chainlink feed mapping must expose
-      // tokenPrice() > 0 (the contract reads it directly inside
-      // addBackingToken). Skip tokens already configured on the vault —
-      // those go through addBacking and won't re-trigger price validation.
-      if (collateralsBeingRegistered.length > 0) {
-        await Promise.all(
-          collateralsBeingRegistered.map(async (c) => {
-            const hasFeed = Boolean(
-              ASSET_PRICE_FEED_BY_TOKEN[c.token.toLowerCase()],
-            );
-            if (hasFeed) return;
-            const tokenAddr = c.token as `0x${string}`;
-            const [symbol, price] = await Promise.all([
-              readTokenSymbol(tokenAddr),
-              readTokenPrice(tokenAddr),
-            ]);
-            const label = tokenLabel(symbol);
-            if (price === null) {
-              validationErrors.push(
-                `We can't find a price source for the backing token ${label}. Pick a supported token (${SUPPORTED_TOKENS_HINT}) or a token issued by your space that already has a price set.`,
-              );
-            } else if (price === 0n) {
-              validationErrors.push(
-                `The backing token ${label} doesn't have a price yet. Set its price first, or pick a supported token (${SUPPORTED_TOKENS_HINT}) instead.`,
-              );
-            }
-          }),
-        );
-      }
-
-      // Maximum-redemption cap requires a non-zero rolling period
-      // (matches `Period must be > 0 when cap is set` in the contract).
-      if (
-        (arg.maxRedemptionPercent ?? 0) > 0 &&
-        (arg.maxRedemptionPeriodDays ?? 0) <= 0
-      ) {
-        validationErrors.push(
-          'Please choose a redemption period to go with the maximum redemption percentage, or set the percentage to 0 to remove the limit.',
-        );
-      }
-
-      if (validationErrors.length > 0) {
-        throw new Error(validationErrors.join('\n'));
-      }
+      // Defense-in-depth: the form layer also runs `preflightTokenBackingVault`
+      // BEFORE invoking the orchestrator (so validation failures don't open
+      // the loading-backdrop modal). We re-run it here because the on-chain
+      // state read by the preflight (vault existence, configured backings,
+      // token prices) could in theory shift between submit and execution.
+      await preflightTokenBackingVault(arg);
 
       // Approve Vault contract to spend tokens on behalf of the Space.
       // Must be the first transactions executed so addBackingToken can transfer tokens.

--- a/packages/epics/src/governance/components/create-proposal-token-backing-vault-form.tsx
+++ b/packages/epics/src/governance/components/create-proposal-token-backing-vault-form.tsx
@@ -74,19 +74,24 @@ export const CreateProposalTokenBackingVaultForm = ({
   // Aggregate every actionable message from the orchestration chain
   // (preflight validation, web2 mutation, web3 wait, etc.) so the user
   // sees the actual revert reason instead of just a generic "Oh snap".
+  // The preflight hook joins multiple problems with `\n`, so split each
+  // raw message into individual lines to render them as separate bullets.
   const errorMessages = React.useMemo(() => {
     const seen = new Set<string>();
     const messages: string[] = [];
+    const pushLines = (raw: string) => {
+      for (const line of raw.split('\n')) {
+        const trimmed = line.trim();
+        if (!trimmed || seen.has(trimmed)) continue;
+        seen.add(trimmed);
+        messages.push(trimmed);
+      }
+    };
     for (const err of errors) {
       if (!err) continue;
-      const msg = err instanceof Error ? err.message : String(err);
-      if (!msg || seen.has(msg)) continue;
-      seen.add(msg);
-      messages.push(msg);
+      pushLines(err instanceof Error ? err.message : String(err));
     }
-    if (formError && !seen.has(formError)) {
-      messages.push(formError);
-    }
+    if (formError) pushLines(formError);
     return messages;
   }, [errors, formError]);
 
@@ -132,11 +137,31 @@ export const CreateProposalTokenBackingVaultForm = ({
 
   const handleCreate = async (data: FormValues) => {
     setFormError(null);
+
+    // Runtime guards. The TS types allow `null | undefined` and we previously
+    // cast with `as number`, which silently passed garbage to the orchestrator.
+    // - Missing `spaceId` would blow up the web2 schema parse with a cryptic Zod error.
+    // - Missing `web3SpaceId` is worse: the orchestrator silently SKIPS the web3 step
+    //   while the web2 agreement still gets created, so the user thinks the proposal
+    //   exists on-chain when it doesn't. Catch both up-front with a friendly message.
+    if (typeof spaceId !== 'number' || !Number.isFinite(spaceId)) {
+      setFormError(
+        tAgreementFlow('plugins.tokenBackingVault.errors.spaceNotReady'),
+      );
+      return;
+    }
+    if (typeof web3SpaceId !== 'number' || !Number.isFinite(web3SpaceId)) {
+      setFormError(
+        tAgreementFlow('plugins.tokenBackingVault.errors.spaceNotOnChain'),
+      );
+      return;
+    }
+
     try {
       await createTokenBackingVault({
         ...data,
-        spaceId: spaceId as number,
-        web3SpaceId: web3SpaceId as number,
+        spaceId,
+        web3SpaceId,
       });
     } catch (err) {
       // SWR mutation already surfaces the error via `errors`, but catching here

--- a/packages/epics/src/governance/components/create-proposal-token-backing-vault-form.tsx
+++ b/packages/epics/src/governance/components/create-proposal-token-backing-vault-form.tsx
@@ -7,6 +7,7 @@ import {
   useMe,
   useJwt,
   useCreateTokenBackingVaultOrchestrator,
+  preflightTokenBackingVault,
   CURRENCY_FEED_OPTIONS,
 } from '@hypha-platform/core/client';
 import { z } from 'zod';
@@ -157,6 +158,34 @@ export const CreateProposalTokenBackingVaultForm = ({
       return;
     }
 
+    // Run the on-chain preflight BEFORE invoking the orchestrator. If we let
+    // the orchestrator start its first task, the loading-backdrop modal opens
+    // immediately and validation failures appear as a full-screen overlay.
+    // Surfacing them inline here keeps the user on the form with the same
+    // controls visible, matching the rest of the validation experience.
+    try {
+      await preflightTokenBackingVault({
+        spaceId: web3SpaceId,
+        spaceToken: data.tokenBackingVault.spaceToken as `0x${string}`,
+        activateVault: data.tokenBackingVault.activateVault,
+        enableRedemption: data.tokenBackingVault.enableRedemption,
+        addCollaterals: data.tokenBackingVault.addCollaterals,
+        removeCollaterals: data.tokenBackingVault.removeCollaterals,
+        referenceCurrency: data.tokenBackingVault.referenceCurrency,
+        tokenPrice: data.tokenBackingVault.tokenPrice,
+        minimumBackingPercent: data.tokenBackingVault.minimumBackingPercent,
+        maxRedemptionPercent: data.tokenBackingVault.maxRedemptionPercent,
+        maxRedemptionPeriodDays: data.tokenBackingVault.maxRedemptionPeriodDays,
+        redemptionStartDate: data.tokenBackingVault.redemptionStartDate,
+        enableAdvancedRedemptionControls:
+          data.tokenBackingVault.enableAdvancedRedemptionControls,
+        redemptionWhitelist: data.tokenBackingVault.redemptionWhitelist,
+      });
+    } catch (err) {
+      setFormError(err instanceof Error ? err.message : String(err));
+      return;
+    }
+
     try {
       await createTokenBackingVault({
         ...data,
@@ -225,7 +254,7 @@ export const CreateProposalTokenBackingVaultForm = ({
           <Separator />
           <div className="flex flex-col gap-2">
             {formError && (
-              <div className="text-error-11 text-2 font-medium">
+              <div className="text-error-11 text-2 font-medium whitespace-pre-line">
                 {formError}
               </div>
             )}

--- a/packages/epics/src/governance/components/create-proposal-token-backing-vault-form.tsx
+++ b/packages/epics/src/governance/components/create-proposal-token-backing-vault-form.tsx
@@ -181,9 +181,8 @@ export const CreateProposalTokenBackingVaultForm = ({
       message={
         isError ? (
           <div className="flex flex-col gap-3 max-w-lg text-left">
-            <div className="font-medium">{tSpaces('errorOhSnap')}</div>
             {errorMessages.length > 0 && (
-              <ul className="text-2 text-neutral-11 list-disc pl-4 space-y-1 whitespace-pre-wrap break-words">
+              <ul className="text-2 text-neutral-11 list-disc pl-4 space-y-2 whitespace-pre-wrap break-words">
                 {errorMessages.map((msg, i) => (
                   <li key={i}>{msg}</li>
                 ))}

--- a/packages/epics/src/governance/components/create-proposal-token-backing-vault-form.tsx
+++ b/packages/epics/src/governance/components/create-proposal-token-backing-vault-form.tsx
@@ -63,12 +63,32 @@ export const CreateProposalTokenBackingVaultForm = ({
     isError,
     isPending,
     progress,
+    errors,
   } = useCreateTokenBackingVaultOrchestrator({
     authToken: jwt,
     config,
   });
 
   const [formError, setFormError] = React.useState<string | null>(null);
+
+  // Aggregate every actionable message from the orchestration chain
+  // (preflight validation, web2 mutation, web3 wait, etc.) so the user
+  // sees the actual revert reason instead of just a generic "Oh snap".
+  const errorMessages = React.useMemo(() => {
+    const seen = new Set<string>();
+    const messages: string[] = [];
+    for (const err of errors) {
+      if (!err) continue;
+      const msg = err instanceof Error ? err.message : String(err);
+      if (!msg || seen.has(msg)) continue;
+      seen.add(msg);
+      messages.push(msg);
+    }
+    if (formError && !seen.has(formError)) {
+      messages.push(formError);
+    }
+    return messages;
+  }, [errors, formError]);
 
   const formRef = React.useRef<HTMLFormElement>(null);
   const form = useForm<FormValues>({
@@ -112,11 +132,18 @@ export const CreateProposalTokenBackingVaultForm = ({
 
   const handleCreate = async (data: FormValues) => {
     setFormError(null);
-    await createTokenBackingVault({
-      ...data,
-      spaceId: spaceId as number,
-      web3SpaceId: web3SpaceId as number,
-    });
+    try {
+      await createTokenBackingVault({
+        ...data,
+        spaceId: spaceId as number,
+        web3SpaceId: web3SpaceId as number,
+      });
+    } catch (err) {
+      // SWR mutation already surfaces the error via `errors`, but catching here
+      // prevents an "Uncaught (in promise)" warning in the console and gives
+      // us a fallback message in case the orchestrator's error channel is empty.
+      setFormError(err instanceof Error ? err.message : String(err));
+    }
   };
 
   return (
@@ -128,8 +155,15 @@ export const CreateProposalTokenBackingVaultForm = ({
       isLoading={isPending}
       message={
         isError ? (
-          <div className="flex flex-col">
-            <div>{tSpaces('errorOhSnap')}</div>
+          <div className="flex flex-col gap-3 max-w-lg text-left">
+            <div className="font-medium">{tSpaces('errorOhSnap')}</div>
+            {errorMessages.length > 0 && (
+              <ul className="text-2 text-neutral-11 list-disc pl-4 space-y-1 whitespace-pre-wrap break-words">
+                {errorMessages.map((msg, i) => (
+                  <li key={i}>{msg}</li>
+                ))}
+              </ul>
+            )}
             <Button onClick={reset}>{tSpaces('reset')}</Button>
           </div>
         ) : (

--- a/packages/epics/src/treasury/components/assets/vaults-section.tsx
+++ b/packages/epics/src/treasury/components/assets/vaults-section.tsx
@@ -8,7 +8,7 @@ import { formatCurrencyValue } from '@hypha-platform/ui-utils';
 import { Empty } from '../../../common';
 import { useParams } from 'next/navigation';
 import { Locale } from '@hypha-platform/i18n';
-import { Button } from '@hypha-platform/ui';
+import { Button, Separator } from '@hypha-platform/ui';
 import Link from 'next/link';
 import { useAuthentication } from '@hypha-platform/authentication';
 import { useIsDelegate, useSpaceBySlug } from '@hypha-platform/core/client';
@@ -115,40 +115,49 @@ export const VaultsSection: FC = () => {
     return null;
   }
 
+  // Treasury page stacks Rewards / Vaults / Balance with only `gap-6` between
+  // them. When the vault block is present the three regions visually merge —
+  // the user reported "everything seems to mush on top of each other". Render
+  // a divider above and below this section (only when it renders) so the
+  // separations show up exclusively when there's a vault to break apart.
   return (
-    <div className="flex flex-col w-full justify-center items-center gap-6">
-      <div className="w-full">
-        <h3 className="text-4">{tTreasury('vaultsSection.title')}</h3>
+    <>
+      <Separator />
+      <div className="flex flex-col w-full justify-center items-center gap-6">
+        <div className="w-full">
+          <h3 className="text-4">{tTreasury('vaultsSection.title')}</h3>
+        </div>
+        {vaults.map((vault, index) => (
+          <SingleVaultSection
+            key={`${vault.spaceToken}-${index}`}
+            vault={vault}
+            isLoading={isLoading}
+            lang={lang}
+            canUpdateVault={canUpdateVault}
+            updateVaultHref={updateVaultHref}
+            updateDisabledTitle={updateDisabledTitle}
+          />
+        ))}
+        {isLoading && vaults.length === 0 && (
+          <SingleVaultSection
+            vault={{
+              spaceToken: '',
+              tokenName: '',
+              tokenSymbol: '',
+              tokenIcon: '',
+              totalUsd: 0,
+              backingPercent: 0,
+              collaterals: [],
+            }}
+            isLoading
+            lang={lang}
+            canUpdateVault={canUpdateVault}
+            updateVaultHref={updateVaultHref}
+            updateDisabledTitle={updateDisabledTitle}
+          />
+        )}
       </div>
-      {vaults.map((vault, index) => (
-        <SingleVaultSection
-          key={`${vault.spaceToken}-${index}`}
-          vault={vault}
-          isLoading={isLoading}
-          lang={lang}
-          canUpdateVault={canUpdateVault}
-          updateVaultHref={updateVaultHref}
-          updateDisabledTitle={updateDisabledTitle}
-        />
-      ))}
-      {isLoading && vaults.length === 0 && (
-        <SingleVaultSection
-          vault={{
-            spaceToken: '',
-            tokenName: '',
-            tokenSymbol: '',
-            tokenIcon: '',
-            totalUsd: 0,
-            backingPercent: 0,
-            collaterals: [],
-          }}
-          isLoading
-          lang={lang}
-          canUpdateVault={canUpdateVault}
-          updateVaultHref={updateVaultHref}
-          updateDisabledTitle={updateDisabledTitle}
-        />
-      )}
-    </div>
+      <Separator />
+    </>
   );
 };

--- a/packages/i18n/src/messages/de.json
+++ b/packages/i18n/src/messages/de.json
@@ -1088,7 +1088,11 @@
         "leaveBlankUseTokenPrice": "Leer lassen, um den Token-Preis zu verwenden ({price} {currency})",
         "leaveBlankForTokenContractPrice": "Leer lassen, um den Token-Vertragspreis zu verwenden",
         "add": "Hinzufügen",
-        "remove": "Entfernen"
+        "remove": "Entfernen",
+        "errors": {
+          "spaceNotReady": "Dein Space ist noch nicht vollständig geladen. Bitte lade die Seite neu und versuche es erneut.",
+          "spaceNotOnChain": "Dein Space wurde noch nicht on-chain veröffentlicht, daher kann kein Backing Vault erstellt werden. Veröffentliche den Space zuerst und komm dann zurück, um den Vault zu erstellen."
+        }
       },
       "issueNewToken": {
         "general": {

--- a/packages/i18n/src/messages/en.json
+++ b/packages/i18n/src/messages/en.json
@@ -1089,7 +1089,11 @@
         "leaveBlankUseTokenPrice": "Leave blank to use token price ({price} {currency})",
         "leaveBlankForTokenContractPrice": "Leave blank for token contract price",
         "add": "Add",
-        "remove": "Remove"
+        "remove": "Remove",
+        "errors": {
+          "spaceNotReady": "Your space isn't fully loaded yet. Please refresh the page and try again.",
+          "spaceNotOnChain": "Your space hasn't been published on-chain yet, so a backing vault can't be created. Publish the space first, then come back to create the vault."
+        }
       },
       "issueNewToken": {
         "general": {

--- a/packages/i18n/src/messages/es.json
+++ b/packages/i18n/src/messages/es.json
@@ -181,7 +181,11 @@
         "leaveBlankUseTokenPrice": "Déjalo en blanco para usar el precio del token ({price} {currency})",
         "leaveBlankForTokenContractPrice": "Déjalo en blanco para usar el precio del contrato del token",
         "add": "Agregar",
-        "remove": "Eliminar"
+        "remove": "Eliminar",
+        "errors": {
+          "spaceNotReady": "Tu espacio aún no se ha cargado por completo. Por favor, actualiza la página y vuelve a intentarlo.",
+          "spaceNotOnChain": "Tu espacio aún no se ha publicado on-chain, por lo que no se puede crear una bóveda de respaldo. Publica el espacio primero y luego vuelve para crear la bóveda."
+        }
       },
       "issueNewToken": {
         "general": {

--- a/packages/i18n/src/messages/fr.json
+++ b/packages/i18n/src/messages/fr.json
@@ -1088,7 +1088,11 @@
         "leaveBlankUseTokenPrice": "Laissez vide pour utiliser le prix du token ({price} {currency})",
         "leaveBlankForTokenContractPrice": "Laissez vide pour utiliser le prix du contrat du token",
         "add": "Ajouter",
-        "remove": "Retirer"
+        "remove": "Retirer",
+        "errors": {
+          "spaceNotReady": "Votre espace n'est pas encore complètement chargé. Veuillez rafraîchir la page et réessayer.",
+          "spaceNotOnChain": "Votre espace n'a pas encore été publié on-chain, donc un coffre de garantie ne peut pas être créé. Publiez d'abord l'espace, puis revenez créer le coffre."
+        }
       },
       "issueNewToken": {
         "general": {

--- a/packages/i18n/src/messages/pt.json
+++ b/packages/i18n/src/messages/pt.json
@@ -181,7 +181,11 @@
         "leaveBlankUseTokenPrice": "Deixe em branco para usar o preço do token ({price} {currency})",
         "leaveBlankForTokenContractPrice": "Deixe em branco para usar o preço do contrato do token",
         "add": "Adicionar",
-        "remove": "Remover"
+        "remove": "Remover",
+        "errors": {
+          "spaceNotReady": "Seu espaço ainda não foi totalmente carregado. Por favor, atualize a página e tente novamente.",
+          "spaceNotOnChain": "Seu espaço ainda não foi publicado on-chain, então um cofre de garantia não pode ser criado. Publique o espaço primeiro e depois volte para criar o cofre."
+        }
       },
       "issueNewToken": {
         "general": {

--- a/packages/storage-evm/.openzeppelin/base.json
+++ b/packages/storage-evm/.openzeppelin/base.json
@@ -53551,6 +53551,403 @@
           ]
         }
       }
+    },
+    "c4dc8128709c5333ba30686c93b3c871fdc59c0781857230a1e408b32a457bce": {
+      "address": "0x0209A2880d3FC6C396410d7f8B8732ded530e141",
+      "txHash": "0x0f7aa3967e6f42395dfc1f502dce0366cfde09b1b4bb285bf6ae4fe65686f5f0",
+      "layout": {
+        "solcVersion": "0.8.28",
+        "storage": [
+          {
+            "label": "vaultCounter",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint256",
+            "contract": "TokenBackingVaultStorage",
+            "src": "contracts/storage/TokenBackingVaultStorage.sol:8"
+          },
+          {
+            "label": "vaults",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_mapping(t_uint256,t_struct(VaultConfig)5713_storage)",
+            "contract": "TokenBackingVaultStorage",
+            "src": "contracts/storage/TokenBackingVaultStorage.sol:10"
+          },
+          {
+            "label": "backingConfigs",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_mapping(t_uint256,t_mapping(t_address,t_struct(BackingTokenConfig)5720_storage))",
+            "contract": "TokenBackingVaultStorage",
+            "src": "contracts/storage/TokenBackingVaultStorage.sol:11"
+          },
+          {
+            "label": "backingTokenList",
+            "offset": 0,
+            "slot": "3",
+            "type": "t_mapping(t_uint256,t_array(t_address)dyn_storage)",
+            "contract": "TokenBackingVaultStorage",
+            "src": "contracts/storage/TokenBackingVaultStorage.sol:13"
+          },
+          {
+            "label": "vaultBackingBalance",
+            "offset": 0,
+            "slot": "4",
+            "type": "t_mapping(t_uint256,t_mapping(t_address,t_uint256))",
+            "contract": "TokenBackingVaultStorage",
+            "src": "contracts/storage/TokenBackingVaultStorage.sol:14"
+          },
+          {
+            "label": "spacesContract",
+            "offset": 0,
+            "slot": "5",
+            "type": "t_address",
+            "contract": "TokenBackingVaultStorage",
+            "src": "contracts/storage/TokenBackingVaultStorage.sol:17"
+          },
+          {
+            "label": "spaceVaultIds",
+            "offset": 0,
+            "slot": "6",
+            "type": "t_mapping(t_uint256,t_array(t_uint256)dyn_storage)",
+            "contract": "TokenBackingVaultStorage",
+            "src": "contracts/storage/TokenBackingVaultStorage.sol:19"
+          },
+          {
+            "label": "vaultKeys",
+            "offset": 0,
+            "slot": "7",
+            "type": "t_mapping(t_bytes32,t_uint256)",
+            "contract": "TokenBackingVaultStorage",
+            "src": "contracts/storage/TokenBackingVaultStorage.sol:20"
+          },
+          {
+            "label": "whitelist",
+            "offset": 0,
+            "slot": "8",
+            "type": "t_mapping(t_uint256,t_mapping(t_address,t_bool))",
+            "contract": "TokenBackingVaultStorage",
+            "src": "contracts/storage/TokenBackingVaultStorage.sol:23"
+          },
+          {
+            "label": "vaultRedemptionPrice",
+            "offset": 0,
+            "slot": "9",
+            "type": "t_mapping(t_uint256,t_uint256)",
+            "contract": "TokenBackingVaultStorage",
+            "src": "contracts/storage/TokenBackingVaultStorage.sol:26"
+          },
+          {
+            "label": "vaultRedemptionPriceCurrencyFeed",
+            "offset": 0,
+            "slot": "10",
+            "type": "t_mapping(t_uint256,t_address)",
+            "contract": "TokenBackingVaultStorage",
+            "src": "contracts/storage/TokenBackingVaultStorage.sol:27"
+          },
+          {
+            "label": "vaultMaxRedemptionBps",
+            "offset": 0,
+            "slot": "11",
+            "type": "t_mapping(t_uint256,t_uint256)",
+            "contract": "TokenBackingVaultStorage",
+            "src": "contracts/storage/TokenBackingVaultStorage.sol:30"
+          },
+          {
+            "label": "vaultRedemptionPeriodDays",
+            "offset": 0,
+            "slot": "12",
+            "type": "t_mapping(t_uint256,t_uint256)",
+            "contract": "TokenBackingVaultStorage",
+            "src": "contracts/storage/TokenBackingVaultStorage.sol:32"
+          },
+          {
+            "label": "vaultDailyRedemptions",
+            "offset": 0,
+            "slot": "13",
+            "type": "t_mapping(t_uint256,t_mapping(t_uint256,t_uint256))",
+            "contract": "TokenBackingVaultStorage",
+            "src": "contracts/storage/TokenBackingVaultStorage.sol:34"
+          },
+          {
+            "label": "whitelistedSpaceIds",
+            "offset": 0,
+            "slot": "14",
+            "type": "t_mapping(t_uint256,t_array(t_uint256)dyn_storage)",
+            "contract": "TokenBackingVaultStorage",
+            "src": "contracts/storage/TokenBackingVaultStorage.sol:38"
+          },
+          {
+            "label": "isWhitelistedSpace",
+            "offset": 0,
+            "slot": "15",
+            "type": "t_mapping(t_uint256,t_mapping(t_uint256,t_bool))",
+            "contract": "TokenBackingVaultStorage",
+            "src": "contracts/storage/TokenBackingVaultStorage.sol:40"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "16",
+            "type": "t_array(t_uint256)35_storage",
+            "contract": "TokenBackingVaultStorage",
+            "src": "contracts/storage/TokenBackingVaultStorage.sol:42"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_struct(InitializableStorage)73_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(OwnableStorage)13_storage": {
+            "label": "struct OwnableUpgradeable.OwnableStorage",
+            "members": [
+              {
+                "label": "_owner",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(ReentrancyGuardStorage)226_storage": {
+            "label": "struct ReentrancyGuardUpgradeable.ReentrancyGuardStorage",
+            "members": [
+              {
+                "label": "_status",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)35_storage": {
+            "label": "uint256[35]",
+            "numberOfBytes": "1120"
+          },
+          "t_array(t_uint256)dyn_storage": {
+            "label": "uint256[]",
+            "numberOfBytes": "32"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(BackingTokenConfig)5720_storage)": {
+            "label": "mapping(address => struct ITokenBackingVault.BackingTokenConfig)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_uint256)": {
+            "label": "mapping(bytes32 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_address)": {
+            "label": "mapping(uint256 => address)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_array(t_address)dyn_storage)": {
+            "label": "mapping(uint256 => address[])",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_array(t_uint256)dyn_storage)": {
+            "label": "mapping(uint256 => uint256[])",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_bool)": {
+            "label": "mapping(uint256 => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_mapping(t_address,t_bool))": {
+            "label": "mapping(uint256 => mapping(address => bool))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_mapping(t_address,t_struct(BackingTokenConfig)5720_storage))": {
+            "label": "mapping(uint256 => mapping(address => struct ITokenBackingVault.BackingTokenConfig))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_mapping(t_address,t_uint256))": {
+            "label": "mapping(uint256 => mapping(address => uint256))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_mapping(t_uint256,t_bool))": {
+            "label": "mapping(uint256 => mapping(uint256 => bool))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_mapping(t_uint256,t_uint256))": {
+            "label": "mapping(uint256 => mapping(uint256 => uint256))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_struct(VaultConfig)5713_storage)": {
+            "label": "mapping(uint256 => struct ITokenBackingVault.VaultConfig)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_uint256)": {
+            "label": "mapping(uint256 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(BackingTokenConfig)5720_storage": {
+            "label": "struct ITokenBackingVault.BackingTokenConfig",
+            "members": [
+              {
+                "label": "priceFeed",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "tokenDecimals",
+                "type": "t_uint8",
+                "offset": 20,
+                "slot": "0"
+              },
+              {
+                "label": "enabled",
+                "type": "t_bool",
+                "offset": 21,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(VaultConfig)5713_storage": {
+            "label": "struct ITokenBackingVault.VaultConfig",
+            "members": [
+              {
+                "label": "spaceId",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "spaceToken",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "redeemEnabled",
+                "type": "t_bool",
+                "offset": 20,
+                "slot": "1"
+              },
+              {
+                "label": "membersOnly",
+                "type": "t_bool",
+                "offset": 21,
+                "slot": "1"
+              },
+              {
+                "label": "whitelistEnabled",
+                "type": "t_bool",
+                "offset": 22,
+                "slot": "1"
+              },
+              {
+                "label": "minimumBackingBps",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "redemptionStartDate",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "3"
+              }
+            ],
+            "numberOfBytes": "128"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.ReentrancyGuard": [
+            {
+              "contract": "ReentrancyGuardUpgradeable",
+              "label": "_status",
+              "type": "t_uint256",
+              "src": "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol:43",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Ownable": [
+            {
+              "contract": "OwnableUpgradeable",
+              "label": "_owner",
+              "type": "t_address",
+              "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:24",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
     }
   }
 }

--- a/packages/storage-evm/.openzeppelin/base.json
+++ b/packages/storage-evm/.openzeppelin/base.json
@@ -53154,6 +53154,403 @@
           ]
         }
       }
+    },
+    "76f4bfe74fea276867ce9d38f2f17b9b3bc4cb76050bfa6ef32f50422c2ab775": {
+      "address": "0x88095Cb18f49268e84483176C324974942Cb5038",
+      "txHash": "0x49d20872d9776f17382135aa13bd6f85335067170cfa3d10c1997f38a031c79e",
+      "layout": {
+        "solcVersion": "0.8.28",
+        "storage": [
+          {
+            "label": "vaultCounter",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint256",
+            "contract": "TokenBackingVaultStorage",
+            "src": "contracts/storage/TokenBackingVaultStorage.sol:8"
+          },
+          {
+            "label": "vaults",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_mapping(t_uint256,t_struct(VaultConfig)9538_storage)",
+            "contract": "TokenBackingVaultStorage",
+            "src": "contracts/storage/TokenBackingVaultStorage.sol:10"
+          },
+          {
+            "label": "backingConfigs",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_mapping(t_uint256,t_mapping(t_address,t_struct(BackingTokenConfig)9545_storage))",
+            "contract": "TokenBackingVaultStorage",
+            "src": "contracts/storage/TokenBackingVaultStorage.sol:11"
+          },
+          {
+            "label": "backingTokenList",
+            "offset": 0,
+            "slot": "3",
+            "type": "t_mapping(t_uint256,t_array(t_address)dyn_storage)",
+            "contract": "TokenBackingVaultStorage",
+            "src": "contracts/storage/TokenBackingVaultStorage.sol:13"
+          },
+          {
+            "label": "vaultBackingBalance",
+            "offset": 0,
+            "slot": "4",
+            "type": "t_mapping(t_uint256,t_mapping(t_address,t_uint256))",
+            "contract": "TokenBackingVaultStorage",
+            "src": "contracts/storage/TokenBackingVaultStorage.sol:14"
+          },
+          {
+            "label": "spacesContract",
+            "offset": 0,
+            "slot": "5",
+            "type": "t_address",
+            "contract": "TokenBackingVaultStorage",
+            "src": "contracts/storage/TokenBackingVaultStorage.sol:17"
+          },
+          {
+            "label": "spaceVaultIds",
+            "offset": 0,
+            "slot": "6",
+            "type": "t_mapping(t_uint256,t_array(t_uint256)dyn_storage)",
+            "contract": "TokenBackingVaultStorage",
+            "src": "contracts/storage/TokenBackingVaultStorage.sol:19"
+          },
+          {
+            "label": "vaultKeys",
+            "offset": 0,
+            "slot": "7",
+            "type": "t_mapping(t_bytes32,t_uint256)",
+            "contract": "TokenBackingVaultStorage",
+            "src": "contracts/storage/TokenBackingVaultStorage.sol:20"
+          },
+          {
+            "label": "whitelist",
+            "offset": 0,
+            "slot": "8",
+            "type": "t_mapping(t_uint256,t_mapping(t_address,t_bool))",
+            "contract": "TokenBackingVaultStorage",
+            "src": "contracts/storage/TokenBackingVaultStorage.sol:23"
+          },
+          {
+            "label": "vaultRedemptionPrice",
+            "offset": 0,
+            "slot": "9",
+            "type": "t_mapping(t_uint256,t_uint256)",
+            "contract": "TokenBackingVaultStorage",
+            "src": "contracts/storage/TokenBackingVaultStorage.sol:26"
+          },
+          {
+            "label": "vaultRedemptionPriceCurrencyFeed",
+            "offset": 0,
+            "slot": "10",
+            "type": "t_mapping(t_uint256,t_address)",
+            "contract": "TokenBackingVaultStorage",
+            "src": "contracts/storage/TokenBackingVaultStorage.sol:27"
+          },
+          {
+            "label": "vaultMaxRedemptionBps",
+            "offset": 0,
+            "slot": "11",
+            "type": "t_mapping(t_uint256,t_uint256)",
+            "contract": "TokenBackingVaultStorage",
+            "src": "contracts/storage/TokenBackingVaultStorage.sol:30"
+          },
+          {
+            "label": "vaultRedemptionPeriodDays",
+            "offset": 0,
+            "slot": "12",
+            "type": "t_mapping(t_uint256,t_uint256)",
+            "contract": "TokenBackingVaultStorage",
+            "src": "contracts/storage/TokenBackingVaultStorage.sol:32"
+          },
+          {
+            "label": "vaultDailyRedemptions",
+            "offset": 0,
+            "slot": "13",
+            "type": "t_mapping(t_uint256,t_mapping(t_uint256,t_uint256))",
+            "contract": "TokenBackingVaultStorage",
+            "src": "contracts/storage/TokenBackingVaultStorage.sol:34"
+          },
+          {
+            "label": "whitelistedSpaceIds",
+            "offset": 0,
+            "slot": "14",
+            "type": "t_mapping(t_uint256,t_array(t_uint256)dyn_storage)",
+            "contract": "TokenBackingVaultStorage",
+            "src": "contracts/storage/TokenBackingVaultStorage.sol:38"
+          },
+          {
+            "label": "isWhitelistedSpace",
+            "offset": 0,
+            "slot": "15",
+            "type": "t_mapping(t_uint256,t_mapping(t_uint256,t_bool))",
+            "contract": "TokenBackingVaultStorage",
+            "src": "contracts/storage/TokenBackingVaultStorage.sol:40"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "16",
+            "type": "t_array(t_uint256)35_storage",
+            "contract": "TokenBackingVaultStorage",
+            "src": "contracts/storage/TokenBackingVaultStorage.sol:42"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_struct(InitializableStorage)73_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(OwnableStorage)13_storage": {
+            "label": "struct OwnableUpgradeable.OwnableStorage",
+            "members": [
+              {
+                "label": "_owner",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(ReentrancyGuardStorage)226_storage": {
+            "label": "struct ReentrancyGuardUpgradeable.ReentrancyGuardStorage",
+            "members": [
+              {
+                "label": "_status",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)35_storage": {
+            "label": "uint256[35]",
+            "numberOfBytes": "1120"
+          },
+          "t_array(t_uint256)dyn_storage": {
+            "label": "uint256[]",
+            "numberOfBytes": "32"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(BackingTokenConfig)9545_storage)": {
+            "label": "mapping(address => struct ITokenBackingVault.BackingTokenConfig)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_uint256)": {
+            "label": "mapping(bytes32 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_address)": {
+            "label": "mapping(uint256 => address)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_array(t_address)dyn_storage)": {
+            "label": "mapping(uint256 => address[])",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_array(t_uint256)dyn_storage)": {
+            "label": "mapping(uint256 => uint256[])",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_bool)": {
+            "label": "mapping(uint256 => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_mapping(t_address,t_bool))": {
+            "label": "mapping(uint256 => mapping(address => bool))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_mapping(t_address,t_struct(BackingTokenConfig)9545_storage))": {
+            "label": "mapping(uint256 => mapping(address => struct ITokenBackingVault.BackingTokenConfig))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_mapping(t_address,t_uint256))": {
+            "label": "mapping(uint256 => mapping(address => uint256))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_mapping(t_uint256,t_bool))": {
+            "label": "mapping(uint256 => mapping(uint256 => bool))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_mapping(t_uint256,t_uint256))": {
+            "label": "mapping(uint256 => mapping(uint256 => uint256))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_struct(VaultConfig)9538_storage)": {
+            "label": "mapping(uint256 => struct ITokenBackingVault.VaultConfig)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_uint256)": {
+            "label": "mapping(uint256 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(BackingTokenConfig)9545_storage": {
+            "label": "struct ITokenBackingVault.BackingTokenConfig",
+            "members": [
+              {
+                "label": "priceFeed",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "tokenDecimals",
+                "type": "t_uint8",
+                "offset": 20,
+                "slot": "0"
+              },
+              {
+                "label": "enabled",
+                "type": "t_bool",
+                "offset": 21,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(VaultConfig)9538_storage": {
+            "label": "struct ITokenBackingVault.VaultConfig",
+            "members": [
+              {
+                "label": "spaceId",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "spaceToken",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "redeemEnabled",
+                "type": "t_bool",
+                "offset": 20,
+                "slot": "1"
+              },
+              {
+                "label": "membersOnly",
+                "type": "t_bool",
+                "offset": 21,
+                "slot": "1"
+              },
+              {
+                "label": "whitelistEnabled",
+                "type": "t_bool",
+                "offset": 22,
+                "slot": "1"
+              },
+              {
+                "label": "minimumBackingBps",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "redemptionStartDate",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "3"
+              }
+            ],
+            "numberOfBytes": "128"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.ReentrancyGuard": [
+            {
+              "contract": "ReentrancyGuardUpgradeable",
+              "label": "_status",
+              "type": "t_uint256",
+              "src": "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol:43",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Ownable": [
+            {
+              "contract": "OwnableUpgradeable",
+              "label": "_owner",
+              "type": "t_address",
+              "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:24",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
     }
   }
 }

--- a/packages/storage-evm/contracts/TokenBackingVaultImplementation.sol
+++ b/packages/storage-evm/contracts/TokenBackingVaultImplementation.sol
@@ -116,8 +116,65 @@ contract TokenBackingVaultImplementation is
   ) internal override onlyOwner {}
 
   // ============================================================
-  //          PRIMARY ENTRY POINT — addBackingToken
+  //          PRIMARY ENTRY POINTS — createVault / addBackingToken
   // ============================================================
+
+  /**
+   * @dev Create an empty vault for a space token.
+   *
+   * Allows setting up the vault parameters (minimum backing, redemption price,
+   * caps) without registering any backing collateral up-front. Backing tokens
+   * can be added later via `addBackingToken`.
+   *
+   * The space token must be priceable at redemption time — either via the
+   * vault's `redemptionPrice` override or via the token's `tokenPrice()`.
+   *
+   * @param redemptionPrice Optional redemption price (6 decimals). 0 = use official token price.
+   * @param redemptionPriceCurrencyFeed Chainlink X/USD feed for the redemption price currency.
+   *        address(0) = USD. Ignored when redemptionPrice is 0.
+   * @param maxRedemptionBps Max % of supply redeemable in rolling period (basis points). 0 = unlimited.
+   * @param maxRedemptionPeriodDays Rolling window in days. Must be > 0 when maxRedemptionBps > 0.
+   */
+  function createVault(
+    uint256 spaceId,
+    address spaceToken,
+    uint256 minimumBackingBps,
+    uint256 redemptionPrice,
+    address redemptionPriceCurrencyFeed,
+    uint256 maxRedemptionBps,
+    uint256 maxRedemptionPeriodDays
+  ) external nonReentrant returns (uint256 vaultId) {
+    _requireExecutorOrOwner(spaceId);
+
+    require(spaceToken != address(0), 'Invalid space token');
+    require(
+      vaultKeys[_getVaultKey(spaceId, spaceToken)] == 0,
+      'Vault already exists'
+    );
+    require(
+      minimumBackingBps <= MAX_BACKING_BPS,
+      'Min backing cannot exceed 1000%'
+    );
+    require(maxRedemptionBps <= BASIS_POINTS, 'Cannot exceed 100%');
+    require(
+      maxRedemptionBps == 0 || maxRedemptionPeriodDays > 0,
+      'Period must be > 0 when cap is set'
+    );
+
+    vaultId = _getOrCreateVault(
+      spaceId,
+      spaceToken,
+      minimumBackingBps,
+      redemptionPrice,
+      redemptionPriceCurrencyFeed,
+      maxRedemptionBps,
+      maxRedemptionPeriodDays
+    );
+
+    _requirePriceableSpaceToken(vaultId, spaceToken);
+
+    return vaultId;
+  }
 
   /**
    * @dev Add one or more backing tokens, optionally funding each.
@@ -164,10 +221,6 @@ contract TokenBackingVaultImplementation is
       'Period must be > 0 when cap is set'
     );
 
-    // Validate the space token has a price set
-    uint256 pegPrice = ISpaceTokenPrice(spaceToken).tokenPrice();
-    require(pegPrice > 0, 'Space token price must be > 0');
-
     vaultId = _getOrCreateVault(
       spaceId,
       spaceToken,
@@ -177,6 +230,13 @@ contract TokenBackingVaultImplementation is
       maxRedemptionBps,
       maxRedemptionPeriodDays
     );
+
+    // The space token must be priceable at redemption time — either via the
+    // vault's redemption-price override or via the token's tokenPrice().
+    // This replaces the unconditional `pegPrice > 0` check so spaces that
+    // peg redemption to a fixed currency (USDC, EUR, etc.) can run with a
+    // tokenPrice() of 0.
+    _requirePriceableSpaceToken(vaultId, spaceToken);
 
     for (uint256 i = 0; i < backingTokens.length; i++) {
       address bt = backingTokens[i];
@@ -834,6 +894,25 @@ contract TokenBackingVaultImplementation is
     bytes32 key = _getVaultKey(spaceId, spaceToken);
     vaultId = vaultKeys[key];
     require(vaultId != 0, 'Vault does not exist');
+  }
+
+  /**
+   * @dev Ensure the vault can value the space token at redemption time.
+   * Either the vault has a non-zero `vaultRedemptionPrice` override stored,
+   * or the space token's own `tokenPrice()` is non-zero. When both are 0,
+   * `_getEffectiveRedemptionPriceInUsd` would return 0 and every redeem call
+   * would revert with `Redemption price is 0`.
+   */
+  function _requirePriceableSpaceToken(
+    uint256 vaultId,
+    address spaceToken
+  ) internal view {
+    if (vaultRedemptionPrice[vaultId] > 0) return;
+    uint256 pegPrice = ISpaceTokenPrice(spaceToken).tokenPrice();
+    require(
+      pegPrice > 0,
+      'Need space token price or redemption price > 0'
+    );
   }
 
   function _requireRedemptionAllowed(

--- a/packages/storage-evm/contracts/TokenBackingVaultImplementation.sol
+++ b/packages/storage-evm/contracts/TokenBackingVaultImplementation.sol
@@ -443,6 +443,7 @@ contract TokenBackingVaultImplementation is
 
     vaultRedemptionPrice[vaultId] = price;
     vaultRedemptionPriceCurrencyFeed[vaultId] = currencyFeed;
+    _requirePriceableSpaceToken(vaultId, spaceToken);
 
     emit RedemptionPriceUpdated(vaultId, price, currencyFeed);
   }

--- a/packages/storage-evm/scripts/base-mainnet-contracts-scripts/create-space-and-vault-no-mint-test.ts
+++ b/packages/storage-evm/scripts/base-mainnet-contracts-scripts/create-space-and-vault-no-mint-test.ts
@@ -51,7 +51,7 @@ const daoProposalsAbi = [
 ];
 
 const regularTokenFactoryAbi = [
-  'function deployToken(uint256 spaceId,string name,string symbol,uint256 maxSupply,bool transferable,bool fixedMaxSupply,bool autoMinting,uint256 tokenPrice,address priceCurrencyFeed,bool useTransferWhitelist,bool useReceiveWhitelist,address[] initialTransferWhitelist,address[] initialReceiveWhitelist) external returns (address)',
+  'function deployToken(uint256 spaceId,string name,string symbol,uint256 maxSupply,bool transferable,bool fixedMaxSupply,bool autoMinting,uint256 tokenPrice,address priceCurrencyFeed,bool useTransferWhitelist,bool useReceiveWhitelist,address[] initialTransferWhitelist,address[] initialReceiveWhitelist,uint256[] initialTransferWhitelistSpaceIds,uint256[] initialReceiveWhitelistSpaceIds,uint256 defaultCreditLimit,uint256[] initialCreditWhitelistSpaceIds,address paymentToken,uint256 paymentTokenPricePerToken,uint256 tokensForSale,uint8 purchaseEligibilityMode,uint256[] initialPurchaseWhitelistSpaceIds) external returns (address)',
   'function getSpaceToken(uint256 spaceId) external view returns (address[])',
 ];
 
@@ -106,6 +106,44 @@ async function loadWallet(
   return new ethers.Wallet(accountData[0].privateKey, provider);
 }
 
+const READ_DELAY_MS = Number(process.env.READ_DELAY_MS ?? 800);
+const TX_DELAY_MS = Number(process.env.TX_DELAY_MS ?? 1500);
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function withRetry<T>(
+  label: string,
+  fn: () => Promise<T>,
+  attempts = 6,
+  baseDelayMs = 1500,
+): Promise<T> {
+  let lastErr: unknown;
+  for (let i = 0; i < attempts; i++) {
+    try {
+      if (i > 0) {
+        const wait = baseDelayMs * Math.pow(2, i - 1);
+        console.log(
+          `  retry ${i}/${attempts - 1} for ${label} after ${wait}ms`,
+        );
+        await sleep(wait);
+      }
+      return await fn();
+    } catch (err) {
+      lastErr = err;
+      const msg = (err as Error)?.message ?? String(err);
+      const rateLimited =
+        msg.includes('over rate limit') ||
+        msg.includes('rate limit') ||
+        msg.includes('429') ||
+        msg.includes('missing revert data');
+      if (!rateLimited) throw err;
+    }
+  }
+  throw lastErr;
+}
+
 function decodeProposalId(receipt: ethers.TransactionReceipt): number {
   const topic = ethers.id(
     'ProposalCreated(uint256,uint256,uint256,uint256,address,bytes)',
@@ -151,7 +189,11 @@ async function createAndExecuteProposal(
   console.log(`- vote tx: ${voteTx.hash}`);
   await voteTx.wait();
 
-  const core = await daoProposals.getProposalCore(proposalId);
+  if (TX_DELAY_MS > 0) await sleep(TX_DELAY_MS);
+
+  const core = await withRetry('getProposalCore', () =>
+    daoProposals.getProposalCore(proposalId),
+  );
   console.log(
     `- executed: ${core.executed}, yesVotes: ${core.yesVotes}, noVotes: ${core.noVotes}`,
   );
@@ -286,6 +328,15 @@ async function main(): Promise<void> {
     false,
     [],
     [],
+    [], // initialTransferWhitelistSpaceIds
+    [], // initialReceiveWhitelistSpaceIds
+    0n, // defaultCreditLimit
+    [], // initialCreditWhitelistSpaceIds
+    zero, // paymentToken (address(0) disables initial sale)
+    0n, // paymentTokenPricePerToken
+    0n, // tokensForSale
+    0, // purchaseEligibilityMode (0 = issuer space only)
+    [], // initialPurchaseWhitelistSpaceIds
   ]);
 
   const deployBackingTokenData = deployIface.encodeFunctionData('deployToken', [
@@ -302,6 +353,15 @@ async function main(): Promise<void> {
     false,
     [],
     [],
+    [], // initialTransferWhitelistSpaceIds
+    [], // initialReceiveWhitelistSpaceIds
+    0n, // defaultCreditLimit
+    [], // initialCreditWhitelistSpaceIds
+    zero, // paymentToken
+    0n, // paymentTokenPricePerToken
+    0n, // tokensForSale
+    0, // purchaseEligibilityMode
+    [], // initialPurchaseWhitelistSpaceIds
   ]);
 
   await createAndExecuteProposal(
@@ -322,8 +382,9 @@ async function main(): Promise<void> {
     'Deploy space token + auto-mint backing token',
   );
 
-  const spaceTokens: string[] = await regularTokenFactory.getSpaceToken(
-    spaceId,
+  if (READ_DELAY_MS > 0) await sleep(READ_DELAY_MS);
+  const spaceTokens: string[] = await withRetry('getSpaceToken', () =>
+    regularTokenFactory.getSpaceToken(spaceId),
   );
   if (spaceTokens.length < 2) {
     throw new Error(`Expected at least 2 tokens, got ${spaceTokens.length}`);
@@ -339,12 +400,21 @@ async function main(): Promise<void> {
     regularSpaceTokenAbi,
     wallet,
   );
-  const backingDecimals = Number(await backingToken.decimals());
+  if (READ_DELAY_MS > 0) await sleep(READ_DELAY_MS);
+  const backingDecimals = Number(
+    await withRetry('decimals', () => backingToken.decimals()),
+  );
   const fundingHuman = process.env.VAULT_FUNDING_AMOUNT ?? '10';
   const fundingAmount = ethers.parseUnits(fundingHuman, backingDecimals);
 
-  const balanceBefore: bigint = await backingToken.balanceOf(executor);
-  const supplyBefore: bigint = await backingToken.totalSupply();
+  if (READ_DELAY_MS > 0) await sleep(READ_DELAY_MS);
+  const balanceBefore: bigint = await withRetry('balanceOf(before)', () =>
+    backingToken.balanceOf(executor),
+  );
+  if (READ_DELAY_MS > 0) await sleep(READ_DELAY_MS);
+  const supplyBefore: bigint = await withRetry('totalSupply(before)', () =>
+    backingToken.totalSupply(),
+  );
   console.log(
     `- executor backing balance before funding: ${ethers.formatUnits(
       balanceBefore,
@@ -423,20 +493,29 @@ async function main(): Promise<void> {
     'Approve + create vault + enable redemption (no mint)',
   );
 
-  const exists = await tokenBackingVault.vaultExists(
-    spaceId,
-    spaceTokenAddress,
+  if (READ_DELAY_MS > 0) await sleep(READ_DELAY_MS);
+  const exists = await withRetry('vaultExists', () =>
+    tokenBackingVault.vaultExists(spaceId, spaceTokenAddress),
   );
   console.log(`- vaultExists: ${exists}`);
   if (!exists) throw new Error('Vault was not created');
 
-  const vaultBalance: bigint = await tokenBackingVault.getBackingBalance(
-    spaceId,
-    spaceTokenAddress,
-    backingTokenAddress,
+  if (READ_DELAY_MS > 0) await sleep(READ_DELAY_MS);
+  const vaultBalance: bigint = await withRetry('getBackingBalance', () =>
+    tokenBackingVault.getBackingBalance(
+      spaceId,
+      spaceTokenAddress,
+      backingTokenAddress,
+    ),
   );
-  const balanceAfter: bigint = await backingToken.balanceOf(executor);
-  const supplyAfter: bigint = await backingToken.totalSupply();
+  if (READ_DELAY_MS > 0) await sleep(READ_DELAY_MS);
+  const balanceAfter: bigint = await withRetry('balanceOf', () =>
+    backingToken.balanceOf(executor),
+  );
+  if (READ_DELAY_MS > 0) await sleep(READ_DELAY_MS);
+  const supplyAfter: bigint = await withRetry('totalSupply', () =>
+    backingToken.totalSupply(),
+  );
 
   console.log('\n=== Final Summary ===');
   console.log(`Space ID: ${spaceId}`);

--- a/packages/storage-evm/scripts/base-mainnet-contracts-scripts/create-space-and-vault-test.ts
+++ b/packages/storage-evm/scripts/base-mainnet-contracts-scripts/create-space-and-vault-test.ts
@@ -51,7 +51,7 @@ const daoProposalsAbi = [
 ];
 
 const regularTokenFactoryAbi = [
-  'function deployToken(uint256 spaceId,string name,string symbol,uint256 maxSupply,bool transferable,bool fixedMaxSupply,bool autoMinting,uint256 tokenPrice,address priceCurrencyFeed,bool useTransferWhitelist,bool useReceiveWhitelist,address[] initialTransferWhitelist,address[] initialReceiveWhitelist) external returns (address)',
+  'function deployToken(uint256 spaceId,string name,string symbol,uint256 maxSupply,bool transferable,bool fixedMaxSupply,bool autoMinting,uint256 tokenPrice,address priceCurrencyFeed,bool useTransferWhitelist,bool useReceiveWhitelist,address[] initialTransferWhitelist,address[] initialReceiveWhitelist,uint256[] initialTransferWhitelistSpaceIds,uint256[] initialReceiveWhitelistSpaceIds,uint256 defaultCreditLimit,uint256[] initialCreditWhitelistSpaceIds,address paymentToken,uint256 paymentTokenPricePerToken,uint256 tokensForSale,uint8 purchaseEligibilityMode,uint256[] initialPurchaseWhitelistSpaceIds) external returns (address)',
   'function getSpaceToken(uint256 spaceId) external view returns (address[])',
 ];
 
@@ -305,6 +305,15 @@ async function main(): Promise<void> {
     useReceiveWhitelist: false,
     initialTransferWhitelist: [] as string[],
     initialReceiveWhitelist: [] as string[],
+    initialTransferWhitelistSpaceIds: [] as bigint[],
+    initialReceiveWhitelistSpaceIds: [] as bigint[],
+    defaultCreditLimit: 0n,
+    initialCreditWhitelistSpaceIds: [] as bigint[],
+    paymentToken: zero,
+    paymentTokenPricePerToken: 0n,
+    tokensForSale: 0n,
+    purchaseEligibilityMode: 0,
+    initialPurchaseWhitelistSpaceIds: [] as bigint[],
   };
 
   const deploySpaceTokenData = deployIface.encodeFunctionData('deployToken', [
@@ -321,6 +330,15 @@ async function main(): Promise<void> {
     defaultDeployArgs.useReceiveWhitelist,
     defaultDeployArgs.initialTransferWhitelist,
     defaultDeployArgs.initialReceiveWhitelist,
+    defaultDeployArgs.initialTransferWhitelistSpaceIds,
+    defaultDeployArgs.initialReceiveWhitelistSpaceIds,
+    defaultDeployArgs.defaultCreditLimit,
+    defaultDeployArgs.initialCreditWhitelistSpaceIds,
+    defaultDeployArgs.paymentToken,
+    defaultDeployArgs.paymentTokenPricePerToken,
+    defaultDeployArgs.tokensForSale,
+    defaultDeployArgs.purchaseEligibilityMode,
+    defaultDeployArgs.initialPurchaseWhitelistSpaceIds,
   ]);
 
   const deployBackingTokenData = deployIface.encodeFunctionData('deployToken', [
@@ -337,6 +355,15 @@ async function main(): Promise<void> {
     defaultDeployArgs.useReceiveWhitelist,
     defaultDeployArgs.initialTransferWhitelist,
     defaultDeployArgs.initialReceiveWhitelist,
+    defaultDeployArgs.initialTransferWhitelistSpaceIds,
+    defaultDeployArgs.initialReceiveWhitelistSpaceIds,
+    defaultDeployArgs.defaultCreditLimit,
+    defaultDeployArgs.initialCreditWhitelistSpaceIds,
+    defaultDeployArgs.paymentToken,
+    defaultDeployArgs.paymentTokenPricePerToken,
+    defaultDeployArgs.tokensForSale,
+    defaultDeployArgs.purchaseEligibilityMode,
+    defaultDeployArgs.initialPurchaseWhitelistSpaceIds,
   ]);
 
   await createAndExecuteProposal(

--- a/packages/storage-evm/scripts/token-upgrade-data/upgrade-results-regular-2026-04-24T18-04-59-093Z.json
+++ b/packages/storage-evm/scripts/token-upgrade-data/upgrade-results-regular-2026-04-24T18-04-59-093Z.json
@@ -1,0 +1,15 @@
+{
+  "tokenType": "Regular",
+  "dryRun": true,
+  "timestamp": "2026-04-24T18:04:59.093Z",
+  "totalTime": "3.25",
+  "results": [
+    {
+      "tokenAddress": "0xc82721CEB329f10284c54Aa61C7341988713683D",
+      "success": true,
+      "oldImplementation": "0xC408B52dFABa2A99F4659B39C15cf37085E33E91",
+      "newImplementation": "0x134599F2d239A37D8DD3Df4A3C7b912e53627882",
+      "error": null
+    }
+  ]
+}

--- a/packages/storage-evm/scripts/token-upgrade-data/upgrade-results-regular-2026-04-24T18-07-17-167Z.json
+++ b/packages/storage-evm/scripts/token-upgrade-data/upgrade-results-regular-2026-04-24T18-07-17-167Z.json
@@ -1,0 +1,15 @@
+{
+  "tokenType": "Regular",
+  "dryRun": true,
+  "timestamp": "2026-04-24T18:07:17.167Z",
+  "totalTime": "3.82",
+  "results": [
+    {
+      "tokenAddress": "0xc82721CEB329f10284c54Aa61C7341988713683D",
+      "success": true,
+      "oldImplementation": "0xC408B52dFABa2A99F4659B39C15cf37085E33E91",
+      "newImplementation": "0x134599F2d239A37D8DD3Df4A3C7b912e53627882",
+      "error": null
+    }
+  ]
+}

--- a/packages/storage-evm/scripts/token-upgrade-data/upgrade-results-regular-2026-04-24T18-10-17-541Z.json
+++ b/packages/storage-evm/scripts/token-upgrade-data/upgrade-results-regular-2026-04-24T18-10-17-541Z.json
@@ -1,0 +1,15 @@
+{
+  "tokenType": "Regular",
+  "dryRun": false,
+  "timestamp": "2026-04-24T18:10:17.542Z",
+  "totalTime": "8.93",
+  "results": [
+    {
+      "tokenAddress": "0xc82721CEB329f10284c54Aa61C7341988713683D",
+      "success": true,
+      "oldImplementation": "0xC408B52dFABa2A99F4659B39C15cf37085E33E91",
+      "newImplementation": "0x134599F2d239A37D8DD3Df4A3C7b912e53627882",
+      "error": null
+    }
+  ]
+}

--- a/packages/storage-evm/scripts/upgrade-multiple-tokens.ts
+++ b/packages/storage-evm/scripts/upgrade-multiple-tokens.ts
@@ -19,10 +19,13 @@ import path from 'path';
 const TOKEN_TYPE: 'Regular' | 'Ownership' | 'Decaying' = 'Regular';
 
 // Token addresses to upgrade (edit this array or load from file)
-const TOKEN_ADDRESSES: string[] = [''];
+// Space ID 803 (executor 0x9C64A299D9C9fC902cc30284Bc5dc3d80E8C9F5a) — DAFCREDITS
+const TOKEN_ADDRESSES: string[] = [
+  '0xc82721CEB329f10284c54Aa61C7341988713683D',
+];
 
 // Set to true to load addresses from a file instead of using TOKEN_ADDRESSES array
-const LOAD_FROM_FILE = true;
+const LOAD_FROM_FILE = false;
 const ADDRESS_FILE_PATH =
   '/Users/vlad/hypha-web/packages/storage-evm/scripts/base-mainnet-contracts-scripts/token-upgrade-data/regular-addresses-2025-11-14T09-30-58-747Z.txt';
 
@@ -123,9 +126,11 @@ async function upgradeToken(
         console.log('  ✅ DRY RUN: Implementation would change!');
       }
 
-      console.log(
-        '  🔍 DRY RUN: Would configure autoMinting=true after upgrade',
-      );
+      if (TOKEN_TYPE === 'Ownership') {
+        console.log(
+          `  🔍 DRY RUN: Would configure ownershipSpacesContract=${SPACES_CONTRACT} after upgrade`,
+        );
+      }
       result.newImplementation = preparedImpl.toString();
       result.success = true;
       return result;
@@ -246,10 +251,9 @@ async function upgradeToken(
       console.log('  ✅ Successfully upgraded!');
     }
 
-    // Post-upgrade configuration for backward compatibility and safety.
-    console.log('  🔧 Configuring post-upgrade settings...');
-    try {
-      if (TOKEN_TYPE === 'Ownership') {
+    if (TOKEN_TYPE === 'Ownership') {
+      console.log('  🔧 Configuring post-upgrade settings...');
+      try {
         const ownershipToken = await ethers.getContractAt(
           'OwnershipSpaceToken',
           tokenAddress,
@@ -274,37 +278,22 @@ async function upgradeToken(
         } else {
           console.log('  ℹ️  ownershipSpacesContract already configured');
         }
-      } else {
-        const tokenContract = await ethers.getContractAt(
-          'RegularSpaceToken',
-          tokenAddress,
+
+        result.success = true;
+      } catch (configError: any) {
+        console.log(
+          `  ⚠️  Warning: Could not configure post-upgrade settings: ${configError.message}`,
         );
-
-        // Check current autoMinting status
-        const currentAutoMinting = await tokenContract.autoMinting();
-        console.log(`  Current autoMinting: ${currentAutoMinting}`);
-
-        if (!currentAutoMinting) {
-          console.log('  Setting autoMinting to true...');
-          const configTx = await tokenContract.setAutoMinting(true);
-          await configTx.wait();
-          console.log('  ✅ AutoMinting enabled (backward compatibility)');
-        } else {
-          console.log('  ℹ️  AutoMinting already enabled, skipping');
+        result.success = implementationChanged;
+        if (!result.success) {
+          result.error =
+            'Implementation unchanged and post-upgrade config failed';
         }
       }
-
+    } else {
+      // Non-Ownership tokens: no post-upgrade config needed.
+      // Reaching here means upgradeProxy succeeded.
       result.success = true;
-    } catch (configError: any) {
-      console.log(
-        `  ⚠️  Warning: Could not configure post-upgrade settings: ${configError.message}`,
-      );
-      // Mark as success if implementation changed, otherwise keep as false
-      result.success = implementationChanged;
-      if (!result.success) {
-        result.error =
-          'Implementation unchanged and post-upgrade config failed';
-      }
     }
   } catch (error: any) {
     console.error(`  ❌ Error: ${error.message}`);

--- a/packages/storage-evm/test/TokenBackingVault.test.ts
+++ b/packages/storage-evm/test/TokenBackingVault.test.ts
@@ -203,7 +203,7 @@ describe('TokenBackingVault', function () {
       expect(config.enabled).to.be.true;
     });
 
-    it('Should reject if space token has no price set', async function () {
+    it('Should reject if space token has no price set and no redemption price override', async function () {
       const { vault, usdc, usdcFeed, executor, SPACE_ID } = await loadFixture(
         deployFixture,
       );
@@ -228,7 +228,307 @@ describe('TokenBackingVault', function () {
             0,
             0,
           ),
-      ).to.be.revertedWith('Space token price must be > 0');
+      ).to.be.revertedWith('Need space token price or redemption price > 0');
+    });
+
+    it('Should accept a zero-price space token when a redemption-price override is provided', async function () {
+      const { vault, usdc, usdcFeed, executor, SPACE_ID } = await loadFixture(
+        deployFixture,
+      );
+
+      // Space token has tokenPrice() == 0 — vault must use the override.
+      const Community = await ethers.getContractFactory('MockSpaceToken');
+      const zeroPriceToken = await Community.deploy('Zero', 'ZERO', 0);
+
+      await expect(
+        vault.connect(executor).addBackingToken(
+          SPACE_ID,
+          await zeroPriceToken.getAddress(),
+          [await usdc.getAddress()],
+          [await usdcFeed.getAddress()],
+          [6],
+          [0],
+          0,
+          1_500_000, // $1.50 redemption price override (6 decimals)
+          ethers.ZeroAddress,
+          0,
+          0,
+        ),
+      ).to.emit(vault, 'VaultCreated');
+
+      const [storedPrice] = await vault.getRedemptionPrice(
+        SPACE_ID,
+        await zeroPriceToken.getAddress(),
+      );
+      expect(storedPrice).to.equal(1_500_000);
+    });
+  });
+
+  // ================================================================
+  //                  EMPTY VAULT CREATION (createVault)
+  // ================================================================
+
+  describe('createVault', function () {
+    it('Should create an empty vault with no backing tokens', async function () {
+      const { vault, communityToken, executor, SPACE_ID } = await loadFixture(
+        deployFixture,
+      );
+
+      await expect(
+        vault
+          .connect(executor)
+          .createVault(
+            SPACE_ID,
+            await communityToken.getAddress(),
+            0,
+            0,
+            ethers.ZeroAddress,
+            0,
+            0,
+          ),
+      ).to.emit(vault, 'VaultCreated');
+
+      expect(
+        await vault.vaultExists(SPACE_ID, await communityToken.getAddress()),
+      ).to.be.true;
+
+      const tokens = await vault.getBackingTokens(
+        SPACE_ID,
+        await communityToken.getAddress(),
+      );
+      expect(tokens.length).to.equal(0);
+    });
+
+    it('Should let backing tokens be added to a vault created via createVault', async function () {
+      const { vault, communityToken, usdc, usdcFeed, executor, SPACE_ID } =
+        await loadFixture(deployFixture);
+
+      await vault.connect(executor).createVault(
+        SPACE_ID,
+        await communityToken.getAddress(),
+        2000, // 20% min backing
+        0,
+        ethers.ZeroAddress,
+        0,
+        0,
+      );
+
+      await usdc.mint(executor.address, 50_000e6);
+      await usdc.connect(executor).approve(await vault.getAddress(), 50_000e6);
+
+      await expect(
+        vault
+          .connect(executor)
+          .addBackingToken(
+            SPACE_ID,
+            await communityToken.getAddress(),
+            [await usdc.getAddress()],
+            [await usdcFeed.getAddress()],
+            [6],
+            [50_000e6],
+            0,
+            0,
+            ethers.ZeroAddress,
+            0,
+            0,
+          ),
+      ).to.emit(vault, 'BackingTokenAdded');
+
+      const balance = await vault.getBackingBalance(
+        SPACE_ID,
+        await communityToken.getAddress(),
+        await usdc.getAddress(),
+      );
+      expect(balance).to.equal(50_000e6);
+
+      // minimumBackingBps was set when the vault was created and must NOT be
+      // reset to 0 when addBackingToken is called for the existing vault.
+      const config = await vault.getVaultConfig(
+        SPACE_ID,
+        await communityToken.getAddress(),
+      );
+      expect(config.minimumBackingBps).to.equal(2000);
+    });
+
+    it('Should accept a zero-price space token when a redemption-price override is provided', async function () {
+      const { vault, executor, SPACE_ID } = await loadFixture(deployFixture);
+
+      const Community = await ethers.getContractFactory('MockSpaceToken');
+      const zeroPriceToken = await Community.deploy('Zero', 'ZERO', 0);
+
+      await expect(
+        vault.connect(executor).createVault(
+          SPACE_ID,
+          await zeroPriceToken.getAddress(),
+          0,
+          2_000_000, // $2 override
+          ethers.ZeroAddress,
+          0,
+          0,
+        ),
+      ).to.emit(vault, 'VaultCreated');
+
+      const [storedPrice] = await vault.getRedemptionPrice(
+        SPACE_ID,
+        await zeroPriceToken.getAddress(),
+      );
+      expect(storedPrice).to.equal(2_000_000);
+    });
+
+    it('Should revert when neither tokenPrice() nor a redemption price override is provided', async function () {
+      const { vault, executor, SPACE_ID } = await loadFixture(deployFixture);
+
+      const Community = await ethers.getContractFactory('MockSpaceToken');
+      const zeroPriceToken = await Community.deploy('Zero', 'ZERO', 0);
+
+      await expect(
+        vault
+          .connect(executor)
+          .createVault(
+            SPACE_ID,
+            await zeroPriceToken.getAddress(),
+            0,
+            0,
+            ethers.ZeroAddress,
+            0,
+            0,
+          ),
+      ).to.be.revertedWith('Need space token price or redemption price > 0');
+
+      // Vault state must NOT have been written when the post-create check reverts.
+      expect(
+        await vault.vaultExists(SPACE_ID, await zeroPriceToken.getAddress()),
+      ).to.be.false;
+    });
+
+    it('Should revert if the vault already exists', async function () {
+      const { vault, communityToken, executor, SPACE_ID } = await loadFixture(
+        deployFixture,
+      );
+
+      await vault
+        .connect(executor)
+        .createVault(
+          SPACE_ID,
+          await communityToken.getAddress(),
+          0,
+          0,
+          ethers.ZeroAddress,
+          0,
+          0,
+        );
+
+      await expect(
+        vault
+          .connect(executor)
+          .createVault(
+            SPACE_ID,
+            await communityToken.getAddress(),
+            0,
+            0,
+            ethers.ZeroAddress,
+            0,
+            0,
+          ),
+      ).to.be.revertedWith('Vault already exists');
+    });
+
+    it('Should reject zero-address space token', async function () {
+      const { vault, executor, SPACE_ID } = await loadFixture(deployFixture);
+
+      await expect(
+        vault
+          .connect(executor)
+          .createVault(
+            SPACE_ID,
+            ethers.ZeroAddress,
+            0,
+            0,
+            ethers.ZeroAddress,
+            0,
+            0,
+          ),
+      ).to.be.revertedWith('Invalid space token');
+    });
+
+    it('Should reject minimumBackingBps > 1000% (100000 bps)', async function () {
+      const { vault, communityToken, executor, SPACE_ID } = await loadFixture(
+        deployFixture,
+      );
+
+      await expect(
+        vault
+          .connect(executor)
+          .createVault(
+            SPACE_ID,
+            await communityToken.getAddress(),
+            100001,
+            0,
+            ethers.ZeroAddress,
+            0,
+            0,
+          ),
+      ).to.be.revertedWith('Min backing cannot exceed 1000%');
+    });
+
+    it('Should reject maxRedemptionBps > 100%', async function () {
+      const { vault, communityToken, executor, SPACE_ID } = await loadFixture(
+        deployFixture,
+      );
+
+      await expect(
+        vault
+          .connect(executor)
+          .createVault(
+            SPACE_ID,
+            await communityToken.getAddress(),
+            0,
+            0,
+            ethers.ZeroAddress,
+            10001,
+            7,
+          ),
+      ).to.be.revertedWith('Cannot exceed 100%');
+    });
+
+    it('Should reject maxRedemptionBps > 0 with periodDays == 0', async function () {
+      const { vault, communityToken, executor, SPACE_ID } = await loadFixture(
+        deployFixture,
+      );
+
+      await expect(
+        vault
+          .connect(executor)
+          .createVault(
+            SPACE_ID,
+            await communityToken.getAddress(),
+            0,
+            0,
+            ethers.ZeroAddress,
+            500,
+            0,
+          ),
+      ).to.be.revertedWith('Period must be > 0 when cap is set');
+    });
+
+    it('Should reject from non-executor', async function () {
+      const { vault, communityToken, alice, SPACE_ID } = await loadFixture(
+        deployFixture,
+      );
+
+      await expect(
+        vault
+          .connect(alice)
+          .createVault(
+            SPACE_ID,
+            await communityToken.getAddress(),
+            0,
+            0,
+            ethers.ZeroAddress,
+            0,
+            0,
+          ),
+      ).to.be.revertedWith('Not authorized: only executor or owner');
     });
   });
 

--- a/playground/global-wallet-test/index.html
+++ b/playground/global-wallet-test/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Privy Global Wallet — Consumer Test</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/playground/global-wallet-test/package.json
+++ b/playground/global-wallet-test/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "global-wallet-test",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@privy-io/react-auth": "^2.25.0",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.0",
+    "@types/react-dom": "^19.2.0",
+    "@vitejs/plugin-react": "^4.7.0",
+    "typescript": "^5.9.0",
+    "vite": "^6.4.0"
+  }
+}

--- a/playground/global-wallet-test/src/App.tsx
+++ b/playground/global-wallet-test/src/App.tsx
@@ -1,0 +1,82 @@
+import {
+  usePrivy,
+  useCrossAppAccounts,
+  useWallets,
+} from '@privy-io/react-auth';
+
+interface AppProps {
+  providerAppId: string;
+}
+
+export default function App({ providerAppId }: AppProps) {
+  const { ready, authenticated, user, login, logout } = usePrivy();
+  const { loginWithCrossAppAccount } = useCrossAppAccounts();
+  const { wallets } = useWallets();
+
+  const crossAppAccount = user?.linkedAccounts?.find(
+    (a) => a.type === 'cross_app' && a.providerApp?.id === providerAppId,
+  );
+
+  if (!ready) {
+    return (
+      <div className="container">
+        <p>Loading Privy…</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container">
+      <h1>Privy Global Wallet — Consumer Test</h1>
+      <p className="muted">
+        Consumer app: <code>{import.meta.env.VITE_PRIVY_APP_ID}</code>
+        <br />
+        Provider app: <code>{providerAppId}</code>
+      </p>
+
+      {!authenticated ? (
+        <div className="actions">
+          <button onClick={login}>Login (Privy modal)</button>
+          <button
+            className="primary"
+            onClick={() => loginWithCrossAppAccount({ appId: providerAppId })}
+          >
+            Login with Global Wallet
+          </button>
+        </div>
+      ) : (
+        <div className="actions">
+          <button onClick={logout}>Logout</button>
+        </div>
+      )}
+
+      {authenticated && (
+        <section>
+          <h2>User</h2>
+          <pre>{JSON.stringify(user, null, 2)}</pre>
+
+          <h2>Cross-app account</h2>
+          <pre>
+            {crossAppAccount
+              ? JSON.stringify(crossAppAccount, null, 2)
+              : 'No cross-app account linked yet.'}
+          </pre>
+
+          <h2>Wallets ({wallets.length})</h2>
+          <pre>
+            {JSON.stringify(
+              wallets.map((w) => ({
+                address: w.address,
+                chainId: w.chainId,
+                walletClientType: w.walletClientType,
+                connectorType: w.connectorType,
+              })),
+              null,
+              2,
+            )}
+          </pre>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/playground/global-wallet-test/src/main.tsx
+++ b/playground/global-wallet-test/src/main.tsx
@@ -1,0 +1,32 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { PrivyProvider } from '@privy-io/react-auth';
+import App from './App';
+import './styles.css';
+
+const PRIVY_APP_ID = import.meta.env.VITE_PRIVY_APP_ID;
+const PROVIDER_APP_ID = 'cm5y07p2z02napk1cutzzx7o6';
+
+if (!PRIVY_APP_ID) {
+  throw new Error('VITE_PRIVY_APP_ID is not set in .env');
+}
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <PrivyProvider
+      appId={PRIVY_APP_ID}
+      config={{
+        loginMethodsAndOrder: {
+          primary: [`privy:${PROVIDER_APP_ID}`, 'email'],
+          overflow: ['detected_ethereum_wallets'],
+        },
+        appearance: {
+          theme: 'light',
+          accentColor: '#7c3aed',
+        },
+      }}
+    >
+      <App providerAppId={PROVIDER_APP_ID} />
+    </PrivyProvider>
+  </StrictMode>,
+);

--- a/playground/global-wallet-test/src/styles.css
+++ b/playground/global-wallet-test/src/styles.css
@@ -1,0 +1,85 @@
+:root {
+  font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+  color-scheme: light;
+  background: #fafafa;
+  color: #111;
+}
+
+body {
+  margin: 0;
+}
+
+.container {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 4rem;
+}
+
+h1 {
+  margin-bottom: 0.25rem;
+}
+
+.muted {
+  color: #6b7280;
+  font-size: 0.875rem;
+  margin-top: 0;
+}
+
+.muted code {
+  background: #f3f4f6;
+  padding: 0.125rem 0.375rem;
+  border-radius: 4px;
+  font-size: 0.8125rem;
+}
+
+.actions {
+  display: flex;
+  gap: 0.75rem;
+  margin: 1.5rem 0 2rem;
+  flex-wrap: wrap;
+}
+
+button {
+  background: #fff;
+  color: #111;
+  border: 1px solid #d4d4d8;
+  border-radius: 8px;
+  padding: 0.625rem 1rem;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: background 120ms ease, border-color 120ms ease;
+}
+
+button:hover {
+  background: #f4f4f5;
+}
+
+button.primary {
+  background: #7c3aed;
+  border-color: #7c3aed;
+  color: #fff;
+}
+
+button.primary:hover {
+  background: #6d28d9;
+  border-color: #6d28d9;
+}
+
+section h2 {
+  font-size: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #374151;
+  margin-top: 2rem;
+  margin-bottom: 0.5rem;
+}
+
+pre {
+  background: #0f172a;
+  color: #e2e8f0;
+  padding: 1rem;
+  border-radius: 8px;
+  overflow-x: auto;
+  font-size: 0.8125rem;
+  line-height: 1.5;
+}

--- a/playground/global-wallet-test/src/vite-env.d.ts
+++ b/playground/global-wallet-test/src/vite-env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_PRIVY_APP_ID: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/playground/global-wallet-test/tsconfig.json
+++ b/playground/global-wallet-test/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/playground/global-wallet-test/tsconfig.node.json
+++ b/playground/global-wallet-test/tsconfig.node.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true,
+    "strict": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/playground/global-wallet-test/vite.config.ts
+++ b/playground/global-wallet-test/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5180,
+    strictPort: true,
+  },
+});


### PR DESCRIPTION
## Summary

Token-backing vault proposals were succeeding at `createProposal` time but reverting silently during execution after voting. Root cause: several `require()` checks inside `TokenBackingVaultImplementation.addBackingToken` are not validated client-side, and `Executor.executeTransactions` drops `returndata`, so the failure surfaced as a generic "Execution failed" with no logs on basescan.

This PR adds preflight validation in `useTokenBackingVaultMutations.web3.rsc.ts` that mirrors the contract `require()` checks and throws actionable errors **before** the proposal is created. It also fixes a small regression from `7dd3fc4a2` where redundant `setRedemptionPrice` / `setMaxRedemptionPercentage` / `setMinimumBacking` calls were appended even when `addBackingToken` had just set the same values during vault creation.

### Validations added

| Check | Maps to contract revert |
|---|---|
| At least one backing collateral when creating a vault | `'No backing tokens specified'` |
| `spaceToken.tokenPrice() > 0` (when creating) | `'Space token price must be > 0'` ← the actual bug we hit |
| Hypha-style backing token has `tokenPrice() > 0` | `'Hypha token price must be > 0'` |
| `maxRedemptionPercent > 0` requires `periodDays > 0` | `'Period must be > 0 when cap is set'` |

Errors are combined into a single message and propagate through the existing `web3.errorCreateTokenBackingVault` channel — no UI changes required.

### Why "create empty vault" isn't allowed

Confirmed against the contract: `_getOrCreateVault` is `internal` and only reachable via `addBackingToken`, which requires `backingTokens.length > 0`. Created vaults need at least one backing token. Surfaced this as an explicit validation error instead of silently failing.

### Bonus: script updates

The two mainnet test scripts (`create-space-and-vault-test.ts`, `create-space-and-vault-no-mint-test.ts`) were also updated to:
- Match the new 22-parameter `RegularTokenFactory.deployToken` signature (whitelist space ids, credit limit, sale config).
- Add `sleep` + `withRetry` around RPC reads to handle Base mainnet rate limits during the propose → vote → execute → verify flow.

## Test plan

- [ ] Create a vault proposal with a space token whose `tokenPrice() == 0` → expect "The selected space token has no price set..." error before signing
- [ ] Create a vault proposal with a backing token that has no Chainlink feed and `tokenPrice() == 0` → expect "Backing token ... has no price set..." error
- [ ] Activate vault without any collaterals → expect "At least one backing collateral is required..." error
- [ ] Set Maximum Redemption % > 0 without picking a period → expect "...rolling period (days) is missing..." error
- [ ] Create a vault with valid space token + USDC backing → proposal creates, votes pass, executes successfully
- [ ] Update an existing vault: change redemption price + add backing → both txs included (regression check)
- [ ] Re-run `pnpm script:create-space-and-vault-no-mint-test` against Base mainnet → completes without rate-limit failures


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Pre-flight validation of backing vault creation parameters
  * Support for empty vault creation and configuration
  * Global Wallet consumer test application with authentication and wallet management

* **Bug Fixes**
  * Enhanced error reporting for backing vault creation with multi-language support (German, English, Spanish, French, Portuguese)

* **UI/UX**
  * Added visual separators in the vaults section
<!-- end of auto-generated comment: release notes by coderabbit.ai -->