### PR TITLE
feat(feature-flags): default product feature flags to on

### DIFF
--- a/apps/web-e2e/src/ai-chat-feature-flag.spec.ts
+++ b/apps/web-e2e/src/ai-chat-feature-flag.spec.ts
@@ -8,8 +8,9 @@ import { AiChatPanelPage } from './pages/ai-chat-panel.page';
  * the panel trigger button and sidebar are rendered. When unset or
  * any other value, only the page children render (no AI panel).
  *
- * Note: This is a NEXT_PUBLIC_ env var, bundled at build time.
- * The "flag disabled" tests require a separate build without the flag.
+ * Note: This is a NEXT_PUBLIC_ env var, bundled at build time. When unset or
+ * "true", AI chat is on. The "flag disabled" tests require a build where it is
+ * not "true" (e.g. empty at build time).
  */
 
 test.describe('AI Chat Panel — Feature Flag Enabled', () => {

--- a/apps/web-e2e/src/ai-chat-feature-flag.spec.ts
+++ b/apps/web-e2e/src/ai-chat-feature-flag.spec.ts
@@ -8,15 +8,16 @@ import { AiChatPanelPage } from './pages/ai-chat-panel.page';
  * the panel trigger button and sidebar are rendered. When unset or
  * any other value, only the page children render (no AI panel).
  *
- * Note: This is a NEXT_PUBLIC_ env var, bundled at build time. When unset or
- * "true", AI chat is on. The "flag disabled" tests require a build where it is
- * not "true" (e.g. empty at build time).
+ * Default runtime: off. E2E enables the flag via `HYPHA_ENABLE_AI_CHAT` cookie
+ * (see `AiChatPanelPage.enableAiChat`). The "flag disabled" tests require a build
+ * where `NEXT_PUBLIC_ENABLE_AI_CHAT` is not "true" for SSR.
  */
 
 test.describe('AI Chat Panel — Feature Flag Enabled', () => {
   let chatPanel: AiChatPanelPage;
 
-  test.beforeEach(async ({ page }) => {
+  test.beforeEach(async ({ context, page }) => {
+    await AiChatPanelPage.enableAiChat(context);
     chatPanel = new AiChatPanelPage(page);
     await chatPanel.open();
   });

--- a/apps/web-e2e/src/human-chat-panel-feature-flag.spec.ts
+++ b/apps/web-e2e/src/human-chat-panel-feature-flag.spec.ts
@@ -9,15 +9,8 @@ import { HumanChatPanelPage } from './pages/human-chat-panel.page';
 test.describe('Human Chat Panel — feature flag enabled (cookie)', () => {
   let chatPanel: HumanChatPanelPage;
 
-  test.beforeEach(async ({ context, page }) => {
-    await context.addCookies([
-      {
-        name: 'HYPHA_ENABLE_HUMAN_CHAT',
-        value: 'true',
-        domain: '127.0.0.1',
-        path: '/',
-      },
-    ]);
+  test.beforeEach(async ({ context, page, baseURL }) => {
+    await HumanChatPanelPage.enableHumanChat(context, baseURL);
     chatPanel = new HumanChatPanelPage(page);
     await chatPanel.open();
   });

--- a/apps/web-e2e/src/human-chat-panel-feature-flag.spec.ts
+++ b/apps/web-e2e/src/human-chat-panel-feature-flag.spec.ts
@@ -2,14 +2,22 @@ import { test, expect } from '@playwright/test';
 import { HumanChatPanelPage } from './pages/human-chat-panel.page';
 
 /**
- * Human Chat defaults to on (see `getEnableHumanChat` in feature-flags). Opt out
- * with cookie or env; emergency rollback uses `HYPHA_DISABLE_HUMAN_CHAT=true`.
+ * Default runtime: off. The enabled describe block sets `HYPHA_ENABLE_HUMAN_CHAT=true`.
+ * Emergency rollback: `HYPHA_DISABLE_HUMAN_CHAT=true`.
  */
 
-test.describe('Human Chat Panel — default (enabled)', () => {
+test.describe('Human Chat Panel — feature flag enabled (cookie)', () => {
   let chatPanel: HumanChatPanelPage;
 
-  test.beforeEach(async ({ page }) => {
+  test.beforeEach(async ({ context, page }) => {
+    await context.addCookies([
+      {
+        name: 'HYPHA_ENABLE_HUMAN_CHAT',
+        value: 'true',
+        domain: '127.0.0.1',
+        path: '/',
+      },
+    ]);
     chatPanel = new HumanChatPanelPage(page);
     await chatPanel.open();
   });

--- a/apps/web-e2e/src/human-chat-panel-feature-flag.spec.ts
+++ b/apps/web-e2e/src/human-chat-panel-feature-flag.spec.ts
@@ -2,8 +2,8 @@ import { test, expect } from '@playwright/test';
 import { HumanChatPanelPage } from './pages/human-chat-panel.page';
 
 /**
- * Human Chat is enabled by default. Emergency rollback uses the kill-switch cookie
- * `HYPHA_DISABLE_HUMAN_CHAT=true` (see `getEnableHumanChat` in feature-flags).
+ * Human Chat defaults to on (see `getEnableHumanChat` in feature-flags). Opt out
+ * with cookie or env; emergency rollback uses `HYPHA_DISABLE_HUMAN_CHAT=true`.
  */
 
 test.describe('Human Chat Panel — default (enabled)', () => {

--- a/apps/web-e2e/src/pages/human-chat-panel.page.ts
+++ b/apps/web-e2e/src/pages/human-chat-panel.page.ts
@@ -1,5 +1,11 @@
-import { Page, Locator } from '@playwright/test';
+import { type BrowserContext, type Locator, type Page } from '@playwright/test';
 import { BasePage } from './base.page';
+
+/**
+ * Feature-flag cookie: mirrors `@hypha-platform/cookie` HYPHA_ENABLE_HUMAN_CHAT (e2e cannot
+ * import the package directly here).
+ */
+const HYPHA_ENABLE_HUMAN_CHAT = 'HYPHA_ENABLE_HUMAN_CHAT';
 
 export class HumanChatPanelPage extends BasePage {
   readonly openButton: Locator;
@@ -15,6 +21,17 @@ export class HumanChatPanelPage extends BasePage {
   readonly chatTab: Locator;
   readonly membersContainer: Locator;
   readonly memberItems: Locator;
+
+  static async enableHumanChat(context: BrowserContext, baseURL?: string) {
+    await context.addCookies([
+      {
+        name: HYPHA_ENABLE_HUMAN_CHAT,
+        value: 'true',
+        domain: new URL(baseURL ?? 'http://127.0.0.1:3000').hostname,
+        path: '/',
+      },
+    ]);
+  }
 
   constructor(page: Page) {
     super(page);

--- a/apps/web/.env.template
+++ b/apps/web/.env.template
@@ -62,11 +62,12 @@ NEXT_PUBLIC_TERMS_URL=https://assets.hypha.earth/files/Hypha_Terms_And_Condition
 NEXT_PUBLIC_PRIVACY_URL=https://assets.hypha.earth/files/Hypha_Privacy_Policy.pdf
 NEXT_PUBLIC_ROOT_URL=https://hypha.earth
 
-# Feature flags — product flags default to ON. Set to "false" to disable (also via cookies; see @hypha-platform/feature-flags).
-# NEXT_PUBLIC_ENABLE_AI_CHAT=false
-# NEXT_PUBLIC_ENABLE_HUMAN_CHAT=false
-# NEXT_PUBLIC_ENABLE_COHERENCE=false
-# NEXT_PUBLIC_ENABLE_SPACE_MEMORY=false
+# Feature flags — AI / Human / Coherence / Space Memory default to OFF. Set to "true" to enable
+# (also via HYPHA_ENABLE_* cookies; see @hypha-platform/feature-flags).
+# NEXT_PUBLIC_ENABLE_AI_CHAT=true
+# NEXT_PUBLIC_ENABLE_HUMAN_CHAT=true
+# NEXT_PUBLIC_ENABLE_COHERENCE=true
+# NEXT_PUBLIC_ENABLE_SPACE_MEMORY=true
 
 # Debug CSP locally
 ENABLE_LOCALHOST_CSP=false

--- a/apps/web/.env.template
+++ b/apps/web/.env.template
@@ -62,10 +62,11 @@ NEXT_PUBLIC_TERMS_URL=https://assets.hypha.earth/files/Hypha_Terms_And_Condition
 NEXT_PUBLIC_PRIVACY_URL=https://assets.hypha.earth/files/Hypha_Privacy_Policy.pdf
 NEXT_PUBLIC_ROOT_URL=https://hypha.earth
 
-# Feature flags — set on Vercel Production when launching panes / Coherence (values: "true")
+# Feature flags — product flags default to ON. Set to "false" to disable (also via cookies; see @hypha-platform/feature-flags).
 # NEXT_PUBLIC_ENABLE_AI_CHAT=false
-# NEXT_PUBLIC_ENABLE_HUMAN_CHAT=true
-# NEXT_PUBLIC_ENABLE_COHERENCE=true
+# NEXT_PUBLIC_ENABLE_HUMAN_CHAT=false
+# NEXT_PUBLIC_ENABLE_COHERENCE=false
+# NEXT_PUBLIC_ENABLE_SPACE_MEMORY=false
 
 # Debug CSP locally
 ENABLE_LOCALHOST_CSP=false

--- a/apps/web/.env.template
+++ b/apps/web/.env.template
@@ -63,7 +63,8 @@ NEXT_PUBLIC_PRIVACY_URL=https://assets.hypha.earth/files/Hypha_Privacy_Policy.pd
 NEXT_PUBLIC_ROOT_URL=https://hypha.earth
 
 # Feature flags — AI / Human / Coherence / Space Memory default to OFF. Set to "true" to enable
-# (also via HYPHA_ENABLE_* cookies; see @hypha-platform/feature-flags).
+# (NEXT_PUBLIC_* are build-time: rebuild after change). For runtime without rebuild, use HYPHA_ENABLE_*
+# cookies; see @hypha-platform/feature-flags.
 # NEXT_PUBLIC_ENABLE_AI_CHAT=true
 # NEXT_PUBLIC_ENABLE_HUMAN_CHAT=true
 # NEXT_PUBLIC_ENABLE_COHERENCE=true

--- a/apps/web/src/app/[lang]/dho/[id]/layout.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/layout.tsx
@@ -118,6 +118,7 @@ export default async function DhoLayout({
         max-width + centering that made the main column look pushed with a void on the left.
       */}
       <div className="flex w-full min-w-0">
+        {/* `px-4!` = 16px: tighter than default Container `px-5` (20px) for DHO hero/tabs vs app chrome */}
         <Container size="lg" className="min-w-0 flex-1 px-4!">
           {/* React 19+: link rel="preload" is hoisted to document head */}
           {heroBannerImageHref !== DEFAULT_SPACE_LEAD_IMAGE ? (

--- a/apps/web/src/app/[lang]/dho/[id]/layout.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/layout.tsx
@@ -112,8 +112,13 @@ export default async function DhoLayout({
 
   return (
     <SpaceAccentPortalBridge>
-      <div className="mx-auto flex max-w-container-2xl">
-        <Container className="min-w-0 flex-grow px-4!">
+      {/*
+        Full-width row: `Container` already applies max-width + horizontal padding.
+        Dropping the extra `mx-auto max-w-container-2xl` wrapper avoided double
+        max-width + centering that made the main column look pushed with a void on the left.
+      */}
+      <div className="flex w-full min-w-0">
+        <Container size="lg" className="min-w-0 flex-1 px-4!">
           {/* React 19+: link rel="preload" is hoisted to document head */}
           {heroBannerImageHref !== DEFAULT_SPACE_LEAD_IMAGE ? (
             <link

--- a/packages/epics/src/common/panel-main-column-scroll-bridge.tsx
+++ b/packages/epics/src/common/panel-main-column-scroll-bridge.tsx
@@ -35,7 +35,7 @@ export function PanelDualSidebarScrollBridge({
   rightContent,
   children,
 }: Props) {
-  const bindScrollRoot = React.useCallback((node: HTMLElement | null) => {
+  const setMainColumnRef = React.useCallback((node: HTMLElement | null) => {
     setMainColumnScrollRoot(node);
   }, []);
 
@@ -59,9 +59,15 @@ export function PanelDualSidebarScrollBridge({
         {leftContent}
         <SidebarResizeHandle />
       </Sidebar>
+      {/*
+        The inner `SidebarProvider` is `h-svh` and lays out the center column + right panel in
+        a row. Scrolling must happen *inside* that row’s center column — not on this outer
+        `SidebarInset`. Otherwise the scrollable height equals the viewport, nothing overflows
+        here, and the real scroll moves to an ancestor/window, breaking `setMainColumnScrollRoot`
+        and DHO sticky chrome (fixed bar + opacity) that subscribe to the main column.
+      */}
       <SidebarInset
-        ref={bindScrollRoot}
-        className={cn('overflow-y-auto narrow-scrollbar')}
+        className={cn('min-h-0 flex-1 flex-col overflow-hidden')}
         style={
           {
             '--main-column-scrollbar-width': '0px',
@@ -84,7 +90,12 @@ export function PanelDualSidebarScrollBridge({
             wrapper they become **separate flex items** next to the right Sidebar: header | content
             | footer | panel in one horizontal row.
           */}
-          <div className="flex min-h-0 min-w-0 flex-1 flex-col">{children}</div>
+          <div
+            ref={setMainColumnRef}
+            className="flex min-h-0 min-w-0 flex-1 flex-col overflow-y-auto narrow-scrollbar"
+          >
+            {children}
+          </div>
           <Sidebar
             side="right"
             variant="sidebar"

--- a/packages/epics/src/common/panel-main-column-scroll-bridge.tsx
+++ b/packages/epics/src/common/panel-main-column-scroll-bridge.tsx
@@ -78,7 +78,13 @@ export function PanelDualSidebarScrollBridge({
             } as React.CSSProperties
           }
         >
-          {children}
+          {/*
+            `SidebarProvider` is `display: flex` (row). The root layout passes several siblings
+            (MenuTop, plugin, main, Footer) as a fragment — fragments flatten, so without this
+            wrapper they become **separate flex items** next to the right Sidebar: header | content
+            | footer | panel in one horizontal row.
+          */}
+          <div className="flex min-h-0 min-w-0 flex-1 flex-col">{children}</div>
           <Sidebar
             side="right"
             variant="sidebar"

--- a/packages/epics/src/common/panel-main-column-scroll-bridge.tsx
+++ b/packages/epics/src/common/panel-main-column-scroll-bridge.tsx
@@ -41,6 +41,7 @@ export function PanelDualSidebarScrollBridge({
 
   return (
     <SidebarProvider
+      defaultOpen={false}
       open={leftOpen}
       onOpenChange={onLeftOpenChange}
       style={
@@ -68,6 +69,7 @@ export function PanelDualSidebarScrollBridge({
         }
       >
         <SidebarProvider
+          defaultOpen={false}
           open={rightOpen}
           onOpenChange={onRightOpenChange}
           style={

--- a/packages/epics/src/common/panel-wrap-layout.tsx
+++ b/packages/epics/src/common/panel-wrap-layout.tsx
@@ -191,6 +191,7 @@ export function PanelWrapLayout({
   } else if (effectiveRight) {
     content = (
       <SidebarProvider
+        defaultOpen={false}
         open={rightOpen}
         onOpenChange={(open) => {
           if (open !== rightOpen) toggleRight();
@@ -218,6 +219,7 @@ export function PanelWrapLayout({
   } else if (effectiveLeft) {
     content = (
       <SidebarProvider
+        defaultOpen={false}
         open={leftOpen}
         onOpenChange={(open) => {
           if (open !== leftOpen) toggleLeft();

--- a/packages/feature-flags/src/index.ts
+++ b/packages/feature-flags/src/index.ts
@@ -14,9 +14,9 @@ import {
 } from './vercel-toolbar-overrides';
 
 /**
- * **Guideline:** product feature flags default **on** in this repo. Disable explicitly via
- * cookie or `NEXT_PUBLIC_*=false`. Vercel Flags Toolbar can still override per key.
- * Human chat kill switch: `HYPHA_DISABLE_HUMAN_CHAT=true` / `NEXT_PUBLIC_DISABLE_HUMAN_CHAT=true`.
+ * **Guideline:** product feature flags (AI / Human / Coherence / Space Memory) default **off**
+ * until enabled via cookie, `NEXT_PUBLIC_*=true`, or Vercel Flags Toolbar. Human chat kill
+ * switch: `HYPHA_DISABLE_HUMAN_CHAT=true` / `NEXT_PUBLIC_DISABLE_HUMAN_CHAT=true`.
  */
 
 /**
@@ -47,25 +47,25 @@ export const flagDefinitionsForDiscovery = {
   },
   enableAiChat: {
     key: 'enable-ai-chat',
-    defaultValue: true,
+    defaultValue: false,
     description:
-      'AI Chat panel on space pages. Opt out: cookie or NEXT_PUBLIC_ENABLE_AI_CHAT=false',
+      'AI Chat panel on space pages. Opt in: cookie or NEXT_PUBLIC_ENABLE_AI_CHAT=true',
     origin: 'hypha' as const,
     options: undefined as undefined,
   },
   enableCoherence: {
     key: 'enable-coherence',
-    defaultValue: true,
+    defaultValue: false,
     description:
-      'Coherence tab and signals. Opt out: NEXT_PUBLIC_ENABLE_COHERENCE=false. Space Memory uses enable-space-memory.',
+      'Coherence tab and signals. Opt in: NEXT_PUBLIC_ENABLE_COHERENCE=true. Space Memory uses enable-space-memory.',
     origin: 'hypha' as const,
     options: undefined as undefined,
   },
   enableSpaceMemory: {
     key: 'enable-space-memory',
-    defaultValue: true,
+    defaultValue: false,
     description:
-      'Space Memory on Coherence tab. Opt out: NEXT_PUBLIC_ENABLE_SPACE_MEMORY=false',
+      'Space Memory on Coherence tab. Opt in: NEXT_PUBLIC_ENABLE_SPACE_MEMORY=true',
     origin: 'hypha' as const,
     options: undefined as undefined,
   },
@@ -74,9 +74,9 @@ export const flagDefinitionsForDiscovery = {
    */
   enableHumanChat: {
     key: 'enable-human-chat',
-    defaultValue: true,
+    defaultValue: false,
     description:
-      'Human Chat panel. Opt out: NEXT_PUBLIC_ENABLE_HUMAN_CHAT=false. Kill-switch: HYPHA_DISABLE_HUMAN_CHAT',
+      'Human Chat panel. Opt in: NEXT_PUBLIC_ENABLE_HUMAN_CHAT=true. Kill-switch: HYPHA_DISABLE_HUMAN_CHAT',
     origin: 'hypha' as const,
     options: undefined as undefined,
   },
@@ -117,7 +117,7 @@ async function getBooleanFlagFromToolbarCookieOrEnv(
   if (cookieValue === 'false') return false;
   if (envValue === 'true') return true;
   if (envValue === 'false') return false;
-  return true;
+  return false;
 }
 
 export async function getEnableAiChat(): Promise<boolean> {
@@ -137,8 +137,7 @@ export async function getEnableCoherence(): Promise<boolean> {
 }
 
 /**
- * Default on; opt out with cookie or `NEXT_PUBLIC_ENABLE_HUMAN_CHAT=false`.
- * Kill switch still wins.
+ * Opt-in via `NEXT_PUBLIC_ENABLE_HUMAN_CHAT`, cookie, or toolbar. Kill switch still wins.
  */
 export async function getEnableHumanChat(): Promise<boolean> {
   const overrides = await getVercelToolbarFlagOverrides();
@@ -157,8 +156,7 @@ export async function getEnableHumanChat(): Promise<boolean> {
   if (legacyEnable === 'true') return true;
   if (legacyEnable === 'false') return false;
 
-  if (process.env.NEXT_PUBLIC_ENABLE_HUMAN_CHAT === 'false') return false;
-  return true;
+  return process.env.NEXT_PUBLIC_ENABLE_HUMAN_CHAT === 'true';
 }
 
 export async function getEnableSpaceMemory(): Promise<boolean> {

--- a/packages/feature-flags/src/index.ts
+++ b/packages/feature-flags/src/index.ts
@@ -14,9 +14,9 @@ import {
 } from './vercel-toolbar-overrides';
 
 /**
- * **Guideline:** safe defaults — features off until enabled via cookie / `NEXT_PUBLIC_*` /
- * Vercel Flags Toolbar. Human Chat uses the same opt-in pattern as Coherence (`NEXT_PUBLIC_ENABLE_*`).
- * Kill switch: `HYPHA_DISABLE_HUMAN_CHAT=true` / `NEXT_PUBLIC_DISABLE_HUMAN_CHAT=true`.
+ * **Guideline:** product feature flags default **on** in this repo. Disable explicitly via
+ * cookie or `NEXT_PUBLIC_*=false`. Vercel Flags Toolbar can still override per key.
+ * Human chat kill switch: `HYPHA_DISABLE_HUMAN_CHAT=true` / `NEXT_PUBLIC_DISABLE_HUMAN_CHAT=true`.
  */
 
 /**
@@ -33,7 +33,8 @@ export const flagDefinitionsForDiscovery = {
   enableWeb3Auth: {
     key: 'enable-web3-auth',
     defaultValue: false,
-    description: 'Use Web3Auth as the auth provider when cookie matches',
+    description:
+      'Web3 auth — enabled only when HYPHA_AUTH_PROVIDER=web3auth (cookie) or toolbar override; not a global product default',
     origin: 'hypha' as const,
     options: undefined as undefined,
   },
@@ -46,23 +47,25 @@ export const flagDefinitionsForDiscovery = {
   },
   enableAiChat: {
     key: 'enable-ai-chat',
-    defaultValue: false,
-    description: 'Enable the AI Chat panel in space pages',
+    defaultValue: true,
+    description:
+      'AI Chat panel on space pages. Opt out: cookie or NEXT_PUBLIC_ENABLE_AI_CHAT=false',
     origin: 'hypha' as const,
     options: undefined as undefined,
   },
   enableCoherence: {
     key: 'enable-coherence',
-    defaultValue: false,
+    defaultValue: true,
     description:
-      'Coherence tab and signals (`NEXT_PUBLIC_ENABLE_COHERENCE`, cookie). Space Memory uses enable-space-memory.',
+      'Coherence tab and signals. Opt out: NEXT_PUBLIC_ENABLE_COHERENCE=false. Space Memory uses enable-space-memory.',
     origin: 'hypha' as const,
     options: undefined as undefined,
   },
   enableSpaceMemory: {
     key: 'enable-space-memory',
-    defaultValue: false,
-    description: 'Show the Space Memory panel on the Coherence tab',
+    defaultValue: true,
+    description:
+      'Space Memory on Coherence tab. Opt out: NEXT_PUBLIC_ENABLE_SPACE_MEMORY=false',
     origin: 'hypha' as const,
     options: undefined as undefined,
   },
@@ -71,9 +74,9 @@ export const flagDefinitionsForDiscovery = {
    */
   enableHumanChat: {
     key: 'enable-human-chat',
-    defaultValue: false,
+    defaultValue: true,
     description:
-      'Human Chat panel (`NEXT_PUBLIC_ENABLE_HUMAN_CHAT`; kill-switch HYPHA_DISABLE_HUMAN_CHAT)',
+      'Human Chat panel. Opt out: NEXT_PUBLIC_ENABLE_HUMAN_CHAT=false. Kill-switch: HYPHA_DISABLE_HUMAN_CHAT',
     origin: 'hypha' as const,
     options: undefined as undefined,
   },
@@ -110,8 +113,11 @@ async function getBooleanFlagFromToolbarCookieOrEnv(
 
   const store = await cookies();
   const cookieValue = store.get(cookieName)?.value;
-  if (cookieValue !== undefined) return cookieValue === 'true';
-  return envValue === 'true';
+  if (cookieValue === 'true') return true;
+  if (cookieValue === 'false') return false;
+  if (envValue === 'true') return true;
+  if (envValue === 'false') return false;
+  return true;
 }
 
 export async function getEnableAiChat(): Promise<boolean> {
@@ -130,7 +136,10 @@ export async function getEnableCoherence(): Promise<boolean> {
   );
 }
 
-/** Opt-in via `NEXT_PUBLIC_ENABLE_HUMAN_CHAT`, cookie, or toolbar; kill-switch still wins. */
+/**
+ * Default on; opt out with cookie or `NEXT_PUBLIC_ENABLE_HUMAN_CHAT=false`.
+ * Kill switch still wins.
+ */
 export async function getEnableHumanChat(): Promise<boolean> {
   const overrides = await getVercelToolbarFlagOverrides();
   const toolbarHumanChat = readBooleanOverride(overrides, 'enable-human-chat');
@@ -145,9 +154,11 @@ export async function getEnableHumanChat(): Promise<boolean> {
   if (process.env.NEXT_PUBLIC_DISABLE_HUMAN_CHAT === 'true') return false;
 
   const legacyEnable = store.get(HYPHA_ENABLE_HUMAN_CHAT)?.value;
-  if (legacyEnable !== undefined) return legacyEnable === 'true';
+  if (legacyEnable === 'true') return true;
+  if (legacyEnable === 'false') return false;
 
-  return process.env.NEXT_PUBLIC_ENABLE_HUMAN_CHAT === 'true';
+  if (process.env.NEXT_PUBLIC_ENABLE_HUMAN_CHAT === 'false') return false;
+  return true;
 }
 
 export async function getEnableSpaceMemory(): Promise<boolean> {

--- a/packages/feature-flags/src/index.ts
+++ b/packages/feature-flags/src/index.ts
@@ -57,7 +57,7 @@ export const flagDefinitionsForDiscovery = {
     key: 'enable-coherence',
     defaultValue: false,
     description:
-      'Coherence tab and signals. Opt in: NEXT_PUBLIC_ENABLE_COHERENCE=true. Space Memory uses enable-space-memory.',
+      'Coherence tab and signals. Opt in: HYPHA_ENABLE_COHERENCE cookie or NEXT_PUBLIC_ENABLE_COHERENCE=true. Space Memory uses enable-space-memory.',
     origin: 'hypha' as const,
     options: undefined as undefined,
   },
@@ -65,7 +65,7 @@ export const flagDefinitionsForDiscovery = {
     key: 'enable-space-memory',
     defaultValue: false,
     description:
-      'Space Memory on Coherence tab. Opt in: NEXT_PUBLIC_ENABLE_SPACE_MEMORY=true',
+      'Space Memory on Coherence tab. Opt in: HYPHA_ENABLE_SPACE_MEMORY cookie or NEXT_PUBLIC_ENABLE_SPACE_MEMORY=true',
     origin: 'hypha' as const,
     options: undefined as undefined,
   },
@@ -76,7 +76,7 @@ export const flagDefinitionsForDiscovery = {
     key: 'enable-human-chat',
     defaultValue: false,
     description:
-      'Human Chat panel. Opt in: NEXT_PUBLIC_ENABLE_HUMAN_CHAT=true. Kill-switch: HYPHA_DISABLE_HUMAN_CHAT',
+      'Human Chat panel. Opt in: HYPHA_ENABLE_HUMAN_CHAT cookie or NEXT_PUBLIC_ENABLE_HUMAN_CHAT=true. Kill-switch: HYPHA_DISABLE_HUMAN_CHAT cookie or NEXT_PUBLIC_DISABLE_HUMAN_CHAT=true',
     origin: 'hypha' as const,
     options: undefined as undefined,
   },

--- a/packages/ui/src/organisms/footer.tsx
+++ b/packages/ui/src/organisms/footer.tsx
@@ -40,7 +40,12 @@ export const Footer = ({
         <div className="pt-6">
           <Logo width={140} />
         </div>
-        <div className="grid grid-cols-1 gap-8 py-8 md:grid-cols-2 md:gap-x-12 md:gap-y-0">
+        {/*
+          Three-column grid: two content columns + empty track (legacy layout).
+          `min-w-0` on each cell prevents text from painting into the next column when
+          the main column is narrow (e.g. beside open side panels).
+        */}
+        <div className="grid grid-cols-1 gap-8 py-8 md:grid-cols-3 md:gap-x-10 md:gap-y-0">
           <div className="flex min-w-0 flex-col items-start space-y-4 md:space-y-0">
             <Text style={customLabelStyles}>{networkLabel}</Text>
             <Button

--- a/packages/ui/src/organisms/footer.tsx
+++ b/packages/ui/src/organisms/footer.tsx
@@ -40,8 +40,8 @@ export const Footer = ({
         <div className="pt-6">
           <Logo width={140} />
         </div>
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-8 md:gap-0 py-8">
-          <div className="flex flex-col items-start space-y-4 md:space-y-0">
+        <div className="grid grid-cols-1 gap-8 py-8 md:grid-cols-2 md:gap-x-12 md:gap-y-0">
+          <div className="flex min-w-0 flex-col items-start space-y-4 md:space-y-0">
             <Text style={customLabelStyles}>{networkLabel}</Text>
             <Button
               asChild
@@ -92,7 +92,7 @@ export const Footer = ({
             </Button>
           </div>
 
-          <div className="flex flex-col items-start space-y-4 md:space-y-0">
+          <div className="flex min-w-0 flex-col items-start space-y-4 md:space-y-0">
             <Text style={customLabelStyles}>{legalLabel}</Text>
             <Button
               asChild

--- a/packages/ui/src/sidebar.tsx
+++ b/packages/ui/src/sidebar.tsx
@@ -244,13 +244,12 @@ const Sidebar = React.forwardRef<HTMLDivElement, SidebarProps>(
           className={cn(
             'relative min-w-0 shrink-0 bg-transparent transition-[width] duration-200 ease-linear',
             'group-data-[side=right]:rotate-180',
-            // Offcanvas: force zero width from React state. The base `w-(--sidebar-width)` can
-            // outrank non-important inline `width: 0` and has left a full-width black flex column
-            // when the sheet is visually closed (e.g. AI / Human shadcn sidebars).
+            // Offcanvas collapsed: `!w-0` beats `w-(--sidebar-width) !important` in Tailwind v4 so
+            // the flex track cannot stay 320px with the panel visually closed. `group-data-[…]`
+            // is redundant with the same collapsed state — width is controlled here only.
             collapsible === 'offcanvas' && state === 'collapsed'
-              ? '!w-0 !min-w-0 !max-w-0 grow-0 basis-0 p-0 m-0 overflow-hidden'
+              ? '!w-0 !min-w-0 !max-w-0 grow-0 basis-0 overflow-hidden'
               : 'w-(--sidebar-width) grow-0',
-            'group-data-[collapsible=offcanvas]:!w-0',
             variant === 'floating' || variant === 'inset'
               ? 'group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)_+_theme(spacing.4))]'
               : 'group-data-[collapsible=icon]:w-(--sidebar-width-icon)',

--- a/packages/ui/src/sidebar.tsx
+++ b/packages/ui/src/sidebar.tsx
@@ -241,20 +241,16 @@ const Sidebar = React.forwardRef<HTMLDivElement, SidebarProps>(
         {/* This is what handles the sidebar gap on desktop */}
         <div
           data-sidebar-gap
-          style={
-            // Offcanvas: set width from React state, not only `data-collapsible` + Tailwind.
-            // Mismatches have left a full `--sidebar-width` flex gap with the panel visually closed.
-            collapsible === 'offcanvas'
-              ? {
-                  width:
-                    state === 'collapsed' ? 0 : 'var(--sidebar-width, 16rem)',
-                }
-              : undefined
-          }
           className={cn(
-            'relative w-(--sidebar-width) min-w-0 shrink-0 bg-transparent transition-[width] duration-200 ease-linear',
-            'group-data-[collapsible=offcanvas]:!w-0',
+            'relative min-w-0 shrink-0 bg-transparent transition-[width] duration-200 ease-linear',
             'group-data-[side=right]:rotate-180',
+            // Offcanvas: force zero width from React state. The base `w-(--sidebar-width)` can
+            // outrank non-important inline `width: 0` and has left a full-width black flex column
+            // when the sheet is visually closed (e.g. AI / Human shadcn sidebars).
+            collapsible === 'offcanvas' && state === 'collapsed'
+              ? '!w-0 !min-w-0 !max-w-0 grow-0 basis-0 p-0 m-0 overflow-hidden'
+              : 'w-(--sidebar-width) grow-0',
+            'group-data-[collapsible=offcanvas]:!w-0',
             variant === 'floating' || variant === 'inset'
               ? 'group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)_+_theme(spacing.4))]'
               : 'group-data-[collapsible=icon]:w-(--sidebar-width-icon)',

--- a/packages/ui/src/sidebar.tsx
+++ b/packages/ui/src/sidebar.tsx
@@ -241,6 +241,16 @@ const Sidebar = React.forwardRef<HTMLDivElement, SidebarProps>(
         {/* This is what handles the sidebar gap on desktop */}
         <div
           data-sidebar-gap
+          style={
+            // Offcanvas: set width from React state, not only `data-collapsible` + Tailwind.
+            // Mismatches have left a full `--sidebar-width` flex gap with the panel visually closed.
+            collapsible === 'offcanvas'
+              ? {
+                  width:
+                    state === 'collapsed' ? 0 : 'var(--sidebar-width, 16rem)',
+                }
+              : undefined
+          }
           className={cn(
             'relative w-(--sidebar-width) min-w-0 shrink-0 bg-transparent transition-[width] duration-200 ease-linear',
             'group-data-[collapsible=offcanvas]:!w-0',

--- a/packages/ui/src/sidebar.tsx
+++ b/packages/ui/src/sidebar.tsx
@@ -242,8 +242,8 @@ const Sidebar = React.forwardRef<HTMLDivElement, SidebarProps>(
         <div
           data-sidebar-gap
           className={cn(
-            'relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear',
-            'group-data-[collapsible=offcanvas]:w-0',
+            'relative w-(--sidebar-width) min-w-0 shrink-0 bg-transparent transition-[width] duration-200 ease-linear',
+            'group-data-[collapsible=offcanvas]:!w-0',
             'group-data-[side=right]:rotate-180',
             variant === 'floating' || variant === 'inset'
               ? 'group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)_+_theme(spacing.4))]'
@@ -254,7 +254,7 @@ const Sidebar = React.forwardRef<HTMLDivElement, SidebarProps>(
           data-sidebar-fixed
           ref={ref}
           className={cn(
-            'fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear md:flex',
+            'fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) overflow-visible transition-[left,right,width] duration-200 ease-linear md:flex',
             side === 'left'
               ? 'left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]'
               : 'right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]',
@@ -563,7 +563,8 @@ const SidebarResizeHandle = React.forwardRef<
           // Layout & hit target (12px wide, centered on edge)
           // Position on the outer edge: right for left-side panels, left for right-side panels
           // Top is offset by --menu-top-height so the handle starts below the menu bar
-          'group/resize absolute bottom-0 z-20 w-3',
+          // z-[45]: above main column so the grip is not partially clipped (overflow/stacking)
+          'group/resize absolute bottom-0 z-[45] w-3',
           'top-[var(--menu-top-height,0px)]',
           'group-data-[side=left]:-right-1.5 group-data-[side=right]:-left-1.5',
           'hidden sm:flex items-center justify-center',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Latest: CodeRabbit autofix (commit `af8a006fc`)
- DHO `layout.tsx`: comment explaining `px-4!` vs default `Container` `px-5`
- `sidebar.tsx`: remove redundant `group-data-[collapsible=offcanvas]:!w-0` (collapsed offcanvas already uses `!w-0` branch); drop no-op `p-0 m-0`; comment clarification
- `feature-flags` discovery: Coherence / Space Memory / Human Chat descriptions include `HYPHA_ENABLE_*` cookie opt-in
- `.env.template`: note that `NEXT_PUBLIC_*` needs rebuild; cookies for runtime
- E2E: `HumanChatPanelPage.enableHumanChat(context, baseURL)` + spec uses it (matches `enableAiChat` pattern)

---

## Summary
Layout fixes for dual AI + Human panels; feature flags default **off** for the four product flags (opt-in via env/cookies).

## Deployment
- Production: keep `NEXT_PUBLIC_ENABLE_*` unset/false for AI, Human, Coherence, Space Memory unless intentionally enabling.
- E2E enables flags via cookies where needed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-68426ccf-9859-4abf-8576-ce6ce2644227"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-68426ccf-9859-4abf-8576-ce6ce2644227"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Behavior Changes**
  * Feature flags (AI Chat, Human Chat, Coherence, Space Memory) now default to OFF; enabling requires explicit opt-in via environment variables or browser cookies and treats the string "true" as enabled. Kill-switches still force-disable.

* **UI Updates**
  * Layout now delegates max-width to container for full-width content; sidebar collapse/resize and footer spacing improved.

* **Tests**
  * E2E test docs updated to reflect cookie-driven flag enablement.

* **Documentation**
  * .env template and flag guidance revised to show opt-in defaults and cookie controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->