### PR TITLE
ci(preview): add deterministic custom preview aliases

### DIFF
--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -49,3 +49,8 @@ jobs:
           project_id: ${{ secrets.NEON_PROJECT_ID }}
           branch: preview/pr-${{ github.event.number }}-${{ steps.branch-name.outputs.current_branch }}
           api_key: ${{ secrets.NEON_API_KEY }}
+
+      - name: Remove deterministic preview alias
+        run: |
+          PREVIEW_ALIAS_DOMAIN="pr-${{ github.event.number }}.preview-app.hypha.earth"
+          npx vercel@latest alias rm "${PREVIEW_ALIAS_DOMAIN}" --yes --token="${{ secrets.VERCEL_TOKEN }}" || true

--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -51,6 +51,19 @@ jobs:
           api_key: ${{ secrets.NEON_API_KEY }}
 
       - name: Remove deterministic preview alias
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          PR_NUMBER: ${{ github.event.number }}
         run: |
-          PREVIEW_ALIAS_DOMAIN="pr-${{ github.event.number }}.preview-app.hypha.earth"
-          npx vercel@latest alias rm "${PREVIEW_ALIAS_DOMAIN}" --yes --token="${{ secrets.VERCEL_TOKEN }}" || true
+          set -euo pipefail
+          PREVIEW_ALIAS_DOMAIN="pr-${PR_NUMBER}.preview-app.hypha.earth"
+
+          if ! out="$(npx --yes vercel@52 alias rm "${PREVIEW_ALIAS_DOMAIN}" --yes --token="${VERCEL_TOKEN}" 2>&1)"; then
+            if echo "${out}" | rg -i "not\\s*found|does not exist|404" >/dev/null; then
+              echo "Alias ${PREVIEW_ALIAS_DOMAIN} not found; nothing to remove."
+            else
+              echo "::error::Failed to remove alias ${PREVIEW_ALIAS_DOMAIN}"
+              echo "${out}"
+              exit 1
+            fi
+          fi

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -146,6 +146,55 @@ jobs:
           BRANCH_DB_URL: ${{ steps.create-branch.outputs.db_url_with_pooler }}
         run: echo preview_url=$(vercel deploy --prebuilt --token=${{ env.VERCEL_TOKEN }} --env BRANCH_DB_URL=${{ env.BRANCH_DB_URL }}) >> $GITHUB_OUTPUT
 
+      - name: Alias preview to deterministic PR domain
+        id: alias
+        run: |
+          PREVIEW_ALIAS_DOMAIN="pr-${{ github.event.pull_request.number }}.preview-app.hypha.earth"
+          vercel alias set "${{ steps.deploy.outputs.preview_url }}" "${PREVIEW_ALIAS_DOMAIN}" --token=${{ env.VERCEL_TOKEN }}
+          echo "preview_custom_url=https://${PREVIEW_ALIAS_DOMAIN}" >> "$GITHUB_OUTPUT"
+
+      - name: Comment custom preview URL on PR
+        uses: actions/github-script@v7
+        env:
+          PREVIEW_CUSTOM_URL: ${{ steps.alias.outputs.preview_custom_url }}
+        with:
+          script: |
+            const marker = '<!-- custom-preview-domain -->';
+            const body = `${marker}
+            🔗 Custom preview URL: ${process.env.PREVIEW_CUSTOM_URL}`;
+
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+
+            const existing = comments.find(
+              (comment) =>
+                comment.user?.type === 'Bot' &&
+                comment.body?.includes(marker),
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }
+
   main:
     needs: [detect-changes]
     runs-on: blacksmith-4vcpu-ubuntu-2404

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -162,9 +162,14 @@ jobs:
 
       - name: Alias preview to deterministic PR domain
         id: alias
+        env:
+          VERCEL_TOKEN: ${{ env.VERCEL_TOKEN }}
+          PREVIEW_ALIAS_SUFFIX: ${{ env.PREVIEW_ALIAS_SUFFIX }}
+          PREVIEW_URL: ${{ steps.deploy.outputs.preview_url }}
         run: |
-          PREVIEW_ALIAS_DOMAIN="pr-${{ env.PREVIEW_ALIAS_SUFFIX }}.preview-app.hypha.earth"
-          vercel alias set "${{ steps.deploy.outputs.preview_url }}" "${PREVIEW_ALIAS_DOMAIN}" --token=${{ env.VERCEL_TOKEN }}
+          set -euo pipefail
+          PREVIEW_ALIAS_DOMAIN="pr-${PREVIEW_ALIAS_SUFFIX}.preview-app.hypha.earth"
+          npx --yes vercel@52 alias set "${PREVIEW_URL}" "${PREVIEW_ALIAS_DOMAIN}" --token="${VERCEL_TOKEN}"
           echo "preview_custom_url=https://${PREVIEW_ALIAS_DOMAIN}" >> "$GITHUB_OUTPUT"
 
       - name: Comment custom preview URL on PR

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -3,6 +3,17 @@ name: Deploy Preview
 on:
   pull_request:
   merge_group:
+  workflow_dispatch:
+    inputs:
+      force_preview_deploy:
+        description: 'Force preview deployment even when detect-changes is false'
+        required: true
+        default: true
+        type: boolean
+      pr_number:
+        description: 'PR number used for deterministic preview alias naming'
+        required: false
+        type: string
 
 concurrency:
   group: deploy-preview-${{ github.event.pull_request.number || github.event.merge_group.head_sha || github.ref }}
