### PR TITLE
fix(matrix): canonical Privy DID in matrix_user_links (#2198)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,4 +17,6 @@
 
 /packages/core/src/common/server/encrypt-matrix-token.ts @plitzenberger
 /packages/core/src/common/server/decrypt-matrix-token.ts @plitzenberger
+/packages/core/src/common/server/encrypt-aes.ts @plitzenberger
+/packages/core/src/matrix/server/actions.ts @plitzenberger
 /packages/core/src/governance/server/resolve-user-matrix-access-token-for-org-memory.ts @plitzenberger

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,20 @@
+# Required reviewers by path
+
+/.github/** @plitzenberger
+/packages/storage-postgres/** @plitzenberger
+/packages/storage-evm/** @n0umen0n
+
+# Additional security-relevant paths
+/apps/web/src/app/api/matrix/token/** @plitzenberger
+/apps/web/src/app/.well-known/jwks.json/** @plitzenberger
+
+/packages/chat-server/src/privy-auth.ts @plitzenberger
+/packages/authentication/** @plitzenberger
+
+/apps/api/src/plugins/db/query/verify-auth.ts @plitzenberger
+/apps/api/src/plugins/db/query/find-person-by-auth.ts @plitzenberger
+/apps/web/src/hooks/use-auth-header.ts @plitzenberger
+
+/packages/core/src/common/server/encrypt-matrix-token.ts @plitzenberger
+/packages/core/src/common/server/decrypt-matrix-token.ts @plitzenberger
+/packages/core/src/governance/server/resolve-user-matrix-access-token-for-org-memory.ts @plitzenberger

--- a/apps/web/src/app/api/matrix/token/route.ts
+++ b/apps/web/src/app/api/matrix/token/route.ts
@@ -7,7 +7,6 @@ import {
   getLinkByPrivyUserId,
   getAdminUserNameAction,
   MatrixSharedSecret,
-  MatrixUserLink,
   updateEncryptedAccessTokenAction,
 } from '@hypha-platform/core/server';
 import { PrivyClient } from '@privy-io/node';
@@ -196,7 +195,7 @@ export async function GET(request: NextRequest) {
     const decoratedPrivyUserId = getDecoratedPrivyId(privyUserId, environment);
 
     const existing = await getLinkByPrivyUserId({
-      privyUserId: decoratedPrivyUserId,
+      privyUserId,
       environment,
     });
     if (existing) {
@@ -238,7 +237,7 @@ export async function GET(request: NextRequest) {
 
             await updateEncryptedAccessTokenAction(
               {
-                privyUserId: decoratedPrivyUserId,
+                privyUserId,
                 environment,
                 encryptedAccessToken,
                 deviceId,
@@ -304,7 +303,7 @@ export async function GET(request: NextRequest) {
             encryptedAccessToken,
             deviceId,
             matrixUserId: userId,
-            privyUserId: decoratedPrivyUserId,
+            privyUserId,
           },
           { authToken },
         );
@@ -329,7 +328,7 @@ export async function GET(request: NextRequest) {
         encryptedAccessToken,
         deviceId,
         matrixUserId,
-        privyUserId: decoratedPrivyUserId,
+        privyUserId,
       },
       { authToken },
     );

--- a/packages/core/src/governance/server/resolve-user-matrix-access-token-for-org-memory.ts
+++ b/packages/core/src/governance/server/resolve-user-matrix-access-token-for-org-memory.ts
@@ -2,7 +2,6 @@ import 'server-only';
 
 import { PrivyClient } from '@privy-io/node';
 import { determineEnvironment } from '../../coherence/lib/determine-environment';
-import { getDecoratedPrivyId } from '../../coherence/lib/get-decorated-privy-id';
 import { MatrixSharedSecret } from '../../coherence/lib/matrix-shared-secret';
 import { decryptMatrixToken } from '../../common/server/decrypt-matrix-token';
 import { getLinkByPrivyUserId } from '../../matrix/server/web3/get-link-by-privy-user-id';
@@ -37,10 +36,9 @@ export async function resolveUserMatrixAccessTokenForOrgMemory(
     return null;
   }
 
-  const decoratedPrivyUserId = getDecoratedPrivyId(privyUserId, environment);
   try {
     const existing = await getLinkByPrivyUserId({
-      privyUserId: decoratedPrivyUserId,
+      privyUserId,
       environment,
     });
     if (!existing?.encryptedAccessToken) {

--- a/packages/storage-postgres/migrations/0047_canonical_matrix_privy_id.sql
+++ b/packages/storage-postgres/migrations/0047_canonical_matrix_privy_id.sql
@@ -1,0 +1,45 @@
+LOCK TABLE "matrix_user_links" IN ACCESS EXCLUSIVE MODE;
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF EXISTS (
+    WITH mapped AS (
+      SELECT
+        id,
+        environment,
+        'did:privy:' || (regexp_match(privy_user_id, '^(dev|prev|prod)_privy_did_privy_(.+)$'))[2] AS target_sub
+      FROM matrix_user_links
+      WHERE privy_user_id ~ '^(dev|prev|prod)_privy_did_privy_.+$'
+    )
+    SELECT 1
+    FROM mapped m
+    JOIN matrix_user_links x
+      ON x.environment = m.environment
+     AND x.privy_user_id = m.target_sub
+     AND x.id <> m.id
+    LIMIT 1
+  ) THEN
+    RAISE EXCEPTION 'Migration aborted: canonical privy_user_id conflict detected';
+  END IF;
+END $$;
+--> statement-breakpoint
+UPDATE matrix_user_links
+SET
+  privy_user_id = 'did:privy:' || (regexp_match(
+    privy_user_id,
+    '^(dev|prev|prod)_privy_did_privy_(.+)$'
+  ))[2],
+  updated_at = now()
+WHERE privy_user_id ~ '^(dev|prev|prod)_privy_did_privy_.+$';
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM matrix_user_links
+    WHERE privy_user_id ~ '^(dev|prev|prod)_privy_did_privy_.+$'
+    LIMIT 1
+  ) THEN
+    RAISE EXCEPTION 'Migration aborted: decorated ids remain after update';
+  END IF;
+END $$;

--- a/packages/storage-postgres/migrations/meta/_journal.json
+++ b/packages/storage-postgres/migrations/meta/_journal.json
@@ -330,6 +330,13 @@
       "when": 1775200000000,
       "tag": "0046_space_chat_room_id",
       "breakpoints": true
+    },
+    {
+      "idx": 47,
+      "version": "7",
+      "when": 1775200100000,
+      "tag": "0047_canonical_matrix_privy_id",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
Aligns `matrix_user_links.privy_user_id` with `people.sub` by storing canonical `did:privy:*` values instead of decorated Matrix localparts.

## Changes
- **Matrix token API:** Look up and persist links using the verified Privy `user_id` (`did:privy:...`). `getDecoratedPrivyId` remains only for Matrix username registration.
- **Org memory:** Resolve existing matrix access token using canonical Privy id when reading `matrix_user_links`.
- **Migration `0047_canonical_matrix_privy_id`:** Transactional rewrite of legacy decorated rows; aborts on uniqueness conflicts.

## Deployment / ops
1. Apply migration on the target DB (short write freeze recommended for production).
2. Deploy this app change so new reads/writes match migrated data.

Closes #2198

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized user identifier handling in Matrix auth flows so raw canonical IDs are used for persistence while decorated IDs remain for display.

* **Database Migration**
  * Migrated existing Matrix user identifiers to a canonical format to ensure consistent storage and prevent identifier conflicts.

* **Chores**
  * Added repository code ownership rules to streamline review responsibilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->