### PR TITLE
fix(ui): sync mobile sidebar Sheet with controlled open state

### DIFF
--- a/packages/ui/src/sidebar.tsx
+++ b/packages/ui/src/sidebar.tsx
@@ -36,8 +36,6 @@ type SidebarContextProps = {
   state: 'expanded' | 'collapsed';
   open: boolean;
   setOpen: (open: boolean) => void;
-  openMobile: boolean;
-  setOpenMobile: (open: boolean) => void;
   isMobile: boolean;
   toggleSidebar: () => void;
 };
@@ -73,7 +71,6 @@ const SidebarProvider = React.forwardRef<HTMLDivElement, SidebarProviderProps>(
     ref,
   ) => {
     const isMobile = useIsMobile() ?? false;
-    const [openMobile, setOpenMobile] = React.useState(false);
 
     // This is the internal state of the sidebar.
     // We use openProp and setOpenProp for control from outside the component.
@@ -96,10 +93,8 @@ const SidebarProvider = React.forwardRef<HTMLDivElement, SidebarProviderProps>(
 
     // Helper to toggle the sidebar.
     const toggleSidebar = React.useCallback(() => {
-      return isMobile
-        ? setOpenMobile((open) => !open)
-        : setOpen((open) => !open);
-    }, [isMobile, setOpen, setOpenMobile]);
+      setOpen((o) => !o);
+    }, [setOpen]);
 
     // Adds a keyboard shortcut to toggle the sidebar.
     React.useEffect(() => {
@@ -137,19 +132,9 @@ const SidebarProvider = React.forwardRef<HTMLDivElement, SidebarProviderProps>(
         open,
         setOpen,
         isMobile,
-        openMobile,
-        setOpenMobile,
         toggleSidebar,
       }),
-      [
-        state,
-        open,
-        setOpen,
-        isMobile,
-        openMobile,
-        setOpenMobile,
-        toggleSidebar,
-      ],
+      [state, open, setOpen, isMobile, toggleSidebar],
     );
 
     return (
@@ -198,7 +183,7 @@ const Sidebar = React.forwardRef<HTMLDivElement, SidebarProps>(
     },
     ref,
   ) => {
-    const { isMobile, state, openMobile, setOpenMobile } = useSidebar();
+    const { isMobile, state, setOpen } = useSidebar();
 
     if (collapsible === 'none') {
       return (
@@ -217,7 +202,7 @@ const Sidebar = React.forwardRef<HTMLDivElement, SidebarProps>(
 
     if (isMobile) {
       return (
-        <Sheet open={openMobile} onOpenChange={setOpenMobile}>
+        <Sheet open={state === 'expanded'} onOpenChange={setOpen}>
           <SheetContent
             ref={ref}
             data-sidebar="sidebar"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cherry-picks [738a7524aa143c9521f3b23b15ff82f31c2b1a9d](https://github.com/hypha-dao/hypha-web/pull/2193/commits/738a7524aa143c9521f3b23b15ff82f31c2b1a9d) from https://github.com/hypha-dao/hypha-web/pull/2193 onto `main`.

## What changed

- `packages/ui/src/sidebar.tsx`: the mobile `Sheet` now uses the same `open` / `setOpen` as `SidebarProvider` (removes separate `openMobile` state) so the mobile sheet stays in sync when layout/panel code toggles sidebar open via `onOpenChange`. This fixes the sheet not opening on mobile while desktop layout still affected the shell after hydration.

## Notes

- Source: PR #2193, commit `738a752` ("fix(ui): sync mobile sidebar Sheet with controlled open state").

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-96e8c7bc-f885-46a6-8503-f017bd24a6a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-96e8c7bc-f885-46a6-8503-f017bd24a6a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

