### PR TITLE
feat(epics): replace DHO tabs with AI left-panel menu

### DIFF
--- a/apps/web/src/app/[lang]/dho/[id]/@tab/layout.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@tab/layout.tsx
@@ -1,7 +1,7 @@
 import { Locale } from '@hypha-platform/i18n';
 import { ReactNode } from 'react';
 import { NavigationTabs } from '../_components/navigation-tabs';
-import { getEnableCoherence } from '@hypha-platform/feature-flags';
+import { getEnableAiChat, getEnableCoherence } from '@hypha-platform/feature-flags';
 
 export default async function TabLayout({
   children,
@@ -12,13 +12,16 @@ export default async function TabLayout({
 }) {
   const { id: daoSlug, lang } = await params;
   const coherenceEnabled = await getEnableCoherence();
+  const aiChatEnabled = await getEnableAiChat();
   return (
     <>
-      <NavigationTabs
-        id={daoSlug}
-        lang={lang}
-        coherenceEnabled={coherenceEnabled}
-      />
+      {!aiChatEnabled ? (
+        <NavigationTabs
+          id={daoSlug}
+          lang={lang}
+          coherenceEnabled={coherenceEnabled}
+        />
+      ) : null}
       {children}
     </>
   );

--- a/apps/web/src/app/[lang]/dho/[id]/@tab/layout.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@tab/layout.tsx
@@ -1,7 +1,10 @@
 import { Locale } from '@hypha-platform/i18n';
 import { ReactNode } from 'react';
 import { NavigationTabs } from '../_components/navigation-tabs';
-import { getEnableAiChat, getEnableCoherence } from '@hypha-platform/feature-flags';
+import {
+  getEnableAiChat,
+  getEnableCoherence,
+} from '@hypha-platform/feature-flags';
 
 export default async function TabLayout({
   children,

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -12,7 +12,7 @@ import { Footer, Html, ThemeProvider } from '@hypha-platform/ui/server';
 import { AuthProvider } from '@hypha-platform/authentication';
 import { useAuthentication } from '@hypha-platform/authentication';
 import {
-  AiLeftPanel,
+  SpaceLeftPanel,
   PanelProviders,
   PanelWrapLayout,
   AiSidebarTrigger,
@@ -140,7 +140,7 @@ export default async function RootLayout({
                       <PanelWrapLayout
                         left={
                           aiChatEnabled
-                            ? { content: <AiLeftPanel /> }
+                            ? { content: <SpaceLeftPanel /> }
                             : undefined
                         }
                         right={

--- a/packages/epics/src/common/ai-panel/ai-panel-header.tsx
+++ b/packages/epics/src/common/ai-panel/ai-panel-header.tsx
@@ -1,15 +1,15 @@
 'use client';
 
 import { PanelLeftClose, RefreshCw, Sparkles } from 'lucide-react';
-import { useSidebar } from '@hypha-platform/ui';
 import { useTranslations } from 'next-intl';
+import { useAiPanel } from '../human-chat-panel-context';
 
 type AiPanelHeaderProps = {
   onResetChat?: () => void;
 };
 
 export function AiPanelHeader({ onResetChat }: AiPanelHeaderProps) {
-  const { toggleSidebar } = useSidebar();
+  const { setContentMode } = useAiPanel();
   const t = useTranslations('AiPanel');
   return (
     <div className="flex min-h-[var(--menu-top-height,65px)] min-w-0 flex-shrink-0 flex-wrap items-center justify-between gap-x-2 gap-y-2 border-b border-border bg-background-2 px-4 py-3">
@@ -35,10 +35,12 @@ export function AiPanelHeader({ onResetChat }: AiPanelHeaderProps) {
         )}
         <button
           type="button"
-          onClick={toggleSidebar}
+          onClick={() => {
+            setContentMode('menu');
+          }}
           className="flex h-7 w-7 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-          title={t('hidePanel')}
-          aria-label={t('closePanel')}
+          title={t('backToMenu')}
+          aria-label={t('backToMenu')}
         >
           <PanelLeftClose className="h-3.5 w-3.5" />
         </button>

--- a/packages/epics/src/common/human-chat-panel-context.tsx
+++ b/packages/epics/src/common/human-chat-panel-context.tsx
@@ -9,14 +9,26 @@ import { createContext, useCallback, useContext, useState } from 'react';
  */
 export type PanelContextValue = {
   open: boolean;
+  setOpen: (value: boolean) => void;
   toggle: () => void;
+  contentMode: 'menu' | 'ai';
+  setContentMode: (mode: 'menu' | 'ai') => void;
+  toggleContentMode: () => void;
+  menuDensity: 'expanded' | 'icon';
+  toggleMenuDensity: () => void;
 };
 
 // ─── AI Panel Context ────────────────────────────────────────────────────────
 
 const AiPanelContext = createContext<PanelContextValue>({
   open: false,
+  setOpen: () => {},
   toggle: () => {},
+  contentMode: 'menu',
+  setContentMode: () => {},
+  toggleContentMode: () => {},
+  menuDensity: 'expanded',
+  toggleMenuDensity: () => {},
 });
 
 export const AiPanelProvider = AiPanelContext.Provider;

--- a/packages/epics/src/common/index.ts
+++ b/packages/epics/src/common/index.ts
@@ -15,6 +15,7 @@ export * from './get-dho-space-slug-from-pathname';
 export * from './get-path-function';
 export * from './ai-panel';
 export { AiLeftPanel } from './ai-left-panel';
+export { SpaceLeftPanel } from './space-left-panel';
 export { AiLeftPanelLayout } from './ai-left-panel-layout';
 export {
   PanelProviders,

--- a/packages/epics/src/common/panel-wrap-layout.tsx
+++ b/packages/epics/src/common/panel-wrap-layout.tsx
@@ -24,14 +24,37 @@ import { PanelScrollInset } from './panel-scroll-inset';
 // MenuTop) to access panel state via useAiPanel() and useHumanChatPanel().
 
 export function PanelProviders({ children }: { children: React.ReactNode }) {
-  const [leftOpen, setLeftOpen] = useState(false);
+  const [leftOpen, setLeftOpen] = useState(true);
   const [rightOpen, setRightOpen] = useState(false);
+  const [leftContentMode, setLeftContentMode] = useState<'menu' | 'ai'>('menu');
+  const [leftMenuDensity, setLeftMenuDensity] = useState<'expanded' | 'icon'>(
+    'expanded',
+  );
 
   const toggleLeft = useCallback(() => setLeftOpen((prev) => !prev), []);
   const toggleRight = useCallback(() => setRightOpen((prev) => !prev), []);
+  const toggleLeftContentMode = useCallback(
+    () => setLeftContentMode((prev) => (prev === 'menu' ? 'ai' : 'menu')),
+    [],
+  );
+  const toggleLeftMenuDensity = useCallback(
+    () => setLeftMenuDensity((prev) => (prev === 'expanded' ? 'icon' : 'expanded')),
+    [],
+  );
 
   return (
-    <AiPanelProvider value={{ open: leftOpen, toggle: toggleLeft }}>
+    <AiPanelProvider
+      value={{
+        open: leftOpen,
+        setOpen: setLeftOpen,
+        toggle: toggleLeft,
+        contentMode: leftContentMode,
+        setContentMode: setLeftContentMode,
+        toggleContentMode: toggleLeftContentMode,
+        menuDensity: leftMenuDensity,
+        toggleMenuDensity: toggleLeftMenuDensity,
+      }}
+    >
       <HumanChatPanelProvider
         open={rightOpen}
         toggle={toggleRight}
@@ -48,17 +71,21 @@ export function PanelProviders({ children }: { children: React.ReactNode }) {
 // regardless of SidebarProvider nesting order.
 
 export function AiSidebarTrigger() {
-  const { open, toggle } = useAiPanel();
+  const { open, setOpen, contentMode, toggleContentMode } = useAiPanel();
   const t = useTranslations('AiPanel');
   const isSpace = useIsSpaceContext();
 
-  if (!isSpace || open) return null;
+  if (!isSpace) return null;
 
   return (
     <button
       type="button"
-      onClick={toggle}
+      onClick={() => {
+        toggleContentMode();
+        if (!open) setOpen(true);
+      }}
       aria-expanded={open}
+      aria-pressed={contentMode === 'ai'}
       className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
       title={t('openPanel')}
       aria-label={t('openPanel')}

--- a/packages/epics/src/common/panel-wrap-layout.tsx
+++ b/packages/epics/src/common/panel-wrap-layout.tsx
@@ -38,7 +38,8 @@ export function PanelProviders({ children }: { children: React.ReactNode }) {
     [],
   );
   const toggleLeftMenuDensity = useCallback(
-    () => setLeftMenuDensity((prev) => (prev === 'expanded' ? 'icon' : 'expanded')),
+    () =>
+      setLeftMenuDensity((prev) => (prev === 'expanded' ? 'icon' : 'expanded')),
     [],
   );
 

--- a/packages/epics/src/common/space-left-menu-panel.tsx
+++ b/packages/epics/src/common/space-left-menu-panel.tsx
@@ -81,67 +81,109 @@ export function SpaceLeftMenuPanel() {
 
   return (
     <>
-      <SidebarHeader className="bg-background-2 border-b border-border p-3">
-        <div className="flex items-center justify-between gap-2">
-          <p
+      <SidebarContent className="relative bg-background-2">
+        <div className="relative flex h-full">
+          <nav
+            className="z-10 flex h-full w-14 shrink-0 flex-col border-r border-border bg-background-2"
+            aria-label={t('leftMenu.title')}
+          >
+            <SidebarHeader className="border-b border-border p-2">
+              <button
+                type="button"
+                onClick={toggleMenuDensity}
+                aria-label={
+                  iconOnly
+                    ? t('leftMenu.expandMenuAriaLabel')
+                    : t('leftMenu.collapseMenuAriaLabel')
+                }
+                title={
+                  iconOnly
+                    ? t('leftMenu.expandMenuAriaLabel')
+                    : t('leftMenu.collapseMenuAriaLabel')
+                }
+                className="flex h-9 w-9 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              >
+                {iconOnly ? (
+                  <ChevronRight className="h-4 w-4" />
+                ) : (
+                  <ChevronLeft className="h-4 w-4" />
+                )}
+              </button>
+            </SidebarHeader>
+            <SidebarMenu className="px-2 py-3">
+              {items.map(({ key, href, label, icon: Icon }) => {
+                const active = activeTab === key;
+                return (
+                  <SidebarMenuItem key={`rail-${key}`}>
+                    <SidebarMenuButton
+                      asChild
+                      isActive={active}
+                      tooltip={label}
+                      className="h-11 justify-center rounded-lg px-0"
+                    >
+                      <Link href={href} aria-label={label}>
+                        <Icon className="h-4 w-4 shrink-0" />
+                      </Link>
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
+                );
+              })}
+            </SidebarMenu>
+          </nav>
+
+          <div
             className={cn(
-              'text-sm font-semibold text-foreground transition-opacity',
-              iconOnly && 'sr-only',
+              'absolute inset-y-0 left-14 right-0 z-20 transition-all duration-200 ease-linear',
+              iconOnly
+                ? 'pointer-events-none -translate-x-2 opacity-0'
+                : 'pointer-events-auto translate-x-0 opacity-100',
             )}
           >
-            {t('leftMenu.title')}
-          </p>
-          <button
-            type="button"
-            onClick={toggleMenuDensity}
-            aria-label={
-              iconOnly
-                ? t('leftMenu.expandMenuAriaLabel')
-                : t('leftMenu.collapseMenuAriaLabel')
-            }
-            title={
-              iconOnly
-                ? t('leftMenu.expandMenuAriaLabel')
-                : t('leftMenu.collapseMenuAriaLabel')
-            }
-            className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-          >
-            {iconOnly ? (
-              <ChevronRight className="h-4 w-4" />
-            ) : (
-              <ChevronLeft className="h-4 w-4" />
-            )}
-          </button>
+            <div className="flex h-full flex-col border-r border-border bg-background-2 shadow-[6px_0_24px_-16px_rgba(0,0,0,0.65)]">
+              <SidebarHeader className="border-b border-border p-3">
+                <div className="flex items-center justify-between gap-2">
+                  <p className="text-sm font-semibold text-foreground">
+                    {t('leftMenu.title')}
+                  </p>
+                  <button
+                    type="button"
+                    onClick={toggleMenuDensity}
+                    aria-label={t('leftMenu.collapseMenuAriaLabel')}
+                    title={t('leftMenu.collapseMenuAriaLabel')}
+                    className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                  >
+                    <ChevronLeft className="h-4 w-4" />
+                  </button>
+                </div>
+              </SidebarHeader>
+              <SidebarMenu className="px-2 py-3">
+                {items.map(({ key, href, label, icon: Icon }) => {
+                  const active = activeTab === key;
+                  return (
+                    <SidebarMenuItem key={`overlay-${key}`}>
+                      <SidebarMenuButton
+                        asChild
+                        isActive={active}
+                        className="h-11 gap-3 rounded-lg px-3 text-sm"
+                      >
+                        <Link href={href} aria-label={label}>
+                          <Icon className="h-4 w-4 shrink-0" />
+                          <span>{label}</span>
+                        </Link>
+                      </SidebarMenuButton>
+                    </SidebarMenuItem>
+                  );
+                })}
+              </SidebarMenu>
+              <SidebarFooter className="mt-auto border-t border-border p-3">
+                <p className="text-xs text-muted-foreground">
+                  {t('leftMenu.footerHint')}
+                </p>
+              </SidebarFooter>
+            </div>
+          </div>
         </div>
-      </SidebarHeader>
-      <SidebarContent className="bg-background-2">
-        <SidebarMenu className="px-2 py-3">
-          {items.map(({ key, href, label, icon: Icon }) => {
-            const active = activeTab === key;
-            return (
-              <SidebarMenuItem key={key}>
-                <SidebarMenuButton
-                  asChild
-                  isActive={active}
-                  tooltip={iconOnly ? label : undefined}
-                  className={cn(
-                    'h-11 gap-3 rounded-lg px-3 text-sm',
-                    iconOnly && 'justify-center px-0',
-                  )}
-                >
-                  <Link href={href} aria-label={label}>
-                    <Icon className="h-4 w-4 shrink-0" />
-                    {!iconOnly ? <span>{label}</span> : null}
-                  </Link>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-            );
-          })}
-        </SidebarMenu>
       </SidebarContent>
-      <SidebarFooter className="bg-background-2 border-t border-border p-3">
-        <p className="text-xs text-muted-foreground">{t('leftMenu.footerHint')}</p>
-      </SidebarFooter>
     </>
   );
 }

--- a/packages/epics/src/common/space-left-menu-panel.tsx
+++ b/packages/epics/src/common/space-left-menu-panel.tsx
@@ -1,0 +1,147 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { useTranslations } from 'next-intl';
+import type { ComponentType } from 'react';
+import {
+  SidebarContent,
+  SidebarFooter,
+  SidebarHeader,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+} from '@hypha-platform/ui';
+import { cn } from '@hypha-platform/ui-utils';
+import {
+  ChevronLeft,
+  ChevronRight,
+  Coins,
+  FileCheck2,
+  Radio,
+  Users,
+} from 'lucide-react';
+
+import { useAiPanel } from './human-chat-panel-context';
+import { getActiveTabFromPath } from './get-active-tab-from-path';
+
+type SpaceLeftMenuItem = {
+  key: string;
+  href: string;
+  label: string;
+  icon: ComponentType<{ className?: string }>;
+};
+
+function getSpaceBasePath(pathname: string): string | null {
+  const match = pathname.match(/^\/([^/]+)\/dho\/([^/]+)/);
+  if (!match) return null;
+  const lang = match[1];
+  const spaceSlug = match[2];
+  if (!lang || !spaceSlug) return null;
+  return `/${lang}/dho/${spaceSlug}`;
+}
+
+export function SpaceLeftMenuPanel() {
+  const pathname = usePathname();
+  const t = useTranslations('AiPanel');
+  const { menuDensity, toggleMenuDensity } = useAiPanel();
+
+  const basePath = getSpaceBasePath(pathname ?? '');
+  const activeTab = getActiveTabFromPath(pathname ?? '');
+  const iconOnly = menuDensity === 'icon';
+
+  const items: SpaceLeftMenuItem[] = basePath
+    ? [
+        {
+          key: 'coherence',
+          href: `${basePath}/coherence`,
+          label: t('leftMenu.signals'),
+          icon: Radio,
+        },
+        {
+          key: 'agreements',
+          href: `${basePath}/agreements`,
+          label: t('leftMenu.proposals'),
+          icon: FileCheck2,
+        },
+        {
+          key: 'members',
+          href: `${basePath}/members`,
+          label: t('leftMenu.members'),
+          icon: Users,
+        },
+        {
+          key: 'treasury',
+          href: `${basePath}/treasury`,
+          label: t('leftMenu.treasury'),
+          icon: Coins,
+        },
+      ]
+    : [];
+
+  return (
+    <>
+      <SidebarHeader className="bg-background-2 border-b border-border p-3">
+        <div className="flex items-center justify-between gap-2">
+          <p
+            className={cn(
+              'text-sm font-semibold text-foreground transition-opacity',
+              iconOnly && 'sr-only',
+            )}
+          >
+            {t('leftMenu.title')}
+          </p>
+          <button
+            type="button"
+            onClick={toggleMenuDensity}
+            aria-label={
+              iconOnly
+                ? t('leftMenu.expandMenuAriaLabel')
+                : t('leftMenu.collapseMenuAriaLabel')
+            }
+            title={
+              iconOnly
+                ? t('leftMenu.expandMenuAriaLabel')
+                : t('leftMenu.collapseMenuAriaLabel')
+            }
+            className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          >
+            {iconOnly ? (
+              <ChevronRight className="h-4 w-4" />
+            ) : (
+              <ChevronLeft className="h-4 w-4" />
+            )}
+          </button>
+        </div>
+      </SidebarHeader>
+      <SidebarContent className="bg-background-2">
+        <SidebarMenu className="px-2 py-3">
+          {items.map(({ key, href, label, icon: Icon }) => {
+            const active = activeTab === key;
+            return (
+              <SidebarMenuItem key={key}>
+                <SidebarMenuButton
+                  asChild
+                  isActive={active}
+                  tooltip={iconOnly ? label : undefined}
+                  className={cn(
+                    'h-11 gap-3 rounded-lg px-3 text-sm',
+                    iconOnly && 'justify-center px-0',
+                  )}
+                >
+                  <Link href={href} aria-label={label}>
+                    <Icon className="h-4 w-4 shrink-0" />
+                    {!iconOnly ? <span>{label}</span> : null}
+                  </Link>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            );
+          })}
+        </SidebarMenu>
+      </SidebarContent>
+      <SidebarFooter className="bg-background-2 border-t border-border p-3">
+        <p className="text-xs text-muted-foreground">{t('leftMenu.footerHint')}</p>
+      </SidebarFooter>
+    </>
+  );
+}

--- a/packages/epics/src/common/space-left-panel.tsx
+++ b/packages/epics/src/common/space-left-panel.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import { AiLeftPanel } from './ai-left-panel';
+import { useAiPanel } from './human-chat-panel-context';
+import { SpaceLeftMenuPanel } from './space-left-menu-panel';
+
+export function SpaceLeftPanel() {
+  const { contentMode } = useAiPanel();
+
+  if (contentMode === 'ai') {
+    return <AiLeftPanel />;
+  }
+
+  return <SpaceLeftMenuPanel />;
+}

--- a/packages/i18n/src/messages/de.json
+++ b/packages/i18n/src/messages/de.json
@@ -1722,6 +1722,7 @@
   },
   "AiPanel": {
     "title": "Hypha AI",
+    "backToMenu": "Zurück zum Menü",
     "suggestions": {
       "aboutSpace": "Erzähl mir etwas über diesen Space",
       "memberCount": "Wie viele Mitglieder hat dieser Space?",
@@ -1738,6 +1739,16 @@
     "loading": "Laden...",
     "openPanel": "Hypha AI öffnen",
     "hidePanel": "AI-Panel ausblenden",
+    "leftMenu": {
+      "title": "Space-Menü",
+      "signals": "Signale",
+      "proposals": "Vorschläge",
+      "members": "Mitglieder",
+      "treasury": "Treasury",
+      "collapseMenuAriaLabel": "Nur Menüsymbole anzeigen",
+      "expandMenuAriaLabel": "Menübeschriftungen anzeigen",
+      "footerHint": "Nutzen Sie Hypha AI für Fragen zu diesem Space."
+    },
     "resetChat": "Chat zurücksetzen",
     "closePanel": "Panel schließen",
     "copyButton": "Kopieren",

--- a/packages/i18n/src/messages/en.json
+++ b/packages/i18n/src/messages/en.json
@@ -1753,6 +1753,7 @@
   },
   "AiPanel": {
     "title": "Hypha AI",
+    "backToMenu": "Back to menu",
     "suggestions": {
       "aboutSpace": "Tell me about this space",
       "memberCount": "How many members does this space have?",
@@ -1769,6 +1770,16 @@
     "loading": "Loading...",
     "openPanel": "Open Hypha AI panel",
     "hidePanel": "Hide AI panel",
+    "leftMenu": {
+      "title": "Space menu",
+      "signals": "Signals",
+      "proposals": "Proposals",
+      "members": "Members",
+      "treasury": "Treasury",
+      "collapseMenuAriaLabel": "Show menu icons only",
+      "expandMenuAriaLabel": "Expand menu labels",
+      "footerHint": "Use Hypha AI to ask about this space."
+    },
     "resetChat": "Reset chat",
     "closePanel": "Close panel",
     "copyButton": "Copy",


### PR DESCRIPTION
## Summary
- Replace DHO top navigation tabs with AI left-panel menu navigation when AI chat is enabled.
- Add left panel content modes (`menu` and `ai`) so the sparkles trigger switches between navigation and assistant chat.
- Implement the menu as a persistent icon rail with a slide-over label panel, keeping icons always visible for orientation.

## Test plan
- [ ] Open a DHO space with AI chat enabled and confirm top tabs are hidden.
- [ ] Verify left panel opens in menu mode and shows Signals/Proposals/Members/Treasury.
- [ ] Collapse menu and confirm icons remain visible (no context loss).
- [ ] Expand menu and confirm labels overlay in while icon rail remains visible.
- [ ] Click each item from icon rail and overlay list; verify active state + routing.
- [ ] Switch to AI mode via sparkles trigger and back to menu via panel header control.

Made with [Cursor](https://cursor.com)