### PR TITLE
fix: authenticated space view clicks + console spam (scrim, OneSignal, SWR)

### DIFF
--- a/packages/epics/src/common/proposal-overlay-shell.tsx
+++ b/packages/epics/src/common/proposal-overlay-shell.tsx
@@ -38,6 +38,9 @@ type ProposalOverlayShellProps = {
  * so close remains on in-app routes.
  *
  * Plain scrim: we still render the scrim `div` ourselves (aligned with MenuTop).
+ * On **`md+` the dialog host is `pointer-events-none`** so centered panels stay usable while
+ * {@link MenuTop} remains reachable; the scrim must also use **`pointer-events-none`**, otherwise
+ * hits pass through the host and are swallowed by the scrim (`z-40`), blocking the main column.
  *
  * **Portals:** `DialogPrimitive.Portal` renders under `document.body`. `--sidebar-*` and
  * `--main-column-scrollbar-width` are mirrored onto `document.documentElement` by
@@ -115,6 +118,7 @@ export function ProposalOverlayShell({
           <div
             className={cn(
               'fixed bottom-0 z-40 hidden bg-black/45 backdrop-blur-md supports-[backdrop-filter]:bg-black/35 md:block',
+              'md:pointer-events-none',
               'left-[var(--sidebar-left-width,0px)] right-[calc(var(--sidebar-right-width,0px)+var(--main-column-scrollbar-width,10px))]',
               'top-[var(--menu-top-height,65px)]',
             )}

--- a/packages/epics/src/spaces/hooks/use-user-space-state.ts
+++ b/packages/epics/src/spaces/hooks/use-user-space-state.ts
@@ -65,19 +65,27 @@ export function useUserSpaceState({
       .map((s) => s.web3SpaceId as number);
   }, [organisationSpaces, effectiveSpaceId]);
 
+  /** Stable tuple for SWR — never `.sort()` in-place on memoized arrays (mutates cached keys). */
+  const organisationSpaceIdsSorted = useMemo(
+    () => [...organisationSpaceIds].sort((a, b) => a - b),
+    [organisationSpaceIds],
+  );
+
   const orgMembershipResults = useSWR(
-    user?.wallet?.address && organisationSpaceIds.length > 0 && isAuthenticated
-      ? ['orgMembership', user.wallet.address, ...organisationSpaceIds.sort()]
+    user?.wallet?.address &&
+      organisationSpaceIdsSorted.length > 0 &&
+      isAuthenticated
+      ? ['orgMembership', user.wallet.address, ...organisationSpaceIdsSorted]
       : null,
     async () => {
-      if (!user?.wallet?.address || organisationSpaceIds.length === 0) {
+      if (!user?.wallet?.address || organisationSpaceIdsSorted.length === 0) {
         return { isOrgMember: false, isOrgDelegate: false };
       }
 
       const userAddress = user.wallet.address as `0x${string}`;
 
       const membershipChecks = await Promise.all(
-        organisationSpaceIds.map(async (spaceId) => {
+        organisationSpaceIdsSorted.map(async (spaceId) => {
           try {
             const [isMemberResult, delegates, spaceDetails] = await Promise.all(
               [

--- a/packages/notifications/src/components/notifications-subscriber.tsx
+++ b/packages/notifications/src/components/notifications-subscriber.tsx
@@ -92,10 +92,14 @@ export function NotificationSubscriber({
     const foregroundWillDisplayHandler = (
       event: NotificationForegroundWillDisplayEvent,
     ) => {
-      console.log('The notification foreground will display:', event);
+      if (DEV_ENV) {
+        console.log('The notification foreground will display:', event);
+      }
     };
     const notificationDismiss = (event: NotificationDismissEvent) => {
-      console.log('The notification dismiss:', event);
+      if (DEV_ENV) {
+        console.log('The notification dismiss:', event);
+      }
     };
     const permissionChangeHandler = (permission: boolean) => {
       if (DEV_ENV) {
@@ -120,26 +124,40 @@ export function NotificationSubscriber({
         });
     };
     const permissionPromptDisplayHandler = () => {
-      console.log('The notification permission prompt display!');
+      if (DEV_ENV) {
+        console.log('The notification permission prompt display!');
+      }
     };
     const slidedownAllowClickHandler = (wasShown: boolean) => {
-      console.log('Slidedown Allow Click:', wasShown);
+      if (DEV_ENV) {
+        console.log('Slidedown Allow Click:', wasShown);
+      }
     };
     const slidedownCancelClick = (wasShown: boolean) => {
-      console.log('Slidedown Cancel Click:', wasShown);
+      if (DEV_ENV) {
+        console.log('Slidedown Cancel Click:', wasShown);
+      }
       setSubscribed(false);
     };
     const slidedownClosedHandler = (wasShown: boolean) => {
-      console.log('Slidedown Closed:', wasShown);
+      if (DEV_ENV) {
+        console.log('Slidedown Closed:', wasShown);
+      }
     };
     const slidedownQueuedHandler = (wasShown: boolean) => {
-      console.log('Slidedown Queued:', wasShown);
+      if (DEV_ENV) {
+        console.log('Slidedown Queued:', wasShown);
+      }
     };
     const slidedownShownHandler = (wasShown: boolean) => {
-      console.log('Slidedown Shown:', wasShown);
+      if (DEV_ENV) {
+        console.log('Slidedown Shown:', wasShown);
+      }
     };
     const userChangeHandler = (change: UserChangeEvent) => {
-      console.log('User change:', change);
+      if (DEV_ENV) {
+        console.log('User change:', change);
+      }
     };
     const subscriptionChangeHandler = (event: SubscriptionChangeEvent) => {
       if (DEV_ENV) {
@@ -157,7 +175,9 @@ export function NotificationSubscriber({
     };
     const initialize = async () => {
       if (initialized) {
-        console.warn('OneSignal should be initialized only once!');
+        if (DEV_ENV) {
+          console.warn('OneSignal should be initialized only once!');
+        }
         return;
       }
       try {
@@ -195,7 +215,9 @@ export function NotificationSubscriber({
           notificationClickHandlerMatch: 'origin',
           notificationClickHandlerAction: 'focus',
         });
-        console.log('OneSignal initialized');
+        if (DEV_ENV) {
+          console.log('OneSignal initialized');
+        }
         setInitialized(true);
         const isSubscribed = await hasPermission();
         setSubscribed(isSubscribed);
@@ -245,7 +267,7 @@ export function NotificationSubscriber({
           subscriptionChangeHandler,
         );
       } catch (err) {
-        console.log('Initialize error:', err);
+        console.error('OneSignal initialize error:', err);
       }
     };
     initialize();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When logged in on the DHO space view, navigation/menus often did not activate modals or routes; Console showed tens of thousands of **hidden** messages climbing rapidly.

## Root causes

1. **`ProposalOverlayShell`** — On `md+`, `DialogPrimitive.Content` uses `pointer-events-none` so `MenuTop` stays usable. Clicks fell through to the **custom scrim** at `z-40`, which still received pointer events and **blocked** the main column (hover/url in status bar could still update; click did not reach links).

2. **`NotificationSubscriber` (OneSignal)** — Multiple SDK listeners called `console.log` on **every** event in production (e.g. `foregroundWillDisplay`, `User.change`). After login OneSignal identifies the user → very high event rate → massive **Verbose** log count (Chrome counts hidden verbose logs).

3. **`useUserSpaceState`** — Org-membership SWR key used `organisationSpaceIds.sort()`, **mutating** the memoized array and destabilizing the cache key.

## Changes

- `md:pointer-events-none` on the scrim + doc comment in `proposal-overlay-shell.tsx`.
- Gate noisy OneSignal logs behind `NODE_ENV === 'development'`; init failure → `console.error`.
- Stable sorted copy for org space ids in `use-user-space-state.ts`.

## QA

- Logged in, desktop width: space nav links and toolbar actions navigate/open aside modals with an overlay route active (or after visiting one).
- Console: enable **Verbose** — hidden counter should not skyrocket from OneSignal `log` spam.
- Optional: `/en/network` **500** in screenshots is a separate API issue; fix server route if it blocks profile/header data.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7546e96-8d3b-4a21-8d27-77a91d5252c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7546e96-8d3b-4a21-8d27-77a91d5252c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

