### PR TITLE
feat: redesign AI sidebar overlay menu and composer UX

### DIFF
--- a/apps/web/src/app/[lang]/dho/[id]/_components/breadcrumbs.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/breadcrumbs.tsx
@@ -1,41 +1,50 @@
 import { findParentSpaceById } from '@hypha-platform/core/server';
-import { SpaceBreadcrumb, SpaceBreadcrumbItem } from '@hypha-platform/epics';
 import { db } from '@hypha-platform/storage-postgres';
 import { Locale } from '@hypha-platform/i18n';
-import { getTranslations } from 'next-intl/server';
+import Link from 'next/link';
+import {
+  Breadcrumb,
+  BreadcrumbEllipsis,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbSeparator,
+} from '@hypha-platform/ui';
+import { ChevronRightIcon } from 'lucide-react';
 import { Fragment } from 'react';
 
-async function RecursiveBreadcrumbItem({
-  spaceId,
-  lang,
-  depth = 0,
-  maxDepth = 2,
-}: {
-  spaceId: number;
-  lang: Locale;
-  depth?: number;
-  maxDepth?: number;
-}) {
-  console.debug('RecursiveBreadcrumbItem', { spaceId, depth, maxDepth });
-  const space = await findParentSpaceById({ id: spaceId }, { db });
-  if (!space || depth > maxDepth) return null;
+type SpaceCrumb = {
+  id: number;
+  slug: string;
+  title: string;
+  parentId: number | null;
+};
 
-  return (
-    <Fragment key={space.id}>
-      {space.parentId && (
-        <RecursiveBreadcrumbItem
-          spaceId={space.parentId}
-          lang={lang}
-          depth={depth + 1}
-          maxDepth={maxDepth}
-        />
-      )}
-      <SpaceBreadcrumbItem
-        lang={lang}
-        breadcrumb={{ slug: space.slug, title: space.title }}
-      />
-    </Fragment>
-  );
+async function getSpaceChain(spaceId: number): Promise<SpaceCrumb[]> {
+  const chain: SpaceCrumb[] = [];
+  const seen = new Set<number>();
+  let cursorId: number | null = spaceId;
+  while (cursorId != null && !seen.has(cursorId)) {
+    seen.add(cursorId);
+    const space = await findParentSpaceById({ id: cursorId }, { db });
+    if (!space) break;
+    chain.push({
+      id: space.id,
+      slug: space.slug,
+      title: space.title,
+      parentId: space.parentId ?? null,
+    });
+    cursorId = space.parentId ?? null;
+  }
+
+  // We gathered from leaf->root; UI needs root->leaf.
+  return chain.reverse();
+}
+
+function getVisibleCrumbs(chain: SpaceCrumb[]): Array<SpaceCrumb | 'ellipsis'> {
+  // Keep full path up to 6 levels; collapse the middle for deeper trees.
+  if (chain.length <= 6) return chain;
+  return [...chain.slice(0, 2), 'ellipsis', ...chain.slice(-3)];
 }
 
 export async function Breadcrumbs({
@@ -45,14 +54,41 @@ export async function Breadcrumbs({
   spaceId: number;
   lang: Locale;
 }) {
-  const tNavigation = await getTranslations('Navigation');
+  const chain = await getSpaceChain(spaceId);
+  const visibleCrumbs = getVisibleCrumbs(chain);
 
   return (
-    <SpaceBreadcrumb
-      rootHref={`/${lang}/my-spaces`}
-      rootLabel={tNavigation('mySpaces')}
-    >
-      <RecursiveBreadcrumbItem spaceId={spaceId} lang={lang} />
-    </SpaceBreadcrumb>
+    <Breadcrumb>
+      <BreadcrumbList>
+        {visibleCrumbs.map((crumb, index) => (
+          <Fragment
+            key={
+              crumb === 'ellipsis' ? `ellipsis-${index}` : `crumb-${crumb.id}`
+            }
+          >
+            {index > 0 ? (
+              <BreadcrumbSeparator>
+                <ChevronRightIcon width={16} height={16} />
+              </BreadcrumbSeparator>
+            ) : null}
+            <BreadcrumbItem>
+              {crumb === 'ellipsis' ? (
+                <BreadcrumbEllipsis className="size-4" />
+              ) : (
+                <BreadcrumbLink asChild>
+                  <Link
+                    href={`/${lang}/dho/${crumb.slug}/agreements`}
+                    className="inline-block max-w-[9rem] truncate align-bottom sm:max-w-[12rem]"
+                    title={crumb.title}
+                  >
+                    {crumb.title}
+                  </Link>
+                </BreadcrumbLink>
+              )}
+            </BreadcrumbItem>
+          </Fragment>
+        ))}
+      </BreadcrumbList>
+    </Breadcrumb>
   );
 }

--- a/apps/web/src/app/[lang]/dho/[id]/_components/navigation-tabs.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/navigation-tabs.tsx
@@ -1,39 +1,16 @@
 'use client';
 
-import * as React from 'react';
 import { Locale } from '@hypha-platform/i18n';
-import { Tabs, TabsList, TabsTrigger } from '@hypha-platform/ui/server';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { getDhoPathAgreements } from '../@tab/agreements/constants';
 import { getDhoPathMembers } from '../@tab/members/constants';
 import { getDhoPathTreasury } from '../@tab/treasury/constants';
-// import { getDhoPathOverview } from '../@tab/overview/constants'; // Overview tab removed
 import { cn } from '@hypha-platform/ui-utils';
-import {
-  getActiveTabFromPath,
-  useMainColumnScrollY,
-} from '@hypha-platform/epics';
+import { getActiveTabFromPath } from '@hypha-platform/epics';
 import { getDhoPathCoherence } from '../@tab/coherence/constants';
-
-/** Subtle scroll parallax: tab strip drifts slightly vs page for depth (see CompactSpaceBannerLead). */
-const TAB_PARALLAX_SCROLL_RATE = 0.07;
-const TAB_PARALLAX_MAX_SHIFT_PX = 18;
-
-function clampTabParallaxScrollY(scrollY: number): number {
-  return Math.min(
-    TAB_PARALLAX_MAX_SHIFT_PX,
-    Math.max(-TAB_PARALLAX_MAX_SHIFT_PX, scrollY * TAB_PARALLAX_SCROLL_RATE),
-  );
-}
-
-function isReducedMotionPreferred(): boolean {
-  if (typeof window === 'undefined') return false;
-  return (
-    window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false
-  );
-}
+import { FileCheck2, HandCoins, Radio, UsersRound } from 'lucide-react';
 
 export function NavigationTabs({
   lang,
@@ -46,35 +23,16 @@ export function NavigationTabs({
   coherenceEnabled?: boolean;
 }) {
   const t = useTranslations('Common');
+  const tCoherence = useTranslations('CoherenceTab');
   const pathname = usePathname();
   const activeTab = getActiveTabFromPath(pathname);
-
-  const mainScrollY = useMainColumnScrollY();
-  const [preferReducedMotion, setPreferReducedMotion] = React.useState(false);
-
-  React.useEffect(() => {
-    const mq = window.matchMedia?.('(prefers-reduced-motion: reduce)');
-    if (!mq) return;
-
-    const sync = () => {
-      setPreferReducedMotion(mq.matches);
-    };
-    sync();
-    mq.addEventListener('change', sync);
-    return () => mq.removeEventListener('change', sync);
-  }, []);
-
-  const tabParallaxY =
-    preferReducedMotion || isReducedMotionPreferred()
-      ? 0
-      : clampTabParallaxScrollY(mainScrollY);
-
-  const tabs = [
+  const menuItems = [
     ...(coherenceEnabled
       ? [
           {
-            title: t('Coherence'),
+            title: tCoherence('signals'),
             name: 'coherence',
+            icon: Radio,
             href: getDhoPathCoherence(lang, id),
           },
         ]
@@ -82,49 +40,45 @@ export function NavigationTabs({
     {
       title: t('Agreements'),
       name: 'agreements',
+      icon: FileCheck2,
       href: getDhoPathAgreements(lang, id),
     },
     {
       title: t('Members'),
       name: 'members',
-      href: getDhoPathMembers(lang as Locale, id as string),
+      icon: UsersRound,
+      href: getDhoPathMembers(lang, id),
     },
     {
       title: t('Treasury'),
       name: 'treasury',
-      href: getDhoPathTreasury(lang as Locale, id as string),
+      icon: HandCoins,
+      href: getDhoPathTreasury(lang, id),
     },
   ];
 
   return (
-    <Tabs value={activeTab} className="mt-6 w-full md:mt-7">
-      {/*
-        Radix ScrollArea's viewport forces overflow-y: hidden, which clips vertical parallax.
-        Native overflow-x-auto keeps horizontal swipe/scroll; vertical padding absorbs translate.
-      */}
-      <div
-        className={cn(
-          'mb-4 w-full overflow-x-auto overflow-y-visible overscroll-x-contain py-[18px]',
-          'touch-pan-x touch-pan-y [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden',
-        )}
-      >
-        <TabsList
-          className="flex h-10 min-w-max will-change-transform md:min-w-0 md:w-full"
-          style={
-            preferReducedMotion
-              ? undefined
-              : { transform: `translate3d(0, ${tabParallaxY}px, 0)` }
-          }
-        >
-          {tabs.map(({ name, href, title }) => (
-            <TabsTrigger asChild key={name} value={name} variant="ghost">
-              <Link href={href} className="w-full" passHref>
-                {title}
-              </Link>
-            </TabsTrigger>
+    <nav className="mt-6 w-full md:mt-7" aria-label="Space navigation">
+      <div className="mb-4 w-full overflow-x-auto [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">
+        <div className="flex min-w-max items-center gap-2 md:min-w-0 md:gap-3">
+          {menuItems.map(({ name, href, title, icon: Icon }) => (
+            <Link
+              key={name}
+              href={href}
+              aria-current={activeTab === name ? 'page' : undefined}
+              className={cn(
+                'inline-flex h-10 min-w-0 items-center gap-2 rounded-lg border px-3 text-sm font-medium transition-colors',
+                activeTab === name
+                  ? 'border-accent-9/40 bg-accent-9/18 text-foreground'
+                  : 'border-transparent text-muted-foreground hover:border-border/70 hover:bg-muted/80 hover:text-foreground',
+              )}
+            >
+              <Icon className="h-4 w-4 shrink-0" aria-hidden />
+              <span className="whitespace-nowrap">{title}</span>
+            </Link>
           ))}
-        </TabsList>
+        </div>
       </div>
-    </Tabs>
+    </nav>
   );
 }

--- a/apps/web/src/app/[lang]/dho/[id]/_components/navigation-tabs.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/navigation-tabs.tsx
@@ -24,6 +24,7 @@ export function NavigationTabs({
 }) {
   const t = useTranslations('Common');
   const tCoherence = useTranslations('CoherenceTab');
+  const tModalAside = useTranslations('ModalAside');
   const pathname = usePathname();
   const activeTab = getActiveTabFromPath(pathname);
   const menuItems = [
@@ -58,7 +59,10 @@ export function NavigationTabs({
   ];
 
   return (
-    <nav className="mt-6 w-full md:mt-7" aria-label="Space navigation">
+    <nav
+      className="mt-6 w-full md:mt-7"
+      aria-label={tModalAside('spaceNavigation')}
+    >
       <div className="mb-4 w-full overflow-x-auto [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">
         <div className="flex min-w-max items-center gap-2 md:min-w-0 md:gap-3">
           {menuItems.map(({ name, href, title, icon: Icon }) => (

--- a/apps/web/src/app/[lang]/dho/[id]/_components/navigation-tabs.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/navigation-tabs.tsx
@@ -10,7 +10,7 @@ import { getDhoPathTreasury } from '../@tab/treasury/constants';
 import { cn } from '@hypha-platform/ui-utils';
 import { getActiveTabFromPath } from '@hypha-platform/epics';
 import { getDhoPathCoherence } from '../@tab/coherence/constants';
-import { FileCheck2, HandCoins, Radio, UsersRound } from 'lucide-react';
+import { Coins, FileCheck2, Radio, UsersRound } from 'lucide-react';
 
 export function NavigationTabs({
   lang,
@@ -53,7 +53,7 @@ export function NavigationTabs({
     {
       title: t('Treasury'),
       name: 'treasury',
-      icon: HandCoins,
+      icon: Coins,
       href: getDhoPathTreasury(lang, id),
     },
   ];

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -24,7 +24,7 @@ import { EvmProvider } from '@hypha-platform/evm';
 import { useMe } from '@hypha-platform/core/client';
 import { ConditionalMatrixProvider } from '@web/components/conditional-matrix-provider';
 import { fileRouter } from '@hypha-platform/core/server';
-import { MenuTop, TooltipProvider } from '@hypha-platform/ui';
+import { TooltipProvider } from '@hypha-platform/ui';
 import { ROOT_URL } from './constants';
 import {
   getEnableAiChat,
@@ -39,6 +39,7 @@ import { getShowLanguageSelect } from '@hypha-platform/feature-flags';
 import ScrollUp from '@web/components/scroll-up';
 import SeamlessScrollPolyfill from '@web/components/seamless-scroll-polyfill';
 import { ThemeStorageNormalize } from '@web/components/theme-storage-normalize';
+import { ConnectedMenuTop } from '@web/components/connected-menu-top';
 import '@web/utils/initialize-proxy';
 
 const lato = Lato({
@@ -151,7 +152,8 @@ export default async function RootLayout({
                       >
                         {/* Fixed menu bar — clamped to center column by SidebarInset */}
                         <div className="sticky top-0 z-30 shrink-0">
-                          <MenuTop
+                          <ConnectedMenuTop
+                            aiChatEnabled={aiChatEnabled}
                             logoHref={ROOT_URL}
                             openMenuLabel={tNav('openMenu')}
                             closeMenuLabel={tNav('closeMenu')}
@@ -185,7 +187,7 @@ export default async function RootLayout({
                                 ) : undefined
                               }
                             />
-                          </MenuTop>
+                          </ConnectedMenuTop>
                         </div>
                         {/* Scrollable content area */}
                         <NextSSRPlugin

--- a/apps/web/src/components/connected-menu-top.tsx
+++ b/apps/web/src/components/connected-menu-top.tsx
@@ -1,9 +1,12 @@
 'use client';
 
 import type { ReactNode } from 'react';
+import { useMemo } from 'react';
 import { usePathname } from 'next/navigation';
 import { MenuTop } from '@hypha-platform/ui';
-import { useAiPanel } from '@hypha-platform/epics';
+import { getDhoSpaceSlugFromPathname } from '@hypha-platform/epics';
+import useSWR from 'swr';
+import { Space } from '@hypha-platform/core/client';
 
 type ConnectedMenuTopProps = {
   children?: ReactNode;
@@ -16,6 +19,24 @@ type ConnectedMenuTopProps = {
   aiChatEnabled: boolean;
 };
 
+function getRootSpaceTitle(
+  activeSpace?: Space,
+  spaces: Space[] = [],
+): string | null {
+  if (!activeSpace) return null;
+  const spacesById = new Map(spaces.map((space) => [space.id, space]));
+  let cursor: Space | undefined = activeSpace;
+  const seen = new Set<number>();
+  while (cursor?.parentId != null) {
+    if (seen.has(cursor.id)) break;
+    seen.add(cursor.id);
+    const parent = spacesById.get(cursor.parentId);
+    if (!parent) break;
+    cursor = parent;
+  }
+  return cursor?.title?.trim() || activeSpace.title?.trim() || null;
+}
+
 export function ConnectedMenuTop({
   children,
   leadingAction,
@@ -27,13 +48,34 @@ export function ConnectedMenuTop({
   aiChatEnabled,
 }: ConnectedMenuTopProps) {
   const pathname = usePathname();
-  const { open: isAiOpen } = useAiPanel();
   const isSpaceRoute = /^\/[^/]+\/dho\/[^/]+/.test(pathname);
-  const hideLogo = aiChatEnabled && isSpaceRoute && !isAiOpen;
+  const activeSpaceSlug = useMemo(
+    () => getDhoSpaceSlugFromPathname(pathname),
+    [pathname],
+  );
+  const { data: allSpaces = [] } = useSWR<Space[]>(
+    isSpaceRoute ? '/api/v1/spaces?parentOnly=false' : null,
+    async (url: string) => {
+      const response = await fetch(url, {
+        headers: { Accept: 'application/json' },
+      });
+      if (!response.ok) return [];
+      return (await response.json()) as Space[];
+    },
+  );
+  const rootSpaceTitle = useMemo(() => {
+    if (!activeSpaceSlug) return null;
+    const activeSpace = allSpaces.find(
+      (space) => space.slug === activeSpaceSlug,
+    );
+    return getRootSpaceTitle(activeSpace, allSpaces);
+  }, [activeSpaceSlug, allSpaces]);
+  const logoText = aiChatEnabled && isSpaceRoute ? rootSpaceTitle : null;
 
   return (
     <MenuTop
-      logoHref={hideLogo ? undefined : logoHref}
+      logoHref={logoHref}
+      logoText={logoText ?? undefined}
       hrefTarget={hrefTarget}
       openMenuLabel={openMenuLabel}
       closeMenuLabel={closeMenuLabel}

--- a/apps/web/src/components/connected-menu-top.tsx
+++ b/apps/web/src/components/connected-menu-top.tsx
@@ -6,6 +6,7 @@ import { usePathname } from 'next/navigation';
 import { MenuTop } from '@hypha-platform/ui';
 import { getDhoSpaceSlugFromPathname } from '@hypha-platform/epics';
 import useSWR from 'swr';
+import { ImagePlus } from 'lucide-react';
 import { DEFAULT_SPACE_AVATAR_IMAGE, Space } from '@hypha-platform/core/client';
 import Link from 'next/link';
 
@@ -33,6 +34,15 @@ function getRootSpace(activeSpace?: Space, spaces: Space[] = []) {
     cursor = parent;
   }
   return cursor ?? activeSpace;
+}
+
+function hasCustomRootLogo(logoUrl: string): boolean {
+  const value = logoUrl.trim();
+  if (!value) return false;
+  return !(
+    value === DEFAULT_SPACE_AVATAR_IMAGE ||
+    value.endsWith(DEFAULT_SPACE_AVATAR_IMAGE)
+  );
 }
 
 export function ConnectedMenuTop({
@@ -82,40 +92,32 @@ export function ConnectedMenuTop({
       : logoHref;
   const rootLogoUrl = rootSpace?.logoUrl?.trim() || '';
   const rootTitle = rootSpace?.title?.trim() || '';
+  const rootHasCustomLogo = hasCustomRootLogo(rootLogoUrl);
 
   const logoNode =
     aiChatEnabled && isSpaceRoute && rootSpace ? (
-      rootLogoUrl ? (
+      rootHasCustomLogo ? (
         <Link
           href={rootSpaceHref ?? '#'}
-          className="inline-flex items-center gap-2"
+          className="inline-flex h-9 w-9 items-center justify-center overflow-hidden rounded-xl bg-muted ring-1 ring-border/70 transition-colors hover:bg-muted/80"
+          aria-label={rootTitle}
+          title={rootTitle}
         >
-          <span className="flex h-9 w-9 items-center justify-center overflow-hidden rounded-xl bg-muted ring-1 ring-border/70">
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
-              src={rootLogoUrl}
-              alt={rootTitle}
-              className="h-full w-full object-cover"
-            />
-          </span>
-          <span className="inline-block max-w-[18rem] truncate text-2xl font-semibold leading-none tracking-tight text-foreground">
-            {rootTitle}
-          </span>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={rootLogoUrl}
+            alt={rootTitle}
+            className="h-full w-full object-cover"
+          />
         </Link>
       ) : (
         <Link
           href={rootConfigHref ?? '#'}
-          className="inline-flex items-center gap-2 rounded-md border border-dashed border-border px-2 py-1 text-sm font-medium text-muted-foreground hover:bg-muted"
+          className="inline-flex h-9 w-9 items-center justify-center rounded-xl border border-dashed border-border bg-muted/40 text-muted-foreground transition-colors hover:bg-muted"
+          aria-label="Upload ecosystem logo"
+          title="Upload ecosystem logo"
         >
-          <span className="flex h-9 w-9 items-center justify-center overflow-hidden rounded-xl bg-muted ring-1 ring-border/70">
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
-              src={DEFAULT_SPACE_AVATAR_IMAGE}
-              alt="Ecosystem Logo"
-              className="h-full w-full object-cover opacity-60"
-            />
-          </span>
-          <span>Ecosystem Logo</span>
+          <ImagePlus className="h-4 w-4" />
         </Link>
       )
     ) : undefined;

--- a/apps/web/src/components/connected-menu-top.tsx
+++ b/apps/web/src/components/connected-menu-top.tsx
@@ -6,7 +6,8 @@ import { usePathname } from 'next/navigation';
 import { MenuTop } from '@hypha-platform/ui';
 import { getDhoSpaceSlugFromPathname } from '@hypha-platform/epics';
 import useSWR from 'swr';
-import { Space } from '@hypha-platform/core/client';
+import { DEFAULT_SPACE_AVATAR_IMAGE, Space } from '@hypha-platform/core/client';
+import Link from 'next/link';
 
 type ConnectedMenuTopProps = {
   children?: ReactNode;
@@ -19,10 +20,7 @@ type ConnectedMenuTopProps = {
   aiChatEnabled: boolean;
 };
 
-function getRootSpaceTitle(
-  activeSpace?: Space,
-  spaces: Space[] = [],
-): string | null {
+function getRootSpace(activeSpace?: Space, spaces: Space[] = []) {
   if (!activeSpace) return null;
   const spacesById = new Map(spaces.map((space) => [space.id, space]));
   let cursor: Space | undefined = activeSpace;
@@ -34,7 +32,7 @@ function getRootSpaceTitle(
     if (!parent) break;
     cursor = parent;
   }
-  return cursor?.title?.trim() || activeSpace.title?.trim() || null;
+  return cursor ?? activeSpace;
 }
 
 export function ConnectedMenuTop({
@@ -49,6 +47,10 @@ export function ConnectedMenuTop({
 }: ConnectedMenuTopProps) {
   const pathname = usePathname();
   const isSpaceRoute = /^\/[^/]+\/dho\/[^/]+/.test(pathname);
+  const lang = useMemo(() => {
+    const match = pathname.match(/^\/([^/]+)\//);
+    return match?.[1] ?? 'en';
+  }, [pathname]);
   const activeSpaceSlug = useMemo(
     () => getDhoSpaceSlugFromPathname(pathname),
     [pathname],
@@ -63,19 +65,65 @@ export function ConnectedMenuTop({
       return (await response.json()) as Space[];
     },
   );
-  const rootSpaceTitle = useMemo(() => {
+  const rootSpace = useMemo(() => {
     if (!activeSpaceSlug) return null;
     const activeSpace = allSpaces.find(
       (space) => space.slug === activeSpaceSlug,
     );
-    return getRootSpaceTitle(activeSpace, allSpaces);
+    return getRootSpace(activeSpace, allSpaces);
   }, [activeSpaceSlug, allSpaces]);
-  const logoText = aiChatEnabled && isSpaceRoute ? rootSpaceTitle : null;
+  const rootConfigHref =
+    rootSpace?.slug != null
+      ? `/${lang}/dho/${rootSpace.slug}/agreements/space-configuration`
+      : logoHref;
+  const rootSpaceHref =
+    rootSpace?.slug != null
+      ? `/${lang}/dho/${rootSpace.slug}/agreements`
+      : logoHref;
+  const rootLogoUrl = rootSpace?.logoUrl?.trim() || '';
+  const rootTitle = rootSpace?.title?.trim() || '';
+
+  const logoNode =
+    aiChatEnabled && isSpaceRoute && rootSpace ? (
+      rootLogoUrl ? (
+        <Link
+          href={rootSpaceHref ?? '#'}
+          className="inline-flex items-center gap-2"
+        >
+          <span className="flex h-9 w-9 items-center justify-center overflow-hidden rounded-xl bg-muted ring-1 ring-border/70">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={rootLogoUrl}
+              alt={rootTitle}
+              className="h-full w-full object-cover"
+            />
+          </span>
+          <span className="inline-block max-w-[18rem] truncate text-2xl font-semibold leading-none tracking-tight text-foreground">
+            {rootTitle}
+          </span>
+        </Link>
+      ) : (
+        <Link
+          href={rootConfigHref ?? '#'}
+          className="inline-flex items-center gap-2 rounded-md border border-dashed border-border px-2 py-1 text-sm font-medium text-muted-foreground hover:bg-muted"
+        >
+          <span className="flex h-9 w-9 items-center justify-center overflow-hidden rounded-xl bg-muted ring-1 ring-border/70">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={DEFAULT_SPACE_AVATAR_IMAGE}
+              alt="Ecosystem Logo"
+              className="h-full w-full object-cover opacity-60"
+            />
+          </span>
+          <span>Ecosystem Logo</span>
+        </Link>
+      )
+    ) : undefined;
 
   return (
     <MenuTop
       logoHref={logoHref}
-      logoText={logoText ?? undefined}
+      logoNode={logoNode}
       hrefTarget={hrefTarget}
       openMenuLabel={openMenuLabel}
       closeMenuLabel={closeMenuLabel}

--- a/apps/web/src/components/connected-menu-top.tsx
+++ b/apps/web/src/components/connected-menu-top.tsx
@@ -7,7 +7,7 @@ import { MenuTop } from '@hypha-platform/ui';
 import { getDhoSpaceSlugFromPathname } from '@hypha-platform/epics';
 import useSWR from 'swr';
 import { ImagePlus } from 'lucide-react';
-import { DEFAULT_SPACE_AVATAR_IMAGE, Space } from '@hypha-platform/core/client';
+import { Space } from '@hypha-platform/core/client';
 import Link from 'next/link';
 
 type ConnectedMenuTopProps = {
@@ -37,12 +37,7 @@ function getRootSpace(activeSpace?: Space, spaces: Space[] = []) {
 }
 
 function hasCustomRootLogo(logoUrl: string): boolean {
-  const value = logoUrl.trim();
-  if (!value) return false;
-  return !(
-    value === DEFAULT_SPACE_AVATAR_IMAGE ||
-    value.endsWith(DEFAULT_SPACE_AVATAR_IMAGE)
-  );
+  return logoUrl.trim().length > 0;
 }
 
 export function ConnectedMenuTop({
@@ -90,7 +85,7 @@ export function ConnectedMenuTop({
     rootSpace?.slug != null
       ? `/${lang}/dho/${rootSpace.slug}/agreements`
       : logoHref;
-  const rootLogoUrl = rootSpace?.logoUrl?.trim() || '';
+  const rootLogoUrl = rootSpace?.ecosystemLogoUrl?.trim() || '';
   const rootTitle = rootSpace?.title?.trim() || '';
   const rootHasCustomLogo = hasCustomRootLogo(rootLogoUrl);
 
@@ -99,7 +94,7 @@ export function ConnectedMenuTop({
       rootHasCustomLogo ? (
         <Link
           href={rootSpaceHref ?? '#'}
-          className="inline-flex h-9 w-9 items-center justify-center overflow-hidden rounded-xl bg-muted ring-1 ring-border/70 transition-colors hover:bg-muted/80"
+          className="inline-flex h-9 max-w-[11rem] items-center justify-start overflow-hidden rounded-md px-1 transition-colors hover:bg-muted/40"
           aria-label={rootTitle}
           title={rootTitle}
         >
@@ -107,17 +102,18 @@ export function ConnectedMenuTop({
           <img
             src={rootLogoUrl}
             alt={rootTitle}
-            className="h-full w-full object-cover"
+            className="h-full w-auto object-contain"
           />
         </Link>
       ) : (
         <Link
           href={rootConfigHref ?? '#'}
-          className="inline-flex h-9 w-9 items-center justify-center rounded-xl border border-dashed border-border bg-muted/40 text-muted-foreground transition-colors hover:bg-muted"
+          className="inline-flex h-9 items-center justify-center gap-1 rounded-md border border-dashed border-border bg-muted/40 px-2 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted"
           aria-label="Upload ecosystem logo"
           title="Upload ecosystem logo"
         >
           <ImagePlus className="h-4 w-4" />
+          <span>Upload Ecosystem Logo</span>
         </Link>
       )
     ) : undefined;

--- a/apps/web/src/components/connected-menu-top.tsx
+++ b/apps/web/src/components/connected-menu-top.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { usePathname } from 'next/navigation';
+import { MenuTop } from '@hypha-platform/ui';
+import { useAiPanel } from '@hypha-platform/epics';
+
+type ConnectedMenuTopProps = {
+  children?: ReactNode;
+  leadingAction?: ReactNode;
+  trailingAction?: ReactNode;
+  logoHref?: string;
+  hrefTarget?: string;
+  openMenuLabel?: string;
+  closeMenuLabel?: string;
+  aiChatEnabled: boolean;
+};
+
+export function ConnectedMenuTop({
+  children,
+  leadingAction,
+  trailingAction,
+  logoHref,
+  hrefTarget,
+  openMenuLabel,
+  closeMenuLabel,
+  aiChatEnabled,
+}: ConnectedMenuTopProps) {
+  const pathname = usePathname();
+  const { open: isAiOpen } = useAiPanel();
+  const isSpaceRoute = /^\/[^/]+\/dho\/[^/]+/.test(pathname);
+  const hideLogo = aiChatEnabled && isSpaceRoute && !isAiOpen;
+
+  return (
+    <MenuTop
+      logoHref={hideLogo ? undefined : logoHref}
+      hrefTarget={hrefTarget}
+      openMenuLabel={openMenuLabel}
+      closeMenuLabel={closeMenuLabel}
+      leadingAction={leadingAction}
+      trailingAction={trailingAction}
+    >
+      {children}
+    </MenuTop>
+  );
+}

--- a/docs/requirements/ai-sidebar-01-space-navigation-redesign.md
+++ b/docs/requirements/ai-sidebar-01-space-navigation-redesign.md
@@ -66,11 +66,26 @@ existing global top-menu behavior that is explicitly out of scope.
 
 ### FR-5: Close-to-Collapsed Behavior (Images 9-10)
 
-- Clicking close collapses the left panel into icon-only rail state.
+- Clicking close collapses the **left navigation menu shell** (the new overlaid
+  menu that contains the former tabs as menu items) into icon-only rail state.
 - Collapsed state shows:
   - active space icon at top
   - vertical icon-only section navigation below
 - Expanding from collapsed state restores full menu with labels and dropdown.
+
+### FR-6: Non-Glitch State Coordination (Overlay vs Composer)
+
+- The menu shell and AI composer are separate visual layers but share one
+  canonical sidebar state: `expanded` or `collapsed`.
+- Close icon always writes the same state transition:
+  - `expanded -> collapsed`
+  - `collapsed -> collapsed` (no-op, no re-animation)
+- If overlay content is not currently visible (e.g. hover not active), close
+  still updates canonical state so next reveal opens in collapsed rail form.
+- Hover/focus reveal must **not** mutate collapse state by itself; it only
+  changes visibility of the shell.
+- Route changes and async data hydration must preserve last explicit collapse
+  state (no automatic expand flicker during mount/re-render).
 
 ## UX + Accessibility Requirements
 
@@ -108,6 +123,11 @@ existing global top-menu behavior that is explicitly out of scope.
   - `ecosystem group identifier` (for dropdown grouping)
 - If ecosystem grouping data is unavailable, fallback behavior:
   - show all spaces in one list, no misleading grouping labels.
+- Sidebar/menu state model:
+  - `sidebarCollapsed: boolean` (source of truth for expanded vs icon rail)
+  - `overlayVisible: boolean` (ephemeral hover/focus visibility)
+  - Render rule: `overlayVisible` decides visibility, `sidebarCollapsed` decides
+    shape; these states must never be conflated.
 
 ## Acceptance Criteria
 
@@ -118,6 +138,10 @@ existing global top-menu behavior that is explicitly out of scope.
 - Menu includes Signals, Agreements, Members, Treasury in that order.
 - AI header no longer shows reload/reset action.
 - Close action collapses to icon-only rail with active space icon + nav icons.
+- Closing while overlay is hidden still results in collapsed state on next open
+  (deterministic state, no visual jump).
+- No double-transition flicker when close is clicked repeatedly or during
+  hover-in/hover-out.
 - Existing top-right menu behavior remains unchanged.
 - No new lint/type errors in touched files.
 

--- a/docs/requirements/ai-sidebar-01-space-navigation-redesign.md
+++ b/docs/requirements/ai-sidebar-01-space-navigation-redesign.md
@@ -1,0 +1,132 @@
+# AI Sidebar + Space Navigation Redesign Spec
+
+## Objective
+
+Rebuild the left-side AI/space navigation experience from scratch on a new branch
+using the `sidebar-01` shadcn block pattern as the interaction baseline.
+
+The redesign aligns Hypha's space navigation and AI panel chrome with the
+expected behavior shown in the provided visual references, while preserving the
+existing global top-menu behavior that is explicitly out of scope.
+
+## References
+
+- Shadcn block: `https://ui.shadcn.com/blocks/sidebar#sidebar-01`
+- Interaction reference (overlay on top of chat): `https://v0.app/chat/Nl34hIcRqcf`
+- User-provided image set (1-10) in this task thread
+
+## Scope
+
+### In Scope
+
+- New left-rail + expanded sidebar behavior for AI/space context.
+- Space switcher dropdown content and ordering.
+- Space section menu items replacing tab-like controls.
+- AI panel top chrome updates (icon/title/dropdown/controls).
+- Collapsed state behavior after close action.
+
+### Out of Scope
+
+- Changes to existing right-side user/profile controls in global top menu.
+- Changes to non-space routes.
+- Backend/domain model refactors unrelated to sidebar behavior.
+
+## Functional Requirements
+
+### FR-1: Space Switcher Dropdown Content (Image 1)
+
+- A dropdown next to the active space icon displays "My Spaces".
+- The first section lists spaces inside the same ecosystem as the active space.
+- A visible delimiter separates that section from "other spaces".
+- Selecting a space navigates to that space route and updates active state.
+
+### FR-2: Hover-Activated Left Menu (Image 2)
+
+- Hovering the top-left entry icon reveals the sidebar menu overlay.
+- Behavior and placement follow the v0 reference: menu appears layered over
+  the AI chat region rather than shifting global layout.
+- Keyboard fallback remains available (focus/trigger must open without hover).
+
+### FR-3: Section Menu Items Replace Tabs (Image 3)
+
+- Replace tab-like section controls with vertical menu items (icon + label):
+  - Signals
+  - Agreements
+  - Members
+  - Treasury
+- Active route is highlighted as selected menu item.
+- Items navigate to the existing section routes (no route rename in this phase).
+
+### FR-4: Top AI Bar Updates (Images 4-8)
+
+- Replace white AI icon with active space icon.
+- Replace "Hypha AI" text with space dropdown trigger next to the icon.
+- Keep remaining top menu elements unchanged unless explicitly listed here.
+- Remove reload/reset action from the AI panel top controls.
+
+### FR-5: Close-to-Collapsed Behavior (Images 9-10)
+
+- Clicking close collapses the left panel into icon-only rail state.
+- Collapsed state shows:
+  - active space icon at top
+  - vertical icon-only section navigation below
+- Expanding from collapsed state restores full menu with labels and dropdown.
+
+## UX + Accessibility Requirements
+
+- Use existing design tokens and shadcn/sidebar primitives from `@hypha-platform/ui`.
+- Hit targets: minimum `44x44` equivalent for interactive icons on touch contexts.
+- Every icon-only control must have `aria-label` and tooltip text.
+- Dropdown and menu must be keyboard navigable:
+  - Enter/Space opens
+  - Arrow keys move focus
+  - Esc closes popover/menu where applicable
+- Active menu item should expose `aria-current="page"` semantics.
+
+## Technical Mapping
+
+- `apps/web/src/app/layout.tsx`
+  - Wire redesigned left trigger/menu integration in `MenuTop` composition.
+- `packages/epics/src/common/ai-panel/ai-panel-header.tsx`
+  - Update AI top bar: space icon + space switcher, remove reload.
+- `apps/web/src/app/[lang]/dho/[id]/_components/navigation-tabs.tsx`
+  - Replace tab presentation with menu-item pattern (icons + labels).
+- `packages/epics/src/common/panel-wrap-layout.tsx`
+  - Ensure collapsed icon rail state is supported without breaking existing panel
+    open/close behavior.
+- New helper component(s) under `packages/epics/src/common/` or
+  `apps/web/src/app/[lang]/dho/[id]/_components/` for:
+  - space grouping logic (ecosystem first, others second),
+  - shared navigation config (label/icon/href/active).
+
+## Data + State Requirements
+
+- Active space metadata needed in client UI:
+  - `space slug`
+  - `space title`
+  - `space icon URL` with fallback
+  - `ecosystem group identifier` (for dropdown grouping)
+- If ecosystem grouping data is unavailable, fallback behavior:
+  - show all spaces in one list, no misleading grouping labels.
+
+## Acceptance Criteria
+
+- On a space route, top-left control reveals sidebar overlay on hover and focus.
+- Space dropdown appears next to active space icon and supports selection.
+- Dropdown groups spaces: same ecosystem first, delimiter, then other spaces.
+- Section navigation appears as icon + label menu items, not tabs.
+- Menu includes Signals, Agreements, Members, Treasury in that order.
+- AI header no longer shows reload/reset action.
+- Close action collapses to icon-only rail with active space icon + nav icons.
+- Existing top-right menu behavior remains unchanged.
+- No new lint/type errors in touched files.
+
+## Implementation Plan (Execution Order)
+
+1. Build shared nav item model (icon + route + active matcher).
+2. Implement space switcher dropdown component and grouping logic.
+3. Replace tab UI with vertical menu UI (desktop + collapsed variants).
+4. Refactor AI panel header for space icon + dropdown and close/collapse actions.
+5. Integrate hover-open trigger behavior in left-top menu entry.
+6. Validate keyboard/accessibility behavior and run lint checks.
+

--- a/packages/core/src/space/client/hooks/useCreateSpaceOrchestrator.ts
+++ b/packages/core/src/space/client/hooks/useCreateSpaceOrchestrator.ts
@@ -164,13 +164,15 @@ export const useCreateSpaceOrchestrator = ({
       const uploadedFileUrls: {
         logoUrl?: string;
         leadImage?: string;
+        ecosystemLogoUrl?: string;
       } = {};
 
       try {
         const logoUrl = (arg as any).logoUrl;
         const leadImage = (arg as any).leadImage;
+        const ecosystemLogoUrl = (arg as any).ecosystemLogoUrl;
 
-        if (logoUrl || leadImage) {
+        if (logoUrl || leadImage || ecosystemLogoUrl) {
           startTask('UPLOAD_FILES');
 
           const uploadPromises: Promise<void>[] = [];
@@ -197,6 +199,18 @@ export const useCreateSpaceOrchestrator = ({
             );
           } else if (typeof leadImage === 'string' && leadImage) {
             uploadedFileUrls.leadImage = leadImage;
+          }
+
+          if (ecosystemLogoUrl instanceof File) {
+            uploadPromises.push(
+              uploadImage([ecosystemLogoUrl]).then((result) => {
+                if (result?.[0]?.ufsUrl) {
+                  uploadedFileUrls.ecosystemLogoUrl = result[0].ufsUrl;
+                }
+              }),
+            );
+          } else if (typeof ecosystemLogoUrl === 'string' && ecosystemLogoUrl) {
+            uploadedFileUrls.ecosystemLogoUrl = ecosystemLogoUrl;
           }
 
           await Promise.all(uploadPromises);
@@ -261,6 +275,7 @@ export const useCreateSpaceOrchestrator = ({
           ...inputCreateSpaceWeb2,
           logoUrl: uploadedFileUrls.logoUrl,
           leadImage: uploadedFileUrls.leadImage,
+          ecosystemLogoUrl: uploadedFileUrls.ecosystemLogoUrl,
         };
         const createdSpace = await web2.createSpace(createSpaceInput);
         web2SpaceId = createdSpace?.id;

--- a/packages/core/src/space/client/hooks/useUpdateSpaceOrchestrator.ts
+++ b/packages/core/src/space/client/hooks/useUpdateSpaceOrchestrator.ts
@@ -91,7 +91,11 @@ export const useUpdateSpaceOrchestrator = ({
 }: UseUpdateSpaceInput) => {
   const web2 = useSpaceMutationsWeb2Rsc(authToken);
   const files = useSpaceFileUploads(authToken, async (uploadedFiles, id) => {
-    if (!uploadedFiles.leadImage && !uploadedFiles.logoUrl) {
+    if (
+      !uploadedFiles.leadImage &&
+      !uploadedFiles.logoUrl &&
+      !uploadedFiles.ecosystemLogoUrl
+    ) {
       return;
     }
     await web2.updateSpaceById({

--- a/packages/core/src/space/server/queries.ts
+++ b/packages/core/src/space/server/queries.ts
@@ -35,6 +35,7 @@ export const findAllSpaces = async (
     .select({
       id: spaces.id,
       logoUrl: spaces.logoUrl,
+      ecosystemLogoUrl: spaces.ecosystemLogoUrl,
       leadImage: spaces.leadImage,
       title: spaces.title,
       description: spaces.description,
@@ -305,6 +306,7 @@ const getSpaceDefaultFields = () => {
   return {
     id: spaces.id,
     logoUrl: spaces.logoUrl,
+    ecosystemLogoUrl: spaces.ecosystemLogoUrl,
     leadImage: spaces.leadImage,
     title: spaces.title,
     description: spaces.description,

--- a/packages/core/src/space/types.ts
+++ b/packages/core/src/space/types.ts
@@ -5,6 +5,7 @@ import { Person } from '@hypha-platform/core/client';
 export interface Space {
   id: number;
   logoUrl?: string | null;
+  ecosystemLogoUrl?: string | null;
   leadImage?: string | null;
   title: string;
   description: string | null;
@@ -35,6 +36,7 @@ export interface CreateSpaceInput {
   title: string;
   description: string;
   logoUrl?: string;
+  ecosystemLogoUrl?: string;
   leadImage?: string;
   slug?: string;
   parentId?: number | null;
@@ -47,6 +49,7 @@ export interface UpdateSpaceInput {
   title?: string;
   description?: string;
   logoUrl?: string;
+  ecosystemLogoUrl?: string;
   leadImage?: string;
   slug?: string;
   parentId?: number | null;

--- a/packages/core/src/space/validation.ts
+++ b/packages/core/src/space/validation.ts
@@ -55,6 +55,7 @@ const createSpaceWeb2Props = {
     .min(1, 'Please add the purpose of your space')
     .max(300, 'Description must contain at most 300 characters'),
   slug: spaceSlugSchema.optional(),
+  ecosystemLogoUrl: z.string().url().optional(),
   web3SpaceId: z.number().optional(),
   parentId: z.number().nullable(),
   categories: z.array(z.enum(CATEGORIES)).default([]),
@@ -115,6 +116,21 @@ export const createSpaceFiles = {
         'File must be an image (JPEG, PNG, GIF, WEBP)',
       ),
   ]),
+  ecosystemLogoUrl: z
+    .union([
+      z.string().url('An ecosystem logo must be a valid URL'),
+      z
+        .instanceof(File)
+        .refine(
+          (file) => file.size <= ALLOWED_IMAGE_FILE_SIZE,
+          'File size must be less than 4MB',
+        )
+        .refine(
+          (file) => DEFAULT_IMAGE_ACCEPT.includes(file.type),
+          'File must be an image (JPEG, PNG, GIF, WEBP)',
+        ),
+    ])
+    .optional(),
 };
 
 export const schemaCreateSpaceFiles = z.object(createSpaceFiles);

--- a/packages/epics/src/common/ai-left-panel.tsx
+++ b/packages/epics/src/common/ai-left-panel.tsx
@@ -212,7 +212,7 @@ export function AiLeftPanel() {
     return (
       <>
         <SidebarHeader className="items-center bg-background-2 p-2">
-          <div className="flex h-8 w-8 items-center justify-center overflow-hidden rounded-xl bg-muted ring-1 ring-border/70">
+          <div className="flex h-7 w-7 items-center justify-center overflow-hidden rounded-xl bg-muted ring-1 ring-border/70">
             {/* eslint-disable-next-line @next/next/no-img-element */}
             <img
               src={activeSpaceIcon}

--- a/packages/epics/src/common/ai-left-panel.tsx
+++ b/packages/epics/src/common/ai-left-panel.tsx
@@ -238,7 +238,7 @@ export function AiLeftPanel() {
             />
           </div>
         </SidebarHeader>
-        <SidebarContent className="relative bg-background-2">
+        <SidebarContent className="relative overflow-visible bg-background-2">
           <SidebarGroup className="p-2">
             <SidebarGroupContent>
               <SidebarMenu className="items-center">
@@ -261,7 +261,7 @@ export function AiLeftPanel() {
           </SidebarGroup>
           {overlayVisible ? (
             <div
-              className="absolute left-[calc(100%+0.5rem)] top-2 z-[60] w-[272px] overflow-hidden rounded-xl border border-border/90 bg-background-2 shadow-2xl"
+              className="absolute left-full top-0 z-[70] w-[272px] overflow-hidden rounded-xl border border-border/90 bg-background-2 shadow-2xl"
               onMouseEnter={showAiOverlay}
               onMouseLeave={hideAiOverlay}
             >

--- a/packages/epics/src/common/ai-left-panel.tsx
+++ b/packages/epics/src/common/ai-left-panel.tsx
@@ -6,10 +6,27 @@ import { DefaultChatTransport } from 'ai';
 import { useAuthentication } from '@hypha-platform/authentication';
 import { useParams, usePathname } from 'next/navigation';
 import { useTranslations } from 'next-intl';
+import Link from 'next/link';
+import {
+  FileCheck2,
+  HandCoins,
+  Radio,
+  UsersRound,
+} from 'lucide-react';
+import {
+  DEFAULT_SPACE_AVATAR_IMAGE,
+  useSpacesBySlugs,
+} from '@hypha-platform/core/client';
 import {
   SidebarHeader,
   SidebarContent,
   SidebarFooter,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  useSidebar,
 } from '@hypha-platform/ui';
 
 import { AiPanelHeader, AiPanelMessages, AiPanelChatBar } from './ai-panel';
@@ -28,7 +45,7 @@ const DEBUG = process.env.NEXT_PUBLIC_CHAT_DEBUG === 'true';
 export function AiLeftPanel() {
   const { isAuthenticated, isLoading, login, getAccessToken } =
     useAuthentication();
-  const params = useParams<{ id?: string }>();
+  const params = useParams<{ id?: string; lang?: string }>();
   const pathname = usePathname();
   const spaceSlugFromPath = useMemo(
     () => getDhoSpaceSlugFromPathname(pathname),
@@ -37,6 +54,49 @@ export function AiLeftPanel() {
   /** Prefer pathname: AiLeftPanel mounts in root layout where `id` is often missing for `/dho/[id]/...` routes. */
   const spaceSlug = spaceSlugFromPath ?? params?.id;
   const t = useTranslations('AiPanel');
+  const tCommon = useTranslations('Common');
+  const tCoherence = useTranslations('CoherenceTab');
+  const lang = typeof params?.lang === 'string' ? params.lang : 'en';
+  const { state: sidebarState } = useSidebar();
+  const isCollapsed = sidebarState === 'collapsed';
+  const { spaces: activeSpaces } = useSpacesBySlugs(spaceSlug ? [spaceSlug] : []);
+  const activeSpaceIcon =
+    activeSpaces[0]?.logoUrl?.trim() || DEFAULT_SPACE_AVATAR_IMAGE;
+  const activeSpaceTitle = activeSpaces[0]?.title?.trim() || t('title');
+
+  const sectionNavItems = useMemo(() => {
+    if (!spaceSlug) return [];
+    return [
+      {
+        key: 'signals',
+        label: tCoherence('signals'),
+        icon: Radio,
+        href: `/${lang}/dho/${spaceSlug}/coherence`,
+        active: pathname.includes('/coherence'),
+      },
+      {
+        key: 'agreements',
+        label: tCommon('Agreements'),
+        icon: FileCheck2,
+        href: `/${lang}/dho/${spaceSlug}/agreements`,
+        active: pathname.includes('/agreements'),
+      },
+      {
+        key: 'members',
+        label: tCommon('Members'),
+        icon: UsersRound,
+        href: `/${lang}/dho/${spaceSlug}/members`,
+        active: pathname.includes('/members'),
+      },
+      {
+        key: 'treasury',
+        label: tCommon('Treasury'),
+        icon: HandCoins,
+        href: `/${lang}/dho/${spaceSlug}/treasury`,
+        active: pathname.includes('/treasury'),
+      },
+    ];
+  }, [lang, pathname, spaceSlug, tCommon, tCoherence]);
 
   const [input, setInput] = useState('');
 
@@ -63,7 +123,7 @@ export function AiLeftPanel() {
     [getAccessToken, spaceSlug],
   );
 
-  const { messages, sendMessage, stop, status, setMessages, error } = useChat({
+  const { messages, sendMessage, stop, status, error } = useChat({
     transport,
   });
 
@@ -100,8 +160,6 @@ export function AiLeftPanel() {
     void stop();
   }, [stop]);
 
-  const handleResetChat = useCallback(() => setMessages([]), [setMessages]);
-
   const handleSuggestionSelect = useCallback(
     async (text: string) => {
       try {
@@ -123,7 +181,7 @@ export function AiLeftPanel() {
     return (
       <>
         <SidebarHeader className="bg-background-2 p-0">
-          <AiPanelHeader onResetChat={handleResetChat} />
+          <AiPanelHeader />
         </SidebarHeader>
         <SidebarContent className="flex flex-1 items-center justify-center">
           <div className="text-sm text-muted-foreground">{t('loading')}</div>
@@ -136,7 +194,7 @@ export function AiLeftPanel() {
     return (
       <>
         <SidebarHeader className="bg-background-2 p-0">
-          <AiPanelHeader onResetChat={handleResetChat} />
+          <AiPanelHeader />
         </SidebarHeader>
         <SidebarContent className="flex flex-1 flex-col items-center justify-center gap-4 p-6">
           <div className="text-center text-sm text-muted-foreground">
@@ -153,12 +211,69 @@ export function AiLeftPanel() {
     );
   }
 
+  if (isCollapsed) {
+    return (
+      <>
+        <SidebarHeader className="items-center bg-background-2 p-2">
+          <div className="flex h-8 w-8 items-center justify-center overflow-hidden rounded-xl bg-muted ring-1 ring-border/70">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={activeSpaceIcon}
+              alt={activeSpaceTitle}
+              className="h-full w-full object-cover"
+            />
+          </div>
+        </SidebarHeader>
+        <SidebarContent className="bg-background-2">
+          <SidebarGroup className="p-2">
+            <SidebarGroupContent>
+              <SidebarMenu className="items-center">
+                {sectionNavItems.map((item) => (
+                  <SidebarMenuItem key={item.key}>
+                    <SidebarMenuButton
+                      asChild
+                      tooltip={item.label}
+                      isActive={item.active}
+                      className="justify-center px-0"
+                    >
+                      <Link href={item.href} aria-label={item.label}>
+                        <item.icon />
+                      </Link>
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
+                ))}
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
+        </SidebarContent>
+      </>
+    );
+  }
+
   return (
     <>
       <SidebarHeader className="bg-background-2 p-0">
-        <AiPanelHeader onResetChat={handleResetChat} />
+        <AiPanelHeader />
       </SidebarHeader>
       <SidebarContent className="bg-background-2 min-h-0">
+        {sectionNavItems.length > 0 ? (
+          <SidebarGroup className="border-b border-border/70 p-2">
+            <SidebarGroupContent>
+              <SidebarMenu>
+                {sectionNavItems.map((item) => (
+                  <SidebarMenuItem key={item.key}>
+                    <SidebarMenuButton asChild isActive={item.active}>
+                      <Link href={item.href}>
+                        <item.icon />
+                        <span>{item.label}</span>
+                      </Link>
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
+                ))}
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
+        ) : null}
         {error && (
           <div
             role="alert"

--- a/packages/epics/src/common/ai-left-panel.tsx
+++ b/packages/epics/src/common/ai-left-panel.tsx
@@ -60,6 +60,14 @@ export function AiLeftPanel() {
   const activeSpaceIcon =
     activeSpaces[0]?.logoUrl?.trim() || DEFAULT_SPACE_AVATAR_IMAGE;
   const activeSpaceTitle = activeSpaces[0]?.title?.trim() || t('title');
+  const isSectionActive = useCallback(
+    (section: 'coherence' | 'agreements' | 'members' | 'treasury') => {
+      if (!spaceSlug) return false;
+      const base = `/${lang}/dho/${spaceSlug}/${section}`;
+      return pathname === base || pathname.startsWith(`${base}/`);
+    },
+    [lang, pathname, spaceSlug],
+  );
 
   const sectionNavItems = useMemo(() => {
     if (!spaceSlug) return [];
@@ -69,31 +77,31 @@ export function AiLeftPanel() {
         label: tCoherence('signals'),
         icon: Radio,
         href: `/${lang}/dho/${spaceSlug}/coherence`,
-        active: pathname.includes('/coherence'),
+        active: isSectionActive('coherence'),
       },
       {
         key: 'agreements',
         label: tCommon('Agreements'),
         icon: FileCheck2,
         href: `/${lang}/dho/${spaceSlug}/agreements`,
-        active: pathname.includes('/agreements'),
+        active: isSectionActive('agreements'),
       },
       {
         key: 'members',
         label: tCommon('Members'),
         icon: UsersRound,
         href: `/${lang}/dho/${spaceSlug}/members`,
-        active: pathname.includes('/members'),
+        active: isSectionActive('members'),
       },
       {
         key: 'treasury',
         label: tCommon('Treasury'),
         icon: HandCoins,
         href: `/${lang}/dho/${spaceSlug}/treasury`,
-        active: pathname.includes('/treasury'),
+        active: isSectionActive('treasury'),
       },
     ];
-  }, [lang, pathname, spaceSlug, tCommon, tCoherence]);
+  }, [isSectionActive, lang, spaceSlug, tCommon, tCoherence]);
 
   const [input, setInput] = useState('');
 

--- a/packages/epics/src/common/ai-left-panel.tsx
+++ b/packages/epics/src/common/ai-left-panel.tsx
@@ -8,10 +8,7 @@ import { useParams, usePathname } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import Link from 'next/link';
 import { Coins, FileCheck2, Radio, Sparkles, UsersRound } from 'lucide-react';
-import {
-  Space,
-  useSpacesBySlugs,
-} from '@hypha-platform/core/client';
+import { Space, useSpacesBySlugs } from '@hypha-platform/core/client';
 import useSWR from 'swr';
 import {
   SidebarHeader,

--- a/packages/epics/src/common/ai-left-panel.tsx
+++ b/packages/epics/src/common/ai-left-panel.tsx
@@ -7,12 +7,7 @@ import { useAuthentication } from '@hypha-platform/authentication';
 import { useParams, usePathname } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import Link from 'next/link';
-import {
-  FileCheck2,
-  HandCoins,
-  Radio,
-  UsersRound,
-} from 'lucide-react';
+import { FileCheck2, HandCoins, Radio, UsersRound } from 'lucide-react';
 import {
   DEFAULT_SPACE_AVATAR_IMAGE,
   useSpacesBySlugs,
@@ -59,7 +54,9 @@ export function AiLeftPanel() {
   const lang = typeof params?.lang === 'string' ? params.lang : 'en';
   const { state: sidebarState } = useSidebar();
   const isCollapsed = sidebarState === 'collapsed';
-  const { spaces: activeSpaces } = useSpacesBySlugs(spaceSlug ? [spaceSlug] : []);
+  const { spaces: activeSpaces } = useSpacesBySlugs(
+    spaceSlug ? [spaceSlug] : [],
+  );
   const activeSpaceIcon =
     activeSpaces[0]?.logoUrl?.trim() || DEFAULT_SPACE_AVATAR_IMAGE;
   const activeSpaceTitle = activeSpaces[0]?.title?.trim() || t('title');

--- a/packages/epics/src/common/ai-left-panel.tsx
+++ b/packages/epics/src/common/ai-left-panel.tsx
@@ -8,16 +8,18 @@ import { useParams, usePathname } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import Link from 'next/link';
 import {
-  FileCheck2,
-  HandCoins,
+  FileText,
+  Landmark,
   PanelLeftClose,
-  Radio,
-  UsersRound,
+  RadioTower,
+  Users,
 } from 'lucide-react';
 import {
+  Space,
   DEFAULT_SPACE_AVATAR_IMAGE,
   useSpacesBySlugs,
 } from '@hypha-platform/core/client';
+import useSWR from 'swr';
 import {
   SidebarHeader,
   SidebarContent,
@@ -66,9 +68,28 @@ export function AiLeftPanel() {
   const { spaces: activeSpaces } = useSpacesBySlugs(
     spaceSlug ? [spaceSlug] : [],
   );
+  const { data: allSpaces = [] } = useSWR<Space[]>(
+    '/api/v1/spaces?parentOnly=false',
+    async (url: string) => {
+      const response = await fetch(url, {
+        headers: { Accept: 'application/json' },
+      });
+      if (!response.ok) return [];
+      return (await response.json()) as Space[];
+    },
+  );
+  const activeSpaceFromList = useMemo(
+    () => allSpaces.find((space) => space.slug === spaceSlug),
+    [allSpaces, spaceSlug],
+  );
   const activeSpaceIcon =
-    activeSpaces[0]?.logoUrl?.trim() || DEFAULT_SPACE_AVATAR_IMAGE;
-  const activeSpaceTitle = activeSpaces[0]?.title?.trim() || t('title');
+    activeSpaceFromList?.logoUrl?.trim() ||
+    activeSpaces[0]?.logoUrl?.trim() ||
+    DEFAULT_SPACE_AVATAR_IMAGE;
+  const activeSpaceTitle =
+    activeSpaceFromList?.title?.trim() ||
+    activeSpaces[0]?.title?.trim() ||
+    t('title');
   const isSectionActive = useCallback(
     (section: 'coherence' | 'agreements' | 'members' | 'treasury') => {
       if (!spaceSlug) return false;
@@ -84,28 +105,28 @@ export function AiLeftPanel() {
       {
         key: 'signals',
         label: tCoherence('signals'),
-        icon: Radio,
+        icon: RadioTower,
         href: `/${lang}/dho/${spaceSlug}/coherence`,
         active: isSectionActive('coherence'),
       },
       {
         key: 'agreements',
         label: tCommon('Agreements'),
-        icon: FileCheck2,
+        icon: FileText,
         href: `/${lang}/dho/${spaceSlug}/agreements`,
         active: isSectionActive('agreements'),
       },
       {
         key: 'members',
         label: tCommon('Members'),
-        icon: UsersRound,
+        icon: Users,
         href: `/${lang}/dho/${spaceSlug}/members`,
         active: isSectionActive('members'),
       },
       {
         key: 'treasury',
         label: tCommon('Treasury'),
-        icon: HandCoins,
+        icon: Landmark,
         href: `/${lang}/dho/${spaceSlug}/treasury`,
         active: isSectionActive('treasury'),
       },
@@ -248,10 +269,10 @@ export function AiLeftPanel() {
                       asChild
                       tooltip={item.label}
                       isActive={item.active}
-                      className="justify-center px-0"
+                      className="h-10 w-10 justify-center rounded-xl p-0"
                     >
                       <Link href={item.href} aria-label={item.label}>
-                        <item.icon />
+                        <item.icon className="h-5 w-5" strokeWidth={2.1} />
                       </Link>
                     </SidebarMenuButton>
                   </SidebarMenuItem>
@@ -272,7 +293,7 @@ export function AiLeftPanel() {
                     <SidebarMenuItem key={`overlay-${item.key}`}>
                       <SidebarMenuButton asChild isActive={item.active}>
                         <Link href={item.href} aria-label={item.label}>
-                          <item.icon />
+                          <item.icon className="h-5 w-5" strokeWidth={2.1} />
                           <span>{item.label}</span>
                         </Link>
                       </SidebarMenuButton>

--- a/packages/epics/src/common/ai-left-panel.tsx
+++ b/packages/epics/src/common/ai-left-panel.tsx
@@ -29,7 +29,6 @@ import {
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
-  useSidebar,
 } from '@hypha-platform/ui';
 
 import { AiPanelHeader, AiPanelMessages, AiPanelChatBar } from './ai-panel';
@@ -61,10 +60,13 @@ export function AiLeftPanel() {
   const tCommon = useTranslations('Common');
   const tCoherence = useTranslations('CoherenceTab');
   const lang = typeof params?.lang === 'string' ? params.lang : 'en';
-  const { state: sidebarState } = useSidebar();
-  const isCollapsed = sidebarState === 'collapsed';
-  const { overlayVisible, showAiOverlay, hideAiOverlay, closeAiPanel } =
-    useAiPanel();
+  const {
+    open: isAiOpen,
+    overlayVisible,
+    showAiOverlay,
+    hideAiOverlay,
+    closeAiPanel,
+  } = useAiPanel();
   const { spaces: activeSpaces } = useSpacesBySlugs(
     spaceSlug ? [spaceSlug] : [],
   );
@@ -246,7 +248,67 @@ export function AiLeftPanel() {
     );
   }
 
-  if (isCollapsed) {
+  if (!isAiOpen) {
+    if (overlayVisible) {
+      return (
+        <>
+          <SidebarHeader className="bg-background-2 p-0">
+            <div className="flex min-h-[var(--menu-top-height,65px)] border-b border-border bg-background-2">
+              <div className="flex w-[72px] shrink-0 items-center justify-center border-r border-border px-2">
+                <div className="flex h-7 w-7 items-center justify-center overflow-hidden rounded-xl bg-muted ring-1 ring-border/70">
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img
+                    src={activeSpaceIcon}
+                    alt={activeSpaceTitle}
+                    className="h-full w-full object-cover"
+                  />
+                </div>
+              </div>
+              <div className="min-w-0 flex-1">
+                <AiPanelHeader showCloseButton={false} />
+              </div>
+            </div>
+          </SidebarHeader>
+          <SidebarContent className="bg-background-2">
+            <div className="flex h-full">
+              <div className="w-[72px] shrink-0 border-r border-border bg-background-2 p-2">
+                <SidebarMenu className="items-center">
+                  {sectionNavItems.map((item) => (
+                    <SidebarMenuItem key={item.key}>
+                      <SidebarMenuButton
+                        asChild
+                        tooltip={item.label}
+                        isActive={item.active}
+                        className="h-10 w-10 justify-center rounded-xl p-0"
+                      >
+                        <Link href={item.href} aria-label={item.label}>
+                          <item.icon className="h-5 w-5" strokeWidth={2.1} />
+                        </Link>
+                      </SidebarMenuButton>
+                    </SidebarMenuItem>
+                  ))}
+                </SidebarMenu>
+              </div>
+              <div className="min-w-0 flex-1 p-2">
+                <SidebarMenu>
+                  {sectionNavItems.map((item) => (
+                    <SidebarMenuItem key={`overlay-${item.key}`}>
+                      <SidebarMenuButton asChild isActive={item.active}>
+                        <Link href={item.href} aria-label={item.label}>
+                          <item.icon className="h-5 w-5" strokeWidth={2.1} />
+                          <span>{item.label}</span>
+                        </Link>
+                      </SidebarMenuButton>
+                    </SidebarMenuItem>
+                  ))}
+                </SidebarMenu>
+              </div>
+            </div>
+          </SidebarContent>
+        </>
+      );
+    }
+
     return (
       <>
         <SidebarHeader className="items-center bg-background-2 p-2">
@@ -280,29 +342,6 @@ export function AiLeftPanel() {
               </SidebarMenu>
             </SidebarGroupContent>
           </SidebarGroup>
-          {overlayVisible ? (
-            <div
-              className="absolute left-full top-0 z-[70] w-[272px] overflow-hidden rounded-xl border border-border/90 bg-background-2 shadow-2xl"
-              onMouseEnter={showAiOverlay}
-              onMouseLeave={hideAiOverlay}
-            >
-              <AiPanelHeader showCloseButton={false} />
-              <div className="p-2">
-                <SidebarMenu>
-                  {sectionNavItems.map((item) => (
-                    <SidebarMenuItem key={`overlay-${item.key}`}>
-                      <SidebarMenuButton asChild isActive={item.active}>
-                        <Link href={item.href} aria-label={item.label}>
-                          <item.icon className="h-5 w-5" strokeWidth={2.1} />
-                          <span>{item.label}</span>
-                        </Link>
-                      </SidebarMenuButton>
-                    </SidebarMenuItem>
-                  ))}
-                </SidebarMenu>
-              </div>
-            </div>
-          ) : null}
         </SidebarContent>
       </>
     );

--- a/packages/epics/src/common/ai-left-panel.tsx
+++ b/packages/epics/src/common/ai-left-panel.tsx
@@ -246,7 +246,7 @@ export function AiLeftPanel() {
       return (
         <>
           <SidebarHeader className="bg-background-2 p-0">
-            <AiPanelHeader showCloseButton={false} />
+            <AiPanelHeader />
           </SidebarHeader>
           <SidebarContent
             className="bg-background-2"

--- a/packages/epics/src/common/ai-left-panel.tsx
+++ b/packages/epics/src/common/ai-left-panel.tsx
@@ -272,7 +272,7 @@ export function AiLeftPanel() {
                       <SidebarMenuButton
                         asChild
                         isActive={item.active}
-                        className="data-[active=true]:bg-accent-9/20 data-[active=true]:text-foreground"
+                        className="rounded-md transition-colors hover:bg-muted/60 hover:text-foreground data-[active=true]:bg-muted data-[active=true]:text-foreground"
                       >
                         <Link
                           href={item.href}
@@ -328,7 +328,7 @@ export function AiLeftPanel() {
                       asChild
                       tooltip={item.label}
                       isActive={item.active}
-                      className="h-10 w-10 justify-center rounded-xl p-0 data-[active=true]:bg-accent-9/20 data-[active=true]:text-foreground"
+                      className="h-10 w-10 justify-center rounded-xl p-0 transition-colors hover:bg-muted/60 hover:text-foreground data-[active=true]:bg-muted data-[active=true]:text-foreground"
                     >
                       <Link
                         href={item.href}

--- a/packages/epics/src/common/ai-left-panel.tsx
+++ b/packages/epics/src/common/ai-left-panel.tsx
@@ -271,8 +271,8 @@ export function AiLeftPanel() {
           </SidebarHeader>
           <SidebarContent className="bg-background-2">
             <div className="flex h-full">
-              <div className="w-[72px] shrink-0 border-r border-border bg-background-2 p-2">
-                <SidebarMenu className="items-center">
+              <div className="w-[72px] shrink-0 border-r border-border bg-background-2 p-2 pt-4">
+                <SidebarMenu className="items-center gap-2">
                   {sectionNavItems.map((item) => (
                     <SidebarMenuItem key={item.key}>
                       <SidebarMenuButton
@@ -311,7 +311,7 @@ export function AiLeftPanel() {
 
     return (
       <>
-        <SidebarHeader className="items-center bg-background-2 p-2">
+        <SidebarHeader className="min-h-[var(--menu-top-height,65px)] items-center justify-center border-b border-border bg-background-2 p-2">
           <div className="flex h-7 w-7 items-center justify-center overflow-hidden rounded-xl bg-muted ring-1 ring-border/70">
             {/* eslint-disable-next-line @next/next/no-img-element */}
             <img
@@ -322,9 +322,9 @@ export function AiLeftPanel() {
           </div>
         </SidebarHeader>
         <SidebarContent className="relative overflow-visible bg-background-2">
-          <SidebarGroup className="p-2">
+          <SidebarGroup className="p-2 pt-4">
             <SidebarGroupContent>
-              <SidebarMenu className="items-center">
+              <SidebarMenu className="items-center gap-2">
                 {sectionNavItems.map((item) => (
                   <SidebarMenuItem key={item.key}>
                     <SidebarMenuButton

--- a/packages/epics/src/common/ai-left-panel.tsx
+++ b/packages/epics/src/common/ai-left-panel.tsx
@@ -254,8 +254,16 @@ export function AiLeftPanel() {
                 <SidebarMenu>
                   {sectionNavItems.map((item) => (
                     <SidebarMenuItem key={`overlay-${item.key}`}>
-                      <SidebarMenuButton asChild isActive={item.active}>
-                        <Link href={item.href} aria-label={item.label}>
+                      <SidebarMenuButton
+                        asChild
+                        isActive={item.active}
+                        className="data-[active=true]:bg-accent-9/20 data-[active=true]:text-foreground"
+                      >
+                        <Link
+                          href={item.href}
+                          aria-label={item.label}
+                          aria-current={item.active ? 'page' : undefined}
+                        >
                           <item.icon className="h-5 w-5" strokeWidth={2.1} />
                           <span>{item.label}</span>
                         </Link>
@@ -292,9 +300,13 @@ export function AiLeftPanel() {
                       asChild
                       tooltip={item.label}
                       isActive={item.active}
-                      className="h-10 w-10 justify-center rounded-xl p-0"
+                      className="h-10 w-10 justify-center rounded-xl p-0 data-[active=true]:bg-accent-9/20 data-[active=true]:text-foreground"
                     >
-                      <Link href={item.href} aria-label={item.label}>
+                      <Link
+                        href={item.href}
+                        aria-label={item.label}
+                        aria-current={item.active ? 'page' : undefined}
+                      >
                         <item.icon className="h-5 w-5" strokeWidth={2.1} />
                       </Link>
                     </SidebarMenuButton>

--- a/packages/epics/src/common/ai-left-panel.tsx
+++ b/packages/epics/src/common/ai-left-panel.tsx
@@ -248,7 +248,11 @@ export function AiLeftPanel() {
           <SidebarHeader className="bg-background-2 p-0">
             <AiPanelHeader showCloseButton={false} />
           </SidebarHeader>
-          <SidebarContent className="bg-background-2">
+          <SidebarContent
+            className="bg-background-2"
+            onMouseEnter={showAiOverlay}
+            onMouseLeave={hideAiOverlay}
+          >
             <SidebarGroup className="p-2 pt-4">
               <SidebarGroupContent>
                 <SidebarMenu>
@@ -290,7 +294,11 @@ export function AiLeftPanel() {
             />
           </div>
         </SidebarHeader>
-        <SidebarContent className="relative overflow-visible bg-background-2">
+        <SidebarContent
+          className="relative overflow-visible bg-background-2"
+          onMouseEnter={showAiOverlay}
+          onMouseLeave={hideAiOverlay}
+        >
           <SidebarGroup className="p-2 pt-4">
             <SidebarGroupContent>
               <SidebarMenu className="items-center gap-2">

--- a/packages/epics/src/common/ai-left-panel.tsx
+++ b/packages/epics/src/common/ai-left-panel.tsx
@@ -26,6 +26,7 @@ import {
 
 import { AiPanelHeader, AiPanelMessages, AiPanelChatBar } from './ai-panel';
 import { getDhoSpaceSlugFromPathname } from './get-dho-space-slug-from-pathname';
+import { useAiPanel } from './human-chat-panel-context';
 
 type ChatUIMessage = {
   id: string;
@@ -54,6 +55,7 @@ export function AiLeftPanel() {
   const lang = typeof params?.lang === 'string' ? params.lang : 'en';
   const { state: sidebarState } = useSidebar();
   const isCollapsed = sidebarState === 'collapsed';
+  const { overlayVisible, showAiOverlay, hideAiOverlay } = useAiPanel();
   const { spaces: activeSpaces } = useSpacesBySlugs(
     spaceSlug ? [spaceSlug] : [],
   );
@@ -229,7 +231,7 @@ export function AiLeftPanel() {
             />
           </div>
         </SidebarHeader>
-        <SidebarContent className="bg-background-2">
+        <SidebarContent className="relative bg-background-2">
           <SidebarGroup className="p-2">
             <SidebarGroupContent>
               <SidebarMenu className="items-center">
@@ -250,6 +252,29 @@ export function AiLeftPanel() {
               </SidebarMenu>
             </SidebarGroupContent>
           </SidebarGroup>
+          {overlayVisible ? (
+            <div
+              className="absolute left-[calc(100%+0.5rem)] top-2 z-[60] w-[272px] overflow-hidden rounded-xl border border-border/90 bg-background-2 shadow-2xl"
+              onMouseEnter={showAiOverlay}
+              onMouseLeave={hideAiOverlay}
+            >
+              <AiPanelHeader showCloseButton={false} />
+              <div className="p-2">
+                <SidebarMenu>
+                  {sectionNavItems.map((item) => (
+                    <SidebarMenuItem key={`overlay-${item.key}`}>
+                      <SidebarMenuButton asChild isActive={item.active}>
+                        <Link href={item.href} aria-label={item.label}>
+                          <item.icon />
+                          <span>{item.label}</span>
+                        </Link>
+                      </SidebarMenuButton>
+                    </SidebarMenuItem>
+                  ))}
+                </SidebarMenu>
+              </div>
+            </div>
+          ) : null}
         </SidebarContent>
       </>
     );

--- a/packages/epics/src/common/ai-left-panel.tsx
+++ b/packages/epics/src/common/ai-left-panel.tsx
@@ -7,7 +7,13 @@ import { useAuthentication } from '@hypha-platform/authentication';
 import { useParams, usePathname } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import Link from 'next/link';
-import { FileCheck2, HandCoins, Radio, UsersRound } from 'lucide-react';
+import {
+  FileCheck2,
+  HandCoins,
+  PanelLeftClose,
+  Radio,
+  UsersRound,
+} from 'lucide-react';
 import {
   DEFAULT_SPACE_AVATAR_IMAGE,
   useSpacesBySlugs,
@@ -55,7 +61,8 @@ export function AiLeftPanel() {
   const lang = typeof params?.lang === 'string' ? params.lang : 'en';
   const { state: sidebarState } = useSidebar();
   const isCollapsed = sidebarState === 'collapsed';
-  const { overlayVisible, showAiOverlay, hideAiOverlay } = useAiPanel();
+  const { overlayVisible, showAiOverlay, hideAiOverlay, closeAiPanel } =
+    useAiPanel();
   const { spaces: activeSpaces } = useSpacesBySlugs(
     spaceSlug ? [spaceSlug] : [],
   );
@@ -282,28 +289,20 @@ export function AiLeftPanel() {
 
   return (
     <>
-      <SidebarHeader className="bg-background-2 p-0">
-        <AiPanelHeader />
+      <SidebarHeader className="border-b border-border bg-background-2 p-2">
+        <div className="flex items-center justify-end">
+          <button
+            type="button"
+            onClick={closeAiPanel}
+            className="flex h-7 w-7 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            title={t('hidePanel')}
+            aria-label={t('closePanel')}
+          >
+            <PanelLeftClose className="h-3.5 w-3.5" />
+          </button>
+        </div>
       </SidebarHeader>
       <SidebarContent className="bg-background-2 min-h-0">
-        {sectionNavItems.length > 0 ? (
-          <SidebarGroup className="border-b border-border/70 p-2">
-            <SidebarGroupContent>
-              <SidebarMenu>
-                {sectionNavItems.map((item) => (
-                  <SidebarMenuItem key={item.key}>
-                    <SidebarMenuButton asChild isActive={item.active}>
-                      <Link href={item.href}>
-                        <item.icon />
-                        <span>{item.label}</span>
-                      </Link>
-                    </SidebarMenuButton>
-                  </SidebarMenuItem>
-                ))}
-              </SidebarMenu>
-            </SidebarGroupContent>
-          </SidebarGroup>
-        ) : null}
         {error && (
           <div
             role="alert"

--- a/packages/epics/src/common/ai-left-panel.tsx
+++ b/packages/epics/src/common/ai-left-panel.tsx
@@ -7,7 +7,7 @@ import { useAuthentication } from '@hypha-platform/authentication';
 import { useParams, usePathname } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import Link from 'next/link';
-import { FileText, Landmark, RadioTower, Users } from 'lucide-react';
+import { Coins, FileCheck2, Radio, UsersRound } from 'lucide-react';
 import {
   Space,
   DEFAULT_SPACE_AVATAR_IMAGE,
@@ -100,28 +100,28 @@ export function AiLeftPanel() {
       {
         key: 'signals',
         label: tCoherence('signals'),
-        icon: RadioTower,
+        icon: Radio,
         href: `/${lang}/dho/${spaceSlug}/coherence`,
         active: isSectionActive('coherence'),
       },
       {
         key: 'agreements',
         label: tCommon('Agreements'),
-        icon: FileText,
+        icon: FileCheck2,
         href: `/${lang}/dho/${spaceSlug}/agreements`,
         active: isSectionActive('agreements'),
       },
       {
         key: 'members',
         label: tCommon('Members'),
-        icon: Users,
+        icon: UsersRound,
         href: `/${lang}/dho/${spaceSlug}/members`,
         active: isSectionActive('members'),
       },
       {
         key: 'treasury',
         label: tCommon('Treasury'),
-        icon: Landmark,
+        icon: Coins,
         href: `/${lang}/dho/${spaceSlug}/treasury`,
         active: isSectionActive('treasury'),
       },

--- a/packages/epics/src/common/ai-left-panel.tsx
+++ b/packages/epics/src/common/ai-left-panel.tsx
@@ -7,13 +7,7 @@ import { useAuthentication } from '@hypha-platform/authentication';
 import { useParams, usePathname } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import Link from 'next/link';
-import {
-  FileText,
-  Landmark,
-  PanelLeftClose,
-  RadioTower,
-  Users,
-} from 'lucide-react';
+import { FileText, Landmark, RadioTower, Users } from 'lucide-react';
 import {
   Space,
   DEFAULT_SPACE_AVATAR_IMAGE,
@@ -65,7 +59,6 @@ export function AiLeftPanel() {
     overlayVisible,
     showAiOverlay,
     hideAiOverlay,
-    closeAiPanel,
   } = useAiPanel();
   const { spaces: activeSpaces } = useSpacesBySlugs(
     spaceSlug ? [spaceSlug] : [],
@@ -253,43 +246,11 @@ export function AiLeftPanel() {
       return (
         <>
           <SidebarHeader className="bg-background-2 p-0">
-            <div className="flex min-h-[var(--menu-top-height,65px)] border-b border-border bg-background-2">
-              <div className="flex w-[72px] shrink-0 items-center justify-center border-r border-border px-2">
-                <div className="flex h-7 w-7 items-center justify-center overflow-hidden rounded-xl bg-muted ring-1 ring-border/70">
-                  {/* eslint-disable-next-line @next/next/no-img-element */}
-                  <img
-                    src={activeSpaceIcon}
-                    alt={activeSpaceTitle}
-                    className="h-full w-full object-cover"
-                  />
-                </div>
-              </div>
-              <div className="min-w-0 flex-1">
-                <AiPanelHeader showCloseButton={false} />
-              </div>
-            </div>
+            <AiPanelHeader showCloseButton={false} />
           </SidebarHeader>
           <SidebarContent className="bg-background-2">
-            <div className="flex h-full">
-              <div className="w-[72px] shrink-0 border-r border-border bg-background-2 p-2 pt-4">
-                <SidebarMenu className="items-center gap-2">
-                  {sectionNavItems.map((item) => (
-                    <SidebarMenuItem key={item.key}>
-                      <SidebarMenuButton
-                        asChild
-                        tooltip={item.label}
-                        isActive={item.active}
-                        className="h-10 w-10 justify-center rounded-xl p-0"
-                      >
-                        <Link href={item.href} aria-label={item.label}>
-                          <item.icon className="h-5 w-5" strokeWidth={2.1} />
-                        </Link>
-                      </SidebarMenuButton>
-                    </SidebarMenuItem>
-                  ))}
-                </SidebarMenu>
-              </div>
-              <div className="min-w-0 flex-1 p-2">
+            <SidebarGroup className="p-2 pt-4">
+              <SidebarGroupContent>
                 <SidebarMenu>
                   {sectionNavItems.map((item) => (
                     <SidebarMenuItem key={`overlay-${item.key}`}>
@@ -302,8 +263,8 @@ export function AiLeftPanel() {
                     </SidebarMenuItem>
                   ))}
                 </SidebarMenu>
-              </div>
-            </div>
+              </SidebarGroupContent>
+            </SidebarGroup>
           </SidebarContent>
         </>
       );
@@ -349,18 +310,8 @@ export function AiLeftPanel() {
 
   return (
     <>
-      <SidebarHeader className="border-b border-border bg-background-2 p-2">
-        <div className="flex items-center justify-end">
-          <button
-            type="button"
-            onClick={closeAiPanel}
-            className="flex h-7 w-7 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-            title={t('hidePanel')}
-            aria-label={t('closePanel')}
-          >
-            <PanelLeftClose className="h-3.5 w-3.5" />
-          </button>
-        </div>
+      <SidebarHeader className="bg-background-2 p-0">
+        <AiPanelHeader />
       </SidebarHeader>
       <SidebarContent className="bg-background-2 min-h-0">
         {error && (

--- a/packages/epics/src/common/ai-left-panel.tsx
+++ b/packages/epics/src/common/ai-left-panel.tsx
@@ -7,10 +7,9 @@ import { useAuthentication } from '@hypha-platform/authentication';
 import { useParams, usePathname } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import Link from 'next/link';
-import { Coins, FileCheck2, Radio, UsersRound } from 'lucide-react';
+import { Coins, FileCheck2, Radio, Sparkles, UsersRound } from 'lucide-react';
 import {
   Space,
-  DEFAULT_SPACE_AVATAR_IMAGE,
   useSpacesBySlugs,
 } from '@hypha-platform/core/client';
 import useSWR from 'swr';
@@ -80,7 +79,7 @@ export function AiLeftPanel() {
   const activeSpaceIcon =
     activeSpaceFromList?.logoUrl?.trim() ||
     activeSpaces[0]?.logoUrl?.trim() ||
-    DEFAULT_SPACE_AVATAR_IMAGE;
+    null;
   const activeSpaceTitle =
     activeSpaceFromList?.title?.trim() ||
     activeSpaces[0]?.title?.trim() ||
@@ -286,12 +285,18 @@ export function AiLeftPanel() {
       <>
         <SidebarHeader className="min-h-[var(--menu-top-height,65px)] items-center justify-center border-b border-border bg-background-2 p-2">
           <div className="flex h-7 w-7 items-center justify-center overflow-hidden rounded-xl bg-muted ring-1 ring-border/70">
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
-              src={activeSpaceIcon}
-              alt={activeSpaceTitle}
-              className="h-full w-full object-cover"
-            />
+            {activeSpaceIcon ? (
+              <>
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={activeSpaceIcon}
+                  alt={activeSpaceTitle}
+                  className="h-full w-full object-cover"
+                />
+              </>
+            ) : (
+              <Sparkles className="h-4 w-4 text-muted-foreground" />
+            )}
           </div>
         </SidebarHeader>
         <SidebarContent

--- a/packages/epics/src/common/ai-left-panel.tsx
+++ b/packages/epics/src/common/ai-left-panel.tsx
@@ -205,6 +205,17 @@ export function AiLeftPanel() {
     },
     [sendMessage, buildMessageOptions],
   );
+  const handleHeaderIconMouseEnter = useCallback(() => {
+    if (!overlayVisible) {
+      showAiOverlay();
+    }
+  }, [overlayVisible, showAiOverlay]);
+
+  const handleExpandedRegionMouseEnter = useCallback(() => {
+    if (overlayVisible) {
+      showAiOverlay();
+    }
+  }, [overlayVisible, showAiOverlay]);
 
   if (isLoading) {
     return (
@@ -244,12 +255,16 @@ export function AiLeftPanel() {
     if (overlayVisible) {
       return (
         <>
-          <SidebarHeader className="bg-background-2 p-0">
+          <SidebarHeader
+            className="bg-background-2 p-0"
+            onMouseEnter={handleExpandedRegionMouseEnter}
+            onMouseLeave={hideAiOverlay}
+          >
             <AiPanelHeader />
           </SidebarHeader>
           <SidebarContent
             className="bg-background-2"
-            onMouseEnter={showAiOverlay}
+            onMouseEnter={handleExpandedRegionMouseEnter}
             onMouseLeave={hideAiOverlay}
           >
             <SidebarGroup className="p-2 pt-4">
@@ -284,7 +299,10 @@ export function AiLeftPanel() {
     return (
       <>
         <SidebarHeader className="min-h-[var(--menu-top-height,65px)] items-center justify-center border-b border-border bg-background-2 p-2">
-          <div className="flex h-7 w-7 items-center justify-center overflow-hidden rounded-xl bg-muted ring-1 ring-border/70">
+          <div
+            className="flex h-7 w-7 items-center justify-center overflow-hidden rounded-xl bg-muted ring-1 ring-border/70"
+            onMouseEnter={handleHeaderIconMouseEnter}
+          >
             {activeSpaceIcon ? (
               <>
                 {/* eslint-disable-next-line @next/next/no-img-element */}

--- a/packages/epics/src/common/ai-panel/ai-panel-chat-bar.tsx
+++ b/packages/epics/src/common/ai-panel/ai-panel-chat-bar.tsx
@@ -1,10 +1,85 @@
 'use client';
 
-import { useCallback, useRef } from 'react';
-import { Send, Square } from 'lucide-react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { AtSign, Mic, Plus, Send, Smile, Square } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 
 import { cn } from '@hypha-platform/ui-utils';
+
+type SpeechRecognitionCtor = new () => SpeechRecognitionLike;
+
+type SpeechRecognitionLike = {
+  continuous: boolean;
+  interimResults: boolean;
+  lang: string;
+  onresult: ((ev: SpeechRecognitionEventLike) => void) | null;
+  onerror: ((ev: { error?: string }) => void) | null;
+  onend: (() => void) | null;
+  start: () => void;
+  stop: () => void;
+  abort: () => void;
+};
+
+type SpeechRecognitionEventLike = {
+  resultIndex: number;
+  results: ArrayLike<{ 0: { transcript: string }; isFinal: boolean }>;
+};
+
+function joinWithSingleSpace(a: string, b: string): string {
+  const left = a.trimEnd();
+  const right = b.trimStart();
+  if (!left) return right;
+  if (!right) return left;
+  if (/\s$/.test(left) || /^\s/.test(right)) return left + right;
+  return `${left} ${right}`;
+}
+
+/** Blinking REC dot (“on-air”) for active dictation control. */
+function ComposerRecOnAirIndicator() {
+  return (
+    <>
+      <style>{`
+        @keyframes hypha-rec-on-air {
+          0%, 100% { opacity: 1; transform: scale(1); filter: brightness(1); }
+          50% { opacity: 0.88; transform: scale(0.94); filter: brightness(1.08); }
+        }
+        @keyframes hypha-rec-halo {
+          0%, 100% { opacity: 0.55; transform: scale(1); }
+          50% { opacity: 0.2; transform: scale(1.35); }
+        }
+        @media (prefers-reduced-motion: reduce) {
+          [data-hypha-rec-on-air], [data-hypha-rec-halo] {
+            animation: none !important;
+          }
+        }
+      `}</style>
+      <span className="relative flex h-[18px] w-[18px] items-center justify-center">
+        <span
+          data-hypha-rec-halo=""
+          className="pointer-events-none absolute h-3 w-3 rounded-full bg-red-500/35 blur-[2px]"
+          style={{
+            animationName: 'hypha-rec-halo',
+            animationDuration: '1.2s',
+            animationTimingFunction: 'ease-in-out',
+            animationIterationCount: 'infinite',
+          }}
+          aria-hidden
+        />
+        <span
+          data-hypha-rec-on-air=""
+          className="motion-safe:relative inline-block h-2 w-2 rounded-full bg-gradient-to-br from-red-400 to-red-600 shadow-[0_0_10px_rgba(239,68,68,0.55),inset_0_1px_0_rgba(255,255,255,0.35)] ring-1 ring-white/25 dark:ring-white/15"
+          style={{
+            animationName: 'hypha-rec-on-air',
+            animationDuration: '1s',
+            animationTimingFunction: 'ease-in-out',
+            animationIterationCount: 'infinite',
+          }}
+          aria-hidden
+        />
+      </span>
+    </>
+  );
+}
 
 type AiPanelChatBarProps = {
   value: string;
@@ -24,7 +99,17 @@ export function AiPanelChatBar({
   placeholder,
 }: AiPanelChatBarProps) {
   const t = useTranslations('AiPanel');
+  const tHuman = useTranslations('HumanChatPanel');
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const speechRecognitionRef = useRef<SpeechRecognitionLike | null>(null);
+  const dictationPrefixRef = useRef('');
+  const dictationInterruptForSendRef = useRef(false);
+  const dictationSessionFinalizedRef = useRef(false);
+  const valueRef = useRef(value);
+  const [isDictating, setIsDictating] = useState(false);
+  const [dictationError, setDictationError] = useState<string | null>(null);
+
+  valueRef.current = value;
 
   const autoResize = useCallback(() => {
     if (textareaRef.current) {
@@ -38,22 +123,205 @@ export function AiPanelChatBar({
     if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
       e.preventDefault();
       if (value.trim().length > 0 && !isStreaming) {
+        if (isDictating) {
+          dictationInterruptForSendRef.current = true;
+          const r = speechRecognitionRef.current;
+          if (r) {
+            try {
+              r.abort();
+            } catch {
+              try {
+                r.stop();
+              } catch {
+                // ignore
+              }
+            }
+            speechRecognitionRef.current = null;
+          }
+          setIsDictating(false);
+        }
         onSend();
       }
     }
   };
 
+  const stopDictation = useCallback(() => {
+    const r = speechRecognitionRef.current;
+    if (r) {
+      try {
+        r.abort();
+      } catch {
+        try {
+          r.stop();
+        } catch {
+          // ignore
+        }
+      }
+      speechRecognitionRef.current = null;
+    }
+    dictationPrefixRef.current = '';
+    setIsDictating(false);
+  }, []);
+
+  const startDictation = useCallback(() => {
+    setDictationError(null);
+    const SR =
+      (globalThis as unknown as { SpeechRecognition?: SpeechRecognitionCtor })
+        .SpeechRecognition ??
+      (
+        globalThis as unknown as {
+          webkitSpeechRecognition?: SpeechRecognitionCtor;
+        }
+      ).webkitSpeechRecognition;
+    if (!SR) {
+      setDictationError(tHuman('dictationNotSupported'));
+      return;
+    }
+    if (isDictating) {
+      stopDictation();
+      return;
+    }
+
+    dictationInterruptForSendRef.current = false;
+    dictationSessionFinalizedRef.current = false;
+    dictationPrefixRef.current = valueRef.current.trimEnd();
+    const rec = new SR();
+    rec.continuous = true;
+    rec.interimResults = true;
+    rec.lang = document.documentElement.lang || 'en';
+    rec.onresult = (ev) => {
+      if (dictationInterruptForSendRef.current) return;
+      let committed = '';
+      let interim = '';
+      for (let i = 0; i < ev.results.length; i++) {
+        const res = ev.results[i];
+        if (!res?.[0]) continue;
+        const transcript = res[0].transcript;
+        if (res.isFinal) {
+          committed = joinWithSingleSpace(committed, transcript.trim());
+        } else {
+          interim = joinWithSingleSpace(interim, transcript);
+        }
+      }
+      const dictated = joinWithSingleSpace(committed, interim.trim());
+      const next = joinWithSingleSpace(dictationPrefixRef.current, dictated);
+      valueRef.current = next;
+      onChange(next);
+      requestAnimationFrame(() => {
+        const el = textareaRef.current;
+        if (!el) return;
+        const end = valueRef.current.length;
+        el.setSelectionRange(end, end);
+      });
+    };
+
+    const finalizeDictationFromBrowser = (opts: {
+      syncValue: boolean;
+      showError: boolean;
+    }) => {
+      if (dictationSessionFinalizedRef.current) return;
+      dictationSessionFinalizedRef.current = true;
+      speechRecognitionRef.current = null;
+      dictationPrefixRef.current = '';
+      setIsDictating(false);
+      if (opts.syncValue) {
+        onChange(valueRef.current.trimEnd());
+      }
+      if (opts.showError) {
+        setDictationError(tHuman('dictationError'));
+      }
+    };
+
+    rec.onerror = (ev) => {
+      const interrupted = dictationInterruptForSendRef.current;
+      if (interrupted) {
+        dictationInterruptForSendRef.current = false;
+      }
+      const errorCode =
+        typeof ev === 'object' && ev !== null && 'error' in ev
+          ? (ev as { error?: string }).error
+          : undefined;
+      const benignError = errorCode === 'aborted';
+      finalizeDictationFromBrowser({
+        syncValue: !interrupted,
+        showError: !interrupted && !benignError,
+      });
+    };
+    rec.onend = () => {
+      const interrupted = dictationInterruptForSendRef.current;
+      if (interrupted) {
+        dictationInterruptForSendRef.current = false;
+      }
+      finalizeDictationFromBrowser({
+        syncValue: !interrupted,
+        showError: false,
+      });
+    };
+
+    speechRecognitionRef.current = rec;
+    try {
+      rec.start();
+      setIsDictating(true);
+      requestAnimationFrame(() => textareaRef.current?.focus());
+    } catch {
+      speechRecognitionRef.current = null;
+      setDictationError(tHuman('dictationNotSupported'));
+    }
+  }, [isDictating, onChange, stopDictation, tHuman]);
+
+  useEffect(() => {
+    return () => {
+      const r = speechRecognitionRef.current;
+      if (!r) return;
+      try {
+        r.abort();
+      } catch {
+        // ignore
+      }
+      speechRecognitionRef.current = null;
+    };
+  }, []);
+
   const canSend = value.trim().length > 0 && !isStreaming;
+  const recordingStopButtonClass =
+    'flex h-7 w-7 shrink-0 items-center justify-center rounded-lg text-red-600 transition-all duration-200 ease-out ' +
+    'border border-red-500/25 bg-gradient-to-b from-red-500/[0.14] via-red-500/[0.08] to-red-950/[0.06] ' +
+    'shadow-[inset_0_1px_0_rgba(255,255,255,0.14),0_1px_3px_rgba(220,38,38,0.14)] ' +
+    'hover:border-red-500/40 hover:from-red-500/[0.2] hover:via-red-500/[0.12] hover:to-red-950/[0.1] hover:text-red-700 hover:shadow-[inset_0_1px_0_rgba(255,255,255,0.18),0_2px_8px_rgba(220,38,38,0.18)] ' +
+    'active:scale-[0.96] active:from-red-500/[0.24] active:via-red-600/[0.14] ' +
+    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500/35 focus-visible:ring-offset-2 focus-visible:ring-offset-background ' +
+    'dark:border-red-400/22 dark:from-red-500/[0.16] dark:via-red-600/[0.1] dark:to-red-950/40 dark:text-red-400 ' +
+    'dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.06),0_1px_4px_rgba(0,0,0,0.35)] ' +
+    'dark:hover:border-red-400/38 dark:hover:text-red-300';
+  const sendMessage = useCallback(() => {
+    if (isDictating) {
+      dictationInterruptForSendRef.current = true;
+      const r = speechRecognitionRef.current;
+      if (r) {
+        try {
+          r.abort();
+        } catch {
+          try {
+            r.stop();
+          } catch {
+            // ignore
+          }
+        }
+        speechRecognitionRef.current = null;
+      }
+      setIsDictating(false);
+    }
+    onSend();
+  }, [isDictating, onSend]);
 
   return (
-    <div className="flex w-full min-w-0 flex-shrink-0 flex-col border-t border-border bg-background-2 p-3">
+    <div className="flex w-full min-w-0 flex-shrink-0 flex-col bg-transparent px-3 pb-3 pt-3">
       <div
         className={cn(
-          'flex min-w-0 flex-col rounded-2xl border border-border bg-muted/50',
+          'flex min-w-0 flex-col rounded-lg border border-border bg-muted/50',
           'transition-all duration-200 focus-within:border-primary/50 focus-within:ring-2 focus-within:ring-primary/20',
         )}
       >
-        {/* Textarea — full width */}
         <textarea
           ref={textareaRef}
           value={value}
@@ -67,40 +335,101 @@ export function AiPanelChatBar({
           rows={1}
           className={cn(
             'min-h-[36px] min-w-0 max-h-[160px] w-full resize-none',
-            'bg-transparent px-3 pt-3 pb-1 text-sm leading-relaxed text-foreground',
+            'bg-transparent px-3 py-2.5 text-sm leading-relaxed text-foreground',
             'placeholder:text-muted-foreground focus:outline-none',
           )}
           style={{ minHeight: '36px', maxHeight: '160px' }}
         />
 
-        {/* Bottom bar */}
-        <div className="flex min-w-0 flex-wrap items-center justify-between gap-x-2 gap-y-1 px-3 pb-2.5">
-          <span className="min-w-0 break-words text-xs text-muted-foreground">
-            {t('newlineHint')}
-          </span>
-          <button
-            type="button"
-            onClick={isStreaming ? onStop : onSend}
-            disabled={!canSend && !isStreaming}
-            className={cn(
-              'flex items-center gap-1.5 rounded-xl px-3 py-1.5 text-xs font-medium transition-all duration-200',
-              canSend || isStreaming
-                ? 'bg-primary text-primary-foreground hover:opacity-90'
-                : 'cursor-not-allowed bg-muted text-muted-foreground',
-            )}
-          >
-            {isStreaming ? (
-              <>
-                <Square className="h-3 w-3" />
-                {t('stopButton')}
-              </>
-            ) : (
-              <>
-                <Send className="h-3 w-3" />
-                {t('sendButton')}
-              </>
-            )}
-          </button>
+        <div className="flex min-w-0 flex-col gap-1 px-2 pb-2.5 pt-0">
+          {dictationError && (
+            <p role="alert" className="px-1 text-xs text-destructive">
+              {dictationError}
+            </p>
+          )}
+          <div className="flex min-w-0 items-center justify-between gap-2">
+            <div className="flex min-w-0 flex-1 items-center gap-0.5">
+              <button
+                type="button"
+                disabled
+                className="flex h-7 w-7 shrink-0 cursor-not-allowed items-center justify-center rounded-md text-muted-foreground opacity-50"
+                aria-label={tHuman('composerAttachMenu')}
+                title={tHuman('composerAttachMenu')}
+              >
+                <Plus className="h-4 w-4" strokeWidth={2} />
+              </button>
+              <button
+                type="button"
+                disabled
+                className="flex h-7 w-7 shrink-0 cursor-not-allowed items-center justify-center rounded-md text-muted-foreground opacity-50"
+                aria-label={tHuman('emoji')}
+                title={tHuman('emoji')}
+              >
+                <Smile className="h-4 w-4" />
+              </button>
+              <button
+                type="button"
+                disabled
+                className="flex h-7 w-7 shrink-0 cursor-not-allowed items-center justify-center rounded-md text-muted-foreground opacity-50"
+                aria-label={tHuman('mention')}
+                title={tHuman('mention')}
+              >
+                <AtSign className="h-4 w-4" aria-hidden />
+              </button>
+              <button
+                type="button"
+                onClick={startDictation}
+                disabled={isStreaming}
+                className={cn(
+                  isDictating
+                    ? recordingStopButtonClass
+                    : 'flex h-7 w-7 shrink-0 items-center justify-center rounded-md transition-colors duration-200 ease-out',
+                  !isDictating &&
+                    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/35 focus-visible:ring-offset-0',
+                  isDictating
+                    ? ''
+                    : 'text-muted-foreground hover:bg-primary/12 hover:text-primary',
+                  isStreaming && 'cursor-not-allowed opacity-50',
+                )}
+                aria-label={
+                  isDictating
+                    ? tHuman('composerStopDictation')
+                    : tHuman('composerDictateMessage')
+                }
+                title={
+                  isDictating
+                    ? tHuman('composerStopDictation')
+                    : tHuman('composerDictateMessage')
+                }
+              >
+                {isDictating ? (
+                  <ComposerRecOnAirIndicator />
+                ) : (
+                  <Mic className="h-4 w-4" strokeWidth={2} />
+                )}
+              </button>
+            </div>
+            <button
+              type="button"
+              onClick={isStreaming ? onStop : sendMessage}
+              disabled={!canSend && !isStreaming}
+              className={cn(
+                'flex h-7 w-7 shrink-0 items-center justify-center rounded-md transition-colors duration-200 ease-out',
+                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/35 focus-visible:ring-offset-0',
+                canSend || isStreaming
+                  ? 'text-primary hover:bg-primary/12 hover:text-primary active:bg-primary/18'
+                  : 'cursor-not-allowed text-muted-foreground/50',
+              )}
+              aria-label={isStreaming ? t('stopButton') : t('sendButton')}
+              title={isStreaming ? t('stopButton') : t('sendButton')}
+            >
+              {isStreaming ? (
+                <Square className="h-3.5 w-3.5" />
+              ) : (
+                <Send className="h-4 w-4" />
+              )}
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/packages/epics/src/common/ai-panel/ai-panel-chat-bar.tsx
+++ b/packages/epics/src/common/ai-panel/ai-panel-chat-bar.tsx
@@ -1,9 +1,23 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
-import { AtSign, Mic, Plus, Send, Smile, Square } from 'lucide-react';
+import { useCallback, useEffect, useId, useRef, useState } from 'react';
+import {
+  ImageIcon,
+  Mic,
+  Paperclip,
+  Plus,
+  Send,
+  Square,
+  Video,
+} from 'lucide-react';
 import { useTranslations } from 'next-intl';
 
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@hypha-platform/ui';
 import { cn } from '@hypha-platform/ui-utils';
 
 type SpeechRecognitionCtor = new () => SpeechRecognitionLike;
@@ -100,6 +114,11 @@ export function AiPanelChatBar({
 }: AiPanelChatBarProps) {
   const t = useTranslations('AiPanel');
   const tHuman = useTranslations('HumanChatPanel');
+  const fileInputId = useId();
+  const imageInputId = useId();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const imageInputRef = useRef<HTMLInputElement>(null);
+  const videoInputRef = useRef<HTMLInputElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const speechRecognitionRef = useRef<SpeechRecognitionLike | null>(null);
   const dictationPrefixRef = useRef('');
@@ -108,6 +127,7 @@ export function AiPanelChatBar({
   const valueRef = useRef(value);
   const [isDictating, setIsDictating] = useState(false);
   const [dictationError, setDictationError] = useState<string | null>(null);
+  const [attachMenuOpen, setAttachMenuOpen] = useState(false);
 
   valueRef.current = value;
 
@@ -314,6 +334,19 @@ export function AiPanelChatBar({
     onSend();
   }, [isDictating, onSend]);
 
+  const handleAttachFile = () => {
+    fileInputRef.current?.click();
+  };
+  const handleAttachImage = () => {
+    imageInputRef.current?.click();
+  };
+  const handleAttachVideo = () => {
+    videoInputRef.current?.click();
+  };
+
+  const iconButtonClass =
+    'flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors duration-200 ease-out hover:bg-primary/12 hover:text-primary active:bg-primary/18 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/35 focus-visible:ring-offset-0';
+
   return (
     <div className="flex w-full min-w-0 flex-shrink-0 flex-col bg-transparent px-3 pb-3 pt-3">
       <div
@@ -340,6 +373,43 @@ export function AiPanelChatBar({
           )}
           style={{ minHeight: '36px', maxHeight: '160px' }}
         />
+        <input
+          ref={fileInputRef}
+          id={fileInputId}
+          type="file"
+          className="sr-only"
+          tabIndex={-1}
+          aria-hidden="true"
+          multiple
+          onChange={(e) => {
+            e.target.value = '';
+          }}
+        />
+        <input
+          ref={imageInputRef}
+          id={imageInputId}
+          type="file"
+          accept="image/*"
+          className="sr-only"
+          tabIndex={-1}
+          aria-hidden="true"
+          multiple
+          onChange={(e) => {
+            e.target.value = '';
+          }}
+        />
+        <input
+          ref={videoInputRef}
+          type="file"
+          accept="video/*"
+          className="sr-only"
+          tabIndex={-1}
+          aria-hidden="true"
+          multiple
+          onChange={(e) => {
+            e.target.value = '';
+          }}
+        />
 
         <div className="flex min-w-0 flex-col gap-1 px-2 pb-2.5 pt-0">
           {dictationError && (
@@ -349,41 +419,58 @@ export function AiPanelChatBar({
           )}
           <div className="flex min-w-0 items-center justify-between gap-2">
             <div className="flex min-w-0 flex-1 items-center gap-0.5">
-              <button
-                type="button"
-                disabled
-                className="flex h-7 w-7 shrink-0 cursor-not-allowed items-center justify-center rounded-md text-muted-foreground opacity-50"
-                aria-label={tHuman('composerAttachMenu')}
-                title={tHuman('composerAttachMenu')}
+              <DropdownMenu
+                modal={false}
+                open={attachMenuOpen}
+                onOpenChange={setAttachMenuOpen}
               >
-                <Plus className="h-4 w-4" strokeWidth={2} />
-              </button>
-              <button
-                type="button"
-                disabled
-                className="flex h-7 w-7 shrink-0 cursor-not-allowed items-center justify-center rounded-md text-muted-foreground opacity-50"
-                aria-label={tHuman('emoji')}
-                title={tHuman('emoji')}
-              >
-                <Smile className="h-4 w-4" />
-              </button>
-              <button
-                type="button"
-                disabled
-                className="flex h-7 w-7 shrink-0 cursor-not-allowed items-center justify-center rounded-md text-muted-foreground opacity-50"
-                aria-label={tHuman('mention')}
-                title={tHuman('mention')}
-              >
-                <AtSign className="h-4 w-4" aria-hidden />
-              </button>
+                <DropdownMenuTrigger asChild>
+                  <button
+                    type="button"
+                    className={iconButtonClass}
+                    aria-label={tHuman('composerAttachMenu')}
+                    title={tHuman('composerAttachMenu')}
+                    aria-expanded={attachMenuOpen}
+                  >
+                    <Plus className="h-4 w-4" strokeWidth={2} />
+                  </button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="start" className="min-w-[200px]">
+                  <DropdownMenuItem
+                    className="cursor-pointer gap-2"
+                    onSelect={() => {
+                      requestAnimationFrame(() => handleAttachImage());
+                    }}
+                  >
+                    <ImageIcon className="h-4 w-4 shrink-0" aria-hidden />
+                    <span>{tHuman('composerAttachImage')}</span>
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    className="cursor-pointer gap-2"
+                    onSelect={() => {
+                      requestAnimationFrame(() => handleAttachVideo());
+                    }}
+                  >
+                    <Video className="h-4 w-4 shrink-0" aria-hidden />
+                    <span>{tHuman('composerAttachVideo')}</span>
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    className="cursor-pointer gap-2"
+                    onSelect={() => {
+                      requestAnimationFrame(() => handleAttachFile());
+                    }}
+                  >
+                    <Paperclip className="h-4 w-4 shrink-0" aria-hidden />
+                    <span>{tHuman('composerAttachFile')}</span>
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
               <button
                 type="button"
                 onClick={startDictation}
                 disabled={isStreaming}
                 className={cn(
-                  isDictating
-                    ? recordingStopButtonClass
-                    : 'flex h-7 w-7 shrink-0 items-center justify-center rounded-md transition-colors duration-200 ease-out',
+                  isDictating ? recordingStopButtonClass : iconButtonClass,
                   !isDictating &&
                     'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/35 focus-visible:ring-offset-0',
                   isDictating

--- a/packages/epics/src/common/ai-panel/ai-panel-header.tsx
+++ b/packages/epics/src/common/ai-panel/ai-panel-header.tsx
@@ -129,7 +129,7 @@ export function AiPanelHeader({
   const fallbackTitle = activeSpace?.title?.trim() || t('title');
 
   return (
-    <div className="flex min-h-[var(--menu-top-height,65px)] min-w-0 flex-shrink-0 flex-wrap items-center justify-between gap-x-2 gap-y-2 border-b border-border bg-background-2 px-4 py-3">
+    <div className="flex h-[var(--menu-top-height,65px)] min-w-0 flex-shrink-0 flex-wrap items-center justify-between gap-x-2 gap-y-2 border-b border-border bg-background-2 px-4 py-2">
       <div className="flex min-w-0 shrink-0 items-center gap-2">
         <div className="flex h-7 w-7 shrink-0 items-center justify-center overflow-hidden rounded-xl bg-muted ring-1 ring-border/70">
           {/* eslint-disable-next-line @next/next/no-img-element */}

--- a/packages/epics/src/common/ai-panel/ai-panel-header.tsx
+++ b/packages/epics/src/common/ai-panel/ai-panel-header.tsx
@@ -104,7 +104,7 @@ export function AiPanelHeader() {
   return (
     <div className="flex min-h-[var(--menu-top-height,65px)] min-w-0 flex-shrink-0 flex-wrap items-center justify-between gap-x-2 gap-y-2 border-b border-border bg-background-2 px-4 py-3">
       <div className="flex min-w-0 shrink-0 items-center gap-2">
-        <div className="flex h-8 w-8 shrink-0 items-center justify-center overflow-hidden rounded-xl bg-muted ring-1 ring-border/70">
+        <div className="flex h-7 w-7 shrink-0 items-center justify-center overflow-hidden rounded-xl bg-muted ring-1 ring-border/70">
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             src={currentIcon}

--- a/packages/epics/src/common/ai-panel/ai-panel-header.tsx
+++ b/packages/epics/src/common/ai-panel/ai-panel-header.tsx
@@ -13,14 +13,17 @@ import {
   DropdownMenuTrigger,
 } from '@hypha-platform/ui';
 import {
+  Address,
   DEFAULT_SPACE_AVATAR_IMAGE,
   Space,
+  useMe,
   useSpacesBySlugs,
 } from '@hypha-platform/core/client';
 import { usePathname, useParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { useAiPanel } from '../human-chat-panel-context';
 import { getDhoSpaceSlugFromPathname } from '../get-dho-space-slug-from-pathname';
+import { useMemberWeb3SpaceIds } from '../../spaces/hooks/use-member-web3-space-ids';
 
 function getEcosystemRootId(
   space: Space,
@@ -63,6 +66,10 @@ export function AiPanelHeader({
   const { spaces: activeSpaces } = useSpacesBySlugs(
     activeSpaceSlug ? [activeSpaceSlug] : [],
   );
+  const { person } = useMe();
+  const { web3SpaceIds } = useMemberWeb3SpaceIds({
+    personAddress: person?.address as Address | undefined,
+  });
   const {
     data: allSpaces = [],
     error: allSpacesError,
@@ -87,14 +94,21 @@ export function AiPanelHeader({
   );
 
   const groupedSpaces = useMemo(() => {
+    const memberSpaceIds = new Set(
+      (web3SpaceIds ?? []).map((id) => id.toString()),
+    );
+    const mySpaces = allSpaces.filter((space) => {
+      if (space.web3SpaceId == null) return false;
+      return memberSpaceIds.has(String(space.web3SpaceId));
+    });
     if (!activeSpace) {
-      return { ecosystem: [] as Space[], others: allSpaces };
+      return { ecosystem: [] as Space[], others: mySpaces };
     }
-    const spacesById = new Map(allSpaces.map((space) => [space.id, space]));
+    const spacesById = new Map(mySpaces.map((space) => [space.id, space]));
     const activeRootId = getEcosystemRootId(activeSpace, spacesById);
     const ecosystem: Space[] = [];
     const others: Space[] = [];
-    for (const space of allSpaces) {
+    for (const space of mySpaces) {
       if (getEcosystemRootId(space, spacesById) === activeRootId) {
         ecosystem.push(space);
       } else {
@@ -105,7 +119,7 @@ export function AiPanelHeader({
     ecosystem.sort(byTitle);
     others.sort(byTitle);
     return { ecosystem, others };
-  }, [activeSpace, allSpaces]);
+  }, [activeSpace, allSpaces, web3SpaceIds]);
 
   const lang = typeof params.lang === 'string' ? params.lang : 'en';
   const currentTitle = activeSpace?.title?.trim() || t('title');
@@ -132,7 +146,7 @@ export function AiPanelHeader({
               className="inline-flex min-w-0 items-center gap-1 rounded-md px-2 py-1.5 text-left text-sm font-semibold text-foreground transition-colors hover:bg-muted"
               aria-label={tNavigation('mySpaces')}
             >
-              <span className="truncate">{currentTitle}</span>
+              <span className="max-w-[11.5rem] truncate">{currentTitle}</span>
               <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
             </button>
           </DropdownMenuTrigger>
@@ -159,7 +173,7 @@ export function AiPanelHeader({
                 <DropdownMenuItem key={space.id} asChild>
                   <Link
                     href={`/${lang}/dho/${space.slug}/agreements`}
-                    className="flex items-center gap-2"
+                    className="flex min-w-0 items-center gap-2"
                   >
                     <span className="h-6 w-6 overflow-hidden rounded-md ring-1 ring-border/60">
                       {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -169,7 +183,9 @@ export function AiPanelHeader({
                         className="h-full w-full object-cover"
                       />
                     </span>
-                    <span className="truncate">{space.title}</span>
+                    <span className="min-w-0 flex-1 truncate">
+                      {space.title}
+                    </span>
                   </Link>
                 </DropdownMenuItem>
               ))}
@@ -186,7 +202,7 @@ export function AiPanelHeader({
                 <DropdownMenuItem key={space.id} asChild>
                   <Link
                     href={`/${lang}/dho/${space.slug}/agreements`}
-                    className="flex items-center gap-2"
+                    className="flex min-w-0 items-center gap-2"
                   >
                     <span className="h-6 w-6 overflow-hidden rounded-md ring-1 ring-border/60">
                       {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -196,7 +212,9 @@ export function AiPanelHeader({
                         className="h-full w-full object-cover"
                       />
                     </span>
-                    <span className="truncate">{space.title}</span>
+                    <span className="min-w-0 flex-1 truncate">
+                      {space.title}
+                    </span>
                   </Link>
                 </DropdownMenuItem>
               ))}

--- a/packages/epics/src/common/ai-panel/ai-panel-header.tsx
+++ b/packages/epics/src/common/ai-panel/ai-panel-header.tsx
@@ -183,7 +183,7 @@ export function AiPanelHeader({
                     <span className="h-6 w-6 overflow-hidden rounded-md ring-1 ring-border/60">
                       {/* eslint-disable-next-line @next/next/no-img-element */}
                       <img
-                        src={getDisplayIcon(space)}
+                        src={getDisplayIcon(space) ?? undefined}
                         alt={space.title}
                         className="h-full w-full object-cover"
                       />
@@ -212,7 +212,7 @@ export function AiPanelHeader({
                     <span className="h-6 w-6 overflow-hidden rounded-md ring-1 ring-border/60">
                       {/* eslint-disable-next-line @next/next/no-img-element */}
                       <img
-                        src={getDisplayIcon(space)}
+                        src={getDisplayIcon(space) ?? undefined}
                         alt={space.title}
                         className="h-full w-full object-cover"
                       />

--- a/packages/epics/src/common/ai-panel/ai-panel-header.tsx
+++ b/packages/epics/src/common/ai-panel/ai-panel-header.tsx
@@ -46,7 +46,11 @@ function getDisplayIcon(space?: Space): string {
   return space?.logoUrl?.trim() || DEFAULT_SPACE_AVATAR_IMAGE;
 }
 
-export function AiPanelHeader({ showCloseButton = true }: { showCloseButton?: boolean }) {
+export function AiPanelHeader({
+  showCloseButton = true,
+}: {
+  showCloseButton?: boolean;
+}) {
   const { closeAiPanel } = useAiPanel();
   const t = useTranslations('AiPanel');
   const tNavigation = useTranslations('Navigation');
@@ -106,7 +110,8 @@ export function AiPanelHeader({ showCloseButton = true }: { showCloseButton?: bo
   const lang = typeof params.lang === 'string' ? params.lang : 'en';
   const currentTitle = activeSpace?.title?.trim() || t('title');
   const currentIcon = getDisplayIcon(activeSpace);
-  const hasSpaces = groupedSpaces.ecosystem.length + groupedSpaces.others.length > 0;
+  const hasSpaces =
+    groupedSpaces.ecosystem.length + groupedSpaces.others.length > 0;
   const fallbackTitle = activeSpace?.title?.trim() || t('title');
 
   return (
@@ -148,26 +153,26 @@ export function AiPanelHeader({ showCloseButton = true }: { showCloseButton?: bo
               <DropdownMenuItem disabled>{fallbackTitle}</DropdownMenuItem>
             ) : null}
             {!isAllSpacesLoading &&
-            !allSpacesError &&
-            hasSpaces &&
-            groupedSpaces.ecosystem.map((space) => (
-              <DropdownMenuItem key={space.id} asChild>
-                <Link
-                  href={`/${lang}/dho/${space.slug}/agreements`}
-                  className="flex items-center gap-2"
-                >
-                  <span className="h-6 w-6 overflow-hidden rounded-md ring-1 ring-border/60">
-                    {/* eslint-disable-next-line @next/next/no-img-element */}
-                    <img
-                      src={getDisplayIcon(space)}
-                      alt={space.title}
-                      className="h-full w-full object-cover"
-                    />
-                  </span>
-                  <span className="truncate">{space.title}</span>
-                </Link>
-              </DropdownMenuItem>
-            ))}
+              !allSpacesError &&
+              hasSpaces &&
+              groupedSpaces.ecosystem.map((space) => (
+                <DropdownMenuItem key={space.id} asChild>
+                  <Link
+                    href={`/${lang}/dho/${space.slug}/agreements`}
+                    className="flex items-center gap-2"
+                  >
+                    <span className="h-6 w-6 overflow-hidden rounded-md ring-1 ring-border/60">
+                      {/* eslint-disable-next-line @next/next/no-img-element */}
+                      <img
+                        src={getDisplayIcon(space)}
+                        alt={space.title}
+                        className="h-full w-full object-cover"
+                      />
+                    </span>
+                    <span className="truncate">{space.title}</span>
+                  </Link>
+                </DropdownMenuItem>
+              ))}
             {!isAllSpacesLoading &&
             !allSpacesError &&
             groupedSpaces.ecosystem.length > 0 &&
@@ -175,26 +180,26 @@ export function AiPanelHeader({ showCloseButton = true }: { showCloseButton?: bo
               <DropdownMenuSeparator />
             ) : null}
             {!isAllSpacesLoading &&
-            !allSpacesError &&
-            hasSpaces &&
-            groupedSpaces.others.map((space) => (
-              <DropdownMenuItem key={space.id} asChild>
-                <Link
-                  href={`/${lang}/dho/${space.slug}/agreements`}
-                  className="flex items-center gap-2"
-                >
-                  <span className="h-6 w-6 overflow-hidden rounded-md ring-1 ring-border/60">
-                    {/* eslint-disable-next-line @next/next/no-img-element */}
-                    <img
-                      src={getDisplayIcon(space)}
-                      alt={space.title}
-                      className="h-full w-full object-cover"
-                    />
-                  </span>
-                  <span className="truncate">{space.title}</span>
-                </Link>
-              </DropdownMenuItem>
-            ))}
+              !allSpacesError &&
+              hasSpaces &&
+              groupedSpaces.others.map((space) => (
+                <DropdownMenuItem key={space.id} asChild>
+                  <Link
+                    href={`/${lang}/dho/${space.slug}/agreements`}
+                    className="flex items-center gap-2"
+                  >
+                    <span className="h-6 w-6 overflow-hidden rounded-md ring-1 ring-border/60">
+                      {/* eslint-disable-next-line @next/next/no-img-element */}
+                      <img
+                        src={getDisplayIcon(space)}
+                        alt={space.title}
+                        className="h-full w-full object-cover"
+                      />
+                    </span>
+                    <span className="truncate">{space.title}</span>
+                  </Link>
+                </DropdownMenuItem>
+              ))}
           </DropdownMenuContent>
         </DropdownMenu>
       </div>

--- a/packages/epics/src/common/ai-panel/ai-panel-header.tsx
+++ b/packages/epics/src/common/ai-panel/ai-panel-header.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link';
 import useSWR from 'swr';
 import { useMemo } from 'react';
-import { ChevronDown, PanelLeftClose } from 'lucide-react';
+import { ChevronDown, PanelLeftClose, Sparkles } from 'lucide-react';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -14,7 +14,6 @@ import {
 } from '@hypha-platform/ui';
 import {
   Address,
-  DEFAULT_SPACE_AVATAR_IMAGE,
   Space,
   useMe,
   useSpacesBySlugs,
@@ -45,8 +44,8 @@ function getEcosystemRootId(
   return cursor?.id ?? space.id;
 }
 
-function getDisplayIcon(space?: Space): string {
-  return space?.logoUrl?.trim() || DEFAULT_SPACE_AVATAR_IMAGE;
+function getDisplayIcon(space?: Space): string | null {
+  return space?.logoUrl?.trim() || null;
 }
 
 export function AiPanelHeader({
@@ -129,21 +128,27 @@ export function AiPanelHeader({
   const fallbackTitle = activeSpace?.title?.trim() || t('title');
 
   return (
-    <div className="flex h-[var(--menu-top-height,65px)] min-w-0 flex-shrink-0 flex-wrap items-center justify-between gap-x-2 gap-y-2 border-b border-border bg-background-2 px-4 py-2">
-      <div className="flex min-w-0 shrink-0 items-center gap-2">
+    <div className="relative flex h-[var(--menu-top-height,65px)] min-w-0 flex-shrink-0 items-center border-b border-border bg-background-2 px-4 py-2">
+      <div className="flex min-w-0 flex-1 items-center gap-2 pr-10">
         <div className="flex h-7 w-7 shrink-0 items-center justify-center overflow-hidden rounded-xl bg-muted ring-1 ring-border/70">
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
-            src={currentIcon}
-            alt={currentTitle}
-            className="h-full w-full object-cover"
-          />
+          {currentIcon ? (
+            <>
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={currentIcon}
+                alt={currentTitle}
+                className="h-full w-full object-cover"
+              />
+            </>
+          ) : (
+            <Sparkles className="h-4 w-4 text-muted-foreground" />
+          )}
         </div>
         <DropdownMenu modal={false}>
           <DropdownMenuTrigger asChild>
             <button
               type="button"
-              className="inline-flex min-w-0 items-center gap-1 rounded-md px-2 py-1.5 text-left text-sm font-semibold text-foreground transition-colors hover:bg-muted"
+              className="inline-flex min-w-0 max-w-full items-center gap-1 rounded-md px-2 py-1.5 text-left text-sm font-semibold text-foreground transition-colors hover:bg-muted"
               aria-label={tNavigation('mySpaces')}
             >
               <span className="max-w-[11.5rem] truncate">{currentTitle}</span>
@@ -222,7 +227,7 @@ export function AiPanelHeader({
         </DropdownMenu>
       </div>
       {showCloseButton ? (
-        <div className="flex min-w-0 flex-wrap items-center justify-end gap-1">
+        <div className="absolute right-4 top-1/2 flex -translate-y-1/2 items-center justify-end">
           <button
             type="button"
             onClick={closeAiPanel}

--- a/packages/epics/src/common/ai-panel/ai-panel-header.tsx
+++ b/packages/epics/src/common/ai-panel/ai-panel-header.tsx
@@ -1,41 +1,182 @@
 'use client';
 
-import { PanelLeftClose, RefreshCw, Sparkles } from 'lucide-react';
-import { useSidebar } from '@hypha-platform/ui';
+import Link from 'next/link';
+import useSWR from 'swr';
+import { useMemo } from 'react';
+import { ChevronDown, PanelLeftClose } from 'lucide-react';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@hypha-platform/ui';
+import {
+  DEFAULT_SPACE_AVATAR_IMAGE,
+  Space,
+  useSpacesBySlugs,
+} from '@hypha-platform/core/client';
+import { usePathname, useParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
+import { useAiPanel } from '../human-chat-panel-context';
+import { getDhoSpaceSlugFromPathname } from '../get-dho-space-slug-from-pathname';
 
-type AiPanelHeaderProps = {
-  onResetChat?: () => void;
-};
+function getEcosystemRootId(
+  space: Space,
+  spacesById: Map<number, Space>,
+): number {
+  let cursor: Space | undefined = space;
+  const seen = new Set<number>();
+  while (cursor?.parentId != null) {
+    if (seen.has(cursor.id)) {
+      break;
+    }
+    seen.add(cursor.id);
+    const parent = spacesById.get(cursor.parentId);
+    if (!parent) {
+      break;
+    }
+    cursor = parent;
+  }
+  return cursor?.id ?? space.id;
+}
 
-export function AiPanelHeader({ onResetChat }: AiPanelHeaderProps) {
-  const { toggleSidebar } = useSidebar();
+function getDisplayIcon(space?: Space): string {
+  return space?.logoUrl?.trim() || DEFAULT_SPACE_AVATAR_IMAGE;
+}
+
+export function AiPanelHeader() {
+  const { closeAiPanel } = useAiPanel();
   const t = useTranslations('AiPanel');
+  const tNavigation = useTranslations('Navigation');
+  const pathname = usePathname();
+  const params = useParams<{ lang?: string }>();
+  const activeSpaceSlug = useMemo(
+    () => getDhoSpaceSlugFromPathname(pathname),
+    [pathname],
+  );
+  const { spaces: activeSpaces } = useSpacesBySlugs(
+    activeSpaceSlug ? [activeSpaceSlug] : [],
+  );
+  const { data: allSpaces = [] } = useSWR<Space[]>(
+    '/api/v1/spaces?parentOnly=false',
+    async (url: string) => {
+      const response = await fetch(url, {
+        headers: { Accept: 'application/json' },
+      });
+      if (!response.ok) return [];
+      return (await response.json()) as Space[];
+    },
+  );
+  const activeSpace = useMemo(
+    () =>
+      allSpaces.find((space) => space.slug === activeSpaceSlug) ??
+      activeSpaces[0],
+    [activeSpaceSlug, allSpaces, activeSpaces],
+  );
+
+  const groupedSpaces = useMemo(() => {
+    if (!activeSpace) {
+      return { ecosystem: [] as Space[], others: allSpaces };
+    }
+    const spacesById = new Map(allSpaces.map((space) => [space.id, space]));
+    const activeRootId = getEcosystemRootId(activeSpace, spacesById);
+    const ecosystem: Space[] = [];
+    const others: Space[] = [];
+    for (const space of allSpaces) {
+      if (getEcosystemRootId(space, spacesById) === activeRootId) {
+        ecosystem.push(space);
+      } else {
+        others.push(space);
+      }
+    }
+    const byTitle = (a: Space, b: Space) => a.title.localeCompare(b.title);
+    ecosystem.sort(byTitle);
+    others.sort(byTitle);
+    return { ecosystem, others };
+  }, [activeSpace, allSpaces]);
+
+  const lang = typeof params.lang === 'string' ? params.lang : 'en';
+  const currentTitle = activeSpace?.title?.trim() || t('title');
+  const currentIcon = getDisplayIcon(activeSpace);
+
   return (
     <div className="flex min-h-[var(--menu-top-height,65px)] min-w-0 flex-shrink-0 flex-wrap items-center justify-between gap-x-2 gap-y-2 border-b border-border bg-background-2 px-4 py-3">
       <div className="flex min-w-0 shrink-0 items-center gap-2">
-        <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-xl bg-primary">
-          <Sparkles className="h-3.5 w-3.5 text-primary-foreground" />
+        <div className="flex h-8 w-8 shrink-0 items-center justify-center overflow-hidden rounded-xl bg-muted ring-1 ring-border/70">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={currentIcon}
+            alt={currentTitle}
+            className="h-full w-full object-cover"
+          />
         </div>
-        <span className="font-semibold text-sm text-foreground">
-          {t('title')}
-        </span>
+        <DropdownMenu modal={false}>
+          <DropdownMenuTrigger asChild>
+            <button
+              type="button"
+              className="inline-flex min-w-0 items-center gap-1 rounded-md px-2 py-1.5 text-left text-sm font-semibold text-foreground transition-colors hover:bg-muted"
+              aria-label={tNavigation('mySpaces')}
+            >
+              <span className="truncate">{currentTitle}</span>
+              <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            align="start"
+            className="w-[min(22rem,calc(100vw-1.5rem))] border border-border/90 p-1"
+          >
+            <DropdownMenuLabel className="px-2 py-1.5 text-1 text-muted-foreground">
+              {tNavigation('mySpaces')}
+            </DropdownMenuLabel>
+            {groupedSpaces.ecosystem.map((space) => (
+              <DropdownMenuItem key={space.id} asChild>
+                <Link
+                  href={`/${lang}/dho/${space.slug}/agreements`}
+                  className="flex items-center gap-2"
+                >
+                  <span className="h-6 w-6 overflow-hidden rounded-md ring-1 ring-border/60">
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src={getDisplayIcon(space)}
+                      alt={space.title}
+                      className="h-full w-full object-cover"
+                    />
+                  </span>
+                  <span className="truncate">{space.title}</span>
+                </Link>
+              </DropdownMenuItem>
+            ))}
+            {groupedSpaces.ecosystem.length > 0 &&
+            groupedSpaces.others.length > 0 ? (
+              <DropdownMenuSeparator />
+            ) : null}
+            {groupedSpaces.others.map((space) => (
+              <DropdownMenuItem key={space.id} asChild>
+                <Link
+                  href={`/${lang}/dho/${space.slug}/agreements`}
+                  className="flex items-center gap-2"
+                >
+                  <span className="h-6 w-6 overflow-hidden rounded-md ring-1 ring-border/60">
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src={getDisplayIcon(space)}
+                      alt={space.title}
+                      className="h-full w-full object-cover"
+                    />
+                  </span>
+                  <span className="truncate">{space.title}</span>
+                </Link>
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
       </div>
       <div className="flex min-w-0 flex-wrap items-center justify-end gap-1">
-        {onResetChat && (
-          <button
-            type="button"
-            onClick={onResetChat}
-            className="flex h-7 w-7 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-            title={t('resetChat')}
-            aria-label={t('resetChat')}
-          >
-            <RefreshCw className="h-3.5 w-3.5" />
-          </button>
-        )}
         <button
           type="button"
-          onClick={toggleSidebar}
+          onClick={closeAiPanel}
           className="flex h-7 w-7 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
           title={t('hidePanel')}
           aria-label={t('closePanel')}

--- a/packages/epics/src/common/ai-panel/ai-panel-header.tsx
+++ b/packages/epics/src/common/ai-panel/ai-panel-header.tsx
@@ -148,7 +148,7 @@ export function AiPanelHeader({
           <DropdownMenuTrigger asChild>
             <button
               type="button"
-              className="inline-flex min-w-0 max-w-full items-center gap-1 rounded-md px-2 py-1.5 text-left text-sm font-semibold text-foreground transition-colors hover:bg-muted"
+              className="inline-flex min-w-0 max-w-full items-center gap-1 rounded-md px-1.5 py-1 text-left text-sm font-semibold text-foreground transition-colors hover:bg-muted/60"
               aria-label={tNavigation('mySpaces')}
             >
               <span className="max-w-[11.5rem] truncate">{currentTitle}</span>
@@ -157,7 +157,7 @@ export function AiPanelHeader({
           </DropdownMenuTrigger>
           <DropdownMenuContent
             align="start"
-            className="w-[min(22rem,calc(100vw-1.5rem))] border border-border/90 p-1"
+            className="w-[min(20rem,calc(100vw-1.5rem))] max-h-[62vh] overflow-y-auto border border-border/90 p-1 narrow-scrollbar"
           >
             <DropdownMenuLabel className="px-2 py-1.5 text-1 text-muted-foreground">
               {tNavigation('mySpaces')}
@@ -175,12 +175,12 @@ export function AiPanelHeader({
               !allSpacesError &&
               hasSpaces &&
               groupedSpaces.ecosystem.map((space) => (
-                <DropdownMenuItem key={space.id} asChild>
+                <DropdownMenuItem key={space.id} asChild className="py-1.5">
                   <Link
                     href={`/${lang}/dho/${space.slug}/agreements`}
                     className="flex min-w-0 items-center gap-2"
                   >
-                    <span className="h-6 w-6 overflow-hidden rounded-md ring-1 ring-border/60">
+                    <span className="h-5 w-5 overflow-hidden rounded-md ring-1 ring-border/60">
                       {/* eslint-disable-next-line @next/next/no-img-element */}
                       <img
                         src={getDisplayIcon(space) ?? undefined}
@@ -204,12 +204,12 @@ export function AiPanelHeader({
               !allSpacesError &&
               hasSpaces &&
               groupedSpaces.others.map((space) => (
-                <DropdownMenuItem key={space.id} asChild>
+                <DropdownMenuItem key={space.id} asChild className="py-1.5">
                   <Link
                     href={`/${lang}/dho/${space.slug}/agreements`}
                     className="flex min-w-0 items-center gap-2"
                   >
-                    <span className="h-6 w-6 overflow-hidden rounded-md ring-1 ring-border/60">
+                    <span className="h-5 w-5 overflow-hidden rounded-md ring-1 ring-border/60">
                       {/* eslint-disable-next-line @next/next/no-img-element */}
                       <img
                         src={getDisplayIcon(space) ?? undefined}

--- a/packages/epics/src/common/ai-panel/ai-panel-header.tsx
+++ b/packages/epics/src/common/ai-panel/ai-panel-header.tsx
@@ -46,7 +46,7 @@ function getDisplayIcon(space?: Space): string {
   return space?.logoUrl?.trim() || DEFAULT_SPACE_AVATAR_IMAGE;
 }
 
-export function AiPanelHeader() {
+export function AiPanelHeader({ showCloseButton = true }: { showCloseButton?: boolean }) {
   const { closeAiPanel } = useAiPanel();
   const t = useTranslations('AiPanel');
   const tNavigation = useTranslations('Navigation');
@@ -198,17 +198,19 @@ export function AiPanelHeader() {
           </DropdownMenuContent>
         </DropdownMenu>
       </div>
-      <div className="flex min-w-0 flex-wrap items-center justify-end gap-1">
-        <button
-          type="button"
-          onClick={closeAiPanel}
-          className="flex h-7 w-7 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-          title={t('hidePanel')}
-          aria-label={t('closePanel')}
-        >
-          <PanelLeftClose className="h-3.5 w-3.5" />
-        </button>
-      </div>
+      {showCloseButton ? (
+        <div className="flex min-w-0 flex-wrap items-center justify-end gap-1">
+          <button
+            type="button"
+            onClick={closeAiPanel}
+            className="flex h-7 w-7 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            title={t('hidePanel')}
+            aria-label={t('closePanel')}
+          >
+            <PanelLeftClose className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/packages/epics/src/common/ai-panel/ai-panel-header.tsx
+++ b/packages/epics/src/common/ai-panel/ai-panel-header.tsx
@@ -59,13 +59,19 @@ export function AiPanelHeader() {
   const { spaces: activeSpaces } = useSpacesBySlugs(
     activeSpaceSlug ? [activeSpaceSlug] : [],
   );
-  const { data: allSpaces = [] } = useSWR<Space[]>(
+  const {
+    data: allSpaces = [],
+    error: allSpacesError,
+    isLoading: isAllSpacesLoading,
+  } = useSWR<Space[]>(
     '/api/v1/spaces?parentOnly=false',
     async (url: string) => {
       const response = await fetch(url, {
         headers: { Accept: 'application/json' },
       });
-      if (!response.ok) return [];
+      if (!response.ok) {
+        throw new Error(`Failed to load spaces: ${response.status}`);
+      }
       return (await response.json()) as Space[];
     },
   );
@@ -100,6 +106,8 @@ export function AiPanelHeader() {
   const lang = typeof params.lang === 'string' ? params.lang : 'en';
   const currentTitle = activeSpace?.title?.trim() || t('title');
   const currentIcon = getDisplayIcon(activeSpace);
+  const hasSpaces = groupedSpaces.ecosystem.length + groupedSpaces.others.length > 0;
+  const fallbackTitle = activeSpace?.title?.trim() || t('title');
 
   return (
     <div className="flex min-h-[var(--menu-top-height,65px)] min-w-0 flex-shrink-0 flex-wrap items-center justify-between gap-x-2 gap-y-2 border-b border-border bg-background-2 px-4 py-3">
@@ -130,7 +138,19 @@ export function AiPanelHeader() {
             <DropdownMenuLabel className="px-2 py-1.5 text-1 text-muted-foreground">
               {tNavigation('mySpaces')}
             </DropdownMenuLabel>
-            {groupedSpaces.ecosystem.map((space) => (
+            {isAllSpacesLoading ? (
+              <DropdownMenuItem disabled>{t('loading')}</DropdownMenuItem>
+            ) : null}
+            {!isAllSpacesLoading && allSpacesError ? (
+              <DropdownMenuItem disabled>{t('streamError')}</DropdownMenuItem>
+            ) : null}
+            {!isAllSpacesLoading && !allSpacesError && !hasSpaces ? (
+              <DropdownMenuItem disabled>{fallbackTitle}</DropdownMenuItem>
+            ) : null}
+            {!isAllSpacesLoading &&
+            !allSpacesError &&
+            hasSpaces &&
+            groupedSpaces.ecosystem.map((space) => (
               <DropdownMenuItem key={space.id} asChild>
                 <Link
                   href={`/${lang}/dho/${space.slug}/agreements`}
@@ -148,11 +168,16 @@ export function AiPanelHeader() {
                 </Link>
               </DropdownMenuItem>
             ))}
-            {groupedSpaces.ecosystem.length > 0 &&
+            {!isAllSpacesLoading &&
+            !allSpacesError &&
+            groupedSpaces.ecosystem.length > 0 &&
             groupedSpaces.others.length > 0 ? (
               <DropdownMenuSeparator />
             ) : null}
-            {groupedSpaces.others.map((space) => (
+            {!isAllSpacesLoading &&
+            !allSpacesError &&
+            hasSpaces &&
+            groupedSpaces.others.map((space) => (
               <DropdownMenuItem key={space.id} asChild>
                 <Link
                   href={`/${lang}/dho/${space.slug}/agreements`}

--- a/packages/epics/src/common/human-chat-panel-context.tsx
+++ b/packages/epics/src/common/human-chat-panel-context.tsx
@@ -9,14 +9,28 @@ import { createContext, useCallback, useContext, useState } from 'react';
  */
 export type PanelContextValue = {
   open: boolean;
+  overlayVisible: boolean;
   toggle: () => void;
+  /** Idempotently expands the AI sidebar without toggling it closed. */
+  openAiPanel: () => void;
+  /** Idempotently collapses the AI sidebar without toggling it open. */
+  closeAiPanel: () => void;
+  /** Shows AI overlay without changing collapsed/expanded intent. */
+  showAiOverlay: () => void;
+  /** Hides AI overlay without changing collapsed/expanded intent. */
+  hideAiOverlay: () => void;
 };
 
 // ─── AI Panel Context ────────────────────────────────────────────────────────
 
 const AiPanelContext = createContext<PanelContextValue>({
   open: false,
+  overlayVisible: false,
   toggle: () => {},
+  openAiPanel: () => {},
+  closeAiPanel: () => {},
+  showAiOverlay: () => {},
+  hideAiOverlay: () => {},
 });
 
 export const AiPanelProvider = AiPanelContext.Provider;

--- a/packages/epics/src/common/index.ts
+++ b/packages/epics/src/common/index.ts
@@ -22,6 +22,7 @@ export {
   AiSidebarTrigger,
   HumanSidebarTrigger,
 } from './panel-wrap-layout';
+export { useAiPanel } from './human-chat-panel-context';
 export {
   useMainColumnScrollY,
   getMainColumnScrollY,

--- a/packages/epics/src/common/panel-main-column-scroll-bridge.tsx
+++ b/packages/epics/src/common/panel-main-column-scroll-bridge.tsx
@@ -13,6 +13,8 @@ import { setMainColumnScrollRoot } from './main-column-scroll';
 type Props = {
   leftOpen: boolean;
   onLeftOpenChange: (open: boolean) => void;
+  onLeftMouseEnter?: () => void;
+  onLeftMouseLeave?: () => void;
   rightOpen: boolean;
   onRightOpenChange: (open: boolean) => void;
   leftContent: React.ReactNode;
@@ -29,6 +31,8 @@ type Props = {
 export function PanelDualSidebarScrollBridge({
   leftOpen,
   onLeftOpenChange,
+  onLeftMouseEnter,
+  onLeftMouseLeave,
   rightOpen,
   onRightOpenChange,
   leftContent,
@@ -53,8 +57,10 @@ export function PanelDualSidebarScrollBridge({
       <Sidebar
         side="left"
         variant="sidebar"
-        collapsible="offcanvas"
+        collapsible="icon"
         className="z-[50]"
+        onMouseEnter={onLeftMouseEnter}
+        onMouseLeave={onLeftMouseLeave}
       >
         {leftContent}
         <SidebarResizeHandle />

--- a/packages/epics/src/common/panel-main-column-scroll-bridge.tsx
+++ b/packages/epics/src/common/panel-main-column-scroll-bridge.tsx
@@ -51,6 +51,7 @@ export function PanelDualSidebarScrollBridge({
       style={
         {
           '--sidebar-width': '320px',
+          '--sidebar-width-icon': '72px',
         } as React.CSSProperties
       }
     >

--- a/packages/epics/src/common/panel-main-column-scroll-bridge.tsx
+++ b/packages/epics/src/common/panel-main-column-scroll-bridge.tsx
@@ -60,8 +60,6 @@ export function PanelDualSidebarScrollBridge({
         variant="sidebar"
         collapsible="icon"
         className="z-[50] overflow-visible"
-        onMouseEnter={onLeftMouseEnter}
-        onMouseLeave={onLeftMouseLeave}
       >
         {leftContent}
         <SidebarResizeHandle />

--- a/packages/epics/src/common/panel-main-column-scroll-bridge.tsx
+++ b/packages/epics/src/common/panel-main-column-scroll-bridge.tsx
@@ -58,7 +58,7 @@ export function PanelDualSidebarScrollBridge({
         side="left"
         variant="sidebar"
         collapsible="icon"
-        className="z-[50]"
+        className="z-[50] overflow-visible"
         onMouseEnter={onLeftMouseEnter}
         onMouseLeave={onLeftMouseLeave}
       >

--- a/packages/epics/src/common/panel-wrap-layout.tsx
+++ b/packages/epics/src/common/panel-wrap-layout.tsx
@@ -1,6 +1,12 @@
 'use client';
 
-import React, { useCallback, useLayoutEffect, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
 import { MessageCircle, Sparkles } from 'lucide-react';
 import {
   SidebarProvider,
@@ -25,13 +31,69 @@ import { PanelScrollInset } from './panel-scroll-inset';
 
 export function PanelProviders({ children }: { children: React.ReactNode }) {
   const [leftOpen, setLeftOpen] = useState(false);
+  const [leftOverlayVisible, setLeftOverlayVisible] = useState(false);
   const [rightOpen, setRightOpen] = useState(false);
+  const leftOverlayHideTimeoutRef = useRef<ReturnType<
+    typeof setTimeout
+  > | null>(null);
 
-  const toggleLeft = useCallback(() => setLeftOpen((prev) => !prev), []);
   const toggleRight = useCallback(() => setRightOpen((prev) => !prev), []);
+  const openLeft = useCallback(() => {
+    setLeftOpen(true);
+    setLeftOverlayVisible(true);
+  }, []);
+  const closeLeft = useCallback(() => {
+    setLeftOpen(false);
+    setLeftOverlayVisible(false);
+  }, []);
+  const showLeftOverlay = useCallback(() => {
+    if (leftOverlayHideTimeoutRef.current) {
+      clearTimeout(leftOverlayHideTimeoutRef.current);
+      leftOverlayHideTimeoutRef.current = null;
+    }
+    setLeftOverlayVisible(true);
+  }, []);
+  const hideLeftOverlay = useCallback(() => {
+    if (leftOverlayHideTimeoutRef.current) {
+      clearTimeout(leftOverlayHideTimeoutRef.current);
+    }
+    leftOverlayHideTimeoutRef.current = setTimeout(() => {
+      setLeftOverlayVisible(false);
+      leftOverlayHideTimeoutRef.current = null;
+    }, 120);
+  }, []);
+  const toggleLeftFromTrigger = useCallback(() => {
+    setLeftOpen((prev) => {
+      const next = !prev;
+      if (next) {
+        setLeftOverlayVisible(true);
+      } else {
+        setLeftOverlayVisible(false);
+      }
+      return next;
+    });
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (leftOverlayHideTimeoutRef.current) {
+        clearTimeout(leftOverlayHideTimeoutRef.current);
+      }
+    };
+  }, []);
 
   return (
-    <AiPanelProvider value={{ open: leftOpen, toggle: toggleLeft }}>
+    <AiPanelProvider
+      value={{
+        open: leftOpen,
+        overlayVisible: leftOverlayVisible,
+        toggle: toggleLeftFromTrigger,
+        openAiPanel: openLeft,
+        closeAiPanel: closeLeft,
+        showAiOverlay: showLeftOverlay,
+        hideAiOverlay: hideLeftOverlay,
+      }}
+    >
       <HumanChatPanelProvider
         open={rightOpen}
         toggle={toggleRight}
@@ -48,17 +110,22 @@ export function PanelProviders({ children }: { children: React.ReactNode }) {
 // regardless of SidebarProvider nesting order.
 
 export function AiSidebarTrigger() {
-  const { open, toggle } = useAiPanel();
+  const { open, overlayVisible, toggle, showAiOverlay, hideAiOverlay } =
+    useAiPanel();
   const t = useTranslations('AiPanel');
   const isSpace = useIsSpaceContext();
 
-  if (!isSpace || open) return null;
+  if (!isSpace) return null;
 
   return (
     <button
       type="button"
       onClick={toggle}
-      aria-expanded={open}
+      onMouseEnter={showAiOverlay}
+      onMouseLeave={hideAiOverlay}
+      onFocus={showAiOverlay}
+      onBlur={hideAiOverlay}
+      aria-expanded={open && overlayVisible}
       className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
       title={t('openPanel')}
       aria-label={t('openPanel')}
@@ -149,7 +216,13 @@ export function PanelWrapLayout({
   left,
   right,
 }: PanelWrapLayoutProps) {
-  const { open: leftOpen, toggle: toggleLeft } = useAiPanel();
+  const {
+    open: leftOpen,
+    overlayVisible: leftOverlayVisible,
+    toggle: toggleLeft,
+    showAiOverlay,
+    hideAiOverlay,
+  } = useAiPanel();
   const { open: rightOpen, toggle: toggleRight } = useHumanChatPanel();
   const isSpace = useIsSpaceContext();
 
@@ -157,7 +230,8 @@ export function PanelWrapLayout({
   const effectiveLeft = isSpace ? left : undefined;
   const effectiveRight = isSpace ? right : undefined;
 
-  const sidebarLeftPx = leftOpen && effectiveLeft ? '320px' : '0px';
+  const leftExpanded = Boolean(leftOpen && leftOverlayVisible);
+  const sidebarLeftPx = effectiveLeft ? (leftExpanded ? '320px' : '48px') : '0px';
   const sidebarRightPx = rightOpen && effectiveRight ? '320px' : '0px';
 
   /** Radix portaled dialogs sit under `body` and do not inherit vars from this div — mirror to `:root`. */
@@ -174,10 +248,12 @@ export function PanelWrapLayout({
   if (effectiveLeft && effectiveRight) {
     content = (
       <PanelDualSidebarScrollBridge
-        leftOpen={leftOpen}
+        leftOpen={leftExpanded}
         onLeftOpenChange={(open) => {
-          if (open !== leftOpen) toggleLeft();
+          if (open !== leftExpanded) toggleLeft();
         }}
+        onLeftMouseEnter={showAiOverlay}
+        onLeftMouseLeave={hideAiOverlay}
         rightOpen={rightOpen}
         onRightOpenChange={(open) => {
           if (open !== rightOpen) toggleRight();
@@ -220,9 +296,9 @@ export function PanelWrapLayout({
     content = (
       <SidebarProvider
         defaultOpen={false}
-        open={leftOpen}
+        open={leftExpanded}
         onOpenChange={(open) => {
-          if (open !== leftOpen) toggleLeft();
+          if (open !== leftExpanded) toggleLeft();
         }}
         style={
           {
@@ -233,8 +309,10 @@ export function PanelWrapLayout({
         <Sidebar
           side="left"
           variant="sidebar"
-          collapsible="offcanvas"
+          collapsible="icon"
           className="z-[50]"
+          onMouseEnter={showAiOverlay}
+          onMouseLeave={hideAiOverlay}
         >
           {effectiveLeft.content}
           <SidebarResizeHandle />

--- a/packages/epics/src/common/panel-wrap-layout.tsx
+++ b/packages/epics/src/common/panel-wrap-layout.tsx
@@ -229,7 +229,7 @@ export function PanelWrapLayout({
   const effectiveLeft = isSpace ? left : undefined;
   const effectiveRight = isSpace ? right : undefined;
 
-  const leftExpanded = Boolean(leftOpen);
+  const leftExpanded = Boolean(leftOpen || leftOverlayVisible);
   const sidebarLeftPx = effectiveLeft
     ? leftExpanded
       ? '320px'

--- a/packages/epics/src/common/panel-wrap-layout.tsx
+++ b/packages/epics/src/common/panel-wrap-layout.tsx
@@ -47,12 +47,13 @@ export function PanelProviders({ children }: { children: React.ReactNode }) {
     setLeftOverlayVisible(false);
   }, []);
   const showLeftOverlay = useCallback(() => {
+    if (leftOpen) return;
     if (leftOverlayHideTimeoutRef.current) {
       clearTimeout(leftOverlayHideTimeoutRef.current);
       leftOverlayHideTimeoutRef.current = null;
     }
     setLeftOverlayVisible(true);
-  }, []);
+  }, [leftOpen]);
   const hideLeftOverlay = useCallback(() => {
     if (leftOverlayHideTimeoutRef.current) {
       clearTimeout(leftOverlayHideTimeoutRef.current);
@@ -65,11 +66,8 @@ export function PanelProviders({ children }: { children: React.ReactNode }) {
   const toggleLeftFromTrigger = useCallback(() => {
     setLeftOpen((prev) => {
       const next = !prev;
-      if (next) {
-        setLeftOverlayVisible(true);
-      } else {
-        setLeftOverlayVisible(false);
-      }
+      // Trigger click controls chat panel visibility; hover controls overlay rail expansion.
+      setLeftOverlayVisible(false);
       return next;
     });
   }, []);
@@ -110,12 +108,11 @@ export function PanelProviders({ children }: { children: React.ReactNode }) {
 // regardless of SidebarProvider nesting order.
 
 export function AiSidebarTrigger() {
-  const { open, overlayVisible, toggle, showAiOverlay, hideAiOverlay } =
-    useAiPanel();
+  const { open, overlayVisible, toggle, showAiOverlay, hideAiOverlay } = useAiPanel();
   const t = useTranslations('AiPanel');
   const isSpace = useIsSpaceContext();
 
-  if (!isSpace) return null;
+  if (!isSpace || open) return null;
 
   return (
     <button
@@ -230,7 +227,7 @@ export function PanelWrapLayout({
   const effectiveLeft = isSpace ? left : undefined;
   const effectiveRight = isSpace ? right : undefined;
 
-  const leftExpanded = Boolean(leftOpen && leftOverlayVisible);
+  const leftExpanded = Boolean(leftOpen);
   const sidebarLeftPx = effectiveLeft
     ? leftExpanded
       ? '320px'

--- a/packages/epics/src/common/panel-wrap-layout.tsx
+++ b/packages/epics/src/common/panel-wrap-layout.tsx
@@ -108,7 +108,8 @@ export function PanelProviders({ children }: { children: React.ReactNode }) {
 // regardless of SidebarProvider nesting order.
 
 export function AiSidebarTrigger() {
-  const { open, overlayVisible, toggle, showAiOverlay, hideAiOverlay } = useAiPanel();
+  const { open, overlayVisible, toggle, showAiOverlay, hideAiOverlay } =
+    useAiPanel();
   const t = useTranslations('AiPanel');
   const isSpace = useIsSpaceContext();
 

--- a/packages/epics/src/common/panel-wrap-layout.tsx
+++ b/packages/epics/src/common/panel-wrap-layout.tsx
@@ -231,7 +231,11 @@ export function PanelWrapLayout({
   const effectiveRight = isSpace ? right : undefined;
 
   const leftExpanded = Boolean(leftOpen && leftOverlayVisible);
-  const sidebarLeftPx = effectiveLeft ? (leftExpanded ? '320px' : '48px') : '0px';
+  const sidebarLeftPx = effectiveLeft
+    ? leftExpanded
+      ? '320px'
+      : '48px'
+    : '0px';
   const sidebarRightPx = rightOpen && effectiveRight ? '320px' : '0px';
 
   /** Radix portaled dialogs sit under `body` and do not inherit vars from this div — mirror to `:root`. */

--- a/packages/epics/src/common/panel-wrap-layout.tsx
+++ b/packages/epics/src/common/panel-wrap-layout.tsx
@@ -61,7 +61,7 @@ export function PanelProviders({ children }: { children: React.ReactNode }) {
     leftOverlayHideTimeoutRef.current = setTimeout(() => {
       setLeftOverlayVisible(false);
       leftOverlayHideTimeoutRef.current = null;
-    }, 120);
+    }, 220);
   }, []);
   const toggleLeftFromTrigger = useCallback(() => {
     setLeftOpen((prev) => {
@@ -312,7 +312,7 @@ export function PanelWrapLayout({
           side="left"
           variant="sidebar"
           collapsible="icon"
-          className="z-[50]"
+          className="z-[50] overflow-visible"
           onMouseEnter={showAiOverlay}
           onMouseLeave={hideAiOverlay}
         >

--- a/packages/epics/src/common/panel-wrap-layout.tsx
+++ b/packages/epics/src/common/panel-wrap-layout.tsx
@@ -108,8 +108,7 @@ export function PanelProviders({ children }: { children: React.ReactNode }) {
 // regardless of SidebarProvider nesting order.
 
 export function AiSidebarTrigger() {
-  const { open, overlayVisible, toggle, showAiOverlay, hideAiOverlay } =
-    useAiPanel();
+  const { open, overlayVisible, toggle } = useAiPanel();
   const t = useTranslations('AiPanel');
   const isSpace = useIsSpaceContext();
 
@@ -119,10 +118,6 @@ export function AiSidebarTrigger() {
     <button
       type="button"
       onClick={toggle}
-      onMouseEnter={showAiOverlay}
-      onMouseLeave={hideAiOverlay}
-      onFocus={showAiOverlay}
-      onBlur={hideAiOverlay}
       aria-expanded={open && overlayVisible}
       className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
       title={t('openPanel')}
@@ -315,8 +310,6 @@ export function PanelWrapLayout({
           variant="sidebar"
           collapsible="icon"
           className="z-[50] overflow-visible"
-          onMouseEnter={showAiOverlay}
-          onMouseLeave={hideAiOverlay}
         >
           {effectiveLeft.content}
           <SidebarResizeHandle />

--- a/packages/epics/src/common/panel-wrap-layout.tsx
+++ b/packages/epics/src/common/panel-wrap-layout.tsx
@@ -174,6 +174,7 @@ const SIDEBAR_WIDTH_MIRROR_KEYS = [
   '--sidebar-right-width',
   '--main-column-scrollbar-width',
 ] as const;
+const LEFT_SIDEBAR_ICON_WIDTH = '72px';
 
 function mirrorMainColumnLayoutVarsToDocument(
   sidebarLeftPx: string,
@@ -232,7 +233,7 @@ export function PanelWrapLayout({
   const sidebarLeftPx = effectiveLeft
     ? leftExpanded
       ? '320px'
-      : '48px'
+      : LEFT_SIDEBAR_ICON_WIDTH
     : '0px';
   const sidebarRightPx = rightOpen && effectiveRight ? '320px' : '0px';
 
@@ -305,6 +306,7 @@ export function PanelWrapLayout({
         style={
           {
             '--sidebar-width': '320px',
+            '--sidebar-width-icon': LEFT_SIDEBAR_ICON_WIDTH,
           } as React.CSSProperties
         }
       >

--- a/packages/epics/src/spaces/components/create-space-form.tsx
+++ b/packages/epics/src/spaces/components/create-space-form.tsx
@@ -158,6 +158,7 @@ export const SpaceForm = ({
 
   const parentSpaceId = form.watch('parentId');
   const slug = form.watch('slug');
+  const isRootConfiguration = label === 'configure' && parentSpaceId === null;
 
   const {
     exists: slugExists,
@@ -464,6 +465,11 @@ export const SpaceForm = ({
                   name="logoUrl"
                   render={({ field }) => (
                     <FormItem>
+                      {isRootConfiguration ? (
+                        <FormLabel className="text-foreground gap-1">
+                          Ecosystem Logo <RequirementMark />
+                        </FormLabel>
+                      ) : null}
                       <FormControl>
                         <UploadAvatar
                           {...field}
@@ -472,10 +478,10 @@ export const SpaceForm = ({
                             typeof values?.logoUrl === 'string'
                               ? values?.logoUrl
                               : typeof defaultValues?.logoUrl === 'string'
-                              ? defaultValues?.logoUrl
-                              : undefined
+                                ? defaultValues?.logoUrl
+                                : undefined
                           }
-                          required={true}
+                          required={isRootConfiguration}
                         />
                       </FormControl>
                       <FormMessage />
@@ -557,8 +563,8 @@ export const SpaceForm = ({
                     typeof values?.leadImage === 'string'
                       ? values?.leadImage
                       : typeof defaultValues?.leadImage === 'string'
-                      ? defaultValues?.leadImage
-                      : undefined
+                        ? defaultValues?.leadImage
+                        : undefined
                   }
                   uploadText={
                     <>

--- a/packages/epics/src/spaces/components/create-space-form.tsx
+++ b/packages/epics/src/spaces/components/create-space-form.tsx
@@ -478,8 +478,8 @@ export const SpaceForm = ({
                             typeof values?.logoUrl === 'string'
                               ? values?.logoUrl
                               : typeof defaultValues?.logoUrl === 'string'
-                                ? defaultValues?.logoUrl
-                                : undefined
+                              ? defaultValues?.logoUrl
+                              : undefined
                           }
                           required={isRootConfiguration}
                         />
@@ -563,8 +563,8 @@ export const SpaceForm = ({
                     typeof values?.leadImage === 'string'
                       ? values?.leadImage
                       : typeof defaultValues?.leadImage === 'string'
-                        ? defaultValues?.leadImage
-                        : undefined
+                      ? defaultValues?.leadImage
+                      : undefined
                   }
                   uploadText={
                     <>

--- a/packages/epics/src/spaces/components/create-space-form.tsx
+++ b/packages/epics/src/spaces/components/create-space-form.tsx
@@ -88,6 +88,7 @@ const DEFAULT_VALUES = {
   title: '',
   description: '',
   logoUrl: '',
+  ecosystemLogoUrl: undefined,
   slug: '',
   leadImage: '',
   categories: [] as Category[],
@@ -465,11 +466,6 @@ export const SpaceForm = ({
                   name="logoUrl"
                   render={({ field }) => (
                     <FormItem>
-                      {isRootConfiguration ? (
-                        <FormLabel className="text-foreground gap-1">
-                          Ecosystem Logo <RequirementMark />
-                        </FormLabel>
-                      ) : null}
                       <FormControl>
                         <UploadAvatar
                           {...field}
@@ -481,7 +477,6 @@ export const SpaceForm = ({
                               ? defaultValues?.logoUrl
                               : undefined
                           }
-                          required={isRootConfiguration}
                         />
                       </FormControl>
                       <FormMessage />
@@ -629,6 +624,38 @@ export const SpaceForm = ({
             )}
           />
         )}
+        {isRootConfiguration ? (
+          <FormField
+            control={form.control}
+            name="ecosystemLogoUrl"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel className="text-foreground">
+                  Upload Ecosystem Logo
+                </FormLabel>
+                <FormControl>
+                  <UploadAvatar
+                    {...field}
+                    maxFileSize={ALLOWED_IMAGE_FILE_SIZE}
+                    defaultImage={
+                      typeof values?.ecosystemLogoUrl === 'string'
+                        ? values?.ecosystemLogoUrl
+                        : typeof defaultValues?.ecosystemLogoUrl === 'string'
+                        ? defaultValues?.ecosystemLogoUrl
+                        : undefined
+                    }
+                  />
+                </FormControl>
+                <p className="text-1 text-neutral-11">
+                  This ecosystem logo will be displayed in the top banner of
+                  your ecosystem and will be shown on every space that belongs
+                  to it, ensuring consistent branding throughout.
+                </p>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        ) : null}
         <FormField
           control={form.control}
           name="categories"

--- a/packages/epics/src/spaces/components/create-subspace-form.tsx
+++ b/packages/epics/src/spaces/components/create-subspace-form.tsx
@@ -73,7 +73,12 @@ export const CreateSubspaceForm = ({
         closeUrl={successfulUrl}
         backUrl={backUrl}
         backLabel={t('backToSettings')}
-        onSubmit={(values) => createSpace(values)}
+        onSubmit={(values) => {
+          // Subspace creation does not use root-only ecosystem branding fields.
+          const { ecosystemLogoUrl: _ecosystemLogoUrl, ...createValues } =
+            values;
+          return createSpace(createValues);
+        }}
         initialParentSpaceId={parentSpaceId as number}
         parentSpaceSlug={parentSpaceSlug}
         label="add"

--- a/packages/storage-postgres/migrations/0048_ecosystem_logo_url.sql
+++ b/packages/storage-postgres/migrations/0048_ecosystem_logo_url.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "spaces"
+ADD COLUMN "ecosystem_logo_url" text;

--- a/packages/storage-postgres/migrations/meta/_journal.json
+++ b/packages/storage-postgres/migrations/meta/_journal.json
@@ -337,6 +337,13 @@
       "when": 1775200100000,
       "tag": "0047_canonical_matrix_privy_id",
       "breakpoints": true
+    },
+    {
+      "idx": 48,
+      "version": "7",
+      "when": 1775400000000,
+      "tag": "0048_ecosystem_logo_url",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/storage-postgres/src/schema/space.ts
+++ b/packages/storage-postgres/src/schema/space.ts
@@ -23,6 +23,7 @@ export const spaces = pgTable(
   {
     id: serial('id').primaryKey(),
     logoUrl: text('logo_url'),
+    ecosystemLogoUrl: text('ecosystem_logo_url'),
     leadImage: text('lead_image'),
     title: text('title').notNull(),
     description: text('description').notNull().default('SHOULD NOT BE EMPTY'),

--- a/packages/ui/src/organisms/menu-top.tsx
+++ b/packages/ui/src/organisms/menu-top.tsx
@@ -14,6 +14,7 @@ type MenuTopProps = {
   trailingAction?: React.ReactNode;
   logoHref?: string;
   logoText?: string;
+  logoNode?: React.ReactNode;
   hrefTarget?: string;
   openMenuLabel?: string;
   closeMenuLabel?: string;
@@ -25,6 +26,7 @@ export const MenuTop = ({
   trailingAction,
   logoHref,
   logoText,
+  logoNode,
   hrefTarget,
   openMenuLabel = 'Open menu',
   closeMenuLabel = 'Close menu',
@@ -89,7 +91,9 @@ export const MenuTop = ({
       >
         <div className="flex items-center gap-2">
           {leadingAction}
-          {logoText ? (
+          {logoNode ? (
+            logoNode
+          ) : logoText ? (
             logoHref ? (
               <Link
                 href={logoHref}

--- a/packages/ui/src/organisms/menu-top.tsx
+++ b/packages/ui/src/organisms/menu-top.tsx
@@ -94,12 +94,12 @@ export const MenuTop = ({
               <Link
                 href={logoHref}
                 target={hrefTarget}
-                className="inline-block max-w-[22rem] truncate text-5xl font-light leading-none tracking-tight text-foreground"
+                className="inline-block max-w-[22rem] truncate text-3xl font-medium leading-none tracking-tight text-foreground"
               >
                 {logoText}
               </Link>
             ) : (
-              <span className="inline-block max-w-[22rem] truncate text-5xl font-light leading-none tracking-tight text-foreground">
+              <span className="inline-block max-w-[22rem] truncate text-3xl font-medium leading-none tracking-tight text-foreground">
                 {logoText}
               </span>
             )

--- a/packages/ui/src/organisms/menu-top.tsx
+++ b/packages/ui/src/organisms/menu-top.tsx
@@ -6,12 +6,14 @@ import { Menu } from 'lucide-react';
 import { RxCross1 } from 'react-icons/rx';
 import { usePathname } from 'next/navigation';
 import clsx from 'clsx';
+import Link from 'next/link';
 
 type MenuTopProps = {
   children?: React.ReactNode;
   leadingAction?: React.ReactNode;
   trailingAction?: React.ReactNode;
   logoHref?: string;
+  logoText?: string;
   hrefTarget?: string;
   openMenuLabel?: string;
   closeMenuLabel?: string;
@@ -22,6 +24,7 @@ export const MenuTop = ({
   leadingAction,
   trailingAction,
   logoHref,
+  logoText,
   hrefTarget,
   openMenuLabel = 'Open menu',
   closeMenuLabel = 'Close menu',
@@ -86,9 +89,23 @@ export const MenuTop = ({
       >
         <div className="flex items-center gap-2">
           {leadingAction}
-          {!!logoHref && (
+          {logoText ? (
+            logoHref ? (
+              <Link
+                href={logoHref}
+                target={hrefTarget}
+                className="inline-block max-w-[22rem] truncate text-5xl font-light leading-none tracking-tight text-foreground"
+              >
+                {logoText}
+              </Link>
+            ) : (
+              <span className="inline-block max-w-[22rem] truncate text-5xl font-light leading-none tracking-tight text-foreground">
+                {logoText}
+              </span>
+            )
+          ) : !!logoHref ? (
             <Logo width={110} href={logoHref} target={hrefTarget} />
-          )}
+          ) : null}
         </div>
 
         {/* Desktop Nav + Trailing action (right-aligned group) */}


### PR DESCRIPTION
## Summary
- implement the sidebar-01 inspired AI left-panel navigation redesign with grouped space switcher, icon+label menu items, and deterministic expanded/collapsed overlay behavior
- align the AI composer UI with the right chat composer and add dictation support, including active recording visual parity and icon ordering parity
- add a dedicated requirements spec for the redesign and codify anti-glitch state transitions between overlay visibility and collapsed intent

## Test plan
- [ ] Open a space route and verify hover/focus on the left trigger reveals the overlay menu without shifting main content
- [ ] Click close and verify the panel collapses to icon-only rail; re-open and confirm no flicker/jump when moving pointer between trigger and rail
- [ ] Verify top-left AI header uses active space icon and dropdown; ensure dropdown groups ecosystem spaces first, then others with a delimiter
- [ ] Verify left menu items render as Signals/Agreements/Members/Treasury with active highlighting and correct navigation
- [ ] Verify AI composer matches right composer visual language and icon order; verify dictation enters text and stop/recording states behave correctly
- [ ] Lint check on touched files passes