### PR TITLE
feat(epics): human chat composer shows display names for @ mentions

### DIFF
--- a/packages/epics/src/common/human-chat-panel/human-chat-display-mention.ts
+++ b/packages/epics/src/common/human-chat-panel/human-chat-display-mention.ts
@@ -1,0 +1,86 @@
+import { extractMentionUserIdsFromPlainBody } from '@hypha-platform/core/client';
+
+/** Zero-width space — keeps `@` + display name visually distinct from a raw MXID in the composer. */
+export const MENTION_DISPLAY_ZWSP = '\u200B';
+
+/**
+ * Escape a Hypha/Matrix display label so it cannot break mention token parsing
+ * (embedded `@` would fragment MXID regexes).
+ */
+export function sanitizeMentionDisplayLabel(label: string): string {
+  return label.replace(/@/g, '').trim();
+}
+
+/**
+ * Token inserted into the composer after picking a mention: `@` + ZWSP + display name + trailing space.
+ * Matrix wire format uses raw `@mxid`; {@link replaceDisplayNameMentionsWithMxids} runs before send.
+ */
+export function formatComposerMentionToken(displayLabel: string): string {
+  const safe = sanitizeMentionDisplayLabel(displayLabel);
+  return `@${MENTION_DISPLAY_ZWSP}${safe} `;
+}
+
+/**
+ * Replace `@` + ZWSP + known display labels with Matrix user IDs for `m.room.message` body.
+ * Longest label first so "John Smith" wins over "John".
+ */
+export function replaceDisplayNameMentionsWithMxids(
+  plain: string,
+  labelToUserId: ReadonlyMap<string, string>,
+): string {
+  const labels = [...labelToUserId.keys()].sort((a, b) => b.length - a.length);
+  let out = '';
+  let i = 0;
+  while (i < plain.length) {
+    const z = plain.indexOf(MENTION_DISPLAY_ZWSP, i);
+    if (z === -1) {
+      out += plain.slice(i);
+      break;
+    }
+    if (z === 0 || plain[z - 1] !== '@') {
+      out += plain.slice(i, z + 1);
+      i = z + 1;
+      continue;
+    }
+
+    const after = plain.slice(z + 1);
+    let matchedLabel: string | undefined;
+    for (const label of labels) {
+      if (!after.startsWith(label)) continue;
+      const next = after[label.length];
+      if (next !== undefined && !/^[\s.,!?;:\n]/.test(next)) continue;
+      matchedLabel = label;
+      break;
+    }
+
+    if (matchedLabel) {
+      const uid = labelToUserId.get(matchedLabel);
+      if (uid) {
+        out += plain.slice(i, z - 1);
+        out += uid;
+        i = z + 1 + matchedLabel.length;
+        continue;
+      }
+    }
+
+    out += plain.slice(i, z + 1);
+    i = z + 1;
+  }
+  return out;
+}
+
+/**
+ * Matrix wire text + MSC3952 user_ids for send. The composer may use
+ * display-name tokens; this converts them to `@mxid` and collects mention ids.
+ */
+export function wireComposerPlainForMatrixSend(
+  composerPlain: string,
+  sanitizedLabelToUserId: ReadonlyMap<string, string>,
+): { wirePlain: string; mentionUserIds: string[] } {
+  const wirePlain = replaceDisplayNameMentionsWithMxids(
+    composerPlain,
+    sanitizedLabelToUserId,
+  );
+  const mentionUserIds = extractMentionUserIdsFromPlainBody(wirePlain);
+  return { wirePlain, mentionUserIds };
+}

--- a/packages/epics/src/common/human-chat-panel/human-chat-mention-token.ts
+++ b/packages/epics/src/common/human-chat-panel/human-chat-mention-token.ts
@@ -2,6 +2,8 @@
  * Parse an active `@query` fragment before the cursor for mention autocomplete.
  */
 
