### PR TITLE
fix(web): DHO hero and tabs fill width beside Human chat panel

### DIFF
--- a/apps/web/src/app/[lang]/dho/[id]/layout.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/layout.tsx
@@ -11,7 +11,6 @@ import {
 } from '@hypha-platform/epics';
 import '../../_shared/space-accent.css';
 import { Locale } from '@hypha-platform/i18n';
-import { Container } from '@hypha-platform/ui';
 import { findSpaceBySlug } from '@hypha-platform/core/server';
 import { getDhoPathAgreements } from './@tab/agreements/constants';
 import { ActionButtons } from './_components/action-buttons';
@@ -113,13 +112,12 @@ export default async function DhoLayout({
   return (
     <SpaceAccentPortalBridge>
       {/*
-        Full-width row: `Container` already applies max-width + horizontal padding.
-        Dropping the extra `mx-auto max-w-container-2xl` wrapper avoided double
-        max-width + centering that made the main column look pushed with a void on the left.
+        Main column must span the full width next to side panels: `Container` max-width + `mx-auto`
+        centers content and leaves empty gutters — very visible when the Human chat panel narrows
+        the column (reads as a dead strip beside the hero / secondary chrome). Use padding only.
       */}
       <div className="flex w-full min-w-0">
-        {/* `px-4!` = 16px: tighter than default Container `px-5` (20px) for DHO hero/tabs vs app chrome */}
-        <Container size="lg" className="min-w-0 flex-1 px-4!">
+        <div className="min-w-0 flex-1 px-4 sm:px-5">
           {/* React 19+: link rel="preload" is hoisted to document head */}
           {heroBannerImageHref !== DEFAULT_SPACE_LEAD_IMAGE ? (
             <link
@@ -224,7 +222,7 @@ export default async function DhoLayout({
             {tab}
             {children}
           </SpaceAccentFromImages>
-        </Container>
+        </div>
         {aside}
       </div>
     </SpaceAccentPortalBridge>

--- a/packages/epics/src/common/panel-main-column-scroll-bridge.tsx
+++ b/packages/epics/src/common/panel-main-column-scroll-bridge.tsx
@@ -89,10 +89,11 @@ export function PanelDualSidebarScrollBridge({
             (MenuTop, plugin, main, Footer) as a fragment — fragments flatten, so without this
             wrapper they become **separate flex items** next to the right Sidebar: header | content
             | footer | panel in one horizontal row.
+            `overflow-x-hidden`: clip horizontal pan so fixed side rails do not reveal a dead gap.
           */}
           <div
             ref={setMainColumnRef}
-            className="flex min-h-0 min-w-0 flex-1 flex-col overflow-y-auto narrow-scrollbar"
+            className="flex min-h-0 min-w-0 flex-1 flex-col overflow-x-hidden overflow-y-auto narrow-scrollbar"
           >
             {children}
           </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

With the Human chat panel open, the space hero / secondary chrome row looked like it “stopped short,” leaving a large empty strip before the chat rail. The banner did not visually “follow” the available width.

## Root cause

`apps/web/.../dho/[id]/layout.tsx` wrapped all space content in `<Container size="lg">`, which applies **`max-w-container-xl` / `xl:max-w-container-2xl`** and **`mx-auto`**. That **centers** a capped-width block inside the main column. When the column is narrowed by the chat panel, the unused space shows up as a **right gutter** — easy to read as a broken banner or misaligned secondary chrome.

## Changes

1. **DHO layout:** Replace `Container` with a simple **`min-w-0 flex-1 px-4 sm:px-5`** wrapper so content uses the **full width** of the main column (padding only, no max-width centering).

2. **Dual-panel scroll bridge:** Add **`overflow-x-hidden`** on the main-column scroll `div` so horizontal pan cannot expose a dead gap beside fixed side panels (pairs with the layout fix).

## QA

- Open a DHO space with Human chat → hero + tab strip should span to the inner edge of the column (minus padding), no large empty column between content and chat.
- AI + Human both on: same; no sideways “empty” pan next to the rail.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2cd167cc-d5ce-4e4e-91dc-b9b3db3a5377"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2cd167cc-d5ce-4e4e-91dc-b9b3db3a5377"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

