### PR TITLE
Configure CODEOWNERS required reviewers for sensitive paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,4 +17,6 @@
 
 /packages/core/src/common/server/encrypt-matrix-token.ts @plitzenberger
 /packages/core/src/common/server/decrypt-matrix-token.ts @plitzenberger
+/packages/core/src/common/server/encrypt-aes.ts @plitzenberger
+/packages/core/src/matrix/server/actions.ts @plitzenberger
 /packages/core/src/governance/server/resolve-user-matrix-access-token-for-org-memory.ts @plitzenberger

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,20 @@
+# Required reviewers by path
+
+/.github/** @plitzenberger
+/packages/storage-postgres/** @plitzenberger
+/packages/storage-evm/** @n0umen0n
+
+# Additional security-relevant paths
+/apps/web/src/app/api/matrix/token/** @plitzenberger
+/apps/web/src/app/.well-known/jwks.json/** @plitzenberger
+
+/packages/chat-server/src/privy-auth.ts @plitzenberger
+/packages/authentication/** @plitzenberger
+
+/apps/api/src/plugins/db/query/verify-auth.ts @plitzenberger
+/apps/api/src/plugins/db/query/find-person-by-auth.ts @plitzenberger
+/apps/web/src/hooks/use-auth-header.ts @plitzenberger
+
+/packages/core/src/common/server/encrypt-matrix-token.ts @plitzenberger
+/packages/core/src/common/server/decrypt-matrix-token.ts @plitzenberger
+/packages/core/src/governance/server/resolve-user-matrix-access-token-for-org-memory.ts @plitzenberger


### PR DESCRIPTION
## Summary
- add a new `.github/CODEOWNERS` file to enforce required reviewers by path
- require `@plitzenberger` for all `.github` and `packages/storage-postgres` changes
- require `@n0umen0n` for `packages/storage-evm`, and keep additional auth/token security paths owned by `@plitzenberger`

## Test plan
- [x] Confirm `.github/CODEOWNERS` is present and committed
- [x] Verify ownership entries match requested paths and usernames
- [ ] Open a test PR touching each owned path and confirm GitHub requests the expected CODEOWNERS
- [ ] Verify branch protection/rulesets require CODEOWNERS approval on protected branches

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration for code ownership and review assignment processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->