### PR TITLE
feat(epics): overlay left menu labels with persistent icon rail

### DIFF
--- a/apps/web/src/app/[lang]/dho/[id]/@tab/layout.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@tab/layout.tsx
@@ -1,7 +1,7 @@
 import { Locale } from '@hypha-platform/i18n';
 import { ReactNode } from 'react';
 import { NavigationTabs } from '../_components/navigation-tabs';
-import { getEnableCoherence } from '@hypha-platform/feature-flags';
+import { getEnableAiChat, getEnableCoherence } from '@hypha-platform/feature-flags';
 
 export default async function TabLayout({
   children,
@@ -12,13 +12,16 @@ export default async function TabLayout({
 }) {
   const { id: daoSlug, lang } = await params;
   const coherenceEnabled = await getEnableCoherence();
+  const aiChatEnabled = await getEnableAiChat();
   return (
     <>
-      <NavigationTabs
-        id={daoSlug}
-        lang={lang}
-        coherenceEnabled={coherenceEnabled}
-      />
+      {!aiChatEnabled ? (
+        <NavigationTabs
+          id={daoSlug}
+          lang={lang}
+          coherenceEnabled={coherenceEnabled}
+        />
+      ) : null}
       {children}
     </>
   );

--- a/apps/web/src/app/[lang]/dho/[id]/@tab/layout.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@tab/layout.tsx
@@ -1,7 +1,10 @@
 import { Locale } from '@hypha-platform/i18n';
 import { ReactNode } from 'react';
 import { NavigationTabs } from '../_components/navigation-tabs';
-import { getEnableAiChat, getEnableCoherence } from '@hypha-platform/feature-flags';
+import {
+  getEnableAiChat,
+  getEnableCoherence,
+} from '@hypha-platform/feature-flags';
 
 export default async function TabLayout({
   children,

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -12,7 +12,7 @@ import { Footer, Html, ThemeProvider } from '@hypha-platform/ui/server';
 import { AuthProvider } from '@hypha-platform/authentication';
 import { useAuthentication } from '@hypha-platform/authentication';
 import {
-  AiLeftPanel,
+  SpaceLeftPanel,
   PanelProviders,
   PanelWrapLayout,
   AiSidebarTrigger,
@@ -140,7 +140,7 @@ export default async function RootLayout({
                       <PanelWrapLayout
                         left={
                           aiChatEnabled
-                            ? { content: <AiLeftPanel /> }
+                            ? { content: <SpaceLeftPanel /> }
                             : undefined
                         }
                         right={

--- a/docs/requirements/ai-left-panel-spec.md
+++ b/docs/requirements/ai-left-panel-spec.md
@@ -1,0 +1,280 @@
+# AI Left Panel — Product + Implementation Spec
+
+## Document control
+
+| Field | Value |
+| --- | --- |
+| Status | Ready for implementation |
+| Target PR | `AI-Left Panel` |
+| Base branch | `main` |
+| Scope | Left panel information architecture, UX model, phased delivery |
+| Constraint | Keep current left panel container and resize behavior |
+
+---
+
+## 1) Goal
+
+Replace top content tabs with a persistent left navigation menu for Space pages, while keeping Hypha AI in the same left panel container.
+
+### 1.1 Desired behavior
+
+- Default view in left panel shows menu navigation (not AI chat).
+- Clicking the AI icon (sparkles) switches the panel content to AI.
+- Clicking the AI icon again returns to the menu view.
+- A compact mode (`<`) shows only menu icons in the left panel.
+- Left panel width must not jump when switching Menu <-> AI.
+- Existing edge drag resize must continue to work.
+
+### 1.2 Menu set (target IA)
+
+- `Ecosystem` (new: space navigation in main panel, not modal)
+- `Signals` (rename of Coherence)
+- `Proposals`
+- `Members`
+- `Treasury`
+- `Rewards` (currently surfaced inside Treasury)
+- `Memory` (currently inside Coherence)
+- `Space settings`
+
+---
+
+## 2) UX recommendation (answer to toggle question)
+
+Yes, a toggle is the best UX approach for this constraint set, with one refinement:
+
+- Use a 2-mode panel switch: `Menu` <-> `AI` in the same left rail.
+- Keep the panel itself open and stable; switch content only.
+- Keep one explicit, independent "Collapse to icons" control for Menu mode.
+
+Why this is best:
+
+- Preserves spatial memory: users always look left for navigation and AI.
+- Avoids width/layout jitter: same container, same drag-resized width token.
+- Fast context switching: one click between navigation and assistant.
+- Lower cognitive load vs moving AI to a different location.
+
+Anti-pattern to avoid:
+
+- Reusing one control for both "close/open panel" and "menu/AI content mode". These are different user intents and should remain separate states.
+
+---
+
+## 3) UX model (state machine)
+
+Left panel should have two independent state dimensions:
+
+1. **Panel visibility**: `open | closed`
+2. **Panel content mode**: `menu | ai`
+3. **Menu density** (when `contentMode=menu`): `expanded | icon-only`
+
+Normative behavior:
+
+- Opening panel restores previous `contentMode`.
+- AI icon toggles only `contentMode` between `menu` and `ai`.
+- `<` collapse control changes only `menuDensity`.
+- Drag-resized width token is shared by both `menu` and `ai` and persists across switches.
+
+Suggested persisted keys:
+
+- `leftPanel.contentMode`
+- `leftPanel.menuDensity`
+- width already stored through existing `--sidebar-width` runtime behavior
+
+---
+
+## 4) Navigation mapping (phase-safe)
+
+To ship incrementally without breaking routing:
+
+- `Signals` -> current `coherence` route
+- `Proposals` -> current `agreements` route (label change only in phase 1)
+- `Members` -> current `members` route
+- `Treasury` -> current `treasury` route
+
+Later-phase destination handling:
+
+- `Rewards` -> Treasury rewards section deep-link/anchor (or dedicated subroute)
+- `Memory` -> Coherence memory section deep-link/route
+- `Ecosystem` -> new main-panel route replacing modal flow
+- `Space settings` -> existing settings path currently reachable via actions
+
+---
+
+## 5) Technical design (Next.js + current architecture)
+
+### 5.1 Existing architecture constraints
+
+- Left sidebar shell is provided by `PanelWrapLayout`.
+- Left panel currently mounts `AiLeftPanel`.
+- AI trigger in top menu currently opens/closes left sidebar (`AiSidebarTrigger`).
+- DHO content tabs are rendered via `@tab/layout.tsx` + `NavigationTabs`.
+
+### 5.2 Target architecture
+
+Introduce a new compositional wrapper in `packages/epics`:
+
+- `SpaceLeftPanel` (new): renders either `MenuPanel` or `AiLeftPanel` inside same `Sidebar` shell.
+- `SpaceLeftPanelProvider` (new/extended context): manages `contentMode` + `menuDensity`.
+- Keep `SidebarResizeHandle` untouched.
+
+High-level file impact:
+
+- `packages/epics/src/common/panel-wrap-layout.tsx`
+  - Add content-mode context wiring.
+  - Keep left sidebar width behavior unchanged.
+- `packages/epics/src/common/ai-left-panel.tsx`
+  - Keep AI chat body mostly unchanged; update header actions to switch mode instead of closing panel in this flow.
+- `apps/web/src/app/layout.tsx`
+  - Mount `SpaceLeftPanel` in left slot instead of plain `AiLeftPanel`.
+  - Update top sparkles action to toggle `menu <-> ai` mode (open panel if currently closed).
+- `apps/web/src/app/[lang]/dho/[id]/_components/navigation-tabs.tsx`
+  - Phase 1: keep for fallback compatibility.
+  - Phase 2+: remove from visible chrome once left menu owns navigation.
+
+### 5.3 Design system requirements (hypha stack)
+
+- Use existing Sidebar primitives from `packages/ui/src/sidebar.tsx`.
+- For icon-only mode, prefer `collapsible="icon"` pattern semantics.
+- Keep token-based colors and spacing (`bg-background-2`, `text-muted-foreground`, etc.).
+- Preserve focus-visible states and ARIA labels for all icon-only actions.
+
+---
+
+## 6) Phased implementation plan
+
+## Phase 1 — Left Menu for existing 4 tabs (MVP)
+
+Goal: ship requested behavior quickly using current routes.
+
+Deliverables:
+
+- New left menu (default mode) with items:
+  - Signals, Proposals, Members, Treasury
+- AI icon toggles panel content:
+  - `menu` -> `ai`
+  - `ai` -> `menu`
+- No left width jump when switching modes
+- Drag resize unchanged
+
+Routing in this phase:
+
+- Signals -> coherence
+- Proposals -> agreements
+- Members -> members
+- Treasury -> treasury
+
+Exit criteria:
+
+- Users can navigate the 4 existing sections from left menu.
+- AI remains available in same panel with one-click switch.
+
+## Phase 2 — Icon-only mode and interaction hardening
+
+Goal: deliver compact navigation without changing panel container behavior.
+
+Deliverables:
+
+- `<` control in menu header toggles `expanded` <-> `icon-only`.
+- Tooltip labels on icon-only menu items.
+- Keyboard navigation and roving focus across menu items.
+- Persist `menuDensity` and `contentMode` between refreshes.
+
+Exit criteria:
+
+- Icon-only mode is fully usable, accessible, and reversible.
+- Panel width remains stable across `menu/ai` switches.
+
+## Phase 3 — Expand IA to full target menu set
+
+Goal: add requested items beyond current 4 tabs.
+
+Deliverables:
+
+- Add menu items: Ecosystem, Rewards, Memory, Space settings.
+- Implement route destinations:
+  - Ecosystem as main-panel page (not modal)
+  - Rewards + Memory via route or deep-link strategy
+  - Space settings via existing settings path alignment
+- Ensure selected-state logic works for nested/subpaths.
+
+Exit criteria:
+
+- Full target menu exists and routes correctly.
+- No regressions in existing space actions/settings flows.
+
+## Phase 4 — Cleanup and migration completion
+
+Goal: remove legacy tab-strip dependency and finalize.
+
+Deliverables:
+
+- Remove visible top tab strip for migrated pages.
+- Keep compatibility redirects/aliases where needed.
+- Update i18n keys and naming (`Coherence` -> `Signals`, `Agreements` -> `Proposals` as product labels).
+- Document final IA and telemetry events.
+
+Exit criteria:
+
+- Left menu is sole primary navigation in DHO space pages.
+- Legacy tabs no longer required for user flows.
+
+---
+
+## 7) QA strategy (must pass each phase)
+
+### 7.1 E2E scenarios (Playwright)
+
+- Default render shows Menu mode in left panel.
+- AI icon toggles to AI panel and back to Menu.
+- Left panel width remains constant across mode switches.
+- Drag resize works in Menu mode and AI mode.
+- Icon-only mode shows icons + tooltips and navigates correctly.
+- Active menu state reflects current route.
+
+### 7.2 Accessibility checks
+
+- All icon buttons have `aria-label`.
+- Focus order is predictable in both modes.
+- Color contrast stays AA in dark theme.
+- Keyboard-only user can:
+  - open/close panel
+  - switch menu/AI mode
+  - switch expanded/icon-only mode
+  - activate navigation item
+
+### 7.3 Regression tests
+
+- Existing AI streaming/suggestions still work.
+- Existing right chat panel behavior unaffected.
+- DHO sticky chrome and main column layout unaffected.
+
+---
+
+## 8) Risks and mitigations
+
+- **State coupling risk:** panel open state and content-mode state can conflict.
+  - Mitigation: explicit state model and dedicated context contract.
+- **Route naming confusion (Agreements vs Proposals, Coherence vs Signals):**
+  - Mitigation: keep route slugs stable first, change labels first, then migrate URLs later if needed.
+- **Layout regressions with fixed/sticky chrome:**
+  - Mitigation: width invariance tests + screenshot regression on space pages.
+
+---
+
+## 9) Recommended rollout
+
+- Ship Phase 1 behind a feature flag (`leftNavV2`).
+- Enable for internal users first.
+- Expand to Phase 2 and Phase 3 after telemetry confirms successful adoption:
+  - AI toggle usage
+  - menu navigation usage
+  - collapse mode usage
+  - no spike in back-navigation or bounce from space pages
+
+---
+
+## 10) Decision summary
+
+- Toggle is the right interaction model if implemented as **content mode switch**, not panel close/open.
+- Keep one stable left container with persistent width and resize.
+- Deliver in phases: start with existing 4 tabs, then expand and finalize IA.

--- a/packages/epics/src/coherence/components/coherence-block.tsx
+++ b/packages/epics/src/coherence/components/coherence-block.tsx
@@ -78,6 +78,7 @@ export function CoherenceBlock({
               label={t('signals')}
               hasSearch={true}
               signals={signals ?? []}
+              leadImage={space?.leadImage}
               isLoading={isSpaceLoading || isSignalsLoading}
               firstPageSize={3}
               pageSize={3}

--- a/packages/epics/src/coherence/components/coherence-block.tsx
+++ b/packages/epics/src/coherence/components/coherence-block.tsx
@@ -78,7 +78,7 @@ export function CoherenceBlock({
               label={t('signals')}
               hasSearch={true}
               signals={signals ?? []}
-              leadImage={space?.leadImage}
+              leadImage={space?.leadImage ?? undefined}
               isLoading={isSpaceLoading || isSignalsLoading}
               firstPageSize={3}
               pageSize={3}

--- a/packages/epics/src/coherence/components/signal-card.tsx
+++ b/packages/epics/src/coherence/components/signal-card.tsx
@@ -67,7 +67,9 @@ const BADGE_COLOR_VARIANT_MAP: Record<string, BadgeProps['colorVariant']> = {
   insight: 'accent',
 };
 
-const HERO_TINT_CLASS_MAP: Record<BadgeProps['colorVariant'], string> = {
+type SignalColorVariant = NonNullable<BadgeProps['colorVariant']>;
+
+const HERO_TINT_CLASS_MAP: Record<SignalColorVariant, string> = {
   accent: 'bg-accent-9/23',
   error: 'bg-error-9/23',
   warn: 'bg-warning-9/23',
@@ -75,7 +77,7 @@ const HERO_TINT_CLASS_MAP: Record<BadgeProps['colorVariant'], string> = {
   neutral: 'bg-neutral-9/23',
 };
 
-const HERO_PRIORITY_GRADIENT_CLASS_MAP: Record<BadgeProps['colorVariant'], string> = {
+const HERO_PRIORITY_GRADIENT_CLASS_MAP: Record<SignalColorVariant, string> = {
   accent: 'to-accent-9/27',
   error: 'to-error-9/27',
   warn: 'to-warning-9/27',
@@ -142,14 +144,17 @@ export const SignalCard: React.FC<SignalCardProps & Coherence> = ({
     [priority],
   );
 
-  const typeColorVariant = React.useMemo<BadgeProps['colorVariant']>(
-    () => BADGE_COLOR_VARIANT_MAP[coherenceType?.colorVariant ?? 'accent'] ?? 'accent',
+  const typeColorVariant = React.useMemo<SignalColorVariant>(
+    () =>
+      BADGE_COLOR_VARIANT_MAP[coherenceType?.colorVariant ?? 'accent'] ??
+      'accent',
     [coherenceType?.colorVariant],
   );
 
-  const priorityColorVariant = React.useMemo<BadgeProps['colorVariant']>(
+  const priorityColorVariant = React.useMemo<SignalColorVariant>(
     () =>
-      BADGE_COLOR_VARIANT_MAP[priorityMeta?.colorVariant ?? 'neutral'] ?? 'neutral',
+      BADGE_COLOR_VARIANT_MAP[priorityMeta?.colorVariant ?? 'neutral'] ??
+      'neutral',
     [priorityMeta?.colorVariant],
   );
 
@@ -174,7 +179,14 @@ export const SignalCard: React.FC<SignalCardProps & Coherence> = ({
       colorVariant: priorityColorVariant,
     };
     return [typeBadge, priorityBadge];
-  }, [coherenceType, priorityMeta, t, typeLabel, typeColorVariant, priorityColorVariant]);
+  }, [
+    coherenceType,
+    priorityMeta,
+    t,
+    typeLabel,
+    typeColorVariant,
+    priorityColorVariant,
+  ]);
 
   const tagList: BadgeItem[] = tags.map((tag) => {
     const displayLabel = (COHERENCE_TAGS as readonly string[]).includes(tag)
@@ -327,7 +339,9 @@ export const SignalCard: React.FC<SignalCardProps & Coherence> = ({
                 onClick={(e) => e.stopPropagation()}
               >
                 <AlertDialogHeader>
-                  <AlertDialogTitle>{tSignalCard('deleteSignal')}</AlertDialogTitle>
+                  <AlertDialogTitle>
+                    {tSignalCard('deleteSignal')}
+                  </AlertDialogTitle>
                   <AlertDialogDescription>
                     {tSignalCard('deleteConfirm')}
                   </AlertDialogDescription>
@@ -379,7 +393,9 @@ export const SignalCard: React.FC<SignalCardProps & Coherence> = ({
           </div>
 
           <div className="flex min-w-0 flex-wrap items-center gap-2 text-1 text-muted-foreground">
-            {metaBadges.length > 0 ? <BadgesList isLoading={isLoading} badges={metaBadges} /> : null}
+            {metaBadges.length > 0 ? (
+              <BadgesList isLoading={isLoading} badges={metaBadges} />
+            ) : null}
             <div className="ml-auto flex min-w-0 items-center gap-3">
               <span className="inline-flex min-w-0 items-center gap-1">
                 <ClockIcon

--- a/packages/epics/src/coherence/components/signal-card.tsx
+++ b/packages/epics/src/coherence/components/signal-card.tsx
@@ -5,6 +5,7 @@ import {
   COHERENCE_PRIORITY_OPTIONS,
   COHERENCE_TAGS,
   COHERENCE_TYPE_OPTIONS,
+  DEFAULT_SPACE_LEAD_IMAGE,
   useCoherenceMutationsWeb2Rsc,
   useJwt,
   useMe,
@@ -18,10 +19,12 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
   BadgeItem,
+  Badge,
   BadgesList,
   Button,
   Card,
   CardContent,
+  CardHeader,
   CardTitle,
   ConfirmDialog,
   Dialog,
@@ -30,6 +33,7 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
+  Image,
   LucideReactIcon,
   Skeleton,
 } from '@hypha-platform/ui';
@@ -49,6 +53,34 @@ type SignalCardProps = {
   refresh: () => Promise<void>;
   onOpenConversation?: () => void;
   className?: string;
+  leadImage?: string;
+};
+
+const BADGE_COLOR_VARIANT_MAP: Record<string, BadgeProps['colorVariant']> = {
+  accent: 'accent',
+  error: 'error',
+  warn: 'warn',
+  warning: 'warn',
+  success: 'success',
+  neutral: 'neutral',
+  tension: 'warn',
+  insight: 'accent',
+};
+
+const HERO_TINT_CLASS_MAP: Record<BadgeProps['colorVariant'], string> = {
+  accent: 'bg-accent-9/23',
+  error: 'bg-error-9/23',
+  warn: 'bg-warning-9/23',
+  success: 'bg-success-9/23',
+  neutral: 'bg-neutral-9/23',
+};
+
+const HERO_PRIORITY_GRADIENT_CLASS_MAP: Record<BadgeProps['colorVariant'], string> = {
+  accent: 'to-accent-9/27',
+  error: 'to-error-9/27',
+  warn: 'to-warning-9/27',
+  success: 'to-success-9/27',
+  neutral: 'to-neutral-9/27',
 };
 
 export const SignalCard: React.FC<SignalCardProps & Coherence> = ({
@@ -67,6 +99,7 @@ export const SignalCard: React.FC<SignalCardProps & Coherence> = ({
   refresh,
   onOpenConversation,
   className,
+  leadImage,
 }) => {
   const { jwt: authToken } = useJwt();
   const { person } = useMe();
@@ -109,13 +142,23 @@ export const SignalCard: React.FC<SignalCardProps & Coherence> = ({
     [priority],
   );
 
+  const typeColorVariant = React.useMemo<BadgeProps['colorVariant']>(
+    () => BADGE_COLOR_VARIANT_MAP[coherenceType?.colorVariant ?? 'accent'] ?? 'accent',
+    [coherenceType?.colorVariant],
+  );
+
+  const priorityColorVariant = React.useMemo<BadgeProps['colorVariant']>(
+    () =>
+      BADGE_COLOR_VARIANT_MAP[priorityMeta?.colorVariant ?? 'neutral'] ?? 'neutral',
+    [priorityMeta?.colorVariant],
+  );
+
   const metaBadges: BadgeItem[] = React.useMemo(() => {
     const typeBadge: BadgeItem = {
       label: typeLabel,
       icon: coherenceType?.icon as LucideReactIcon,
-      variant: 'outline',
-      colorVariant: (coherenceType?.colorVariant ??
-        'accent') as BadgeProps['colorVariant'],
+      variant: 'soft',
+      colorVariant: typeColorVariant,
     };
     if (!priorityMeta) return [typeBadge];
     const priorityLabel = t(
@@ -127,11 +170,11 @@ export const SignalCard: React.FC<SignalCardProps & Coherence> = ({
     const priorityBadge: BadgeItem = {
       label: priorityLabel,
       icon: priorityMeta.icon as LucideReactIcon,
-      variant: 'outline',
-      colorVariant: priorityMeta.colorVariant as BadgeProps['colorVariant'],
+      variant: 'soft',
+      colorVariant: priorityColorVariant,
     };
     return [typeBadge, priorityBadge];
-  }, [coherenceType, priorityMeta, t, typeLabel]);
+  }, [coherenceType, priorityMeta, t, typeLabel, typeColorVariant, priorityColorVariant]);
 
   const tagList: BadgeItem[] = tags.map((tag) => {
     const displayLabel = (COHERENCE_TAGS as readonly string[]).includes(tag)
@@ -218,79 +261,111 @@ export const SignalCard: React.FC<SignalCardProps & Coherence> = ({
         className,
       )}
     >
+      <CardHeader className="relative h-48 shrink-0 overflow-hidden p-0">
+        <Skeleton
+          className="h-full min-w-full"
+          width="100%"
+          height="192px"
+          loading={isLoading}
+        >
+          <Image
+            width={640}
+            height={192}
+            className="h-full w-full object-cover"
+            src={leadImage || DEFAULT_SPACE_LEAD_IMAGE}
+            alt={title || ''}
+          />
+          <div
+            className={cn(
+              'absolute inset-0 pointer-events-none',
+              HERO_TINT_CLASS_MAP[typeColorVariant],
+            )}
+            aria-hidden
+          />
+          <div
+            className={cn(
+              'absolute inset-0 pointer-events-none bg-gradient-to-tr from-transparent via-transparent',
+              HERO_PRIORITY_GRADIENT_CLASS_MAP[priorityColorVariant],
+            )}
+            aria-hidden
+          />
+          <div
+            className="pointer-events-none absolute inset-x-0 bottom-0 h-16 bg-gradient-to-t from-black/22 to-transparent"
+            aria-hidden
+          />
+        </Skeleton>
+        {isCreator && slug ? (
+          <>
+            <Button
+              type="button"
+              variant="outline"
+              colorVariant="neutral"
+              size="sm"
+              className="absolute right-3 top-3 z-10 h-10 w-10 shrink-0 rounded-none border border-white/15 bg-black/45 p-0 text-neutral-1 shadow-sm backdrop-blur-[1px] hover:bg-black/55 hover:text-white focus-visible:ring-2 focus-visible:ring-white/70"
+              disabled={isLoading}
+              aria-label={tSignalCard('deleteMenu')}
+              title={tSignalCard('deleteMenu')}
+              onClick={(e) => {
+                e.stopPropagation();
+                setDeleteOpen(true);
+              }}
+            >
+              <Trash2 className="h-4 w-4" aria-hidden />
+            </Button>
+            <AlertDialog
+              open={deleteOpen}
+              onOpenChange={(open) => {
+                setDeleteOpen(open);
+                if (!open) setDeleteError(null);
+              }}
+            >
+              <AlertDialogContent
+                overlayClassName="bg-black/75 backdrop-blur-sm supports-[backdrop-filter]:bg-black/65"
+                className="border-l-[3px] border-l-[var(--space-accent)]"
+                style={spaceAccentPortalStyle}
+                data-space-accent-scope=""
+                onClick={(e) => e.stopPropagation()}
+              >
+                <AlertDialogHeader>
+                  <AlertDialogTitle>{tSignalCard('deleteSignal')}</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    {tSignalCard('deleteConfirm')}
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                {deleteError ? (
+                  <p
+                    role="alert"
+                    className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+                  >
+                    {deleteError}
+                  </p>
+                ) : null}
+                <AlertDialogFooter>
+                  <AlertDialogCancel asChild>
+                    <Button variant="outline" colorVariant="neutral">
+                      {t('noLeave')}
+                    </Button>
+                  </AlertDialogCancel>
+                  <Button
+                    type="button"
+                    colorVariant="accent"
+                    onClick={async (e) => {
+                      e.stopPropagation();
+                      const deleted = await handleDelete();
+                      if (deleted) setDeleteOpen(false);
+                    }}
+                  >
+                    {tSignalCard('deleteConfirmAction')}
+                  </Button>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          </>
+        ) : null}
+      </CardHeader>
       <CardContent className="relative flex min-h-0 flex-1 flex-col gap-0 p-0">
         <div className="relative flex min-h-0 flex-1 flex-col gap-3 px-4 pb-3 pt-4">
-          {isCreator && slug ? (
-            <>
-              <Button
-                type="button"
-                variant="ghost"
-                colorVariant="neutral"
-                size="sm"
-                className="absolute right-3 top-3 z-10 h-8 w-8 shrink-0 p-0 text-muted-foreground hover:text-destructive"
-                disabled={isLoading}
-                aria-label={tSignalCard('deleteMenu')}
-                title={tSignalCard('deleteMenu')}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setDeleteOpen(true);
-                }}
-              >
-                <Trash2 className="h-4 w-4" aria-hidden />
-              </Button>
-              <AlertDialog
-                open={deleteOpen}
-                onOpenChange={(open) => {
-                  setDeleteOpen(open);
-                  if (!open) setDeleteError(null);
-                }}
-              >
-                <AlertDialogContent
-                  overlayClassName="bg-black/75 backdrop-blur-sm supports-[backdrop-filter]:bg-black/65"
-                  className="border-l-[3px] border-l-[var(--space-accent)]"
-                  style={spaceAccentPortalStyle}
-                  data-space-accent-scope=""
-                  onClick={(e) => e.stopPropagation()}
-                >
-                  <AlertDialogHeader>
-                    <AlertDialogTitle>
-                      {tSignalCard('deleteSignal')}
-                    </AlertDialogTitle>
-                    <AlertDialogDescription>
-                      {tSignalCard('deleteConfirm')}
-                    </AlertDialogDescription>
-                  </AlertDialogHeader>
-                  {deleteError ? (
-                    <p
-                      role="alert"
-                      className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
-                    >
-                      {deleteError}
-                    </p>
-                  ) : null}
-                  <AlertDialogFooter>
-                    <AlertDialogCancel asChild>
-                      <Button variant="outline" colorVariant="neutral">
-                        {t('noLeave')}
-                      </Button>
-                    </AlertDialogCancel>
-                    <Button
-                      type="button"
-                      colorVariant="accent"
-                      onClick={async (e) => {
-                        e.stopPropagation();
-                        const deleted = await handleDelete();
-                        if (deleted) setDeleteOpen(false);
-                      }}
-                    >
-                      {tSignalCard('deleteConfirmAction')}
-                    </Button>
-                  </AlertDialogFooter>
-                </AlertDialogContent>
-              </AlertDialog>
-            </>
-          ) : null}
-          <div className={cn('min-w-0', isCreator && slug && 'pr-10')}>
+          <div className="min-w-0">
             <Skeleton
               className="min-w-0"
               width="100%"
@@ -303,22 +378,31 @@ export const SignalCard: React.FC<SignalCardProps & Coherence> = ({
             </Skeleton>
           </div>
 
-          <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-2 text-1 text-muted-foreground">
-            {metaBadges.length > 0 ? (
-              <BadgesList isLoading={isLoading} badges={metaBadges} />
-            ) : null}
-            <span className="inline-flex min-w-0 items-center gap-1">
-              <ClockIcon
-                className="h-3.5 w-3.5 shrink-0 opacity-70"
-                aria-hidden
-              />
-              {createdAt
-                ? formatDistanceToNow(new Date(createdAt), {
-                    addSuffix: true,
-                    locale: dateFnsLocale,
-                  })
-                : ''}
-            </span>
+          <div className="flex min-w-0 flex-wrap items-center gap-2 text-1 text-muted-foreground">
+            {metaBadges.length > 0 ? <BadgesList isLoading={isLoading} badges={metaBadges} /> : null}
+            <div className="ml-auto flex min-w-0 items-center gap-3">
+              <span className="inline-flex min-w-0 items-center gap-1">
+                <ClockIcon
+                  className="h-3.5 w-3.5 shrink-0 opacity-70"
+                  aria-hidden
+                />
+                {createdAt
+                  ? formatDistanceToNow(new Date(createdAt), {
+                      addSuffix: true,
+                      locale: dateFnsLocale,
+                    })
+                  : ''}
+              </span>
+              <Badge
+                isLoading={isLoading}
+                variant="outline"
+                colorVariant="neutral"
+                className="gap-1.5"
+              >
+                <Users size={12} aria-hidden />
+                <span>{t('mentions', { count: messages })}</span>
+              </Badge>
+            </div>
           </div>
 
           <Skeleton
@@ -397,15 +481,6 @@ export const SignalCard: React.FC<SignalCardProps & Coherence> = ({
           {tagList?.length > 0 ? (
             <BadgesList isLoading={isLoading} badges={tagList ?? []} />
           ) : null}
-
-          <div className="flex flex-row gap-1">
-            <Skeleton loading={isLoading} height="16px" width="80px">
-              <Users size={12} />
-              <div className="text-neutral-11 text-1">
-                {t('mentions', { count: messages })}
-              </div>
-            </Skeleton>
-          </div>
         </div>
 
         <div className="mt-auto flex min-h-[4.25rem] shrink-0 flex-col justify-center border-t border-border px-4 py-3">

--- a/packages/epics/src/coherence/components/signal-grid.container.tsx
+++ b/packages/epics/src/coherence/components/signal-grid.container.tsx
@@ -3,6 +3,7 @@ import { SignalGrid } from './signal-grid';
 
 type SignalGridContainerProps = {
   basePath: string;
+  leadImage?: string;
   pagination: {
     page: number;
     firstPageSize: number;
@@ -17,6 +18,7 @@ type SignalGridContainerProps = {
 
 export const SignalGridContainer = ({
   basePath,
+  leadImage,
   pagination,
   signals,
   refresh,
@@ -34,6 +36,7 @@ export const SignalGridContainer = ({
     <SignalGrid
       isLoading={false}
       basePath={basePath}
+      leadImage={leadImage}
       signals={paginatedSignals.map((signal) => ({
         ...signal,
       }))}

--- a/packages/epics/src/coherence/components/signal-grid.tsx
+++ b/packages/epics/src/coherence/components/signal-grid.tsx
@@ -6,6 +6,7 @@ import { Coherence } from '@hypha-platform/core/client';
 type SignalGridProps = {
   isLoading: boolean;
   basePath: string;
+  leadImage?: string;
   signals: Coherence[];
   refresh: () => Promise<void>;
   onSignalClick?: (signal: Coherence) => void;
@@ -14,6 +15,7 @@ type SignalGridProps = {
 export function SignalGrid({
   isLoading,
   basePath,
+  leadImage,
   signals,
   refresh,
   onSignalClick,
@@ -25,6 +27,7 @@ export function SignalGrid({
           <SignalCard
             key={signal.id}
             {...signal}
+            leadImage={leadImage}
             className="h-full w-full min-h-0"
             isLoading={isLoading}
             refresh={refresh}
@@ -48,6 +51,7 @@ export function SignalGrid({
           >
             <SignalCard
               {...signal}
+              leadImage={leadImage}
               className="h-full w-full min-h-0"
               isLoading={isLoading}
               refresh={refresh}
@@ -62,6 +66,7 @@ export function SignalGrid({
           >
             <SignalCard
               {...signal}
+              leadImage={leadImage}
               className="h-full w-full min-h-0"
               isLoading={isLoading}
               refresh={refresh}

--- a/packages/epics/src/coherence/components/signal-section.tsx
+++ b/packages/epics/src/coherence/components/signal-section.tsx
@@ -17,6 +17,7 @@ import { useTranslations } from 'next-intl';
 type SignalSectionProps = {
   basePath: string;
   signals: Coherence[];
+  leadImage?: string;
   label?: string;
   hasSearch?: boolean;
   isLoading: boolean;
@@ -30,6 +31,7 @@ type SignalSectionProps = {
 export const SignalSection: FC<SignalSectionProps> = ({
   basePath,
   signals,
+  leadImage,
   label,
   hasSearch = false,
   isLoading,
@@ -89,6 +91,7 @@ export const SignalSection: FC<SignalSectionProps> = ({
             <SignalGridContainer
               key={`signal-container-${index}`}
               basePath={basePath}
+              leadImage={leadImage}
               pagination={{
                 page: index + 1,
                 firstPageSize,

--- a/packages/epics/src/common/ai-panel/ai-panel-header.tsx
+++ b/packages/epics/src/common/ai-panel/ai-panel-header.tsx
@@ -1,15 +1,15 @@
 'use client';
 
 import { PanelLeftClose, RefreshCw, Sparkles } from 'lucide-react';
-import { useSidebar } from '@hypha-platform/ui';
 import { useTranslations } from 'next-intl';
+import { useAiPanel } from '../human-chat-panel-context';
 
 type AiPanelHeaderProps = {
   onResetChat?: () => void;
 };
 
 export function AiPanelHeader({ onResetChat }: AiPanelHeaderProps) {
-  const { toggleSidebar } = useSidebar();
+  const { setContentMode } = useAiPanel();
   const t = useTranslations('AiPanel');
   return (
     <div className="flex min-h-[var(--menu-top-height,65px)] min-w-0 flex-shrink-0 flex-wrap items-center justify-between gap-x-2 gap-y-2 border-b border-border bg-background-2 px-4 py-3">
@@ -35,10 +35,12 @@ export function AiPanelHeader({ onResetChat }: AiPanelHeaderProps) {
         )}
         <button
           type="button"
-          onClick={toggleSidebar}
+          onClick={() => {
+            setContentMode('menu');
+          }}
           className="flex h-7 w-7 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-          title={t('hidePanel')}
-          aria-label={t('closePanel')}
+          title={t('backToMenu')}
+          aria-label={t('backToMenu')}
         >
           <PanelLeftClose className="h-3.5 w-3.5" />
         </button>

--- a/packages/epics/src/common/human-chat-panel-context.tsx
+++ b/packages/epics/src/common/human-chat-panel-context.tsx
@@ -9,14 +9,26 @@ import { createContext, useCallback, useContext, useState } from 'react';
  */
 export type PanelContextValue = {
   open: boolean;
+  setOpen: (value: boolean) => void;
   toggle: () => void;
+  contentMode: 'menu' | 'ai';
+  setContentMode: (mode: 'menu' | 'ai') => void;
+  toggleContentMode: () => void;
+  menuDensity: 'expanded' | 'icon';
+  toggleMenuDensity: () => void;
 };
 
 // ─── AI Panel Context ────────────────────────────────────────────────────────
 
 const AiPanelContext = createContext<PanelContextValue>({
   open: false,
+  setOpen: () => {},
   toggle: () => {},
+  contentMode: 'menu',
+  setContentMode: () => {},
+  toggleContentMode: () => {},
+  menuDensity: 'expanded',
+  toggleMenuDensity: () => {},
 });
 
 export const AiPanelProvider = AiPanelContext.Provider;

--- a/packages/epics/src/common/index.ts
+++ b/packages/epics/src/common/index.ts
@@ -15,6 +15,7 @@ export * from './get-dho-space-slug-from-pathname';
 export * from './get-path-function';
 export * from './ai-panel';
 export { AiLeftPanel } from './ai-left-panel';
+export { SpaceLeftPanel } from './space-left-panel';
 export { AiLeftPanelLayout } from './ai-left-panel-layout';
 export {
   PanelProviders,

--- a/packages/epics/src/common/panel-wrap-layout.tsx
+++ b/packages/epics/src/common/panel-wrap-layout.tsx
@@ -24,14 +24,37 @@ import { PanelScrollInset } from './panel-scroll-inset';
 // MenuTop) to access panel state via useAiPanel() and useHumanChatPanel().
 
 export function PanelProviders({ children }: { children: React.ReactNode }) {
-  const [leftOpen, setLeftOpen] = useState(false);
+  const [leftOpen, setLeftOpen] = useState(true);
   const [rightOpen, setRightOpen] = useState(false);
+  const [leftContentMode, setLeftContentMode] = useState<'menu' | 'ai'>('menu');
+  const [leftMenuDensity, setLeftMenuDensity] = useState<'expanded' | 'icon'>(
+    'expanded',
+  );
 
   const toggleLeft = useCallback(() => setLeftOpen((prev) => !prev), []);
   const toggleRight = useCallback(() => setRightOpen((prev) => !prev), []);
+  const toggleLeftContentMode = useCallback(
+    () => setLeftContentMode((prev) => (prev === 'menu' ? 'ai' : 'menu')),
+    [],
+  );
+  const toggleLeftMenuDensity = useCallback(
+    () => setLeftMenuDensity((prev) => (prev === 'expanded' ? 'icon' : 'expanded')),
+    [],
+  );
 
   return (
-    <AiPanelProvider value={{ open: leftOpen, toggle: toggleLeft }}>
+    <AiPanelProvider
+      value={{
+        open: leftOpen,
+        setOpen: setLeftOpen,
+        toggle: toggleLeft,
+        contentMode: leftContentMode,
+        setContentMode: setLeftContentMode,
+        toggleContentMode: toggleLeftContentMode,
+        menuDensity: leftMenuDensity,
+        toggleMenuDensity: toggleLeftMenuDensity,
+      }}
+    >
       <HumanChatPanelProvider
         open={rightOpen}
         toggle={toggleRight}
@@ -48,17 +71,21 @@ export function PanelProviders({ children }: { children: React.ReactNode }) {
 // regardless of SidebarProvider nesting order.
 
 export function AiSidebarTrigger() {
-  const { open, toggle } = useAiPanel();
+  const { open, setOpen, contentMode, toggleContentMode } = useAiPanel();
   const t = useTranslations('AiPanel');
   const isSpace = useIsSpaceContext();
 
-  if (!isSpace || open) return null;
+  if (!isSpace) return null;
 
   return (
     <button
       type="button"
-      onClick={toggle}
+      onClick={() => {
+        toggleContentMode();
+        if (!open) setOpen(true);
+      }}
       aria-expanded={open}
+      aria-pressed={contentMode === 'ai'}
       className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
       title={t('openPanel')}
       aria-label={t('openPanel')}

--- a/packages/epics/src/common/panel-wrap-layout.tsx
+++ b/packages/epics/src/common/panel-wrap-layout.tsx
@@ -38,7 +38,8 @@ export function PanelProviders({ children }: { children: React.ReactNode }) {
     [],
   );
   const toggleLeftMenuDensity = useCallback(
-    () => setLeftMenuDensity((prev) => (prev === 'expanded' ? 'icon' : 'expanded')),
+    () =>
+      setLeftMenuDensity((prev) => (prev === 'expanded' ? 'icon' : 'expanded')),
     [],
   );
 

--- a/packages/epics/src/common/space-left-menu-panel.tsx
+++ b/packages/epics/src/common/space-left-menu-panel.tsx
@@ -140,7 +140,9 @@ export function SpaceLeftMenuPanel() {
         </SidebarMenu>
       </SidebarContent>
       <SidebarFooter className="bg-background-2 border-t border-border p-3">
-        <p className="text-xs text-muted-foreground">{t('leftMenu.footerHint')}</p>
+        <p className="text-xs text-muted-foreground">
+          {t('leftMenu.footerHint')}
+        </p>
       </SidebarFooter>
     </>
   );

--- a/packages/epics/src/common/space-left-menu-panel.tsx
+++ b/packages/epics/src/common/space-left-menu-panel.tsx
@@ -81,69 +81,109 @@ export function SpaceLeftMenuPanel() {
 
   return (
     <>
-      <SidebarHeader className="bg-background-2 border-b border-border p-3">
-        <div className="flex items-center justify-between gap-2">
-          <p
+      <SidebarContent className="relative bg-background-2">
+        <div className="relative flex h-full">
+          <nav
+            className="z-10 flex h-full w-14 shrink-0 flex-col border-r border-border bg-background-2"
+            aria-label={t('leftMenu.title')}
+          >
+            <SidebarHeader className="border-b border-border p-2">
+              <button
+                type="button"
+                onClick={toggleMenuDensity}
+                aria-label={
+                  iconOnly
+                    ? t('leftMenu.expandMenuAriaLabel')
+                    : t('leftMenu.collapseMenuAriaLabel')
+                }
+                title={
+                  iconOnly
+                    ? t('leftMenu.expandMenuAriaLabel')
+                    : t('leftMenu.collapseMenuAriaLabel')
+                }
+                className="flex h-9 w-9 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              >
+                {iconOnly ? (
+                  <ChevronRight className="h-4 w-4" />
+                ) : (
+                  <ChevronLeft className="h-4 w-4" />
+                )}
+              </button>
+            </SidebarHeader>
+            <SidebarMenu className="px-2 py-3">
+              {items.map(({ key, href, label, icon: Icon }) => {
+                const active = activeTab === key;
+                return (
+                  <SidebarMenuItem key={`rail-${key}`}>
+                    <SidebarMenuButton
+                      asChild
+                      isActive={active}
+                      tooltip={label}
+                      className="h-11 justify-center rounded-lg px-0"
+                    >
+                      <Link href={href} aria-label={label}>
+                        <Icon className="h-4 w-4 shrink-0" />
+                      </Link>
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
+                );
+              })}
+            </SidebarMenu>
+          </nav>
+
+          <div
             className={cn(
-              'text-sm font-semibold text-foreground transition-opacity',
-              iconOnly && 'sr-only',
+              'absolute inset-y-0 left-14 right-0 z-20 transition-all duration-200 ease-linear',
+              iconOnly
+                ? 'pointer-events-none -translate-x-2 opacity-0'
+                : 'pointer-events-auto translate-x-0 opacity-100',
             )}
           >
-            {t('leftMenu.title')}
-          </p>
-          <button
-            type="button"
-            onClick={toggleMenuDensity}
-            aria-label={
-              iconOnly
-                ? t('leftMenu.expandMenuAriaLabel')
-                : t('leftMenu.collapseMenuAriaLabel')
-            }
-            title={
-              iconOnly
-                ? t('leftMenu.expandMenuAriaLabel')
-                : t('leftMenu.collapseMenuAriaLabel')
-            }
-            className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-          >
-            {iconOnly ? (
-              <ChevronRight className="h-4 w-4" />
-            ) : (
-              <ChevronLeft className="h-4 w-4" />
-            )}
-          </button>
+            <div className="flex h-full flex-col border-r border-border bg-background-2 shadow-[6px_0_24px_-16px_rgba(0,0,0,0.65)]">
+              <SidebarHeader className="border-b border-border p-3">
+                <div className="flex items-center justify-between gap-2">
+                  <p className="text-sm font-semibold text-foreground">
+                    {t('leftMenu.title')}
+                  </p>
+                  <button
+                    type="button"
+                    onClick={toggleMenuDensity}
+                    aria-label={t('leftMenu.collapseMenuAriaLabel')}
+                    title={t('leftMenu.collapseMenuAriaLabel')}
+                    className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                  >
+                    <ChevronLeft className="h-4 w-4" />
+                  </button>
+                </div>
+              </SidebarHeader>
+              <SidebarMenu className="px-2 py-3">
+                {items.map(({ key, href, label, icon: Icon }) => {
+                  const active = activeTab === key;
+                  return (
+                    <SidebarMenuItem key={`overlay-${key}`}>
+                      <SidebarMenuButton
+                        asChild
+                        isActive={active}
+                        className="h-11 gap-3 rounded-lg px-3 text-sm"
+                      >
+                        <Link href={href} aria-label={label}>
+                          <Icon className="h-4 w-4 shrink-0" />
+                          <span>{label}</span>
+                        </Link>
+                      </SidebarMenuButton>
+                    </SidebarMenuItem>
+                  );
+                })}
+              </SidebarMenu>
+              <SidebarFooter className="mt-auto border-t border-border p-3">
+                <p className="text-xs text-muted-foreground">
+                  {t('leftMenu.footerHint')}
+                </p>
+              </SidebarFooter>
+            </div>
+          </div>
         </div>
-      </SidebarHeader>
-      <SidebarContent className="bg-background-2">
-        <SidebarMenu className="px-2 py-3">
-          {items.map(({ key, href, label, icon: Icon }) => {
-            const active = activeTab === key;
-            return (
-              <SidebarMenuItem key={key}>
-                <SidebarMenuButton
-                  asChild
-                  isActive={active}
-                  tooltip={iconOnly ? label : undefined}
-                  className={cn(
-                    'h-11 gap-3 rounded-lg px-3 text-sm',
-                    iconOnly && 'justify-center px-0',
-                  )}
-                >
-                  <Link href={href} aria-label={label}>
-                    <Icon className="h-4 w-4 shrink-0" />
-                    {!iconOnly ? <span>{label}</span> : null}
-                  </Link>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-            );
-          })}
-        </SidebarMenu>
       </SidebarContent>
-      <SidebarFooter className="bg-background-2 border-t border-border p-3">
-        <p className="text-xs text-muted-foreground">
-          {t('leftMenu.footerHint')}
-        </p>
-      </SidebarFooter>
     </>
   );
 }

--- a/packages/epics/src/common/space-left-menu-panel.tsx
+++ b/packages/epics/src/common/space-left-menu-panel.tsx
@@ -1,0 +1,147 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { useTranslations } from 'next-intl';
+import type { ComponentType } from 'react';
+import {
+  SidebarContent,
+  SidebarFooter,
+  SidebarHeader,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+} from '@hypha-platform/ui';
+import { cn } from '@hypha-platform/ui-utils';
+import {
+  ChevronLeft,
+  ChevronRight,
+  Coins,
+  FileCheck2,
+  Radio,
+  Users,
+} from 'lucide-react';
+
+import { useAiPanel } from './human-chat-panel-context';
+import { getActiveTabFromPath } from './get-active-tab-from-path';
+
+type SpaceLeftMenuItem = {
+  key: string;
+  href: string;
+  label: string;
+  icon: ComponentType<{ className?: string }>;
+};
+
+function getSpaceBasePath(pathname: string): string | null {
+  const match = pathname.match(/^\/([^/]+)\/dho\/([^/]+)/);
+  if (!match) return null;
+  const lang = match[1];
+  const spaceSlug = match[2];
+  if (!lang || !spaceSlug) return null;
+  return `/${lang}/dho/${spaceSlug}`;
+}
+
+export function SpaceLeftMenuPanel() {
+  const pathname = usePathname();
+  const t = useTranslations('AiPanel');
+  const { menuDensity, toggleMenuDensity } = useAiPanel();
+
+  const basePath = getSpaceBasePath(pathname ?? '');
+  const activeTab = getActiveTabFromPath(pathname ?? '');
+  const iconOnly = menuDensity === 'icon';
+
+  const items: SpaceLeftMenuItem[] = basePath
+    ? [
+        {
+          key: 'coherence',
+          href: `${basePath}/coherence`,
+          label: t('leftMenu.signals'),
+          icon: Radio,
+        },
+        {
+          key: 'agreements',
+          href: `${basePath}/agreements`,
+          label: t('leftMenu.proposals'),
+          icon: FileCheck2,
+        },
+        {
+          key: 'members',
+          href: `${basePath}/members`,
+          label: t('leftMenu.members'),
+          icon: Users,
+        },
+        {
+          key: 'treasury',
+          href: `${basePath}/treasury`,
+          label: t('leftMenu.treasury'),
+          icon: Coins,
+        },
+      ]
+    : [];
+
+  return (
+    <>
+      <SidebarHeader className="bg-background-2 border-b border-border p-3">
+        <div className="flex items-center justify-between gap-2">
+          <p
+            className={cn(
+              'text-sm font-semibold text-foreground transition-opacity',
+              iconOnly && 'sr-only',
+            )}
+          >
+            {t('leftMenu.title')}
+          </p>
+          <button
+            type="button"
+            onClick={toggleMenuDensity}
+            aria-label={
+              iconOnly
+                ? t('leftMenu.expandMenuAriaLabel')
+                : t('leftMenu.collapseMenuAriaLabel')
+            }
+            title={
+              iconOnly
+                ? t('leftMenu.expandMenuAriaLabel')
+                : t('leftMenu.collapseMenuAriaLabel')
+            }
+            className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          >
+            {iconOnly ? (
+              <ChevronRight className="h-4 w-4" />
+            ) : (
+              <ChevronLeft className="h-4 w-4" />
+            )}
+          </button>
+        </div>
+      </SidebarHeader>
+      <SidebarContent className="bg-background-2">
+        <SidebarMenu className="px-2 py-3">
+          {items.map(({ key, href, label, icon: Icon }) => {
+            const active = activeTab === key;
+            return (
+              <SidebarMenuItem key={key}>
+                <SidebarMenuButton
+                  asChild
+                  isActive={active}
+                  tooltip={iconOnly ? label : undefined}
+                  className={cn(
+                    'h-11 gap-3 rounded-lg px-3 text-sm',
+                    iconOnly && 'justify-center px-0',
+                  )}
+                >
+                  <Link href={href} aria-label={label}>
+                    <Icon className="h-4 w-4 shrink-0" />
+                    {!iconOnly ? <span>{label}</span> : null}
+                  </Link>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            );
+          })}
+        </SidebarMenu>
+      </SidebarContent>
+      <SidebarFooter className="bg-background-2 border-t border-border p-3">
+        <p className="text-xs text-muted-foreground">{t('leftMenu.footerHint')}</p>
+      </SidebarFooter>
+    </>
+  );
+}

--- a/packages/epics/src/common/space-left-panel.tsx
+++ b/packages/epics/src/common/space-left-panel.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import { AiLeftPanel } from './ai-left-panel';
+import { useAiPanel } from './human-chat-panel-context';
+import { SpaceLeftMenuPanel } from './space-left-menu-panel';
+
+export function SpaceLeftPanel() {
+  const { contentMode } = useAiPanel();
+
+  if (contentMode === 'ai') {
+    return <AiLeftPanel />;
+  }
+
+  return <SpaceLeftMenuPanel />;
+}

--- a/packages/i18n/src/messages/de.json
+++ b/packages/i18n/src/messages/de.json
@@ -1722,6 +1722,7 @@
   },
   "AiPanel": {
     "title": "Hypha AI",
+    "backToMenu": "Zurück zum Menü",
     "suggestions": {
       "aboutSpace": "Erzähl mir etwas über diesen Space",
       "memberCount": "Wie viele Mitglieder hat dieser Space?",
@@ -1738,6 +1739,16 @@
     "loading": "Laden...",
     "openPanel": "Hypha AI öffnen",
     "hidePanel": "AI-Panel ausblenden",
+    "leftMenu": {
+      "title": "Space-Menü",
+      "signals": "Signale",
+      "proposals": "Vorschläge",
+      "members": "Mitglieder",
+      "treasury": "Treasury",
+      "collapseMenuAriaLabel": "Nur Menüsymbole anzeigen",
+      "expandMenuAriaLabel": "Menübeschriftungen anzeigen",
+      "footerHint": "Nutzen Sie Hypha AI für Fragen zu diesem Space."
+    },
     "resetChat": "Chat zurücksetzen",
     "closePanel": "Panel schließen",
     "copyButton": "Kopieren",

--- a/packages/i18n/src/messages/en.json
+++ b/packages/i18n/src/messages/en.json
@@ -1753,6 +1753,7 @@
   },
   "AiPanel": {
     "title": "Hypha AI",
+    "backToMenu": "Back to menu",
     "suggestions": {
       "aboutSpace": "Tell me about this space",
       "memberCount": "How many members does this space have?",
@@ -1769,6 +1770,16 @@
     "loading": "Loading...",
     "openPanel": "Open Hypha AI panel",
     "hidePanel": "Hide AI panel",
+    "leftMenu": {
+      "title": "Space menu",
+      "signals": "Signals",
+      "proposals": "Proposals",
+      "members": "Members",
+      "treasury": "Treasury",
+      "collapseMenuAriaLabel": "Show menu icons only",
+      "expandMenuAriaLabel": "Expand menu labels",
+      "footerHint": "Use Hypha AI to ask about this space."
+    },
     "resetChat": "Reset chat",
     "closePanel": "Close panel",
     "copyButton": "Copy",


### PR DESCRIPTION
## Summary
- Update the space left menu to use a two-layer navigation: a persistent icon rail plus a slide-over label menu.
- Keep Signals/Proposals/Members/Treasury icons always visible so users maintain context even when labels are hidden.
- Match the requested v0 interaction style while preserving existing routing and active-state behavior.

## Test plan
- [ ] Open a space route and verify the left AI panel shows icons at all times.
- [ ] Toggle the menu to expanded state and confirm labels slide in as an overlay.
- [ ] Toggle back to icon mode and confirm only the icon rail remains interactive.
- [ ] Navigate through Signals, Proposals, Members, and Treasury from both rail and overlay.
- [ ] Verify keyboard focus and aria labels on toggle/buttons still work.

Made with [Cursor](https://cursor.com)