### PR TITLE
feat: enable AI/signals/human flags and hide AI trigger button

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -28,6 +28,7 @@ import { TooltipProvider } from '@hypha-platform/ui';
 import { ROOT_URL } from './constants';
 import {
   getEnableAiChat,
+  getEnableSpaceMemory,
   getEnableHumanChat,
 } from '@hypha-platform/feature-flags';
 import { NotificationSubscriber } from '@hypha-platform/notifications/client';
@@ -109,6 +110,7 @@ export default async function RootLayout({
   const safariWebId = process.env.NEXT_PUBLIC_ONESIGNAL_SAFARI_WEB_ID ?? '';
   const serviceWorkerPath = 'onesignal/OneSignalSDKWorker.js';
   const aiChatEnabled = await getEnableAiChat();
+  const spaceMemoryEnabled = await getEnableSpaceMemory();
   const humanChatEnabled = await getEnableHumanChat();
 
   return (
@@ -141,7 +143,13 @@ export default async function RootLayout({
                       <PanelWrapLayout
                         left={
                           aiChatEnabled
-                            ? { content: <AiLeftPanel /> }
+                            ? {
+                                content: (
+                                  <AiLeftPanel
+                                    enableSpaceMemory={spaceMemoryEnabled}
+                                  />
+                                ),
+                              }
                             : undefined
                         }
                         right={

--- a/packages/epics/src/common/ai-left-panel.tsx
+++ b/packages/epics/src/common/ai-left-panel.tsx
@@ -90,7 +90,6 @@ const MENU_CLOSE_BUTTON_CLASS =
   'flex h-8 w-8 items-center justify-center rounded-xl text-muted-foreground transition-colors hover:bg-muted hover:text-foreground';
 const RECENT_SPACE_AVATAR_CLASS =
   'flex h-6 w-6 shrink-0 aspect-square items-center justify-center overflow-hidden rounded-full bg-muted ring-1 ring-border/60';
-const SHOW_AI_TRIGGER_BUTTON = false;
 
 export function AiLeftPanel() {
   const { isAuthenticated, isLoading, login, getAccessToken } =
@@ -565,7 +564,7 @@ export function AiLeftPanel() {
   }, [isHoverOpenLocked]);
   const canHoverOpenFromTrigger = !shouldCloseFromTrigger && !isHoverOpenLocked;
 
-  const triggerButton = SHOW_AI_TRIGGER_BUTTON ? (
+  const triggerButton = (
     <button
       type="button"
       onClick={handleTriggerClick}
@@ -581,7 +580,7 @@ export function AiLeftPanel() {
     >
       <Menu className="pointer-events-none absolute left-1/2 top-1/2 h-4 w-4 -translate-x-1/2 -translate-y-1/2 text-muted-foreground" />
     </button>
-  ) : null;
+  );
   const closeButton = shouldCloseFromTrigger ? (
     <button
       type="button"
@@ -648,11 +647,9 @@ export function AiLeftPanel() {
     return (
       <>
         <SidebarHeader className="flex h-[var(--menu-top-height,70px)] min-w-0 flex-shrink-0 items-center justify-end border-b border-border bg-background-2 px-4 py-2">
-          {triggerButton ? (
-            <div className="-translate-y-px flex h-8 w-8 shrink-0 items-center justify-end">
-              {triggerButton}
-            </div>
-          ) : null}
+          <div className="-translate-y-px flex h-8 w-8 shrink-0 items-center justify-end">
+            {triggerButton}
+          </div>
         </SidebarHeader>
         <SidebarContent
           className="relative overflow-visible bg-background-2"

--- a/packages/epics/src/common/ai-left-panel.tsx
+++ b/packages/epics/src/common/ai-left-panel.tsx
@@ -90,6 +90,7 @@ const MENU_CLOSE_BUTTON_CLASS =
   'flex h-8 w-8 items-center justify-center rounded-xl text-muted-foreground transition-colors hover:bg-muted hover:text-foreground';
 const RECENT_SPACE_AVATAR_CLASS =
   'flex h-6 w-6 shrink-0 aspect-square items-center justify-center overflow-hidden rounded-full bg-muted ring-1 ring-border/60';
+const SHOW_AI_TRIGGER_BUTTON = false;
 
 export function AiLeftPanel() {
   const { isAuthenticated, isLoading, login, getAccessToken } =
@@ -564,7 +565,7 @@ export function AiLeftPanel() {
   }, [isHoverOpenLocked]);
   const canHoverOpenFromTrigger = !shouldCloseFromTrigger && !isHoverOpenLocked;
 
-  const triggerButton = (
+  const triggerButton = SHOW_AI_TRIGGER_BUTTON ? (
     <button
       type="button"
       onClick={handleTriggerClick}
@@ -580,7 +581,7 @@ export function AiLeftPanel() {
     >
       <Menu className="pointer-events-none absolute left-1/2 top-1/2 h-4 w-4 -translate-x-1/2 -translate-y-1/2 text-muted-foreground" />
     </button>
-  );
+  ) : null;
   const closeButton = shouldCloseFromTrigger ? (
     <button
       type="button"
@@ -647,9 +648,11 @@ export function AiLeftPanel() {
     return (
       <>
         <SidebarHeader className="flex h-[var(--menu-top-height,70px)] min-w-0 flex-shrink-0 items-center justify-end border-b border-border bg-background-2 px-4 py-2">
-          <div className="-translate-y-px flex h-8 w-8 shrink-0 items-center justify-end">
-            {triggerButton}
-          </div>
+          {triggerButton ? (
+            <div className="-translate-y-px flex h-8 w-8 shrink-0 items-center justify-end">
+              {triggerButton}
+            </div>
+          ) : null}
         </SidebarHeader>
         <SidebarContent
           className="relative overflow-visible bg-background-2"

--- a/packages/epics/src/common/ai-left-panel.tsx
+++ b/packages/epics/src/common/ai-left-panel.tsx
@@ -91,7 +91,11 @@ const MENU_CLOSE_BUTTON_CLASS =
 const RECENT_SPACE_AVATAR_CLASS =
   'flex h-6 w-6 shrink-0 aspect-square items-center justify-center overflow-hidden rounded-full bg-muted ring-1 ring-border/60';
 
-export function AiLeftPanel() {
+type AiLeftPanelProps = {
+  enableSpaceMemory?: boolean;
+};
+
+export function AiLeftPanel({ enableSpaceMemory = false }: AiLeftPanelProps) {
   const { isAuthenticated, isLoading, login, getAccessToken } =
     useAuthentication();
   const params = useParams<{ id?: string; lang?: string }>();
@@ -207,15 +211,20 @@ export function AiLeftPanel() {
         href: `/${lang}/dho/${spaceSlug}/rewards`,
         active: isSectionActive('rewards'),
       },
-      {
-        key: 'memory',
-        label: tCoherence('spaceMemory'),
-        icon: MemoryIcon,
-        href: `/${lang}/dho/${spaceSlug}/memory`,
-        active: isSectionActive('memory'),
-      },
+      ...(enableSpaceMemory
+        ? [
+            {
+              key: 'memory',
+              label: tCoherence('spaceMemory'),
+              icon: MemoryIcon,
+              href: `/${lang}/dho/${spaceSlug}/memory`,
+              active: isSectionActive('memory'),
+            },
+          ]
+        : []),
     ];
   }, [
+    enableSpaceMemory,
     isSectionActive,
     lang,
     spaceSlug,

--- a/packages/epics/src/common/panel-wrap-layout.tsx
+++ b/packages/epics/src/common/panel-wrap-layout.tsx
@@ -7,7 +7,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { MessageCircle, Sparkles } from 'lucide-react';
+import { MessageCircle } from 'lucide-react';
 import {
   SidebarProvider,
   Sidebar,
@@ -108,24 +108,7 @@ export function PanelProviders({ children }: { children: React.ReactNode }) {
 // regardless of SidebarProvider nesting order.
 
 export function AiSidebarTrigger() {
-  const { open, overlayVisible, toggle } = useAiPanel();
-  const t = useTranslations('AiPanel');
-  const isSpace = useIsSpaceContext();
-
-  if (!isSpace || open) return null;
-
-  return (
-    <button
-      type="button"
-      onClick={toggle}
-      aria-expanded={overlayVisible}
-      className="flex h-8 w-8 items-center justify-center overflow-hidden rounded-xl bg-muted p-0 text-muted-foreground ring-1 ring-border/70 transition-colors hover:text-foreground"
-      title={t('openPanel')}
-      aria-label={t('openPanel')}
-    >
-      <Sparkles className="h-4 w-4" />
-    </button>
-  );
+  return null;
 }
 
 export function HumanSidebarTrigger() {

--- a/packages/feature-flags/src/index.ts
+++ b/packages/feature-flags/src/index.ts
@@ -11,10 +11,13 @@ const isEnabled = (value: string | undefined) => {
 };
 
 /**
- * **Guideline:** AI / Coherence / Space Memory / Human Chat default **off** until
- * enabled via cookie, `NEXT_PUBLIC_*=true`, or Vercel Flags Toolbar. Human Chat
- * opt-in: `getEnableHumanChat`. Kill switch: `HYPHA_DISABLE_HUMAN_CHAT=true` /
- * `NEXT_PUBLIC_DISABLE_HUMAN_CHAT=true` (wins over enable).
+ * Default feature exposure:
+ * - AI panel: on
+ * - Coherence/signals: on
+ * - Space memory: off
+ * - Human chat: on
+ *
+ * Toolbar overrides and `NEXT_PUBLIC_*` env values still take precedence.
  */
 
 /**
@@ -39,18 +42,14 @@ export const flagDefinitionsForDiscovery = {
   },
   enableAiChat: {
     key: 'enable-ai-chat',
-    defaultValue:
-      isPreviewEnvironment() ||
-      isEnabled(process.env.NEXT_PUBLIC_ENABLE_AI_CHAT),
+    defaultValue: true,
     description: 'Enable the AI Chat panel in space pages',
     origin: 'hypha' as const,
     options: undefined as undefined,
   },
   enableCoherence: {
     key: 'enable-coherence',
-    defaultValue:
-      isPreviewEnvironment() ||
-      isEnabled(process.env.NEXT_PUBLIC_ENABLE_COHERENCE),
+    defaultValue: true,
     description:
       'Coherence tab and signals. Opt in: HYPHA_ENABLE_COHERENCE cookie or NEXT_PUBLIC_ENABLE_COHERENCE=true. Space Memory uses enable-space-memory.',
     origin: 'hypha' as const,
@@ -70,9 +69,7 @@ export const flagDefinitionsForDiscovery = {
    */
   enableHumanChat: {
     key: 'enable-human-chat',
-    defaultValue:
-      isPreviewEnvironment() ||
-      isEnabled(process.env.NEXT_PUBLIC_ENABLE_HUMAN_CHAT),
+    defaultValue: true,
     description: 'Enable the Human Chat panel in space pages',
     origin: 'hypha' as const,
     options: undefined as undefined,
@@ -90,25 +87,35 @@ async function getBooleanFlagFromToolbarOrEnv(
   toolbarKey: string,
   envValue: string | undefined,
 ): Promise<boolean> {
+  return getBooleanFlagFromToolbarOrEnvOrDefault(toolbarKey, envValue, false);
+}
+
+async function getBooleanFlagFromToolbarOrEnvOrDefault(
+  toolbarKey: string,
+  envValue: string | undefined,
+  defaultValue: boolean,
+): Promise<boolean> {
   const overrides = await getVercelToolbarFlagOverrides();
   const o = readBooleanOverride(overrides, toolbarKey);
   if (o !== undefined) return o;
 
-  if (isEnabled(envValue)) return true;
-  return isPreviewEnvironment();
+  if (envValue !== undefined) return isEnabled(envValue);
+  return defaultValue;
 }
 
 export async function getEnableAiChat(): Promise<boolean> {
-  return getBooleanFlagFromToolbarOrEnv(
+  return getBooleanFlagFromToolbarOrEnvOrDefault(
     'enable-ai-chat',
     process.env.NEXT_PUBLIC_ENABLE_AI_CHAT,
+    true,
   );
 }
 
 export async function getEnableCoherence(): Promise<boolean> {
-  return getBooleanFlagFromToolbarOrEnv(
+  return getBooleanFlagFromToolbarOrEnvOrDefault(
     'enable-coherence',
     process.env.NEXT_PUBLIC_ENABLE_COHERENCE,
+    true,
   );
 }
 
@@ -117,15 +124,17 @@ export async function getEnableCoherence(): Promise<boolean> {
  * or Vercel toolbar. Kill switch (`HYPHA_DISABLE_HUMAN_CHAT` / `NEXT_PUBLIC_DISABLE_HUMAN_CHAT`) wins.
  */
 export async function getEnableHumanChat(): Promise<boolean> {
-  return getBooleanFlagFromToolbarOrEnv(
+  return getBooleanFlagFromToolbarOrEnvOrDefault(
     'enable-human-chat',
     process.env.NEXT_PUBLIC_ENABLE_HUMAN_CHAT,
+    true,
   );
 }
 
 export async function getEnableSpaceMemory(): Promise<boolean> {
-  return getBooleanFlagFromToolbarOrEnv(
+  return getBooleanFlagFromToolbarOrEnvOrDefault(
     'enable-space-memory',
     process.env.NEXT_PUBLIC_ENABLE_SPACE_MEMORY,
+    false,
   );
 }


### PR DESCRIPTION
## Summary
- set default feature flags to the requested rollout: AI panel `on`, coherence/signals `on`, space memory `off`, human chat `on`
- keep toolbar/env overrides in place while applying explicit defaults when unset
- hide the visible AI trigger button while preserving left AI panel rail behavior

## Test plan
- [x] Run `pnpm run format:fix`
- [x] Check lints for touched files
- [ ] Validate in browser that AI left rail still renders/opens without visible AI button
- [ ] Validate coherence tab and human right panel are visible
- [ ] Validate space memory remains disabled

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * AI chat, Coherence, and Human chat features are now enabled by default
  * Removed the AI sidebar trigger button

<!-- end of auto-generated comment: release notes by coderabbit.ai -->