### PR TITLE
fix: stop console flood when logged in (OneSignal + org SWR key)

### DIFF
--- a/packages/epics/src/spaces/hooks/use-user-space-state.ts
+++ b/packages/epics/src/spaces/hooks/use-user-space-state.ts
@@ -65,19 +65,27 @@ export function useUserSpaceState({
       .map((s) => s.web3SpaceId as number);
   }, [organisationSpaces, effectiveSpaceId]);
 
+  /** Stable tuple for SWR — never `.sort()` in-place on memoized arrays (mutates cached keys). */
+  const organisationSpaceIdsSorted = useMemo(
+    () => [...organisationSpaceIds].sort((a, b) => a - b),
+    [organisationSpaceIds],
+  );
+
   const orgMembershipResults = useSWR(
-    user?.wallet?.address && organisationSpaceIds.length > 0 && isAuthenticated
-      ? ['orgMembership', user.wallet.address, ...organisationSpaceIds.sort()]
+    user?.wallet?.address &&
+      organisationSpaceIdsSorted.length > 0 &&
+      isAuthenticated
+      ? ['orgMembership', user.wallet.address, ...organisationSpaceIdsSorted]
       : null,
     async () => {
-      if (!user?.wallet?.address || organisationSpaceIds.length === 0) {
+      if (!user?.wallet?.address || organisationSpaceIdsSorted.length === 0) {
         return { isOrgMember: false, isOrgDelegate: false };
       }
 
       const userAddress = user.wallet.address as `0x${string}`;
 
       const membershipChecks = await Promise.all(
-        organisationSpaceIds.map(async (spaceId) => {
+        organisationSpaceIdsSorted.map(async (spaceId) => {
           try {
             const [isMemberResult, delegates, spaceDetails] = await Promise.all(
               [

--- a/packages/notifications/src/components/notifications-subscriber.tsx
+++ b/packages/notifications/src/components/notifications-subscriber.tsx
@@ -92,10 +92,14 @@ export function NotificationSubscriber({
     const foregroundWillDisplayHandler = (
       event: NotificationForegroundWillDisplayEvent,
     ) => {
-      console.log('The notification foreground will display:', event);
+      if (DEV_ENV) {
+        console.log('The notification foreground will display:', event);
+      }
     };
     const notificationDismiss = (event: NotificationDismissEvent) => {
-      console.log('The notification dismiss:', event);
+      if (DEV_ENV) {
+        console.log('The notification dismiss:', event);
+      }
     };
     const permissionChangeHandler = (permission: boolean) => {
       if (DEV_ENV) {
@@ -120,26 +124,40 @@ export function NotificationSubscriber({
         });
     };
     const permissionPromptDisplayHandler = () => {
-      console.log('The notification permission prompt display!');
+      if (DEV_ENV) {
+        console.log('The notification permission prompt display!');
+      }
     };
     const slidedownAllowClickHandler = (wasShown: boolean) => {
-      console.log('Slidedown Allow Click:', wasShown);
+      if (DEV_ENV) {
+        console.log('Slidedown Allow Click:', wasShown);
+      }
     };
     const slidedownCancelClick = (wasShown: boolean) => {
-      console.log('Slidedown Cancel Click:', wasShown);
+      if (DEV_ENV) {
+        console.log('Slidedown Cancel Click:', wasShown);
+      }
       setSubscribed(false);
     };
     const slidedownClosedHandler = (wasShown: boolean) => {
-      console.log('Slidedown Closed:', wasShown);
+      if (DEV_ENV) {
+        console.log('Slidedown Closed:', wasShown);
+      }
     };
     const slidedownQueuedHandler = (wasShown: boolean) => {
-      console.log('Slidedown Queued:', wasShown);
+      if (DEV_ENV) {
+        console.log('Slidedown Queued:', wasShown);
+      }
     };
     const slidedownShownHandler = (wasShown: boolean) => {
-      console.log('Slidedown Shown:', wasShown);
+      if (DEV_ENV) {
+        console.log('Slidedown Shown:', wasShown);
+      }
     };
     const userChangeHandler = (change: UserChangeEvent) => {
-      console.log('User change:', change);
+      if (DEV_ENV) {
+        console.log('User change:', change);
+      }
     };
     const subscriptionChangeHandler = (event: SubscriptionChangeEvent) => {
       if (DEV_ENV) {
@@ -157,7 +175,9 @@ export function NotificationSubscriber({
     };
     const initialize = async () => {
       if (initialized) {
-        console.warn('OneSignal should be initialized only once!');
+        if (DEV_ENV) {
+          console.warn('OneSignal should be initialized only once!');
+        }
         return;
       }
       try {
@@ -195,7 +215,9 @@ export function NotificationSubscriber({
           notificationClickHandlerMatch: 'origin',
           notificationClickHandlerAction: 'focus',
         });
-        console.log('OneSignal initialized');
+        if (DEV_ENV) {
+          console.log('OneSignal initialized');
+        }
         setInitialized(true);
         const isSubscribed = await hasPermission();
         setSubscribed(isSubscribed);
@@ -245,7 +267,7 @@ export function NotificationSubscriber({
           subscriptionChangeHandler,
         );
       } catch (err) {
-        console.log('Initialize error:', err);
+        console.error('OneSignal initialize error:', err);
       }
     };
     initialize();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Chrome showed tens of thousands of hidden console entries growing quickly while logged in (often on Agreements). Two contributors:

1. **`NotificationSubscriber`** — Many OneSignal event handlers called `console.log` on **every** SDK event in production (`foregroundWillDisplay`, slidedown, user change, etc.). Logged-in users trigger these events far more often.

2. **`useUserSpaceState`** — The org-membership SWR key used `organisationSpaceIds.sort()`, which **mutates** the memoized array in place. That can destabilize SWR identity and cause unnecessary churn.

## Changes

- Wrap noisy OneSignal logs behind `DEV_ENV` (same pattern as existing notification click logging).
- Use `[...organisationSpaceIds].sort()` in a dedicated `useMemo` for a stable key and fetcher input.
- Promote OneSignal init failure from `console.log` to `console.error` (still one line per failure).

## QA notes

With **Default levels** + **Verbose off**, hidden count should stay flat after load. Preload warnings for UploadThing URLs are separate (browser + unused preloads); can tune document images separately if needed.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7546e96-8d3b-4a21-8d27-77a91d5252c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7546e96-8d3b-4a21-8d27-77a91d5252c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

