### PR TITLE
fix(epics): human chat @ mention picker shows name only

### DIFF
--- a/packages/epics/src/common/human-chat-panel/human-chat-mention-candidate-row.tsx
+++ b/packages/epics/src/common/human-chat-panel/human-chat-mention-candidate-row.tsx
@@ -67,7 +67,7 @@ export function HumanChatMentionCandidateRow({
       role="option"
       aria-selected={isActive}
       aria-busy={busy || undefined}
-      title={matrixUserId}
+      title={resolvedName}
       disabled={!privySub && loadingLink}
       className={cn(
         'flex w-full min-w-0 items-center gap-2.5 rounded-sm px-2 py-1.5 text-left text-sm',
@@ -84,13 +84,8 @@ export function HumanChatMentionCandidateRow({
         className={cn('shrink-0', APP_CHROME_SUBTLE_SQUARE_RADIUS)}
         isLoading={busy}
       />
-      <span className="min-w-0 flex-1">
-        <span className="block truncate font-medium leading-snug">
-          {resolvedName}
-        </span>
-        <span className="block truncate font-mono text-[11px] text-muted-foreground">
-          {matrixUserId}
-        </span>
+      <span className="min-w-0 flex-1 truncate font-medium leading-snug">
+        {resolvedName}
       </span>
     </button>
   );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Human Chat composer `@` autocomplete listed each member on two lines: resolved Hypha **name** and the raw **Matrix user ID** (often long Privy-linked handles). Product feedback: show only the human-readable line.

## Changes

- **`HumanChatMentionCandidateRow`**: Removed the monospace subtitle that rendered `matrixUserId`.
- **`title` tooltip**: Uses the resolved display name instead of the Matrix ID so hovering does not expose the technical handle.

Composer behavior (inserted mention tokens / Matrix semantics) is unchanged — this is presentation only in the picker dropdown.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2cd167cc-d5ce-4e4e-91dc-b9b3db3a5377"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2cd167cc-d5ce-4e4e-91dc-b9b3db3a5377"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

