### PR TITLE
fix(epics): prevent empty gap beside chat panel (clip main column X overflow)

### DIFF
--- a/packages/epics/src/common/panel-main-column-scroll-bridge.tsx
+++ b/packages/epics/src/common/panel-main-column-scroll-bridge.tsx
@@ -89,10 +89,13 @@ export function PanelDualSidebarScrollBridge({
             (MenuTop, plugin, main, Footer) as a fragment — fragments flatten, so without this
             wrapper they become **separate flex items** next to the right Sidebar: header | content
             | footer | panel in one horizontal row.
+            `overflow-x-hidden`: the Human/AI panels are `position:fixed`; without clipping X on
+            this scrollport, trackpad horizontal scroll pans the column and exposes a dead gap
+            between content and the fixed panel.
           */}
           <div
             ref={setMainColumnRef}
-            className="flex min-h-0 min-w-0 flex-1 flex-col overflow-y-auto narrow-scrollbar"
+            className="flex min-h-0 min-w-0 flex-1 flex-col overflow-x-hidden overflow-y-auto narrow-scrollbar"
           >
             {children}
           </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

With **both** AI and Human chat panels enabled, the main column scroll root lives in `PanelDualSidebarScrollBridge`. The Human panel is `position: fixed`; the flex row only reserves width via `data-sidebar-gap`. The scroll container had `overflow-y-auto` but **no horizontal clip**, so trackpad/touch **horizontal scroll** could pan the main column and reveal **empty background** between page content and the fixed chat rail — matching the “empty space column” report.

## Fix

Add `overflow-x-hidden` on the main-column scroll `div` (alongside existing `overflow-y-auto`) so the column cannot shift sideways.

## Scope

- Only affects the **dual-panel** code path (AI + Human both enabled). Single-panel `PanelScrollInset` already inherits `overflow-x-hidden` from `SidebarInset`.

## QA

- Space page, both panels on: open Human chat, attempt horizontal pan on main content — content should stay aligned to the left edge of the column; no dead strip.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2cd167cc-d5ce-4e4e-91dc-b9b3db3a5377"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2cd167cc-d5ce-4e4e-91dc-b9b3db3a5377"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

