### PR TITLE
fix: prevent first-load space route 500s

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack --port 3000",
-    "build": "next build",
+    "build": "node --max-old-space-size=6144 ./node_modules/next/dist/bin/next build",
     "start": "next start",
     "lint": "next lint",
     "check-types": "tsc --noEmit",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -42,6 +42,7 @@
   "devDependencies": {
     "@hypha-platform/config-eslint": "workspace:*",
     "@hypha-platform/config-typescript": "workspace:*",
+    "@tailwindcss/postcss": "^4.1.11",
     "@types/d3": "^7.4.3",
     "@types/node": "^22.14.0",
     "@types/react": "^19.1.2",

--- a/apps/web/src/app/[lang]/dho/[id]/@aside/[tab]/select-navigation-action/page.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@aside/[tab]/select-navigation-action/page.tsx
@@ -13,7 +13,7 @@ export default async function SelectNavigationActions({
   params: Promise<{ id: string; lang: Locale; tab: string }>;
 }) {
   const { id: daoSlug, lang } = await params;
-  let spaceNavigationLabel = 'Space navigation';
+  let spaceNavigationLabel: string | undefined;
   try {
     const tModalAside = await getTranslations('ModalAside');
     spaceNavigationLabel = tModalAside('spaceNavigation');

--- a/apps/web/src/app/[lang]/dho/[id]/@aside/[tab]/select-navigation-action/page.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@aside/[tab]/select-navigation-action/page.tsx
@@ -13,12 +13,21 @@ export default async function SelectNavigationActions({
   params: Promise<{ id: string; lang: Locale; tab: string }>;
 }) {
   const { id: daoSlug, lang } = await params;
-  const tModalAside = await getTranslations('ModalAside');
+  let spaceNavigationLabel = 'Space navigation';
+  try {
+    const tModalAside = await getTranslations('ModalAside');
+    spaceNavigationLabel = tModalAside('spaceNavigation');
+  } catch (error) {
+    console.error(
+      '[select-navigation-action/page] Failed to load ModalAside translations',
+      error,
+    );
+  }
   return (
     <ProposalOverlayShell>
       <div className="flex flex-col gap-5">
         <ModalStickyNavigation
-          contextTitle={tModalAside('spaceNavigation')}
+          contextTitle={spaceNavigationLabel}
           closeDropSegment={PATH_SELECT_NAVIGATION_ACTION}
           showBack={false}
         />

--- a/apps/web/src/app/[lang]/dho/[id]/@tab/ecosystem-navigation/page.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@tab/ecosystem-navigation/page.tsx
@@ -12,7 +12,15 @@ type PageProps = {
 export default async function EcosystemNavigationPage(props: PageProps) {
   const params = await props.params;
   const { lang, id } = params;
-  const spaceFromDb = await findSpaceBySlug({ slug: id }, { db });
+  let spaceFromDb: Awaited<ReturnType<typeof findSpaceBySlug>> = null;
+  try {
+    spaceFromDb = await findSpaceBySlug({ slug: id }, { db });
+  } catch (error) {
+    console.error('[ecosystem-navigation/page] Failed to load space by slug', {
+      error,
+      slug: id,
+    });
+  }
 
   if (!spaceFromDb) {
     return notFound();

--- a/apps/web/src/app/[lang]/dho/[id]/_components/dho-sticky-space-chrome.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/dho-sticky-space-chrome.tsx
@@ -25,6 +25,12 @@ export type DhoStickySpaceChromeProps = {
 
 function useMenuTopOffsetPx(): number {
   const [px, setPx] = React.useState(70);
+  const pxRef = React.useRef(px);
+  const rafRef = React.useRef<number | null>(null);
+
+  React.useEffect(() => {
+    pxRef.current = px;
+  }, [px]);
 
   React.useLayoutEffect(() => {
     const read = () => {
@@ -32,18 +38,33 @@ function useMenuTopOffsetPx(): number {
         '--menu-top-height',
       );
       const n = parseFloat(raw);
-      setPx(Number.isFinite(n) && n > 0 ? n : 70);
+      const next = Number.isFinite(n) && n > 0 ? n : 70;
+      if (next !== pxRef.current) {
+        pxRef.current = next;
+        setPx(next);
+      }
+    };
+    const scheduleRead = () => {
+      if (rafRef.current !== null) return;
+      rafRef.current = requestAnimationFrame(() => {
+        rafRef.current = null;
+        read();
+      });
     };
     read();
-    const mo = new MutationObserver(read);
+    const mo = new MutationObserver(scheduleRead);
     mo.observe(document.documentElement, {
       attributes: true,
       attributeFilter: ['style', 'class'],
     });
-    window.addEventListener('resize', read);
+    window.addEventListener('resize', scheduleRead);
     return () => {
       mo.disconnect();
-      window.removeEventListener('resize', read);
+      window.removeEventListener('resize', scheduleRead);
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
     };
   }, []);
 

--- a/apps/web/src/app/[lang]/dho/[id]/_components/ecosystem-navigation-main-panel.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/ecosystem-navigation-main-panel.tsx
@@ -278,7 +278,7 @@ export function EcosystemNavigationMainPanel({
             </h1>
           }
           className={
-            resolvedTheme === 'dark' ? 'bg-background-2' : 'bg-neutral-2/85'
+            resolvedTheme === 'light' ? 'bg-neutral-2/85' : 'bg-background-2'
           }
           visualizationClassName="min-h-0"
         />

--- a/apps/web/src/app/[lang]/dho/[id]/_components/ecosystem-navigation-main-panel.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/ecosystem-navigation-main-panel.tsx
@@ -114,16 +114,31 @@ export function EcosystemNavigationMainPanel({
 
   useEffect(() => {
     if (!currentSpace || !currentSpaceSlug) {
-      setSelectedSpace(null);
+      setSelectedSpace((previous) => (previous === null ? previous : null));
       return;
     }
-    setSelectedSpace({
-      id: currentSpace.id,
-      name: currentSpace.title,
-      slug: currentSpaceSlug,
-      logoUrl: currentSpace.logoUrl,
-      parentId: currentSpace.parentId ?? null,
-      root: true,
+    setSelectedSpace((previous) => {
+      const next = {
+        id: currentSpace.id,
+        name: currentSpace.title,
+        slug: currentSpaceSlug,
+        logoUrl: currentSpace.logoUrl,
+        parentId: currentSpace.parentId ?? null,
+        root: true,
+      } satisfies VisibleSpace;
+
+      if (
+        previous?.id === next.id &&
+        previous.slug === next.slug &&
+        previous.name === next.name &&
+        previous.logoUrl === next.logoUrl &&
+        previous.parentId === next.parentId &&
+        previous.root === next.root
+      ) {
+        return previous;
+      }
+
+      return next;
     });
   }, [currentSpace, currentSpaceSlug]);
 

--- a/apps/web/src/app/[lang]/dho/[id]/_components/space-visualization.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/space-visualization.tsx
@@ -131,7 +131,7 @@ export function SpaceVisualization({
     if (!svgRef.current || !focusRef.current) return;
 
     const getSelectedSpaceFillColor = () =>
-      themeRef.current === 'dark' ? '#1a1a1a' : '#ffffff';
+      themeRef.current === 'light' ? '#ffffff' : '#1a1a1a';
 
     const svg = d3.select(svgRef.current);
     const orbits = svg.selectAll<SVGCircleElement, SpaceHierarchyNode>(
@@ -167,7 +167,7 @@ export function SpaceVisualization({
     if (!svgRef.current) return;
 
     const getSelectedSpaceFillColor = () =>
-      themeRef.current === 'dark' ? '#1a1a1a' : '#ffffff';
+      themeRef.current === 'light' ? '#ffffff' : '#1a1a1a';
 
     const getStrokeWidth = (depth: number): number => {
       return (

--- a/apps/web/src/app/[lang]/network/page.tsx
+++ b/apps/web/src/app/[lang]/network/page.tsx
@@ -49,11 +49,19 @@ export default async function Index(props: PageProps) {
 
   const { lang } = params;
 
-  const spaces = await getAllSpaces({
-    search: query?.trim() || undefined,
-    parentOnly: false,
-    omitArchived: true,
-  });
+  let spaces: Space[] = [];
+  try {
+    spaces = await getAllSpaces({
+      search: query?.trim() || undefined,
+      parentOnly: false,
+      omitArchived: true,
+    });
+  } catch (error) {
+    console.error('[network/page] Failed to load spaces', {
+      error,
+      query: query?.trim() || undefined,
+    });
+  }
 
   const uniqueCategories = extractUniqueCategories(spaces);
 

--- a/apps/web/src/app/error.tsx
+++ b/apps/web/src/app/error.tsx
@@ -1,5 +1,33 @@
 'use client';
 
+import { useEffect } from 'react';
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error('[app/error] Unhandled client error', error);
+  }, [error]);
+
+  return (
+    <div className="flex min-h-[50vh] flex-col items-center justify-center gap-4 p-8 text-center">
+      <h2 className="text-lg font-medium">Something went wrong.</h2>
+      <button
+        type="button"
+        onClick={() => reset()}
+        className="rounded-md border border-border px-4 py-2 text-sm hover:bg-muted"
+      >
+        Try again
+      </button>
+    </div>
+  );
+}
+('use client');
+
 import React, { useEffect } from 'react';
 import { Button } from '@hypha-platform/ui';
 import { ReloadIcon } from '@radix-ui/react-icons';

--- a/apps/web/src/app/error.tsx
+++ b/apps/web/src/app/error.tsx
@@ -1,33 +1,5 @@
 'use client';
 
-import { useEffect } from 'react';
-
-export default function Error({
-  error,
-  reset,
-}: {
-  error: Error & { digest?: string };
-  reset: () => void;
-}) {
-  useEffect(() => {
-    console.error('[app/error] Unhandled client error', error);
-  }, [error]);
-
-  return (
-    <div className="flex min-h-[50vh] flex-col items-center justify-center gap-4 p-8 text-center">
-      <h2 className="text-lg font-medium">Something went wrong.</h2>
-      <button
-        type="button"
-        onClick={() => reset()}
-        className="rounded-md border border-border px-4 py-2 text-sm hover:bg-muted"
-      >
-        Try again
-      </button>
-    </div>
-  );
-}
-('use client');
-
 import React, { useEffect } from 'react';
 import { Button } from '@hypha-platform/ui';
 import { ReloadIcon } from '@radix-ui/react-icons';
@@ -42,7 +14,7 @@ export default function AppError({
 }) {
   const tCommon = useTranslations('Common');
   useEffect(() => {
-    console.error(error);
+    console.error('[app/error] Unhandled client error', error);
   }, [error]);
 
   return (

--- a/apps/web/src/app/global-error.tsx
+++ b/apps/web/src/app/global-error.tsx
@@ -16,7 +16,9 @@ function GlobalErrorContent({ reset }: { reset: () => void }) {
   return (
     <div className="relative flex min-h-screen w-full items-center justify-center">
       <div className="absolute inset-0 flex flex-col items-center justify-center gap-6 p-2 text-center md:p-0">
-        <h2 className="text-9 font-medium">{tCommon('errorMaintenanceTitle')}</h2>
+        <h2 className="text-9 font-medium">
+          {tCommon('errorMaintenanceTitle')}
+        </h2>
         <p className="text-4 text-neutral-11">
           {tCommon('errorMaintenanceDescription')}
         </p>
@@ -60,7 +62,10 @@ export default function GlobalError({
     };
 
     loadMessages().catch((loadError) => {
-      console.error('[app/global-error] Failed to load i18n messages', loadError);
+      console.error(
+        '[app/global-error] Failed to load i18n messages',
+        loadError,
+      );
     });
 
     return () => {

--- a/apps/web/src/app/global-error.tsx
+++ b/apps/web/src/app/global-error.tsx
@@ -1,7 +1,10 @@
 'use client';
 
 import '@hypha-platform/ui-utils/global.css';
-import { loadLocaleMessages } from '@hypha-platform/i18n/messages';
+import {
+  defaultMessages,
+  loadLocaleMessages,
+} from '@hypha-platform/i18n/messages';
 import { Button } from '@hypha-platform/ui';
 import { ReloadIcon } from '@radix-ui/react-icons';
 import { NextIntlClientProvider, useTranslations } from 'next-intl';
@@ -44,7 +47,10 @@ export default function GlobalError({
   error: Error & { digest?: string };
   reset: () => void;
 }) {
-  const [intlState, setIntlState] = useState<IntlState | null>(null);
+  const [intlState, setIntlState] = useState<IntlState>({
+    locale: 'en',
+    messages: defaultMessages,
+  });
 
   useEffect(() => {
     console.error('[app/global-error] Unhandled root error', error);
@@ -73,8 +79,8 @@ export default function GlobalError({
     };
   }, []);
 
-  const locale = intlState?.locale ?? 'en';
-  const messages = intlState?.messages ?? {};
+  const locale = intlState.locale;
+  const messages = intlState.messages;
 
   return (
     <html>

--- a/apps/web/src/app/global-error.tsx
+++ b/apps/web/src/app/global-error.tsx
@@ -1,44 +1,10 @@
 'use client';
 
 import '@hypha-platform/ui-utils/global.css';
-import {
-  defaultMessages,
-  loadLocaleMessages,
-} from '@hypha-platform/i18n/messages';
+import { getLocaleMessagesSync } from '@hypha-platform/i18n/messages';
 import { Button } from '@hypha-platform/ui';
 import { ReloadIcon } from '@radix-ui/react-icons';
-import { NextIntlClientProvider, useTranslations } from 'next-intl';
-import { useEffect, useState } from 'react';
-
-type Messages = Record<string, unknown>;
-type IntlState = { locale: string; messages: Messages };
-
-function GlobalErrorContent({ reset }: { reset: () => void }) {
-  const tCommon = useTranslations('Common');
-
-  return (
-    <div className="relative flex min-h-screen w-full items-center justify-center">
-      <div className="absolute inset-0 flex flex-col items-center justify-center gap-6 p-2 text-center md:p-0">
-        <h2 className="text-9 font-medium">
-          {tCommon('errorMaintenanceTitle')}
-        </h2>
-        <p className="text-4 text-neutral-11">
-          {tCommon('errorMaintenanceDescription')}
-        </p>
-        <Button
-          type="button"
-          colorVariant="accent"
-          variant="default"
-          className="gap-2"
-          onClick={reset}
-        >
-          <ReloadIcon />
-          {tCommon('errorRefreshPage')}
-        </Button>
-      </div>
-    </div>
-  );
-}
+import { useEffect } from 'react';
 
 export default function GlobalError({
   error,
@@ -47,47 +13,45 @@ export default function GlobalError({
   error: Error & { digest?: string };
   reset: () => void;
 }) {
-  const [intlState, setIntlState] = useState<IntlState>({
-    locale: 'en',
-    messages: defaultMessages,
-  });
-
   useEffect(() => {
     console.error('[app/global-error] Unhandled root error', error);
   }, [error]);
 
-  useEffect(() => {
-    let cancelled = false;
-
-    const loadMessages = async () => {
-      const locale = window.location.pathname.split('/').filter(Boolean)[0];
-      const data = await loadLocaleMessages(locale);
-      if (!cancelled) {
-        setIntlState(data);
-      }
-    };
-
-    loadMessages().catch((loadError) => {
-      console.error(
-        '[app/global-error] Failed to load i18n messages',
-        loadError,
-      );
-    });
-
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  const locale = intlState.locale;
-  const messages = intlState.messages;
+  const localeFromPath =
+    typeof window === 'undefined'
+      ? 'en'
+      : window.location.pathname.split('/').filter(Boolean)[0];
+  const { messages } = getLocaleMessagesSync(localeFromPath);
+  const common =
+    (messages['Common'] as Record<string, unknown> | undefined) ?? {};
+  const maintenanceTitle =
+    (common['errorMaintenanceTitle'] as string | undefined) ??
+    "We'll Be Back Shortly!";
+  const maintenanceDescription =
+    (common['errorMaintenanceDescription'] as string | undefined) ??
+    "Hypha is taking a short break while we roll out updates. We'll be back soon with exciting improvements on the way!";
+  const refreshLabel =
+    (common['errorRefreshPage'] as string | undefined) ?? 'Refresh Page';
 
   return (
     <html>
       <body>
-        <NextIntlClientProvider locale={locale} messages={messages}>
-          <GlobalErrorContent reset={reset} />
-        </NextIntlClientProvider>
+        <div className="relative flex min-h-screen w-full items-center justify-center">
+          <div className="absolute inset-0 flex flex-col items-center justify-center gap-6 p-2 text-center md:p-0">
+            <h2 className="text-9 font-medium">{maintenanceTitle}</h2>
+            <p className="text-4 text-neutral-11">{maintenanceDescription}</p>
+            <Button
+              type="button"
+              colorVariant="accent"
+              variant="default"
+              className="gap-2"
+              onClick={reset}
+            >
+              <ReloadIcon />
+              {refreshLabel}
+            </Button>
+          </div>
+        </div>
       </body>
     </html>
   );

--- a/apps/web/src/app/global-error.tsx
+++ b/apps/web/src/app/global-error.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import '@hypha-platform/ui-utils/global.css';
 import { useEffect } from 'react';
 
 export default function GlobalError({

--- a/apps/web/src/app/global-error.tsx
+++ b/apps/web/src/app/global-error.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error('[app/global-error] Unhandled root error', error);
+  }, [error]);
+
+  return (
+    <html>
+      <body>
+        <div className="flex min-h-screen flex-col items-center justify-center gap-4 p-8 text-center">
+          <h2 className="text-lg font-medium">Something went wrong.</h2>
+          <button
+            type="button"
+            onClick={() => reset()}
+            className="rounded-md border border-border px-4 py-2 text-sm hover:bg-muted"
+          >
+            Try again
+          </button>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/apps/web/src/app/global-error.tsx
+++ b/apps/web/src/app/global-error.tsx
@@ -1,7 +1,39 @@
 'use client';
 
 import '@hypha-platform/ui-utils/global.css';
-import { useEffect } from 'react';
+import { loadLocaleMessages } from '@hypha-platform/i18n/messages';
+import { Button } from '@hypha-platform/ui';
+import { ReloadIcon } from '@radix-ui/react-icons';
+import { NextIntlClientProvider, useTranslations } from 'next-intl';
+import { useEffect, useState } from 'react';
+
+type Messages = Record<string, unknown>;
+type IntlState = { locale: string; messages: Messages };
+
+function GlobalErrorContent({ reset }: { reset: () => void }) {
+  const tCommon = useTranslations('Common');
+
+  return (
+    <div className="relative flex min-h-screen w-full items-center justify-center">
+      <div className="absolute inset-0 flex flex-col items-center justify-center gap-6 p-2 text-center md:p-0">
+        <h2 className="text-9 font-medium">{tCommon('errorMaintenanceTitle')}</h2>
+        <p className="text-4 text-neutral-11">
+          {tCommon('errorMaintenanceDescription')}
+        </p>
+        <Button
+          type="button"
+          colorVariant="accent"
+          variant="default"
+          className="gap-2"
+          onClick={reset}
+        >
+          <ReloadIcon />
+          {tCommon('errorRefreshPage')}
+        </Button>
+      </div>
+    </div>
+  );
+}
 
 export default function GlobalError({
   error,
@@ -10,23 +42,41 @@ export default function GlobalError({
   error: Error & { digest?: string };
   reset: () => void;
 }) {
+  const [intlState, setIntlState] = useState<IntlState | null>(null);
+
   useEffect(() => {
     console.error('[app/global-error] Unhandled root error', error);
   }, [error]);
 
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadMessages = async () => {
+      const locale = window.location.pathname.split('/').filter(Boolean)[0];
+      const data = await loadLocaleMessages(locale);
+      if (!cancelled) {
+        setIntlState(data);
+      }
+    };
+
+    loadMessages().catch((loadError) => {
+      console.error('[app/global-error] Failed to load i18n messages', loadError);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const locale = intlState?.locale ?? 'en';
+  const messages = intlState?.messages ?? {};
+
   return (
     <html>
       <body>
-        <div className="flex min-h-screen flex-col items-center justify-center gap-4 p-8 text-center">
-          <h2 className="text-lg font-medium">Something went wrong.</h2>
-          <button
-            type="button"
-            onClick={() => reset()}
-            className="rounded-md border border-border px-4 py-2 text-sm hover:bg-muted"
-          >
-            Try again
-          </button>
-        </div>
+        <NextIntlClientProvider locale={locale} messages={messages}>
+          <GlobalErrorContent reset={reset} />
+        </NextIntlClientProvider>
       </body>
     </html>
   );

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -114,6 +114,7 @@ export default async function RootLayout({
   let navNetworkLabel = 'network';
   let navOpenMenuLabel = 'openMenu';
   let navCloseMenuLabel = 'closeMenu';
+  let navSelectLanguageLabel = 'selectLanguage';
   let footerNetworkLabel = 'network';
   let footerLegalLabel = 'legal';
   let footerHyphaServicesLabel = 'hyphaServices';
@@ -146,6 +147,7 @@ export default async function RootLayout({
     navNetworkLabel = tNav('network');
     navOpenMenuLabel = tNav('openMenu');
     navCloseMenuLabel = tNav('closeMenu');
+    navSelectLanguageLabel = tNav('selectLanguage');
   } catch (error) {
     console.error(
       '[app/layout] Failed to resolve Navigation translations',
@@ -261,7 +263,9 @@ export default async function RootLayout({
                             ]}
                             trailingBeforeProfile={
                               isLanguageSelectVisible ? (
-                                <ConnectedLanguageSelect />
+                                <ConnectedLanguageSelect
+                                  selectLanguageLabel={navSelectLanguageLabel}
+                                />
                               ) : undefined
                             }
                           />

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -20,7 +20,6 @@ import {
   ConnectedButtonProfile,
 } from '@hypha-platform/epics';
 import { ConnectedHumanRightPanel } from '@web/components/connected-human-right-panel';
-import { EvmProvider } from '@hypha-platform/evm';
 import { useMe } from '@hypha-platform/core/client';
 import { ConditionalMatrixProvider } from '@web/components/conditional-matrix-provider';
 import { fileRouter } from '@hypha-platform/core/server';
@@ -202,100 +201,96 @@ export default async function RootLayout({
           disableTransitionOnChange
         >
           <ThemeStorageNormalize />
-          <EvmProvider>
-            <NextIntlClientProvider locale={locale} messages={messages}>
-              <TooltipProvider>
-                <NotificationSubscriber
-                  appId={notificationAppId}
-                  safariWebId={safariWebId}
-                  serviceWorkerPath={serviceWorkerPath}
-                >
-                  <ConditionalMatrixProvider enabled={humanChatEnabled}>
-                    <PanelProviders>
-                      <PanelWrapLayout
-                        left={
-                          aiChatEnabled
-                            ? {
-                                content: (
-                                  <AiLeftPanel
-                                    enableSpaceMemory={spaceMemoryEnabled}
-                                  />
-                                ),
-                              }
-                            : undefined
-                        }
-                        right={
-                          humanChatEnabled
-                            ? { content: <ConnectedHumanRightPanel /> }
-                            : undefined
-                        }
-                      >
-                        {/* Fixed menu bar — clamped to center column by SidebarInset */}
-                        <div className="sticky top-0 z-30 shrink-0">
-                          <ConnectedMenuTop
-                            aiChatEnabled={aiChatEnabled}
-                            logoHref={ROOT_URL}
-                            openMenuLabel={navOpenMenuLabel}
-                            closeMenuLabel={navCloseMenuLabel}
-                            leadingAction={
-                              aiChatEnabled ? <AiSidebarTrigger /> : undefined
+          <NextIntlClientProvider locale={locale} messages={messages}>
+            <TooltipProvider>
+              <NotificationSubscriber
+                appId={notificationAppId}
+                safariWebId={safariWebId}
+                serviceWorkerPath={serviceWorkerPath}
+              >
+                <ConditionalMatrixProvider enabled={humanChatEnabled}>
+                  <PanelProviders>
+                    <PanelWrapLayout
+                      left={
+                        aiChatEnabled
+                          ? {
+                              content: (
+                                <AiLeftPanel
+                                  enableSpaceMemory={spaceMemoryEnabled}
+                                />
+                              ),
                             }
-                            trailingAction={
-                              humanChatEnabled ? (
-                                <HumanSidebarTrigger />
+                          : undefined
+                      }
+                      right={
+                        humanChatEnabled
+                          ? { content: <ConnectedHumanRightPanel /> }
+                          : undefined
+                      }
+                    >
+                      {/* Fixed menu bar — clamped to center column by SidebarInset */}
+                      <div className="sticky top-0 z-30 shrink-0">
+                        <ConnectedMenuTop
+                          aiChatEnabled={aiChatEnabled}
+                          logoHref={ROOT_URL}
+                          openMenuLabel={navOpenMenuLabel}
+                          closeMenuLabel={navCloseMenuLabel}
+                          leadingAction={
+                            aiChatEnabled ? <AiSidebarTrigger /> : undefined
+                          }
+                          trailingAction={
+                            humanChatEnabled ? (
+                              <HumanSidebarTrigger />
+                            ) : undefined
+                          }
+                        >
+                          <ConnectedButtonProfile
+                            useAuthentication={useAuthentication}
+                            useMe={useMe}
+                            newUserRedirectPath="/profile/signup"
+                            baseRedirectPath="/my-spaces"
+                            navItems={[
+                              {
+                                label: navMySpacesLabel,
+                                href: `/${locale}/my-spaces`,
+                              },
+                              {
+                                label: navNetworkLabel,
+                                href: `/${locale}/network`,
+                              },
+                            ]}
+                            trailingBeforeProfile={
+                              isLanguageSelectVisible ? (
+                                <ConnectedLanguageSelect />
                               ) : undefined
                             }
-                          >
-                            <ConnectedButtonProfile
-                              useAuthentication={useAuthentication}
-                              useMe={useMe}
-                              newUserRedirectPath="/profile/signup"
-                              baseRedirectPath="/my-spaces"
-                              navItems={[
-                                {
-                                  label: navMySpacesLabel,
-                                  href: `/${locale}/my-spaces`,
-                                },
-                                {
-                                  label: navNetworkLabel,
-                                  href: `/${locale}/network`,
-                                },
-                              ]}
-                              trailingBeforeProfile={
-                                isLanguageSelectVisible ? (
-                                  <ConnectedLanguageSelect />
-                                ) : undefined
-                              }
-                            />
-                          </ConnectedMenuTop>
+                          />
+                        </ConnectedMenuTop>
+                      </div>
+                      {/* Scrollable content area */}
+                      <NextSSRPlugin
+                        routerConfig={extractRouterConfig(fileRouter)}
+                      />
+                      <div className="mb-auto pb-8">
+                        <div className="flex h-full justify-normal pt-4 md:pt-5">
+                          <div className="w-full h-full">{children}</div>
                         </div>
-                        {/* Scrollable content area */}
-                        <NextSSRPlugin
-                          routerConfig={extractRouterConfig(fileRouter)}
-                        />
-                        <div className="mb-auto pb-8">
-                          <div className="flex h-full justify-normal pt-4 md:pt-5">
-                            <div className="w-full h-full">{children}</div>
-                          </div>
-                        </div>
-                        <Footer
-                          networkLabel={footerNetworkLabel}
-                          legalLabel={footerLegalLabel}
-                          hyphaServicesLabel={footerHyphaServicesLabel}
-                          hyphaTokenomicsLabel={footerHyphaTokenomicsLabel}
-                          licensingPolicyLabel={footerLicensingPolicyLabel}
-                          termsAndConditionsLabel={
-                            footerTermsAndConditionsLabel
-                          }
-                          privacyPolicyLabel={footerPrivacyPolicyLabel}
-                        />
-                      </PanelWrapLayout>
-                    </PanelProviders>
-                  </ConditionalMatrixProvider>
-                </NotificationSubscriber>
-              </TooltipProvider>
-            </NextIntlClientProvider>
-          </EvmProvider>
+                      </div>
+                      <Footer
+                        networkLabel={footerNetworkLabel}
+                        legalLabel={footerLegalLabel}
+                        hyphaServicesLabel={footerHyphaServicesLabel}
+                        hyphaTokenomicsLabel={footerHyphaTokenomicsLabel}
+                        licensingPolicyLabel={footerLicensingPolicyLabel}
+                        termsAndConditionsLabel={footerTermsAndConditionsLabel}
+                        privacyPolicyLabel={footerPrivacyPolicyLabel}
+                      />
+                    </PanelWrapLayout>
+                  </PanelProviders>
+                </ConditionalMatrixProvider>
+              </NotificationSubscriber>
+            </TooltipProvider>
+          </NextIntlClientProvider>
         </ThemeProvider>
       </AuthProvider>
       {shouldInjectToolbar && <VercelToolbar />}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -110,18 +110,18 @@ export default async function RootLayout({
   let spaceMemoryEnabled = false;
   let humanChatEnabled = false;
 
-  let navMySpacesLabel = 'mySpaces';
-  let navNetworkLabel = 'network';
-  let navOpenMenuLabel = 'openMenu';
-  let navCloseMenuLabel = 'closeMenu';
-  let navSelectLanguageLabel = 'selectLanguage';
-  let footerNetworkLabel = 'network';
-  let footerLegalLabel = 'legal';
-  let footerHyphaServicesLabel = 'hyphaServices';
-  let footerHyphaTokenomicsLabel = 'hyphaTokenomics';
-  let footerLicensingPolicyLabel = 'licensingPolicy';
-  let footerTermsAndConditionsLabel = 'termsAndConditions';
-  let footerPrivacyPolicyLabel = 'privacyPolicy';
+  let navMySpacesLabel = 'My Spaces';
+  let navNetworkLabel = 'Network';
+  let navOpenMenuLabel = 'Open menu';
+  let navCloseMenuLabel = 'Close menu';
+  let navSelectLanguageLabel = 'Select language';
+  let footerNetworkLabel = 'Network';
+  let footerLegalLabel = 'Legal';
+  let footerHyphaServicesLabel = 'Hypha Services';
+  let footerHyphaTokenomicsLabel = 'Hypha Tokenomics';
+  let footerLicensingPolicyLabel = 'Licensing Policy';
+  let footerTermsAndConditionsLabel = 'Terms and Conditions';
+  let footerPrivacyPolicyLabel = 'Privacy Policy';
 
   try {
     isLanguageSelectVisible = await getShowLanguageSelect();

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -101,17 +101,89 @@ export default async function RootLayout({
   children: React.ReactNode;
 }) {
   const shouldInjectToolbar = process.env.NODE_ENV === 'development';
-  const isLanguageSelectVisible = await getShowLanguageSelect();
-  const locale = await getLocale();
-  const messages = await getMessages();
-  const tNav = await getTranslations('Navigation');
-  const tFooter = await getTranslations('Footer');
   const notificationAppId = process.env.NEXT_PUBLIC_ONESIGNAL_APP_ID ?? '';
   const safariWebId = process.env.NEXT_PUBLIC_ONESIGNAL_SAFARI_WEB_ID ?? '';
   const serviceWorkerPath = 'onesignal/OneSignalSDKWorker.js';
-  const aiChatEnabled = await getEnableAiChat();
-  const spaceMemoryEnabled = await getEnableSpaceMemory();
-  const humanChatEnabled = await getEnableHumanChat();
+  let isLanguageSelectVisible = false;
+  let locale = 'en';
+  let messages: Record<string, unknown> = {};
+  let aiChatEnabled = true;
+  let spaceMemoryEnabled = false;
+  let humanChatEnabled = true;
+
+  let navMySpacesLabel = 'mySpaces';
+  let navNetworkLabel = 'network';
+  let navOpenMenuLabel = 'openMenu';
+  let navCloseMenuLabel = 'closeMenu';
+  let footerNetworkLabel = 'network';
+  let footerLegalLabel = 'legal';
+  let footerHyphaServicesLabel = 'hyphaServices';
+  let footerHyphaTokenomicsLabel = 'hyphaTokenomics';
+  let footerLicensingPolicyLabel = 'licensingPolicy';
+  let footerTermsAndConditionsLabel = 'termsAndConditions';
+  let footerPrivacyPolicyLabel = 'privacyPolicy';
+
+  try {
+    isLanguageSelectVisible = await getShowLanguageSelect();
+  } catch (error) {
+    console.error('[app/layout] Failed to resolve showLanguageSelect', error);
+  }
+
+  try {
+    locale = await getLocale();
+  } catch (error) {
+    console.error('[app/layout] Failed to resolve locale', error);
+  }
+
+  try {
+    messages = await getMessages();
+  } catch (error) {
+    console.error('[app/layout] Failed to resolve messages', error);
+  }
+
+  try {
+    const tNav = await getTranslations('Navigation');
+    navMySpacesLabel = tNav('mySpaces');
+    navNetworkLabel = tNav('network');
+    navOpenMenuLabel = tNav('openMenu');
+    navCloseMenuLabel = tNav('closeMenu');
+  } catch (error) {
+    console.error(
+      '[app/layout] Failed to resolve Navigation translations',
+      error,
+    );
+  }
+
+  try {
+    const tFooter = await getTranslations('Footer');
+    footerNetworkLabel = tFooter('network');
+    footerLegalLabel = tFooter('legal');
+    footerHyphaServicesLabel = tFooter('hyphaServices');
+    footerHyphaTokenomicsLabel = tFooter('hyphaTokenomics');
+    footerLicensingPolicyLabel = tFooter('licensingPolicy');
+    footerTermsAndConditionsLabel = tFooter('termsAndConditions');
+    footerPrivacyPolicyLabel = tFooter('privacyPolicy');
+  } catch (error) {
+    console.error('[app/layout] Failed to resolve Footer translations', error);
+  }
+
+  try {
+    aiChatEnabled = await getEnableAiChat();
+  } catch (error) {
+    console.error('[app/layout] Failed to resolve aiChatEnabled', error);
+  }
+
+  try {
+    spaceMemoryEnabled = await getEnableSpaceMemory();
+  } catch (error) {
+    console.error('[app/layout] Failed to resolve spaceMemoryEnabled', error);
+  }
+
+  try {
+    humanChatEnabled = await getEnableHumanChat();
+  } catch (error) {
+    console.error('[app/layout] Failed to resolve humanChatEnabled', error);
+  }
 
   return (
     <Html lang={locale} className={clsx(lato.variable, sourceSans.variable)}>
@@ -163,8 +235,8 @@ export default async function RootLayout({
                           <ConnectedMenuTop
                             aiChatEnabled={aiChatEnabled}
                             logoHref={ROOT_URL}
-                            openMenuLabel={tNav('openMenu')}
-                            closeMenuLabel={tNav('closeMenu')}
+                            openMenuLabel={navOpenMenuLabel}
+                            closeMenuLabel={navCloseMenuLabel}
                             leadingAction={
                               aiChatEnabled ? <AiSidebarTrigger /> : undefined
                             }
@@ -181,11 +253,11 @@ export default async function RootLayout({
                               baseRedirectPath="/my-spaces"
                               navItems={[
                                 {
-                                  label: tNav('mySpaces'),
+                                  label: navMySpacesLabel,
                                   href: `/${locale}/my-spaces`,
                                 },
                                 {
-                                  label: tNav('network'),
+                                  label: navNetworkLabel,
                                   href: `/${locale}/network`,
                                 },
                               ]}
@@ -207,15 +279,15 @@ export default async function RootLayout({
                           </div>
                         </div>
                         <Footer
-                          networkLabel={tFooter('network')}
-                          legalLabel={tFooter('legal')}
-                          hyphaServicesLabel={tFooter('hyphaServices')}
-                          hyphaTokenomicsLabel={tFooter('hyphaTokenomics')}
-                          licensingPolicyLabel={tFooter('licensingPolicy')}
-                          termsAndConditionsLabel={tFooter(
-                            'termsAndConditions',
-                          )}
-                          privacyPolicyLabel={tFooter('privacyPolicy')}
+                          networkLabel={footerNetworkLabel}
+                          legalLabel={footerLegalLabel}
+                          hyphaServicesLabel={footerHyphaServicesLabel}
+                          hyphaTokenomicsLabel={footerHyphaTokenomicsLabel}
+                          licensingPolicyLabel={footerLicensingPolicyLabel}
+                          termsAndConditionsLabel={
+                            footerTermsAndConditionsLabel
+                          }
+                          privacyPolicyLabel={footerPrivacyPolicyLabel}
                         />
                       </PanelWrapLayout>
                     </PanelProviders>

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -123,40 +123,66 @@ export default async function RootLayout({
   let footerTermsAndConditionsLabel = 'Terms and Conditions';
   let footerPrivacyPolicyLabel = 'Privacy Policy';
 
-  try {
-    isLanguageSelectVisible = await getShowLanguageSelect();
-  } catch (error) {
-    console.error('[app/layout] Failed to resolve showLanguageSelect', error);
+  const [
+    languageSelectResult,
+    localeResult,
+    messagesResult,
+    navTranslationsResult,
+    footerTranslationsResult,
+    aiChatEnabledResult,
+    spaceMemoryEnabledResult,
+    humanChatEnabledResult,
+  ] = await Promise.allSettled([
+    getShowLanguageSelect(),
+    getLocale(),
+    getMessages(),
+    getTranslations('Navigation'),
+    getTranslations('Footer'),
+    getEnableAiChat(),
+    getEnableSpaceMemory(),
+    getEnableHumanChat(),
+  ]);
+
+  if (languageSelectResult.status === 'fulfilled') {
+    isLanguageSelectVisible = languageSelectResult.value;
+  } else {
+    console.error(
+      '[app/layout] Failed to resolve showLanguageSelect',
+      languageSelectResult.reason,
+    );
   }
 
-  try {
-    locale = await getLocale();
-  } catch (error) {
-    console.error('[app/layout] Failed to resolve locale', error);
+  if (localeResult.status === 'fulfilled') {
+    locale = localeResult.value;
+  } else {
+    console.error('[app/layout] Failed to resolve locale', localeResult.reason);
   }
 
-  try {
-    messages = await getMessages();
-  } catch (error) {
-    console.error('[app/layout] Failed to resolve messages', error);
+  if (messagesResult.status === 'fulfilled') {
+    messages = messagesResult.value;
+  } else {
+    console.error(
+      '[app/layout] Failed to resolve messages',
+      messagesResult.reason,
+    );
   }
 
-  try {
-    const tNav = await getTranslations('Navigation');
+  if (navTranslationsResult.status === 'fulfilled') {
+    const tNav = navTranslationsResult.value;
     navMySpacesLabel = tNav('mySpaces');
     navNetworkLabel = tNav('network');
     navOpenMenuLabel = tNav('openMenu');
     navCloseMenuLabel = tNav('closeMenu');
     navSelectLanguageLabel = tNav('selectLanguage');
-  } catch (error) {
+  } else {
     console.error(
       '[app/layout] Failed to resolve Navigation translations',
-      error,
+      navTranslationsResult.reason,
     );
   }
 
-  try {
-    const tFooter = await getTranslations('Footer');
+  if (footerTranslationsResult.status === 'fulfilled') {
+    const tFooter = footerTranslationsResult.value;
     footerNetworkLabel = tFooter('network');
     footerLegalLabel = tFooter('legal');
     footerHyphaServicesLabel = tFooter('hyphaServices');
@@ -164,26 +190,38 @@ export default async function RootLayout({
     footerLicensingPolicyLabel = tFooter('licensingPolicy');
     footerTermsAndConditionsLabel = tFooter('termsAndConditions');
     footerPrivacyPolicyLabel = tFooter('privacyPolicy');
-  } catch (error) {
-    console.error('[app/layout] Failed to resolve Footer translations', error);
+  } else {
+    console.error(
+      '[app/layout] Failed to resolve Footer translations',
+      footerTranslationsResult.reason,
+    );
   }
 
-  try {
-    aiChatEnabled = (await getEnableAiChat()) === true;
-  } catch (error) {
-    console.error('[app/layout] Failed to resolve aiChatEnabled', error);
+  if (aiChatEnabledResult.status === 'fulfilled') {
+    aiChatEnabled = aiChatEnabledResult.value === true;
+  } else {
+    console.error(
+      '[app/layout] Failed to resolve aiChatEnabled',
+      aiChatEnabledResult.reason,
+    );
   }
 
-  try {
-    spaceMemoryEnabled = (await getEnableSpaceMemory()) === true;
-  } catch (error) {
-    console.error('[app/layout] Failed to resolve spaceMemoryEnabled', error);
+  if (spaceMemoryEnabledResult.status === 'fulfilled') {
+    spaceMemoryEnabled = spaceMemoryEnabledResult.value === true;
+  } else {
+    console.error(
+      '[app/layout] Failed to resolve spaceMemoryEnabled',
+      spaceMemoryEnabledResult.reason,
+    );
   }
 
-  try {
-    humanChatEnabled = (await getEnableHumanChat()) === true;
-  } catch (error) {
-    console.error('[app/layout] Failed to resolve humanChatEnabled', error);
+  if (humanChatEnabledResult.status === 'fulfilled') {
+    humanChatEnabled = humanChatEnabledResult.value === true;
+  } else {
+    console.error(
+      '[app/layout] Failed to resolve humanChatEnabled',
+      humanChatEnabledResult.reason,
+    );
   }
 
   return (

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -7,6 +7,7 @@ import type { Metadata } from 'next';
 
 import { NextIntlClientProvider } from 'next-intl';
 import { getLocale, getMessages, getTranslations } from 'next-intl/server';
+import { defaultMessages } from '@hypha-platform/i18n/messages';
 
 import { Footer, Html, ThemeProvider } from '@hypha-platform/ui/server';
 import { AuthProvider } from '@hypha-platform/authentication';
@@ -105,7 +106,7 @@ export default async function RootLayout({
   const serviceWorkerPath = 'onesignal/OneSignalSDKWorker.js';
   let isLanguageSelectVisible = false;
   let locale = 'en';
-  let messages: Record<string, unknown> = {};
+  let messages: Record<string, unknown> = defaultMessages;
   let aiChatEnabled = false;
   let spaceMemoryEnabled = false;
   let humanChatEnabled = false;

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -106,9 +106,9 @@ export default async function RootLayout({
   let isLanguageSelectVisible = false;
   let locale = 'en';
   let messages: Record<string, unknown> = {};
-  let aiChatEnabled = true;
+  let aiChatEnabled = false;
   let spaceMemoryEnabled = false;
-  let humanChatEnabled = true;
+  let humanChatEnabled = false;
 
   let navMySpacesLabel = 'mySpaces';
   let navNetworkLabel = 'network';
@@ -167,19 +167,19 @@ export default async function RootLayout({
   }
 
   try {
-    aiChatEnabled = await getEnableAiChat();
+    aiChatEnabled = (await getEnableAiChat()) === true;
   } catch (error) {
     console.error('[app/layout] Failed to resolve aiChatEnabled', error);
   }
 
   try {
-    spaceMemoryEnabled = await getEnableSpaceMemory();
+    spaceMemoryEnabled = (await getEnableSpaceMemory()) === true;
   } catch (error) {
     console.error('[app/layout] Failed to resolve spaceMemoryEnabled', error);
   }
 
   try {
-    humanChatEnabled = await getEnableHumanChat();
+    humanChatEnabled = (await getEnableHumanChat()) === true;
   } catch (error) {
     console.error('[app/layout] Failed to resolve humanChatEnabled', error);
   }

--- a/apps/web/src/components/connected-human-right-panel.tsx
+++ b/apps/web/src/components/connected-human-right-panel.tsx
@@ -1,8 +1,23 @@
 'use client';
 
+import { useEffect, useState } from 'react';
 import { HumanRightPanel } from '@hypha-platform/epics';
+import { useSidebar } from '@hypha-platform/ui';
 import { useMembers } from '@web/hooks/use-members';
 
 export function ConnectedHumanRightPanel() {
+  const { open } = useSidebar();
+  const [hasOpened, setHasOpened] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      setHasOpened(true);
+    }
+  }, [open]);
+
+  if (!hasOpened) {
+    return null;
+  }
+
   return <HumanRightPanel useMembers={useMembers} />;
 }

--- a/apps/web/src/components/connected-language-select.tsx
+++ b/apps/web/src/components/connected-language-select.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useLocale, useTranslations } from 'next-intl';
+import { useLocale } from 'next-intl';
 import { usePathname } from 'next/navigation';
 import { useEffect, useMemo, useState } from 'react';
 import { LanguageSelect } from '@hypha-platform/ui';
@@ -14,10 +14,15 @@ function localeFromPathname(pathname: string): string | null {
     : null;
 }
 
-export function ConnectedLanguageSelect() {
+type ConnectedLanguageSelectProps = {
+  selectLanguageLabel: string;
+};
+
+export function ConnectedLanguageSelect({
+  selectLanguageLabel,
+}: ConnectedLanguageSelectProps) {
   const pathname = usePathname();
   const intlLocale = useLocale();
-  const tNav = useTranslations('Navigation');
 
   const pathLocale = useMemo(() => localeFromPathname(pathname), [pathname]);
   const urlLocale = pathLocale ?? intlLocale;
@@ -54,7 +59,7 @@ export function ConnectedLanguageSelect() {
       currentLocale={activeLocale}
       locales={locales}
       onLocaleChange={handleLocaleChange}
-      ariaLabel={tNav('selectLanguage')}
+      ariaLabel={selectLanguageLabel}
     />
   );
 }

--- a/apps/web/src/hooks/use-members.ts
+++ b/apps/web/src/hooks/use-members.ts
@@ -46,8 +46,6 @@ export const useMembers: UseMembers = ({
     return `?${queryString.stringify(effectiveFilter)}`;
   }, [page, pageSize, searchTerm, paginationDisabled]);
 
-  console.debug('useMembers', { queryParams });
-
   const endpoint = React.useMemo(
     () => `/api/v1/spaces/${spaceSlug}/members${queryParams}`,
     [spaceSlug, queryParams],

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -89,14 +89,6 @@ function applyCsp(response: NextResponse, request: NextRequest): NextResponse {
 }
 
 export function middleware(request: NextRequest) {
-  const rawUrl = request.url;
-  const hasPrivyOauthParams = /[?&]privy_oauth(?:_|=|&|$)/i.test(rawUrl);
-  if (hasPrivyOauthParams && request.nextUrl.search) {
-    const sanitizedUrl = request.nextUrl.clone();
-    sanitizedUrl.search = '';
-    return NextResponse.redirect(sanitizedUrl);
-  }
-
   const response = i18nMiddleware(request);
 
   if (response.status === 301 || response.status === 302) {

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -74,7 +74,7 @@ function applyCsp(response: NextResponse, request: NextRequest): NextResponse {
       "font-src 'self' https://fonts.gstatic.com https://vercel.live",
       "object-src 'none'",
       "base-uri 'self'",
-      "form-action 'self' https://auth.privy.io https://privy.hypha.earth https://accounts.google.com https://*.google.com",
+      "form-action 'self' https://auth.privy.io https://privy.hypha.earth https://accounts.google.com",
       "frame-ancestors 'none'",
       `child-src https://auth.privy.io https://privy.hypha.earth https://verify.walletconnect.com https://verify.walletconnect.org ${UPLOADTHING_FRAME_HOST}`,
       `frame-src https://auth.privy.io https://privy.hypha.earth https://verify.walletconnect.com https://verify.walletconnect.org https://challenges.cloudflare.com https://vercel.live ${UPLOADTHING_FRAME_HOST}`,

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -89,6 +89,20 @@ function applyCsp(response: NextResponse, request: NextRequest): NextResponse {
 }
 
 export function middleware(request: NextRequest) {
+  const hasPrivyOauthParams = Array.from(
+    request.nextUrl.searchParams.keys(),
+  ).some((key) => key === 'privy_oauth' || key.startsWith('privy_oauth_'));
+  if (hasPrivyOauthParams) {
+    const sanitizedUrl = request.nextUrl.clone();
+    const keys = Array.from(sanitizedUrl.searchParams.keys());
+    for (const key of keys) {
+      if (key === 'privy_oauth' || key.startsWith('privy_oauth_')) {
+        sanitizedUrl.searchParams.delete(key);
+      }
+    }
+    return NextResponse.redirect(sanitizedUrl);
+  }
+
   const response = i18nMiddleware(request);
 
   if (response.status === 301 || response.status === 302) {

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -74,7 +74,7 @@ function applyCsp(response: NextResponse, request: NextRequest): NextResponse {
       "font-src 'self' https://fonts.gstatic.com https://vercel.live",
       "object-src 'none'",
       "base-uri 'self'",
-      "form-action 'self'",
+      "form-action 'self' https://auth.privy.io https://privy.hypha.earth https://accounts.google.com https://*.google.com",
       "frame-ancestors 'none'",
       `child-src https://auth.privy.io https://privy.hypha.earth https://verify.walletconnect.com https://verify.walletconnect.org ${UPLOADTHING_FRAME_HOST}`,
       `frame-src https://auth.privy.io https://privy.hypha.earth https://verify.walletconnect.com https://verify.walletconnect.org https://challenges.cloudflare.com https://vercel.live ${UPLOADTHING_FRAME_HOST}`,

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -89,17 +89,11 @@ function applyCsp(response: NextResponse, request: NextRequest): NextResponse {
 }
 
 export function middleware(request: NextRequest) {
-  const hasPrivyOauthParams = Array.from(
-    request.nextUrl.searchParams.keys(),
-  ).some((key) => key === 'privy_oauth' || key.startsWith('privy_oauth_'));
-  if (hasPrivyOauthParams) {
+  const rawUrl = request.url;
+  const hasPrivyOauthParams = /[?&]privy_oauth(?:_|=|&|$)/i.test(rawUrl);
+  if (hasPrivyOauthParams && request.nextUrl.search) {
     const sanitizedUrl = request.nextUrl.clone();
-    const keys = Array.from(sanitizedUrl.searchParams.keys());
-    for (const key of keys) {
-      if (key === 'privy_oauth' || key.startsWith('privy_oauth_')) {
-        sanitizedUrl.searchParams.delete(key);
-      }
-    }
+    sanitizedUrl.search = '';
     return NextResponse.redirect(sanitizedUrl);
   }
 

--- a/packages/core/src/common/web3/governance-public-client.ts
+++ b/packages/core/src/common/web3/governance-public-client.ts
@@ -1,4 +1,4 @@
-import { createPublicClient, fallback, http } from 'viem';
+import { createPublicClient, fallback, http, type PublicClient } from 'viem';
 import type { Chain } from 'viem/chains';
 import { base } from 'viem/chains';
 
@@ -12,7 +12,7 @@ const governanceChains: Record<number, Chain> = {
  * Public client for reading governance txs (same chain as `getGovernanceChainId()`).
  * Prefer this over the legacy `public-client` singleton for receipt waits.
  */
-export function createGovernancePublicClient() {
+export function createGovernancePublicClient(): PublicClient {
   const chainId = getGovernanceChainId();
   const chain = governanceChains[chainId];
   if (!chain) {

--- a/packages/core/src/common/web3/governance-public-client.ts
+++ b/packages/core/src/common/web3/governance-public-client.ts
@@ -28,5 +28,5 @@ export function createGovernancePublicClient(): PublicClient {
           http('https://mainnet.base.org'),
         ])
       : http('https://mainnet.base.org'),
-  });
+  }) as unknown as PublicClient;
 }

--- a/packages/core/src/common/web3/governance-public-client.ts
+++ b/packages/core/src/common/web3/governance-public-client.ts
@@ -1,4 +1,4 @@
-import { createPublicClient, http } from 'viem';
+import { createPublicClient, fallback, http } from 'viem';
 import type { Chain } from 'viem/chains';
 import { base } from 'viem/chains';
 
@@ -23,7 +23,10 @@ export function createGovernancePublicClient() {
   return createPublicClient({
     chain,
     transport: process.env.NEXT_PUBLIC_RPC_URL
-      ? http(process.env.NEXT_PUBLIC_RPC_URL)
-      : http(),
+      ? fallback([
+          http(process.env.NEXT_PUBLIC_RPC_URL),
+          http('https://mainnet.base.org'),
+        ])
+      : http('https://mainnet.base.org'),
   });
 }

--- a/packages/core/src/common/web3/public-client.ts
+++ b/packages/core/src/common/web3/public-client.ts
@@ -1,10 +1,10 @@
-import { createPublicClient, fallback, http } from 'viem';
+import { createPublicClient, fallback, http, type PublicClient } from 'viem';
 import { base } from 'viem/chains';
 
 /**
  * @deprecated Insecure. Use server-side version instead
  */
-export const publicClient = createPublicClient({
+export const publicClient: PublicClient = createPublicClient({
   batch: {
     multicall: { wait: 100 },
   },

--- a/packages/core/src/common/web3/public-client.ts
+++ b/packages/core/src/common/web3/public-client.ts
@@ -1,4 +1,4 @@
-import { createPublicClient, http } from 'viem';
+import { createPublicClient, fallback, http } from 'viem';
 import { base } from 'viem/chains';
 
 /**
@@ -10,6 +10,9 @@ export const publicClient = createPublicClient({
   },
   chain: base,
   transport: process.env.NEXT_PUBLIC_RPC_URL
-    ? http(process.env.NEXT_PUBLIC_RPC_URL)
-    : http(),
+    ? fallback([
+        http(process.env.NEXT_PUBLIC_RPC_URL),
+        http('https://mainnet.base.org'),
+      ])
+    : http('https://mainnet.base.org'),
 });

--- a/packages/core/src/common/web3/public-client.ts
+++ b/packages/core/src/common/web3/public-client.ts
@@ -4,7 +4,7 @@ import { base } from 'viem/chains';
 /**
  * @deprecated Insecure. Use server-side version instead
  */
-export const publicClient: PublicClient = createPublicClient({
+export const publicClient = createPublicClient({
   batch: {
     multicall: { wait: 100 },
   },
@@ -15,4 +15,4 @@ export const publicClient: PublicClient = createPublicClient({
         http('https://mainnet.base.org'),
       ])
     : http('https://mainnet.base.org'),
-});
+}) as unknown as PublicClient;

--- a/packages/core/src/governance/client/hooks/useActivateSpacesMutations.web3.rsc.ts
+++ b/packages/core/src/governance/client/hooks/useActivateSpacesMutations.web3.rsc.ts
@@ -23,7 +23,8 @@ import { getDuration } from '@hypha-platform/ui-utils';
 import { getGovernanceChainId } from './governance-chain-id';
 import z from 'zod';
 
-const USDC_TOKEN = TOKENS.find((t) => t.symbol === 'USDC');
+const TOKENS_SAFE = Array.isArray(TOKENS) ? TOKENS : [];
+const USDC_TOKEN = TOKENS_SAFE.find((t) => t.symbol === 'USDC');
 const chainId = getGovernanceChainId();
 
 type PaymentToken = 'USDC' | 'HYPHA';

--- a/packages/core/src/governance/client/hooks/useActivateSpacesMutations.web3.rsc.ts
+++ b/packages/core/src/governance/client/hooks/useActivateSpacesMutations.web3.rsc.ts
@@ -64,7 +64,12 @@ export const useActivateSpacesMutationsWeb3Rpc = ({
 
       const tokenAddress =
         arg.paymentToken === 'USDC'
-          ? (USDC_TOKEN?.address as `0x${string}`)
+          ? (() => {
+              if (!USDC_TOKEN?.address) {
+                throw new Error('USDC token not configured in TOKENS');
+              }
+              return USDC_TOKEN.address;
+            })()
           : (hyphaTokenAddress[chainId] as `0x${string}`);
       const decimals = await getTokenDecimals(tokenAddress);
       const parsedAmounts = arg.amounts.map((a) =>
@@ -72,8 +77,11 @@ export const useActivateSpacesMutationsWeb3Rpc = ({
       );
 
       if (arg.paymentToken === 'USDC') {
+        if (!USDC_TOKEN?.address) {
+          throw new Error('USDC token not configured in TOKENS');
+        }
         transactions.push({
-          target: USDC_TOKEN?.address as `0x${string}`,
+          target: USDC_TOKEN.address,
           value: 0,
           data: encodeFunctionData({
             abi: erc20Abi,

--- a/packages/core/src/governance/client/hooks/useBuyHyphaTokensMutations.web3.rsc.ts
+++ b/packages/core/src/governance/client/hooks/useBuyHyphaTokensMutations.web3.rsc.ts
@@ -51,6 +51,9 @@ export const useBuyHyphaTokensMutationsWeb3Rpc = ({
       if (!client) {
         throw new Error('Smart wallet client not available');
       }
+      if (!PAYMENT_TOKEN?.address) {
+        throw new Error('USDC payment token not configured');
+      }
 
       const duration = await publicClient.readContract(
         getSpaceMinProposalDuration({ spaceId: BigInt(arg.spaceId) }),
@@ -58,13 +61,11 @@ export const useBuyHyphaTokensMutationsWeb3Rpc = ({
 
       const transactions: z.infer<typeof transactionSchema>[] = [];
 
-      const usdcDecimals = await getTokenDecimals(
-        PAYMENT_TOKEN?.address as `0x${string}`,
-      );
+      const usdcDecimals = await getTokenDecimals(PAYMENT_TOKEN.address);
       const amount = parseUnits(arg.usdcAmount, usdcDecimals ?? 6);
 
       transactions.push({
-        target: PAYMENT_TOKEN?.address as `0x${string}`,
+        target: PAYMENT_TOKEN.address,
         value: 0,
         data: encodeFunctionData({
           abi: erc20Abi,

--- a/packages/core/src/governance/client/hooks/useBuyHyphaTokensMutations.web3.rsc.ts
+++ b/packages/core/src/governance/client/hooks/useBuyHyphaTokensMutations.web3.rsc.ts
@@ -23,7 +23,8 @@ import { getDuration } from '@hypha-platform/ui-utils';
 import { getGovernanceChainId } from './governance-chain-id';
 import z from 'zod';
 
-const PAYMENT_TOKEN = TOKENS.find((t) => t.symbol === 'USDC');
+const TOKENS_SAFE = Array.isArray(TOKENS) ? TOKENS : [];
+const PAYMENT_TOKEN = TOKENS_SAFE.find((t) => t.symbol === 'USDC');
 const chainId = getGovernanceChainId();
 
 interface InvestInHyphaInput {

--- a/packages/core/src/governance/client/hooks/useSpaceTokenPurchaseMutations.web3.rsc.ts
+++ b/packages/core/src/governance/client/hooks/useSpaceTokenPurchaseMutations.web3.rsc.ts
@@ -15,8 +15,9 @@ import { decayingSpaceTokenAbi } from '@hypha-platform/core/generated';
 import { getDuration } from '@hypha-platform/ui-utils';
 
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000' as const;
-const USDC_TOKEN = TOKENS.find((token) => token.symbol === 'USDC');
-const EURC_TOKEN = TOKENS.find((token) => token.symbol === 'EURC');
+const TOKENS_SAFE = Array.isArray(TOKENS) ? TOKENS : [];
+const USDC_TOKEN = TOKENS_SAFE.find((token) => token.symbol === 'USDC');
+const EURC_TOKEN = TOKENS_SAFE.find((token) => token.symbol === 'EURC');
 
 type SpaceTokenPurchaseInput = {
   spaceId: number;

--- a/packages/core/src/people/client/web3/useActivateSpacesMutation.ts
+++ b/packages/core/src/people/client/web3/useActivateSpacesMutation.ts
@@ -44,20 +44,19 @@ export const useActivateSpacesMutation = () => {
         throw new Error('spaceIds and amounts length mismatch');
       }
 
-      const usdcTokenAddress =
-        paymentToken === 'USDC' ? USDC_TOKEN?.address : undefined;
-
-      if (paymentToken === 'USDC' && !usdcTokenAddress) {
-        throw new Error(
-          'USDC token not configured: cannot proceed with USDC payment',
-        );
-      }
-
-      const decimals = await getTokenDecimals(
+      const paymentTokenAddress: `0x${string}` =
         paymentToken === 'USDC'
-          ? usdcTokenAddress
-          : hyphaTokenAddress[8453],
-      );
+          ? (() => {
+              if (!USDC_TOKEN?.address) {
+                throw new Error(
+                  'USDC token not configured: cannot proceed with USDC payment',
+                );
+              }
+              return USDC_TOKEN.address;
+            })()
+          : (hyphaTokenAddress[8453] as `0x${string}`);
+
+      const decimals = await getTokenDecimals(paymentTokenAddress);
 
       const parsedAmounts = amounts.map((a) =>
         parseUnits(a.toString(), decimals ?? 6),
@@ -65,7 +64,7 @@ export const useActivateSpacesMutation = () => {
 
       if (paymentToken === 'USDC') {
         await client.writeContract({
-          address: usdcTokenAddress,
+          address: paymentTokenAddress,
           abi: erc20Abi,
           functionName: 'approve',
           args: [

--- a/packages/core/src/people/client/web3/useActivateSpacesMutation.ts
+++ b/packages/core/src/people/client/web3/useActivateSpacesMutation.ts
@@ -44,7 +44,10 @@ export const useActivateSpacesMutation = () => {
         throw new Error('spaceIds and amounts length mismatch');
       }
 
-      if (paymentToken === 'USDC' && !USDC_TOKEN?.address) {
+      const usdcTokenAddress =
+        paymentToken === 'USDC' ? USDC_TOKEN?.address : undefined;
+
+      if (paymentToken === 'USDC' && !usdcTokenAddress) {
         throw new Error(
           'USDC token not configured: cannot proceed with USDC payment',
         );
@@ -52,7 +55,7 @@ export const useActivateSpacesMutation = () => {
 
       const decimals = await getTokenDecimals(
         paymentToken === 'USDC'
-          ? USDC_TOKEN.address
+          ? usdcTokenAddress
           : hyphaTokenAddress[8453],
       );
 
@@ -62,7 +65,7 @@ export const useActivateSpacesMutation = () => {
 
       if (paymentToken === 'USDC') {
         await client.writeContract({
-          address: USDC_TOKEN.address,
+          address: usdcTokenAddress,
           abi: erc20Abi,
           functionName: 'approve',
           args: [

--- a/packages/core/src/people/client/web3/useActivateSpacesMutation.ts
+++ b/packages/core/src/people/client/web3/useActivateSpacesMutation.ts
@@ -44,9 +44,15 @@ export const useActivateSpacesMutation = () => {
         throw new Error('spaceIds and amounts length mismatch');
       }
 
+      if (paymentToken === 'USDC' && !USDC_TOKEN?.address) {
+        throw new Error(
+          'USDC token not configured: cannot proceed with USDC payment',
+        );
+      }
+
       const decimals = await getTokenDecimals(
         paymentToken === 'USDC'
-          ? (USDC_TOKEN?.address as `0x${string}`)
+          ? USDC_TOKEN.address
           : hyphaTokenAddress[8453],
       );
 
@@ -56,7 +62,7 @@ export const useActivateSpacesMutation = () => {
 
       if (paymentToken === 'USDC') {
         await client.writeContract({
-          address: USDC_TOKEN?.address as `0x${string}`,
+          address: USDC_TOKEN.address,
           abi: erc20Abi,
           functionName: 'approve',
           args: [

--- a/packages/core/src/people/client/web3/useActivateSpacesMutation.ts
+++ b/packages/core/src/people/client/web3/useActivateSpacesMutation.ts
@@ -16,7 +16,8 @@ interface ActivateSpacesInput {
   paymentToken: PaymentToken;
 }
 
-const USDC_TOKEN = TOKENS.find((t) => t.symbol === 'USDC');
+const TOKENS_SAFE = Array.isArray(TOKENS) ? TOKENS : [];
+const USDC_TOKEN = TOKENS_SAFE.find((t) => t.symbol === 'USDC');
 
 export const useActivateSpacesMutation = () => {
   const { client } = useSmartWallets();

--- a/packages/core/src/people/client/web3/useInvestInHyphaMutation.ts
+++ b/packages/core/src/people/client/web3/useInvestInHyphaMutation.ts
@@ -30,14 +30,15 @@ export const useInvestInHyphaMutation = () => {
       if (!client) {
         throw new Error('Smart wallet client not available');
       }
+      if (!PAYMENT_TOKEN?.address) {
+        throw new Error('USDC token is not configured');
+      }
 
-      const usdcDecimals = await getTokenDecimals(
-        PAYMENT_TOKEN?.address as `0x${string}`,
-      );
+      const usdcDecimals = await getTokenDecimals(PAYMENT_TOKEN.address);
       const amount = parseUnits(arg.usdcAmount, usdcDecimals ?? 6);
 
       await client.writeContract({
-        address: PAYMENT_TOKEN?.address as `0x${string}`,
+        address: PAYMENT_TOKEN.address,
         abi: erc20Abi,
         functionName: 'approve',
         args: [hyphaTokenAddress[8453] as `0x${string}`, amount],

--- a/packages/core/src/people/client/web3/useInvestInHyphaMutation.ts
+++ b/packages/core/src/people/client/web3/useInvestInHyphaMutation.ts
@@ -8,7 +8,8 @@ import { hyphaTokenAbi, hyphaTokenAddress } from '../../../generated';
 import { TOKENS } from '@hypha-platform/core/client';
 import { erc20Abi } from 'viem';
 
-const PAYMENT_TOKEN = TOKENS.find((t) => t.symbol === 'USDC');
+const TOKENS_SAFE = Array.isArray(TOKENS) ? TOKENS : [];
+const PAYMENT_TOKEN = TOKENS_SAFE.find((t) => t.symbol === 'USDC');
 
 interface InvestInHyphaInput {
   usdcAmount: string;

--- a/packages/core/src/space/server/web3/get-all-spaces.ts
+++ b/packages/core/src/space/server/web3/get-all-spaces.ts
@@ -30,19 +30,19 @@ export async function getAllSpaces(
     );
 
     const [web3details, web3proposalsIds] = await Promise.all([
-      fetchSpaceDetails({ spaceIds: web3SpaceIds, allowFailure: true }).catch(
-        (error) => {
-          console.error('[getAllSpaces] Failed to fetch space details', {
-            error,
-            web3SpaceCount: web3SpaceIds.length,
-          });
-          return [];
-        },
-      ),
+      fetchSpaceDetails({ spaceIds: web3SpaceIds, allowFailure: true }).catch<
+        Awaited<ReturnType<typeof fetchSpaceDetails>>
+      >((error) => {
+        console.error('[getAllSpaces] Failed to fetch space details', {
+          error,
+          web3SpaceCount: web3SpaceIds.length,
+        });
+        return [];
+      }),
       fetchSpaceProposalsIds({
         spaceIds: web3SpaceIds,
         allowFailure: true,
-      }).catch((error) => {
+      }).catch<Awaited<ReturnType<typeof fetchSpaceProposalsIds>>>((error) => {
         console.error('[getAllSpaces] Failed to fetch space proposals ids', {
           error,
           web3SpaceCount: web3SpaceIds.length,

--- a/packages/core/src/space/server/web3/get-all-spaces.ts
+++ b/packages/core/src/space/server/web3/get-all-spaces.ts
@@ -28,9 +28,27 @@ export async function getAllSpaces(
     const web3SpaceIds = spacesWithWeb3Id.map(({ web3SpaceId }) =>
       BigInt(web3SpaceId!),
     );
+
     const [web3details, web3proposalsIds] = await Promise.all([
-      fetchSpaceDetails({ spaceIds: web3SpaceIds }),
-      fetchSpaceProposalsIds({ spaceIds: web3SpaceIds }),
+      fetchSpaceDetails({ spaceIds: web3SpaceIds, allowFailure: true }).catch(
+        (error) => {
+          console.error('[getAllSpaces] Failed to fetch space details', {
+            error,
+            web3SpaceCount: web3SpaceIds.length,
+          });
+          return [];
+        },
+      ),
+      fetchSpaceProposalsIds({
+        spaceIds: web3SpaceIds,
+        allowFailure: true,
+      }).catch((error) => {
+        console.error('[getAllSpaces] Failed to fetch space proposals ids', {
+          error,
+          web3SpaceCount: web3SpaceIds.length,
+        });
+        return [];
+      }),
     ]);
 
     const details = formMap(web3details);
@@ -63,6 +81,10 @@ export async function getAllSpaces(
 
     return enrichedSpaces;
   } catch (error) {
+    console.error('[getAllSpaces] Failed to fetch spaces from database', {
+      error,
+      filters: props,
+    });
     throw new Error('Failed to get spaces', {
       cause: error instanceof Error ? error : new Error(String(error)),
     });

--- a/packages/core/src/space/server/web3/get-all-spaces.ts
+++ b/packages/core/src/space/server/web3/get-all-spaces.ts
@@ -7,7 +7,7 @@ import {
   fetchSpaceDetails,
   fetchSpaceProposalsIds,
 } from '@hypha-platform/core/client';
-import { formMap } from './internal';
+import { formMap, readWithWarmupRetry } from './internal';
 
 interface GetAllSpacesProps {
   search?: string;
@@ -30,18 +30,26 @@ export async function getAllSpaces(
     );
 
     const [web3details, web3proposalsIds] = await Promise.all([
-      fetchSpaceDetails({ spaceIds: web3SpaceIds, allowFailure: true }).catch<
-        Awaited<ReturnType<typeof fetchSpaceDetails>>
-      >((error) => {
+      readWithWarmupRetry({
+        label: 'getAllSpaces/space-details',
+        spaceIds: web3SpaceIds,
+        read: () =>
+          fetchSpaceDetails({ spaceIds: web3SpaceIds, allowFailure: true }),
+      }).catch<Awaited<ReturnType<typeof fetchSpaceDetails>>>((error) => {
         console.error('[getAllSpaces] Failed to fetch space details', {
           error,
           web3SpaceCount: web3SpaceIds.length,
         });
         return [];
       }),
-      fetchSpaceProposalsIds({
+      readWithWarmupRetry({
+        label: 'getAllSpaces/space-proposals',
         spaceIds: web3SpaceIds,
-        allowFailure: true,
+        read: () =>
+          fetchSpaceProposalsIds({
+            spaceIds: web3SpaceIds,
+            allowFailure: true,
+          }),
       }).catch<Awaited<ReturnType<typeof fetchSpaceProposalsIds>>>((error) => {
         console.error('[getAllSpaces] Failed to fetch space proposals ids', {
           error,

--- a/packages/core/src/space/server/web3/get-space-by-slug.ts
+++ b/packages/core/src/space/server/web3/get-space-by-slug.ts
@@ -7,6 +7,7 @@ import {
   fetchSpaceDetails,
   fetchSpaceProposalsIds,
 } from '@hypha-platform/core/client';
+import { readWithWarmupRetry } from './internal';
 
 interface GetSpaceBySlugProps {
   slug: string;
@@ -33,9 +34,12 @@ export async function getSpaceBySlug({
     const web3SpaceIds = [web3SpaceId];
 
     const [web3details, web3proposalsIds] = await Promise.all([
-      fetchSpaceDetails({ spaceIds: web3SpaceIds, allowFailure: true }).catch<
-        Awaited<ReturnType<typeof fetchSpaceDetails>>
-      >((error) => {
+      readWithWarmupRetry({
+        label: 'getSpaceBySlug/space-details',
+        spaceIds: web3SpaceIds,
+        read: () =>
+          fetchSpaceDetails({ spaceIds: web3SpaceIds, allowFailure: true }),
+      }).catch<Awaited<ReturnType<typeof fetchSpaceDetails>>>((error) => {
         console.error('[getSpaceBySlug] Failed to fetch space details', {
           error,
           slug,
@@ -43,9 +47,14 @@ export async function getSpaceBySlug({
         });
         return [];
       }),
-      fetchSpaceProposalsIds({
+      readWithWarmupRetry({
+        label: 'getSpaceBySlug/space-proposals',
         spaceIds: web3SpaceIds,
-        allowFailure: true,
+        read: () =>
+          fetchSpaceProposalsIds({
+            spaceIds: web3SpaceIds,
+            allowFailure: true,
+          }),
       }).catch<Awaited<ReturnType<typeof fetchSpaceProposalsIds>>>((error) => {
         console.error('[getSpaceBySlug] Failed to fetch space proposals ids', {
           error,

--- a/packages/core/src/space/server/web3/get-space-by-slug.ts
+++ b/packages/core/src/space/server/web3/get-space-by-slug.ts
@@ -32,29 +32,29 @@ export async function getSpaceBySlug({
 
     const web3SpaceIds = [web3SpaceId];
 
-    let web3details: Awaited<ReturnType<typeof fetchSpaceDetails>> = [];
-    let web3proposalsIds: Awaited<ReturnType<typeof fetchSpaceProposalsIds>> =
-      [];
-
-    try {
-      [web3details, web3proposalsIds] = await Promise.all([
-        fetchSpaceDetails({ spaceIds: web3SpaceIds }),
-        fetchSpaceProposalsIds({ spaceIds: web3SpaceIds }),
-      ]);
-    } catch (error) {
-      console.error('[getSpaceBySlug] Failed to fetch web3 enrichment', {
-        error,
-        slug,
-        web3SpaceId: web3SpaceId.toString(),
-      });
-      return {
-        ...space,
-        memberCount: 0,
-        memberAddresses: [],
-        documentCount: 0,
-        onChainDataMissing: true,
-      };
-    }
+    const [web3details, web3proposalsIds] = await Promise.all([
+      fetchSpaceDetails({ spaceIds: web3SpaceIds, allowFailure: true }).catch<
+        Awaited<ReturnType<typeof fetchSpaceDetails>>
+      >((error) => {
+        console.error('[getSpaceBySlug] Failed to fetch space details', {
+          error,
+          slug,
+          web3SpaceId: web3SpaceId.toString(),
+        });
+        return [];
+      }),
+      fetchSpaceProposalsIds({
+        spaceIds: web3SpaceIds,
+        allowFailure: true,
+      }).catch<Awaited<ReturnType<typeof fetchSpaceProposalsIds>>>((error) => {
+        console.error('[getSpaceBySlug] Failed to fetch space proposals ids', {
+          error,
+          slug,
+          web3SpaceId: web3SpaceId.toString(),
+        });
+        return [];
+      }),
+    ]);
 
     const [spaceDetails] = web3details;
     const [spaceProposals] = web3proposalsIds;
@@ -69,6 +69,7 @@ export async function getSpaceBySlug({
             .filter((m): m is `0x${string}` => /^0x[a-f0-9]{40}$/.test(m))
         : [],
       documentCount: spaceProposals?.accepted.length ?? 0,
+      onChainDataMissing: !spaceDetails || !spaceProposals,
     };
   } catch (error) {
     console.error('[getSpaceBySlug] Failed to fetch space', { error, slug });

--- a/packages/core/src/space/server/web3/get-space-by-slug.ts
+++ b/packages/core/src/space/server/web3/get-space-by-slug.ts
@@ -47,7 +47,13 @@ export async function getSpaceBySlug({
         slug,
         web3SpaceId: web3SpaceId.toString(),
       });
-      return space;
+      return {
+        ...space,
+        memberCount: 0,
+        memberAddresses: [],
+        documentCount: 0,
+        onChainDataMissing: true,
+      };
     }
 
     const [spaceDetails] = web3details;

--- a/packages/core/src/space/server/web3/get-space-by-slug.ts
+++ b/packages/core/src/space/server/web3/get-space-by-slug.ts
@@ -32,10 +32,23 @@ export async function getSpaceBySlug({
 
     const web3SpaceIds = [web3SpaceId];
 
-    const [web3details, web3proposalsIds] = await Promise.all([
-      fetchSpaceDetails({ spaceIds: web3SpaceIds }),
-      fetchSpaceProposalsIds({ spaceIds: web3SpaceIds }),
-    ]);
+    let web3details: Awaited<ReturnType<typeof fetchSpaceDetails>> = [];
+    let web3proposalsIds: Awaited<ReturnType<typeof fetchSpaceProposalsIds>> =
+      [];
+
+    try {
+      [web3details, web3proposalsIds] = await Promise.all([
+        fetchSpaceDetails({ spaceIds: web3SpaceIds }),
+        fetchSpaceProposalsIds({ spaceIds: web3SpaceIds }),
+      ]);
+    } catch (error) {
+      console.error('[getSpaceBySlug] Failed to fetch web3 enrichment', {
+        error,
+        slug,
+        web3SpaceId: web3SpaceId.toString(),
+      });
+      return space;
+    }
 
     const [spaceDetails] = web3details;
     const [spaceProposals] = web3proposalsIds;
@@ -52,6 +65,7 @@ export async function getSpaceBySlug({
       documentCount: spaceProposals?.accepted.length ?? 0,
     };
   } catch (error) {
+    console.error('[getSpaceBySlug] Failed to fetch space', { error, slug });
     throw new Error('Failed to get space', {
       cause: error instanceof Error ? error : new Error(String(error)),
     });

--- a/packages/core/src/space/server/web3/internal.ts
+++ b/packages/core/src/space/server/web3/internal.ts
@@ -3,3 +3,69 @@ export function formMap<T extends { spaceId: bigint }>(
 ): Map<bigint, T> {
   return new Map(input.map((element) => [element.spaceId, element]));
 }
+
+type ReadWithWarmupRetryProps<T> = {
+  label: string;
+  spaceIds: bigint[];
+  read: () => Promise<T[]>;
+  maxAttempts?: number;
+  retryDelayMs?: number;
+};
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Mitigate first-hit/cold-start RPC jitter:
+ * - retries once on thrown errors
+ * - retries once when all requested reads came back empty
+ */
+export async function readWithWarmupRetry<T>({
+  label,
+  spaceIds,
+  read,
+  maxAttempts = 2,
+  retryDelayMs = 300,
+}: ReadWithWarmupRetryProps<T>): Promise<T[]> {
+  if (spaceIds.length === 0) return [];
+
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      const result = await read();
+      const shouldRetryForEmpty = result.length === 0 && attempt < maxAttempts;
+
+      if (!shouldRetryForEmpty) {
+        return result;
+      }
+
+      console.warn(`[${label}] Empty RPC enrichment result, retrying`, {
+        attempt,
+        maxAttempts,
+        web3SpaceCount: spaceIds.length,
+      });
+    } catch (error) {
+      lastError = error;
+      if (attempt >= maxAttempts) {
+        throw error;
+      }
+      console.warn(`[${label}] RPC read failed, retrying`, {
+        attempt,
+        maxAttempts,
+        web3SpaceCount: spaceIds.length,
+        error,
+      });
+    }
+
+    await sleep(retryDelayMs * attempt);
+  }
+
+  throw (
+    lastError ??
+    new Error(
+      `[${label}] RPC read failed after retries without explicit error object`,
+    )
+  );
+}

--- a/packages/epics/src/common/button-close.tsx
+++ b/packages/epics/src/common/button-close.tsx
@@ -36,7 +36,6 @@ export const ButtonClose = ({
         closeUrl = pathname.replace(dropSegment, '');
       }
     } else {
-      console.debug('ButtonClose: closeUrl or dropSegment must be provided');
       return null;
     }
   }

--- a/packages/epics/src/governance/hooks/use-space-documents-with-statuses.ts
+++ b/packages/epics/src/governance/hooks/use-space-documents-with-statuses.ts
@@ -99,6 +99,7 @@ export const useSpaceDocumentsWithStatuses = ({
     () => `/api/v1/spaces/${spaceSlug}/documents/all${queryParams}`,
     [spaceSlug, queryParams],
   );
+  const shouldFetchDocuments = Boolean(spaceSlug?.trim());
 
   const {
     data: documentsFromDb,
@@ -106,7 +107,7 @@ export const useSpaceDocumentsWithStatuses = ({
     mutate,
     error,
   } = useSWR(
-    [endpoint],
+    shouldFetchDocuments ? [endpoint] : null,
     async ([endpoint]) => {
       const token = await getAccessToken();
       const headers: HeadersInit = {};

--- a/packages/epics/src/spaces/components/my-filtered-spaces.tsx
+++ b/packages/epics/src/spaces/components/my-filtered-spaces.tsx
@@ -41,7 +41,7 @@ export function MyFilteredSpaces({
     });
   const [hideArchivedSpaces, setHideArchivedSpaces] = React.useState(true);
   const tSpaces = useTranslations('Spaces');
-  const tCommon = useTranslations('Common');
+  const tMyWallet = useTranslations('MyWallet');
 
   const memberFilteredSpaces = React.useMemo(
     () => filterSpaces(spaces, person?.slug, web3SpaceIds),
@@ -69,7 +69,7 @@ export function MyFilteredSpaces({
   return (
     <div className="space-y-6">
       <SectionFilter
-        count={isLoadingSpaces ? tCommon('loading') : displayedSpaces.length}
+        count={isLoadingSpaces ? tMyWallet('loading') : displayedSpaces.length}
         label={tSpaces('mySpacesLabel')}
       >
         <label
@@ -88,7 +88,7 @@ export function MyFilteredSpaces({
       </SectionFilter>
       {isLoadingSpaces ? (
         <Text className="text-3 text-muted-foreground">
-          {tCommon('loading')}
+          {tMyWallet('loading')}
         </Text>
       ) : (
         <SpaceCardList

--- a/packages/epics/src/spaces/components/my-filtered-spaces.tsx
+++ b/packages/epics/src/spaces/components/my-filtered-spaces.tsx
@@ -34,12 +34,14 @@ export function MyFilteredSpaces({
   spaces: Space[];
   showLoadMore?: boolean;
 }) {
-  const { person } = useMe();
-  const { web3SpaceIds } = useMemberWeb3SpaceIds({
-    personAddress: person?.address as Address | undefined,
-  });
+  const { person, isLoading: isLoadingPerson } = useMe();
+  const { web3SpaceIds, isLoading: isLoadingMemberSpaceIds } =
+    useMemberWeb3SpaceIds({
+      personAddress: person?.address as Address | undefined,
+    });
   const [hideArchivedSpaces, setHideArchivedSpaces] = React.useState(true);
   const tSpaces = useTranslations('Spaces');
+  const tCommon = useTranslations('Common');
 
   const memberFilteredSpaces = React.useMemo(
     () => filterSpaces(spaces, person?.slug, web3SpaceIds),
@@ -52,6 +54,11 @@ export function MyFilteredSpaces({
       useGeneralState: false,
     });
 
+  const isLoadingSpaces =
+    isLoadingPerson ||
+    (Boolean(person?.address) && isLoadingMemberSpaceIds) ||
+    isDiscoverabilityLoading;
+
   const displayedSpaces = React.useMemo(() => {
     if (hideArchivedSpaces) {
       return filteredSpaces.filter((space) => !isSpaceArchived(space));
@@ -62,7 +69,7 @@ export function MyFilteredSpaces({
   return (
     <div className="space-y-6">
       <SectionFilter
-        count={displayedSpaces.length}
+        count={isLoadingSpaces ? tCommon('loading') : displayedSpaces.length}
         label={tSpaces('mySpacesLabel')}
       >
         <label
@@ -79,12 +86,18 @@ export function MyFilteredSpaces({
           <span>{tSpaces('hideArchivedSpaces')}</span>
         </label>
       </SectionFilter>
-      <SpaceCardList
-        lang={lang}
-        spaces={displayedSpaces}
-        showLoadMore={showLoadMore}
-        showExitButton={true}
-      />
+      {isLoadingSpaces ? (
+        <Text className="text-3 text-muted-foreground">
+          {tCommon('loading')}
+        </Text>
+      ) : (
+        <SpaceCardList
+          lang={lang}
+          spaces={displayedSpaces}
+          showLoadMore={showLoadMore}
+          showExitButton={true}
+        />
+      )}
     </div>
   );
 }

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -19,6 +19,7 @@
     ".": "./src/index.ts",
     "./client": "./src/client.ts",
     "./request": "./src/request.ts",
+    "./messages": "./src/messages.ts",
     "./routing": "./src/routing.ts",
     "./navigation": "./src/navigation.ts"
   }

--- a/packages/i18n/src/messages.ts
+++ b/packages/i18n/src/messages.ts
@@ -1,0 +1,59 @@
+import type { Locale } from './routing';
+import { routing } from './routing';
+
+type Messages = Record<string, unknown>;
+
+const FALLBACK_LOCALE: Locale = routing.defaultLocale;
+
+export function resolveLocale(locale: string | null | undefined): Locale {
+  if (!locale) {
+    return FALLBACK_LOCALE;
+  }
+  return routing.locales.includes(locale as Locale)
+    ? (locale as Locale)
+    : FALLBACK_LOCALE;
+}
+
+export async function loadLocaleMessages(
+  localeInput: string | null | undefined,
+): Promise<{ locale: Locale; messages: Messages }> {
+  const locale = resolveLocale(localeInput);
+  const defaultMessages = (await import('./messages/en.json')).default as Messages;
+  let localeMessages: Messages = {};
+
+  try {
+    localeMessages = (
+      await import(`./messages/${locale}.json`)
+    ).default as Messages;
+  } catch (error) {
+    console.warn(
+      `[i18n] Missing messages for locale "${locale}", falling back to English.`,
+      error,
+    );
+  }
+
+  return {
+    locale,
+    messages: deepMerge(defaultMessages, localeMessages),
+  };
+}
+
+function deepMerge(base: Messages, override: Messages): Messages {
+  const result: Messages = { ...base };
+
+  for (const [key, value] of Object.entries(override)) {
+    const baseValue = result[key];
+
+    if (isObject(baseValue) && isObject(value)) {
+      result[key] = deepMerge(baseValue, value);
+    } else {
+      result[key] = value;
+    }
+  }
+
+  return result;
+}
+
+function isObject(value: unknown): value is Messages {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/packages/i18n/src/messages.ts
+++ b/packages/i18n/src/messages.ts
@@ -1,11 +1,22 @@
 import type { Locale } from './routing';
 import { routing } from './routing';
 import enMessages from './messages/en.json';
+import deMessages from './messages/de.json';
+import esMessages from './messages/es.json';
+import frMessages from './messages/fr.json';
+import ptMessages from './messages/pt.json';
 
 type Messages = Record<string, unknown>;
 
 const FALLBACK_LOCALE: Locale = routing.defaultLocale;
 export const defaultMessages: Messages = enMessages as Messages;
+const localeMessagesMap: Record<Locale, Messages> = {
+  en: enMessages as Messages,
+  de: deMessages as Messages,
+  es: esMessages as Messages,
+  fr: frMessages as Messages,
+  pt: ptMessages as Messages,
+};
 
 export function resolveLocale(locale: string | null | undefined): Locale {
   if (!locale) {
@@ -35,6 +46,17 @@ export async function loadLocaleMessages(
   return {
     locale,
     messages: deepMerge(defaultMessages, localeMessages),
+  };
+}
+
+export function getLocaleMessagesSync(localeInput: string | null | undefined): {
+  locale: Locale;
+  messages: Messages;
+} {
+  const locale = resolveLocale(localeInput);
+  return {
+    locale,
+    messages: deepMerge(defaultMessages, localeMessagesMap[locale] ?? {}),
   };
 }
 

--- a/packages/i18n/src/messages.ts
+++ b/packages/i18n/src/messages.ts
@@ -1,9 +1,11 @@
 import type { Locale } from './routing';
 import { routing } from './routing';
+import enMessages from './messages/en.json';
 
 type Messages = Record<string, unknown>;
 
 const FALLBACK_LOCALE: Locale = routing.defaultLocale;
+export const defaultMessages: Messages = enMessages as Messages;
 
 export function resolveLocale(locale: string | null | undefined): Locale {
   if (!locale) {
@@ -18,8 +20,6 @@ export async function loadLocaleMessages(
   localeInput: string | null | undefined,
 ): Promise<{ locale: Locale; messages: Messages }> {
   const locale = resolveLocale(localeInput);
-  const defaultMessages = (await import('./messages/en.json'))
-    .default as Messages;
   let localeMessages: Messages = {};
 
   try {

--- a/packages/i18n/src/messages.ts
+++ b/packages/i18n/src/messages.ts
@@ -18,13 +18,13 @@ export async function loadLocaleMessages(
   localeInput: string | null | undefined,
 ): Promise<{ locale: Locale; messages: Messages }> {
   const locale = resolveLocale(localeInput);
-  const defaultMessages = (await import('./messages/en.json')).default as Messages;
+  const defaultMessages = (await import('./messages/en.json'))
+    .default as Messages;
   let localeMessages: Messages = {};
 
   try {
-    localeMessages = (
-      await import(`./messages/${locale}.json`)
-    ).default as Messages;
+    localeMessages = (await import(`./messages/${locale}.json`))
+      .default as Messages;
   } catch (error) {
     console.warn(
       `[i18n] Missing messages for locale "${locale}", falling back to English.`,

--- a/packages/i18n/src/request.ts
+++ b/packages/i18n/src/request.ts
@@ -1,50 +1,13 @@
 import { getRequestConfig } from 'next-intl/server';
-import { hasLocale } from 'next-intl';
-import { routing } from './routing';
+import { loadLocaleMessages, resolveLocale } from './messages';
 
 export default getRequestConfig(async ({ requestLocale }) => {
   const requested = await requestLocale;
-  const locale = hasLocale(routing.locales, requested)
-    ? requested
-    : routing.defaultLocale;
-
-  const defaultMessages = (await import('./messages/en.json')).default;
-  let localeMessages: Record<string, unknown> = {};
-
-  try {
-    localeMessages = (await import(`./messages/${locale}.json`)).default;
-  } catch (error) {
-    console.warn(
-      `[i18n] Missing messages for locale "${locale}", falling back to English.`,
-      error,
-    );
-  }
+  const locale = resolveLocale(requested);
+  const { messages } = await loadLocaleMessages(locale);
 
   return {
     locale,
-    messages: deepMerge(defaultMessages, localeMessages),
+    messages,
   };
 });
-
-function deepMerge(
-  base: Record<string, unknown>,
-  override: Record<string, unknown>,
-): Record<string, unknown> {
-  const result: Record<string, unknown> = { ...base };
-
-  for (const [key, value] of Object.entries(override)) {
-    const baseValue = result[key];
-
-    if (isObject(baseValue) && isObject(value)) {
-      result[key] = deepMerge(baseValue, value);
-    } else {
-      result[key] = value;
-    }
-  }
-
-  return result;
-}
-
-function isObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}

--- a/packages/notifications/src/components/notifications-subscriber.tsx
+++ b/packages/notifications/src/components/notifications-subscriber.tsx
@@ -36,13 +36,18 @@ export function NotificationSubscriber({
   const [subscribed, setSubscribed] = React.useState(false);
   const [loggedIn, setLoggedIn] = React.useState(false);
   const hasInitAttemptRef = React.useRef(false);
+  const syncedExternalIdRef = React.useRef<string | null>(null);
   const router = useRouter();
+  const personSlug = person?.slug ?? null;
 
   React.useEffect(() => {
     if (!initialized || !OneSignal || isLoading) {
       return;
     }
-    if (person?.slug) {
+    if (personSlug) {
+      if (syncedExternalIdRef.current === personSlug) {
+        return;
+      }
       const loginNotifications = async (personSlug: string) => {
         try {
           const currentExternalId = OneSignal.User.externalId;
@@ -52,6 +57,7 @@ export function NotificationSubscriber({
             }
             await OneSignal.login(personSlug);
           }
+          syncedExternalIdRef.current = personSlug;
           setLoggedIn(true);
           const isSubscribed = await hasPermission();
           setSubscribed(isSubscribed);
@@ -59,8 +65,11 @@ export function NotificationSubscriber({
           console.error('Error on login:', err);
         }
       };
-      loginNotifications(person.slug);
+      loginNotifications(personSlug);
     } else {
+      if (syncedExternalIdRef.current === null) {
+        return;
+      }
       const logoutNotifications = async () => {
         try {
           if (OneSignal.User.externalId) {
@@ -69,13 +78,14 @@ export function NotificationSubscriber({
         } catch (err) {
           console.error('Error on logout:', err);
         } finally {
+          syncedExternalIdRef.current = null;
           setLoggedIn(false);
           setSubscribed(false);
         }
       };
       logoutNotifications();
     }
-  }, [initialized, OneSignal, isLoading, person]);
+  }, [initialized, isLoading, personSlug]);
 
   React.useEffect(() => {
     const initialize = async () => {
@@ -134,7 +144,7 @@ export function NotificationSubscriber({
       }
     };
     initialize();
-  }, [appId, safariWebId, serviceWorkerPath, initialized, person?.slug]);
+  }, [appId, safariWebId, serviceWorkerPath, initialized, personSlug]);
 
   React.useEffect(() => {
     if (!initialized) {

--- a/packages/notifications/src/components/notifications-subscriber.tsx
+++ b/packages/notifications/src/components/notifications-subscriber.tsx
@@ -17,6 +17,8 @@ import {
 import { useRouter } from 'next/navigation';
 
 const DEV_ENV = process.env.NODE_ENV === 'development';
+let oneSignalInitPromise: Promise<void> | null = null;
+let oneSignalInitialized = false;
 
 export interface NotificationSubscriberProps {
   appId: string;
@@ -97,10 +99,17 @@ export function NotificationSubscriber({
       }
       hasInitAttemptRef.current = true;
       try {
+        if (oneSignalInitialized) {
+          setInitialized(true);
+          const alreadySubscribed = await hasPermission();
+          setSubscribed(alreadySubscribed);
+          return;
+        }
+
         const scope = serviceWorkerPath
           ? `/${serviceWorkerPath.split('/').filter(Boolean)[0]}/`
           : '/';
-        await OneSignal.init({
+        oneSignalInitPromise ??= OneSignal.init({
           appId,
           safari_web_id: safariWebId,
           serviceWorkerPath,
@@ -130,12 +139,18 @@ export function NotificationSubscriber({
           },
           notificationClickHandlerMatch: 'origin',
           notificationClickHandlerAction: 'focus',
+        }).then(() => {
+          oneSignalInitialized = true;
         });
+
+        await oneSignalInitPromise;
+        oneSignalInitPromise = null;
         console.log('OneSignal initialized');
         setInitialized(true);
         const isSubscribed = await hasPermission();
         setSubscribed(isSubscribed);
       } catch (err) {
+        oneSignalInitPromise = null;
         hasInitAttemptRef.current = false;
         console.error(
           '[notifications-subscriber] OneSignal initialization error:',

--- a/packages/notifications/src/components/notifications-subscriber.tsx
+++ b/packages/notifications/src/components/notifications-subscriber.tsx
@@ -35,6 +35,7 @@ export function NotificationSubscriber({
   const [initialized, setInitialized] = React.useState(false);
   const [subscribed, setSubscribed] = React.useState(false);
   const [loggedIn, setLoggedIn] = React.useState(false);
+  const hasInitAttemptRef = React.useRef(false);
   const router = useRouter();
 
   React.useEffect(() => {
@@ -156,10 +157,13 @@ export function NotificationSubscriber({
       }
     };
     const initialize = async () => {
-      if (initialized) {
-        console.warn('OneSignal should be initialized only once!');
+      if (initialized || hasInitAttemptRef.current) {
         return;
       }
+      if (!person?.slug || !appId) {
+        return;
+      }
+      hasInitAttemptRef.current = true;
       try {
         const scope = serviceWorkerPath
           ? `/${serviceWorkerPath.split('/').filter(Boolean)[0]}/`
@@ -245,6 +249,7 @@ export function NotificationSubscriber({
           subscriptionChangeHandler,
         );
       } catch (err) {
+        hasInitAttemptRef.current = false;
         console.log('Initialize error:', err);
       }
     };
@@ -296,7 +301,7 @@ export function NotificationSubscriber({
         subscriptionChangeHandler,
       );
     };
-  }, [appId, safariWebId, serviceWorkerPath, router]);
+  }, [appId, safariWebId, serviceWorkerPath, router, initialized, person?.slug]);
 
   return (
     <NotificationsContext.Provider

--- a/packages/notifications/src/components/notifications-subscriber.tsx
+++ b/packages/notifications/src/components/notifications-subscriber.tsx
@@ -250,7 +250,10 @@ export function NotificationSubscriber({
         );
       } catch (err) {
         hasInitAttemptRef.current = false;
-        console.log('Initialize error:', err);
+        console.error(
+          '[notifications-subscriber] OneSignal initialization error:',
+          err,
+        );
       }
     };
     initialize();

--- a/packages/notifications/src/components/notifications-subscriber.tsx
+++ b/packages/notifications/src/components/notifications-subscriber.tsx
@@ -301,7 +301,14 @@ export function NotificationSubscriber({
         subscriptionChangeHandler,
       );
     };
-  }, [appId, safariWebId, serviceWorkerPath, router, initialized, person?.slug]);
+  }, [
+    appId,
+    safariWebId,
+    serviceWorkerPath,
+    router,
+    initialized,
+    person?.slug,
+  ]);
 
   return (
     <NotificationsContext.Provider

--- a/packages/notifications/src/components/notifications-subscriber.tsx
+++ b/packages/notifications/src/components/notifications-subscriber.tsx
@@ -78,6 +78,69 @@ export function NotificationSubscriber({
   }, [initialized, OneSignal, isLoading, person]);
 
   React.useEffect(() => {
+    const initialize = async () => {
+      if (initialized || hasInitAttemptRef.current) {
+        return;
+      }
+      if (!person?.slug || !appId) {
+        return;
+      }
+      hasInitAttemptRef.current = true;
+      try {
+        const scope = serviceWorkerPath
+          ? `/${serviceWorkerPath.split('/').filter(Boolean)[0]}/`
+          : '/';
+        await OneSignal.init({
+          appId,
+          safari_web_id: safariWebId,
+          serviceWorkerPath,
+          serviceWorkerParam: { scope },
+          allowLocalhostAsSecureOrigin: DEV_ENV,
+          promptOptions: {
+            slidedown: {
+              prompts: [
+                {
+                  autoPrompt: false,
+                  categories: [],
+                  delay: {},
+                  text: {
+                    actionMessage:
+                      'Subscribe if you’d like to be notified about proposals and other Network activity.',
+                    acceptButton: 'Subscribe',
+                    cancelMessage: 'Later',
+                  },
+                  type: 'push',
+                },
+              ],
+            },
+          },
+          welcomeNotification: {
+            disable: true,
+            message: '',
+          },
+          notificationClickHandlerMatch: 'origin',
+          notificationClickHandlerAction: 'focus',
+        });
+        console.log('OneSignal initialized');
+        setInitialized(true);
+        const isSubscribed = await hasPermission();
+        setSubscribed(isSubscribed);
+      } catch (err) {
+        hasInitAttemptRef.current = false;
+        console.error(
+          '[notifications-subscriber] OneSignal initialization error:',
+          err,
+        );
+      }
+    };
+    initialize();
+  }, [appId, safariWebId, serviceWorkerPath, initialized, person?.slug]);
+
+  React.useEffect(() => {
+    if (!initialized) {
+      return;
+    }
+
     const notificationClickHandler = (event: NotificationClickEvent) => {
       if (DEV_ENV) {
         console.log('The notification was clicked!', event);
@@ -156,107 +219,47 @@ export function NotificationSubscriber({
         });
       }
     };
-    const initialize = async () => {
-      if (initialized || hasInitAttemptRef.current) {
-        return;
-      }
-      if (!person?.slug || !appId) {
-        return;
-      }
-      hasInitAttemptRef.current = true;
-      try {
-        const scope = serviceWorkerPath
-          ? `/${serviceWorkerPath.split('/').filter(Boolean)[0]}/`
-          : '/';
-        await OneSignal.init({
-          appId,
-          safari_web_id: safariWebId,
-          serviceWorkerPath,
-          serviceWorkerParam: { scope },
-          allowLocalhostAsSecureOrigin: DEV_ENV,
-          promptOptions: {
-            slidedown: {
-              prompts: [
-                {
-                  autoPrompt: false,
-                  categories: [],
-                  delay: {},
-                  text: {
-                    actionMessage:
-                      'Subscribe if you’d like to be notified about proposals and other Network activity.',
-                    acceptButton: 'Subscribe',
-                    cancelMessage: 'Later',
-                  },
-                  type: 'push',
-                },
-              ],
-            },
-          },
-          welcomeNotification: {
-            disable: true,
-            message: '',
-          },
-          notificationClickHandlerMatch: 'origin',
-          notificationClickHandlerAction: 'focus',
-        });
-        console.log('OneSignal initialized');
-        setInitialized(true);
-        const isSubscribed = await hasPermission();
-        setSubscribed(isSubscribed);
-        OneSignal.Notifications.addEventListener(
-          'click',
-          notificationClickHandler,
-        );
-        OneSignal.Notifications.addEventListener(
-          'foregroundWillDisplay',
-          foregroundWillDisplayHandler,
-        );
-        OneSignal.Notifications.addEventListener(
-          'dismiss',
-          notificationDismiss,
-        );
-        OneSignal.Notifications.addEventListener(
-          'permissionChange',
-          permissionChangeHandler,
-        );
-        OneSignal.Notifications.addEventListener(
-          'permissionPromptDisplay',
-          permissionPromptDisplayHandler,
-        );
-        OneSignal.Slidedown.addEventListener(
-          'slidedownAllowClick',
-          slidedownAllowClickHandler,
-        );
-        OneSignal.Slidedown.addEventListener(
-          'slidedownCancelClick',
-          slidedownCancelClick,
-        );
-        OneSignal.Slidedown.addEventListener(
-          'slidedownClosed',
-          slidedownClosedHandler,
-        );
-        OneSignal.Slidedown.addEventListener(
-          'slidedownQueued',
-          slidedownQueuedHandler,
-        );
-        OneSignal.Slidedown.addEventListener(
-          'slidedownShown',
-          slidedownShownHandler,
-        );
-        OneSignal.User.addEventListener('change', userChangeHandler);
-        OneSignal.User.PushSubscription.addEventListener(
-          'change',
-          subscriptionChangeHandler,
-        );
-      } catch (err) {
-        hasInitAttemptRef.current = false;
-        console.error(
-          '[notifications-subscriber] OneSignal initialization error:',
-          err,
-        );
-      }
-    };
-    initialize();
+
+    OneSignal.Notifications.addEventListener('click', notificationClickHandler);
+    OneSignal.Notifications.addEventListener(
+      'foregroundWillDisplay',
+      foregroundWillDisplayHandler,
+    );
+    OneSignal.Notifications.addEventListener('dismiss', notificationDismiss);
+    OneSignal.Notifications.addEventListener(
+      'permissionChange',
+      permissionChangeHandler,
+    );
+    OneSignal.Notifications.addEventListener(
+      'permissionPromptDisplay',
+      permissionPromptDisplayHandler,
+    );
+    OneSignal.Slidedown.addEventListener(
+      'slidedownAllowClick',
+      slidedownAllowClickHandler,
+    );
+    OneSignal.Slidedown.addEventListener(
+      'slidedownCancelClick',
+      slidedownCancelClick,
+    );
+    OneSignal.Slidedown.addEventListener(
+      'slidedownClosed',
+      slidedownClosedHandler,
+    );
+    OneSignal.Slidedown.addEventListener(
+      'slidedownQueued',
+      slidedownQueuedHandler,
+    );
+    OneSignal.Slidedown.addEventListener(
+      'slidedownShown',
+      slidedownShownHandler,
+    );
+    OneSignal.User.addEventListener('change', userChangeHandler);
+    OneSignal.User.PushSubscription.addEventListener(
+      'change',
+      subscriptionChangeHandler,
+    );
+
     return () => {
       OneSignal.Notifications.removeEventListener(
         'click',
@@ -304,14 +307,7 @@ export function NotificationSubscriber({
         subscriptionChangeHandler,
       );
     };
-  }, [
-    appId,
-    safariWebId,
-    serviceWorkerPath,
-    router,
-    initialized,
-    person?.slug,
-  ]);
+  }, [initialized, router]);
 
   return (
     <NotificationsContext.Provider

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -839,6 +839,9 @@ importers:
       '@hypha-platform/config-typescript':
         specifier: workspace:*
         version: link:../../config/typescript
+      '@tailwindcss/postcss':
+        specifier: ^4.1.11
+        version: 4.1.11
       '@types/d3':
         specifier: ^7.4.3
         version: 7.4.3
@@ -9239,6 +9242,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-darwin-arm64@1.5.0':
     resolution: {integrity: sha512-YmocNlEcX/AgJv8gI41bhjMOTcKcea4D2nRIbZj+MhRtSH5+vEU8r/pFuTuoF+JjVplLsBueU+CILfBPVISyGQ==}
@@ -13164,20 +13168,20 @@ packages:
 
   glob@5.0.15:
     resolution: {integrity: sha512-c9IPMazfRITpmAAKi22dK1VKxGDX9ehhqfABDriL/lzO92xcUKEJPQHrVA/2YHSNFB4iFlykVmWvwo48nr3OxA==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@7.1.7:
     resolution: {integrity: sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
     engines: {node: '>=12'}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   global-modules@0.2.3:
     resolution: {integrity: sha512-JeXuCbvYzYXcwE6acL9V2bAOeSIGl4dD+iwLY9iUx2VBJJ80R18HCn+JCwHM9Oegdfya3lEkGCdaRkSyc10hDA==}
@@ -19665,6 +19669,7 @@ packages:
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@11.1.0:
@@ -19677,10 +19682,12 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:


### PR DESCRIPTION
## Investigation (before implementation)
- Reported behavior narrowed to first navigation from `/en/network` into a space route (`/${lang}/dho/${slug}/agreements`), where Vercel shows a white 500 page once.
- Traced route execution chain and identified two fail-fast server boundaries:
  - `getAllSpaces()` (network list load) did strict web3 enrichment.
  - `getSpaceBySlug()` (space agreements page) also did strict web3 enrichment and rethrew.
- This matches first-hit transient failures (RPC/provider warm-up jitter): initial request can fail, refresh then succeeds.

## Implementation
- Hardened `getAllSpaces()` to degrade gracefully when web3 multicalls fail:
  - uses `allowFailure: true`
  - catches detail/proposal fetch failures and falls back to DB-only list enrichment
  - adds targeted server logs for observability
- Hardened `getSpaceBySlug()` similarly for first-click space route:
  - catches web3 enrichment failures and returns DB-backed space object
  - preserves full error throw for true DB/read failures
  - adds contextual server logs (`slug`, `web3SpaceId`)

## Validation
- `pnpm exec prettier --write packages/core/src/space/server/web3/get-all-spaces.ts`
- `pnpm exec prettier --write packages/core/src/space/server/web3/get-space-by-slug.ts`
- `pnpm turbo run lint --filter=@hypha-platform/core` (passes; existing warnings only)

## Expected outcome
- First-click navigation into space pages no longer hard-fails to Vercel white 500 on transient web3 enrichment issues.
- Network and space pages render with DB-backed data while web3 enrichment recovers on subsequent requests.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added simple client and global error fallbacks so unhandled errors show a retry UI instead of crashing.

* **Bug Fixes**
  * More resilient on-chain/enrichment and page data loads: failures are logged and partial results returned so pages render.
  * Notifications init is guarded to avoid repeated or premature setups when identity changes.

* **Performance**
  * Stabilized top-offset calculation with a debounced RAF-based update loop.

* **Refactor**
  * Root layout resolves localization/labels and feature flags per request and passes pre-resolved labels to the UI.

* **Chores**
  * Defensive token lookups added to prevent runtime errors; CSP form-action broadened.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->