@@ -62,7 +73,9 @@ jobs:
 
   deploy-preview:
     needs: [detect-changes, check-types, i18n-verify]
-    if: github.event_name == 'pull_request' && needs.detect-changes.outputs.has_preview_deploy_changes == 'true'
+    if: |
+      (github.event_name == 'pull_request' && needs.detect-changes.outputs.has_preview_deploy_changes == 'true') ||
+      (github.event_name == 'workflow_dispatch' && inputs.force_preview_deploy == true)
     runs-on: blacksmith-4vcpu-ubuntu-2404
     env:
       NEON_DATABASE_USERNAME: ${{ secrets.DB_USER_NAME }}
@@ -74,7 +87,8 @@ jobs:
       PRIVATE_KEY: ${{ secrets.EVM_SC_OWNER_PRIVATE_KEY }}
       DEFAULT_DB_AUTHENTICATED_URL: ${{ secrets.POSTGRES_AUTHENTICATED_URL }}
       DEFAULT_DB_ANONYMOUS_URL: ${{ secrets.POSTGRES_ANONYMOUS_URL }}
-      PR_OR_QUEUE_HEAD: ${{ github.event.pull_request.number || github.event.merge_group.head_sha }}
+      PR_OR_QUEUE_HEAD: ${{ github.event.pull_request.number || github.event.merge_group.head_sha || inputs.pr_number || github.run_id }}
+      PREVIEW_ALIAS_SUFFIX: ${{ github.event.pull_request.number || inputs.pr_number || github.run_id }}
 
     steps:
       - uses: actions/checkout@v4
@@ -149,11 +163,12 @@ jobs:
       - name: Alias preview to deterministic PR domain
         id: alias
         run: |
-          PREVIEW_ALIAS_DOMAIN="pr-${{ github.event.pull_request.number }}.preview-app.hypha.earth"
+          PREVIEW_ALIAS_DOMAIN="pr-${{ env.PREVIEW_ALIAS_SUFFIX }}.preview-app.hypha.earth"
           vercel alias set "${{ steps.deploy.outputs.preview_url }}" "${PREVIEW_ALIAS_DOMAIN}" --token=${{ env.VERCEL_TOKEN }}
           echo "preview_custom_url=https://${PREVIEW_ALIAS_DOMAIN}" >> "$GITHUB_OUTPUT"
 
       - name: Comment custom preview URL on PR
+        if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
         env:
           PREVIEW_CUSTOM_URL: ${{ steps.alias.outputs.preview_custom_url }}

--- a/apps/web/.env.template
+++ b/apps/web/.env.template
@@ -16,10 +16,9 @@ NEXT_PUBLIC_CONNECT_SOURCES="https://*.uploadthing.com, https://auth.privy.io, h
 NEXT_PUBLIC_IMAGE_HOSTS="utfs.io, github.githubassets.com"
 
 # Privy
-# Production uses HttpOnly cookies via privy.hypha.earth (scoped to hypha.earth).
-# Preview deployments on *.vercel.app need a separate Privy app with localStorage
-# auth, since the cookie domain won't match. Set this env var per-environment in
-# the Vercel dashboard (Settings > Environment Variables > scope to Production/Preview).
+# Use the same Privy production app for both Production and Preview deployments
+# on hypha.earth custom domains (for example *.preview-app.hypha.earth).
+# Configure the same value in Vercel for all environments to avoid app-id drift.
 NEXT_PUBLIC_PRIVY_APP_ID=cm5y07p2z02napk1cutzzx7o6
 
 # Comma-separated extra Privy app IDs whose JWKS keys should be served from

--- a/apps/web/.preview-deploy-noop-2200.md
+++ b/apps/web/.preview-deploy-noop-2200.md
@@ -1,3 +1,4 @@
 Temporary no-op file to trigger preview deployment workflow for PR #2201.
 
 Safe to remove before or after validating custom preview alias behavior.
+

--- a/apps/web/.preview-deploy-noop-2200.md
+++ b/apps/web/.preview-deploy-noop-2200.md
@@ -1,0 +1,3 @@
+Temporary no-op file to trigger preview deployment workflow for PR #2201.
+
+Safe to remove before or after validating custom preview alias behavior.

--- a/apps/web/.preview-deploy-noop-2200.md
+++ b/apps/web/.preview-deploy-noop-2200.md
@@ -1,4 +1,0 @@
-Temporary no-op file to trigger preview deployment workflow for PR #2201.
-
-Safe to remove before or after validating custom preview alias behavior.
-


### PR DESCRIPTION
## Summary
- add a deterministic alias step in preview deploys so each PR gets `pr-<number>.preview-app.hypha.earth`
- add PR comment upsert logic to surface the custom preview URL directly in the PR thread
- remove the deterministic alias automatically when a PR is closed

## Test plan
- [x] Open a PR and confirm the preview workflow creates `pr-<number>.preview-app.hypha.earth`
- [x] Confirm the PR has a bot comment with the custom preview URL and it updates on re-runs
- [x] Confirm Privy auth works with wildcard allowlisting on `*.preview-app.hypha.earth`
- [x] Close the PR and confirm alias cleanup runs successfully

Closes #2200

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PR previews now use predictable custom domain URLs for easier access and sharing

* **Chores**
  * Improved automatic cleanup of preview deployments when pull requests are closed

<!-- end of auto-generated comment: release notes by coderabbit.ai -->