### PR TITLE
fix: prevent infinite setState loop in HumanRightPanel on cold load

### DIFF
--- a/packages/epics/src/common/human-right-panel.tsx
+++ b/packages/epics/src/common/human-right-panel.tsx
@@ -600,7 +600,10 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
     spaceSlug,
     paginationDisabled: true,
   });
-  const spaceMembers = spaceMembersResult?.data ?? [];
+  const spaceMembers = useMemo(
+    () => spaceMembersResult?.data ?? [],
+    [spaceMembersResult?.data],
+  );
   const { space, isLoading: isSpaceLoading } = useSpaceBySlug(spaceSlug ?? '');
   const { userState: userSpaceState, isLoading: isUserSpaceStateLoading } =
     useUserSpaceState({
@@ -1251,8 +1254,8 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
 
   useEffect(() => {
     if (!roomId || !client) return;
-    setMessages((prev) =>
-      prev.map((m) => {
+    setMessages((prev) => {
+      const next = prev.map((m) => {
         const sid = m.senderMatrixId?.trim();
         const isSelfRow = Boolean(
           currentUserIdRef.current && sid && sid === currentUserIdRef.current,
@@ -1322,8 +1325,10 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
           avatarUrl: nextMemberAvatar,
           replyTo: nextReply,
         };
-      }),
-    );
+      });
+      // Return the same array reference when nothing changed to avoid a re-render
+      return next.every((m, i) => m === prev[i]) ? prev : next;
+    });
   }, [
     roomId,
     client,


### PR DESCRIPTION
Stabilise `spaceMembers` with useMemo so the `?? []` fallback doesn't create a new array reference on every render when member data isn't loaded yet.  This prevents `matrixUserIdToPersonLabel` (which depends on `spaceMembers`) from producing a new Map instance every render, which was triggering the label-resync effect on every render.

Also make the label-resync `setMessages` call idempotent: if every mapped element is the same reference as its predecessor, return `prev` unchanged so React skips the re-render entirely.

Together these break the 25-iteration cycle that caused React Error #185 ("Maximum update depth exceeded") on hard cache reset.