+import { MENTION_DISPLAY_ZWSP } from './human-chat-display-mention';
+
 export type ActiveAtToken = {
   /** Index of `@` in `value`. */
   start: number;
@@ -32,10 +34,14 @@ export function getActiveAtToken(
   if (!isAtWordStart(value, atIdx)) return null;
 
   const afterAt = before.slice(atIdx + 1);
-  if (afterAt.includes('\n')) return null;
-  if (/\s/.test(afterAt)) return null;
+  /** Composer tokens are `@` + ZWSP + display name — strip ZWSP for query matching. */
+  const afterForQuery = afterAt.startsWith(MENTION_DISPLAY_ZWSP)
+    ? afterAt.slice(MENTION_DISPLAY_ZWSP.length)
+    : afterAt;
+  if (afterForQuery.includes('\n')) return null;
+  if (/\s/.test(afterForQuery)) return null;
 
-  const query = afterAt.slice(0, MAX_QUERY_LEN);
+  const query = afterForQuery.slice(0, MAX_QUERY_LEN);
   /** Unicode letters / marks / numbers — `\w` is ASCII-only and rejects José, Zoë, etc. */
   if (!/^[\p{L}\p{M}\p{N}_.=\-/:']*$/u.test(query)) return null;
 

--- a/packages/epics/src/common/human-chat-panel/human-chat-panel-chat-bar.tsx
+++ b/packages/epics/src/common/human-chat-panel/human-chat-panel-chat-bar.tsx
@@ -62,6 +62,7 @@ import {
   useDraftVoiceDuration,
 } from './human-chat-panel-voice-audio-row';
 import { HumanChatMentionCandidateRow } from './human-chat-mention-candidate-row';
+import { formatComposerMentionToken } from './human-chat-display-mention';
 
 type SpeechRecognitionCtor = new () => SpeechRecognitionLike;
 
@@ -745,7 +746,7 @@ export function HumanChatPanelChatBar({
       const el = textareaRef.current;
       const tok = atTokenRef.current;
       if (!el || !tok) return;
-      const insertion = `${member.userId} `;
+      const insertion = formatComposerMentionToken(member.displayLabel);
       const start = tok.start;
       const end = el.selectionStart ?? value.length;
       const { next, caret } = insertAtCaret(value, start, end, insertion);

--- a/packages/epics/src/common/human-right-panel.tsx
+++ b/packages/epics/src/common/human-right-panel.tsx
@@ -91,6 +91,10 @@ import {
 } from './human-chat-panel/matrix-room-member-display';
 import { getActiveTabFromPath } from './get-active-tab-from-path';
 import { useCallJoinChime } from './human-chat-panel/use-call-join-chime';
+import {
+  sanitizeMentionDisplayLabel,
+  wireComposerPlainForMatrixSend,
+} from './human-chat-panel/human-chat-display-mention';
 
 function personRosterLabel(p: Person, unknownLabel: string): string {
   const full = [p.name, p.surname].filter(Boolean).join(' ').trim();
@@ -827,6 +831,17 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
       ),
     [mentionCandidates],
   );
+
+  /** Sanitized display label → MXID for converting composer `@Name` tokens before Matrix send. */
+  const mentionSanitizedLabelToUserId = useMemo(() => {
+    const m = new Map<string, string>();
+    for (const [userId, label] of mentionLabelByUserId) {
+      const key = sanitizeMentionDisplayLabel(label);
+      if (!key || m.has(key)) continue;
+      m.set(key, userId);
+    }
+    return m;
+  }, [mentionLabelByUserId]);
 
   const resolveMentionMemberLabel = useCallback(
     (userId: string) =>
@@ -1673,11 +1688,15 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
     setDraftAttachments([]);
     const pendingId =
       savedAttachments.length > 0 ? `hypha-send-pending-${Date.now()}` : null;
+    const { wirePlain, mentionUserIds } = wireComposerPlainForMatrixSend(
+      text,
+      mentionSanitizedLabelToUserId,
+    );
     if (pendingId) {
       setSendingPending({
         id: pendingId,
         attachmentCount: savedAttachments.length,
-        captionPreview: text,
+        captionPreview: wirePlain,
         uploadedCount: 0,
       });
     }
@@ -1706,7 +1725,8 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
           await matrixRef.current.editRoomMessage({
             roomId,
             targetEventId: editTargetEventId,
-            message: text,
+            message: wirePlain,
+            mentionUserIds,
             existingMediaSlots: slots,
             ...(newFiles.length > 0 ? { newAttachments: newFiles } : {}),
             ...(newFiles.length > 0 ? { signal } : {}),
@@ -1718,13 +1738,15 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
           await matrixRef.current.editRoomMessage({
             roomId,
             targetEventId: editTargetEventId,
-            message: text,
+            message: wirePlain,
+            mentionUserIds,
           });
         }
       } else {
         await matrixRef.current.sendMessage({
           roomId,
-          message: text,
+          message: wirePlain,
+          mentionUserIds,
           signal,
           ...(replyToEventId ? { replyToEventId } : {}),
           ...(savedAttachments.length > 0
@@ -1814,7 +1836,15 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
       setEditDraft(savedEditDraft);
       setDraftAttachments(savedAttachments);
     }
-  }, [input, roomId, replyDraft, editDraft, draftAttachments, t]);
+  }, [
+    input,
+    roomId,
+    replyDraft,
+    editDraft,
+    draftAttachments,
+    mentionSanitizedLabelToUserId,
+    t,
+  ]);
 
   useEffect(() => {
     return () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After picking someone in the `@` mention list, the composer inserted the raw Matrix user ID (`@prod_privy_did_...`), which is hard to read.

## Approach

- **Composer UX:** On pick, insert a display-oriented token: `@` + zero-width space + sanitized Hypha/profile **first + last name** (same `displayLabel` as the picker), not the MXID.
- **Matrix wire:** Before `sendMessage` / `editRoomMessage`, rewrite those tokens back to `@mxid` and pass **`mentionUserIds`** so MSC3952 `m.mentions` and highlight notifications stay correct (explicit IDs avoid relying on body parsing alone).
- **Autocomplete:** `getActiveAtToken` skips the ZWSP when building the filter query so typing after `@` still matches names.

## Files

- `human-chat-display-mention.ts` — token formatting, replacement, wire helper
- `human-chat-mention-token.ts` — ZWSP-aware query
- `human-chat-panel-chat-bar.tsx` — insert display token
- `human-right-panel.tsx` — map sanitized labels → MXIDs, wire send path

## Notes

- Labels are sanitized (strip `@`) so tokens cannot embed accidental MXID-like fragments.
- Longest label wins when replacing so overlapping names behave predictably.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2cd167cc-d5ce-4e4e-91dc-b9b3db3a5377"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2cd167cc-d5ce-4e4e-91dc-b9b3db3a5377"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

