### PR TITLE
fix(chat): show “You” / Hypha profile after reload for own Matrix messages

### DIFF
--- a/packages/epics/src/common/human-right-panel.tsx
+++ b/packages/epics/src/common/human-right-panel.tsx
@@ -874,10 +874,34 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
     if (!roomId || !client) return;
     setMessages((prev) =>
       prev.map((m) => {
-        const newSenderName =
-          m.role === 'member' && m.senderMatrixId
-            ? resolveMemberLabelRef.current(m.senderMatrixId)
-            : m.senderName;
+        const sid = m.senderMatrixId?.trim();
+        const isSelfRow = Boolean(
+          currentUserIdRef.current && sid && sid === currentUserIdRef.current,
+        );
+
+        /**
+         * On cold load, `client.getUserId()` can be null when we first map
+         * Matrix events to UI — own messages are misclassified as `member` and
+         * get a technical Matrix/Privy display label. Re-sync when Matrix id arrives.
+         */
+        let nextRole = m.role;
+        let newSenderName = m.senderName;
+        let nextMemberAvatar = m.avatarUrl;
+        if (isSelfRow) {
+          nextRole = 'user';
+          newSenderName = undefined;
+          nextMemberAvatar = currentUserAvatarUrlRef.current ?? m.avatarUrl;
+        } else if (m.role === 'member' && sid) {
+          newSenderName = resolveMemberLabelRef.current(sid);
+          nextMemberAvatar =
+            matrixMemberAvatarSquare(
+              matrixClientRef.current,
+              roomIdRef.current,
+              sid,
+              96,
+            ) ?? m.avatarUrl;
+        }
+
         const newAuthorLabel =
           m.replyTo?.sourceUserId != null
             ? resolveMemberLabelRef.current(m.replyTo.sourceUserId)
@@ -902,17 +926,8 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
               }
             : m.replyTo;
 
-        const nextMemberAvatar =
-          m.role === 'member' && m.senderMatrixId
-            ? matrixMemberAvatarSquare(
-                matrixClientRef.current,
-                roomIdRef.current,
-                m.senderMatrixId,
-                96,
-              ) ?? m.avatarUrl
-            : m.avatarUrl;
-
         if (
+          nextRole === m.role &&
           newSenderName === m.senderName &&
           nextReply?.authorLabel === m.replyTo?.authorLabel &&
           nextReply?.authorAvatarUrl === m.replyTo?.authorAvatarUrl &&
@@ -923,13 +938,22 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
 
         return {
           ...m,
+          role: nextRole,
           senderName: newSenderName,
           avatarUrl: nextMemberAvatar,
           replyTo: nextReply,
         };
       }),
     );
-  }, [roomId, client, currentUserId, me?.name, me?.surname, t]);
+  }, [
+    roomId,
+    client,
+    currentUserId,
+    currentUserAvatarUrl,
+    me?.name,
+    me?.surname,
+    t,
+  ]);
 
   // Backfill avatar on self-authored messages after useMe() resolves
   useEffect(() => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After a full page reload, chat rows authored by the current user sometimes showed bridged Privy Matrix IDs (`@prod_privy…`) in large text instead of **You** / Hypha profile names. Live updates looked correct because `client.getUserId()` was already available when mapping events.

## Cause

History is hydrated into UI messages (`toUIMessage`) **before** the Matrix client exposes `getUserId()`. Own events were classified as `role: member` with `senderName` resolved from Matrix member state (technical displaynames). The reconciliation effect only refreshed labels when `role === member` *and* treated self rows differently from Hypha-backed **user** rows, so rows never migrated to the **You** path when `currentUserId` hydrated later.

## Fix

Extend the existing message reconciliation effect in `human-right-panel.tsx` to:

1. Detect rows whose `senderMatrixId` equals the hydrated `currentUserId`.
2. Flip them to `role: user`, clear stale `senderName`, and prefer `useMe()` avatar.
3. Re-run when `currentUserAvatarUrl` resolves so avatars stay in sync.

## Verification

Manual: reload a space chat with your own messages — header should show **You** (or profile) and body should not substitute MXID pills for ordinary text once hydrated.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0e8fd13f-58bc-40d1-82fb-1aa4cbad3c15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0e8fd13f-58bc-40d1-82fb-1aa4cbad3c15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

