### PR TITLE
Add LocalScale global wallet login

### DIFF
--- a/apps/web/.env.template
+++ b/apps/web/.env.template
@@ -20,6 +20,9 @@ NEXT_PUBLIC_IMAGE_HOSTS="utfs.io, github.githubassets.com"
 # on hypha.earth custom domains (for example *.preview-app.hypha.earth).
 # Configure the same value in Vercel for all environments to avoid app-id drift.
 NEXT_PUBLIC_PRIVY_APP_ID=cm5y07p2z02napk1cutzzx7o6
+# Enables LocalScale as a Privy global wallet login option once their app is
+# configured as a cross-app/global-wallet provider in Privy.
+# NEXT_PUBLIC_LOCAL_SCALE_GLOBAL_WALLET_APP_ID=cmhuvof94005fky0dhm6cfxvg
 
 # Comma-separated extra Privy app IDs whose JWKS keys should be served from
 # /.well-known/jwks.json. Set on PRODUCTION so Neon Authorize accepts JWTs

--- a/apps/web/src/app/(mobile)/signin/layout.tsx
+++ b/apps/web/src/app/(mobile)/signin/layout.tsx
@@ -36,11 +36,17 @@ export default async function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
+  const localScaleGlobalWalletAppId =
+    process.env.NEXT_PUBLIC_LOCAL_SCALE_GLOBAL_WALLET_APP_ID?.trim();
+
   return (
     <Html className={clsx(lato.variable, sourceSans.variable)}>
       <AuthProvider
         config={{
           appId: process.env.NEXT_PUBLIC_PRIVY_APP_ID!,
+          globalWalletProviderAppIds: localScaleGlobalWalletAppId
+            ? [localScaleGlobalWalletAppId]
+            : undefined,
         }}
       >
         <ThemeProvider

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -109,6 +109,8 @@ export default async function RootLayout({
   const serviceWorkerPath = 'onesignal/OneSignalSDKWorker.js';
   const aiChatEnabled = await getEnableAiChat();
   const humanChatEnabled = await getEnableHumanChat();
+  const localScaleGlobalWalletAppId =
+    process.env.NEXT_PUBLIC_LOCAL_SCALE_GLOBAL_WALLET_APP_ID?.trim();
 
   return (
     <Html lang={locale} className={clsx(lato.variable, sourceSans.variable)}>
@@ -117,6 +119,9 @@ export default async function RootLayout({
       <AuthProvider
         config={{
           appId: process.env.NEXT_PUBLIC_PRIVY_APP_ID!,
+          globalWalletProviderAppIds: localScaleGlobalWalletAppId
+            ? [localScaleGlobalWalletAppId]
+            : undefined,
         }}
       >
         <ThemeProvider

--- a/packages/authentication/src/global-wallets.ts
+++ b/packages/authentication/src/global-wallets.ts
@@ -1,4 +1,4 @@
 export const LOCAL_SCALE_GLOBAL_WALLET_APP_ID = 'cmhuvof94005fky0dhm6cfxvg';
 
-export const LOCAL_SCALE_GLOBAL_WALLET_LOGIN_METHOD =
-  `privy:${LOCAL_SCALE_GLOBAL_WALLET_APP_ID}` as const;
+export const toPrivyGlobalWalletLoginMethod = (providerAppId: string) =>
+  `privy:${providerAppId}` as const;

--- a/packages/authentication/src/global-wallets.ts
+++ b/packages/authentication/src/global-wallets.ts
@@ -1,0 +1,4 @@
+export const LOCAL_SCALE_GLOBAL_WALLET_APP_ID = 'cmhuvof94005fky0dhm6cfxvg';
+
+export const LOCAL_SCALE_GLOBAL_WALLET_LOGIN_METHOD =
+  `privy:${LOCAL_SCALE_GLOBAL_WALLET_APP_ID}` as const;

--- a/packages/authentication/src/index.ts
+++ b/packages/authentication/src/index.ts
@@ -1,3 +1,4 @@
 export * from './shared/types';
 export * from './provider';
 export * from './use-authentication';
+export * from './global-wallets';

--- a/packages/authentication/src/provider.tsx
+++ b/packages/authentication/src/provider.tsx
@@ -34,7 +34,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({
         defaultChain: base,
         ...(hasGlobalWalletLoginMethods && {
           loginMethodsAndOrder: {
-            primary: [...globalWalletLoginMethods, 'email'],
+            primary: ['email', ...globalWalletLoginMethods],
             overflow: ['detected_ethereum_wallets'],
           },
         }),

--- a/packages/authentication/src/provider.tsx
+++ b/packages/authentication/src/provider.tsx
@@ -6,6 +6,7 @@ import { SmartWalletsProvider } from '@privy-io/react-auth/smart-wallets';
 import React from 'react';
 import { base } from '@wagmi/core/chains';
 import { EvmProvider } from '@hypha-platform/evm';
+import { LOCAL_SCALE_GLOBAL_WALLET_LOGIN_METHOD } from './global-wallets';
 
 export type PrivyAuthProviderConfig = {
   appId: string;
@@ -22,7 +23,13 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({
 }) => {
   return (
     <PrivyProvider
-      config={{ defaultChain: base }}
+      config={{
+        defaultChain: base,
+        loginMethodsAndOrder: {
+          primary: [LOCAL_SCALE_GLOBAL_WALLET_LOGIN_METHOD, 'email'],
+          overflow: ['detected_ethereum_wallets'],
+        },
+      }}
       appId={providerProps.config.appId}
     >
       <SmartWalletsProvider>

--- a/packages/authentication/src/provider.tsx
+++ b/packages/authentication/src/provider.tsx
@@ -6,10 +6,11 @@ import { SmartWalletsProvider } from '@privy-io/react-auth/smart-wallets';
 import React from 'react';
 import { base } from '@wagmi/core/chains';
 import { EvmProvider } from '@hypha-platform/evm';
-import { LOCAL_SCALE_GLOBAL_WALLET_LOGIN_METHOD } from './global-wallets';
+import { toPrivyGlobalWalletLoginMethod } from './global-wallets';
 
 export type PrivyAuthProviderConfig = {
   appId: string;
+  globalWalletProviderAppIds?: string[];
 };
 
 type AuthProviderProps = {
@@ -21,14 +22,22 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({
   children,
   ...providerProps
 }) => {
+  const globalWalletLoginMethods =
+    providerProps.config.globalWalletProviderAppIds?.map(
+      toPrivyGlobalWalletLoginMethod,
+    ) ?? [];
+  const hasGlobalWalletLoginMethods = globalWalletLoginMethods.length > 0;
+
   return (
     <PrivyProvider
       config={{
         defaultChain: base,
-        loginMethodsAndOrder: {
-          primary: [LOCAL_SCALE_GLOBAL_WALLET_LOGIN_METHOD, 'email'],
-          overflow: ['detected_ethereum_wallets'],
-        },
+        ...(hasGlobalWalletLoginMethods && {
+          loginMethodsAndOrder: {
+            primary: [...globalWalletLoginMethods, 'email'],
+            overflow: ['detected_ethereum_wallets'],
+          },
+        }),
       }}
       appId={providerProps.config.appId}
     >

--- a/packages/authentication/src/use-authentication.ts
+++ b/packages/authentication/src/use-authentication.ts
@@ -4,6 +4,41 @@ import { usePrivy, useWallets } from '@privy-io/react-auth';
 import React from 'react';
 import { useSetActiveWallet } from '@privy-io/wagmi';
 import { useRouter } from 'next/navigation';
+import { LOCAL_SCALE_GLOBAL_WALLET_APP_ID } from './global-wallets';
+
+type CrossAppAccountWithWallets = {
+  type: 'cross_app';
+  providerApp?: {
+    id?: string;
+  };
+  embeddedWallets?: {
+    address?: string;
+  }[];
+};
+
+const isEvmAddress = (
+  address: string | null | undefined,
+): address is `0x${string}` =>
+  typeof address === 'string' && address.startsWith('0x');
+
+const getLocalScaleWalletAddress = (
+  linkedAccounts: ReadonlyArray<unknown> | undefined,
+): `0x${string}` | undefined => {
+  const localScaleAccount = linkedAccounts?.find(
+    (account): account is CrossAppAccountWithWallets => {
+      if (!account || typeof account !== 'object') return false;
+
+      const candidate = account as CrossAppAccountWithWallets;
+      return (
+        candidate.type === 'cross_app' &&
+        candidate.providerApp?.id === LOCAL_SCALE_GLOBAL_WALLET_APP_ID
+      );
+    },
+  );
+  const address = localScaleAccount?.embeddedWallets?.[0]?.address;
+
+  return isEvmAddress(address) ? address : undefined;
+};
 
 export function useAuthentication() {
   const {
@@ -28,15 +63,25 @@ export function useAuthentication() {
     );
   }, [privyUser]);
 
+  const localScaleWalletAddress = React.useMemo(
+    () => getLocalScaleWalletAddress(privyUser?.linkedAccounts),
+    [privyUser?.linkedAccounts],
+  );
+
+  const smartWalletAddress = isEvmAddress(smartWallet?.address)
+    ? smartWallet.address
+    : undefined;
+  const walletAddress = localScaleWalletAddress || smartWalletAddress;
+
   React.useEffect(() => {
     const activeWallet = wallets.find(
-      (wallet) => wallet.address === smartWallet?.address,
+      (wallet) => wallet.address.toLowerCase() === walletAddress?.toLowerCase(),
     );
 
     if (activeWallet) {
       setActiveWallet(activeWallet);
     }
-  }, [smartWallet?.address, wallets, setActiveWallet]);
+  }, [walletAddress, wallets, setActiveWallet]);
 
   const login = React.useCallback(async (): Promise<void> => {
     privyLogin();
@@ -62,11 +107,11 @@ export function useAuthentication() {
         privyUser.email?.address ||
         privyUser.google?.email ||
         privyUser.apple?.email,
-      ...(smartWallet?.address && {
-        wallet: { address: smartWallet.address as `0x${string}` },
+      ...(walletAddress && {
+        wallet: { address: walletAddress },
       }),
     };
-  }, [privyUser, authenticated, smartWallet]);
+  }, [privyUser, authenticated, walletAddress]);
 
   const isEmbeddedWallet = React.useMemo(() => {
     return !!(smartWallet?.smartWalletType === 'coinbase_smart_wallet');

--- a/push-auth-test.md
+++ b/push-auth-test.md
@@ -1,0 +1,3 @@
+Push auth test.
+
+This file was added to confirm that pushing to GitHub uses HTTPS credentials instead of SSH.


### PR DESCRIPTION
## Summary
- Add LocalScale as a primary Privy global wallet login option.
- Keep email and detected Ethereum wallet sign-in available for existing Hypha users.
- Surface the LocalScale cross-app embedded wallet address through Hypha's existing auth user shape.

## Test plan
- Ran targeted formatting with `pnpm dlx prettier@latest --write packages/authentication/src/global-wallets.ts packages/authentication/src/index.ts packages/authentication/src/provider.tsx packages/authentication/src/use-authentication.ts`.
- Not run: package lint, because the checkout does not currently have `eslint` installed in local node_modules.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added local-scale global wallet as an authentication option.
  * Authentication now exposes optional global-wallet configuration and adjusts login-method ordering to surface global-wallet options.
  * Wallet address resolution improved to prefer and normalize a local-scale linked wallet when present.

* **Chores**
  * Added an environment variable entry to enable the local-scale global wallet.

* **Tests/Docs**
  * Added a short note to validate push authentication method.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->