### PR TITLE
docs(requirements): add onboarding adventure spec

### DIFF
--- a/apps/web/src/app/[lang]/dho/[id]/@tab/overview/_components/home-token-holdings-dashboard.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@tab/overview/_components/home-token-holdings-dashboard.tsx
@@ -981,7 +981,9 @@ function MembersEvolutionWidget({
   return (
     <Card className="min-w-0 overflow-hidden border-border/60 bg-card/95">
       <CardHeader className="pb-0">
-        <CardTitle className="text-lg">{tTokenHoldings('members.title')}</CardTitle>
+        <CardTitle className="text-lg">
+          {tTokenHoldings('members.title')}
+        </CardTitle>
         <CardDescription className="text-xs">
           {tTokenHoldings('members.subtitle')}
         </CardDescription>
@@ -1260,7 +1262,9 @@ function SignalsPulseMapWidget({
   return (
     <Card className="min-w-0 overflow-hidden border-border/60 bg-card/95">
       <CardHeader className="pb-2">
-        <CardTitle className="text-lg">{tTokenHoldings('signals.title')}</CardTitle>
+        <CardTitle className="text-lg">
+          {tTokenHoldings('signals.title')}
+        </CardTitle>
         <CardDescription className="text-xs">
           {tTokenHoldings('signals.subtitle')}
         </CardDescription>
@@ -1495,7 +1499,10 @@ export function HomeTokenHoldingsDashboard({
           ? [{ value: 'energy', label: tTokenHoldings('filters.energy') }]
           : []),
         { value: 'activity', label: tTokenHoldings('filters.activity') },
-        { value: 'distribution', label: tTokenHoldings('filters.distribution') },
+        {
+          value: 'distribution',
+          label: tTokenHoldings('filters.distribution'),
+        },
       ] as Array<{ value: HomeSectionFilter; label: string }>,
     [showEnergyWidget, tTokenHoldings],
   );
@@ -1640,9 +1647,12 @@ export function HomeTokenHoldingsDashboard({
                               <TooltipTrigger asChild>
                                 <button
                                   type="button"
-                                  aria-label={tTokenHoldings('tokenDetailsAria', {
-                                    tokenName: token.name,
-                                  })}
+                                  aria-label={tTokenHoldings(
+                                    'tokenDetailsAria',
+                                    {
+                                      tokenName: token.name,
+                                    },
+                                  )}
                                   className="inline-flex h-5 w-5 items-center justify-center rounded-full text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                                 >
                                   <CircleHelp className="h-4 w-4" />

--- a/apps/web/src/app/[lang]/onboarding/_components/onboarding-adventure-page.tsx
+++ b/apps/web/src/app/[lang]/onboarding/_components/onboarding-adventure-page.tsx
@@ -1,0 +1,318 @@
+'use client';
+
+import { ReactNode, useMemo, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useLocale, useTranslations } from 'next-intl';
+import QRCode from 'react-qr-code';
+import {
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Combobox,
+  Container,
+} from '@hypha-platform/ui';
+import { copyToClipboard } from '@hypha-platform/ui-utils';
+import {
+  Compass,
+  Copy,
+  ExternalLink,
+  Handshake,
+  PlusCircle,
+  Wallet,
+} from 'lucide-react';
+import { useAllSpaces } from '@web/hooks/use-all-spaces';
+import { Space } from '@hypha-platform/core/client';
+
+const EXCHANGE_LINKS = [
+  { id: 'coinbase', label: 'Coinbase', href: 'https://www.coinbase.com' },
+  { id: 'wirex', label: 'Wirex', href: 'https://wirexapp.com' },
+  { id: 'kraken', label: 'Kraken', href: 'https://www.kraken.com' },
+] as const;
+
+const getSpacePath = (lang: string, spaceSlug: string) =>
+  `/${lang}/dho/${spaceSlug}/agreements`;
+
+const getNetworkPath = (lang: string) => `/${lang}/network`;
+const getCreateSpacePath = (lang: string) => `/${lang}/my-spaces/create`;
+
+export function OnboardingAdventurePage() {
+  const t = useTranslations('OnboardingAdventure');
+  const locale = useLocale();
+  const router = useRouter();
+  const { spaces, isLoading } = useAllSpaces();
+
+  const [joinSpaceSlug, setJoinSpaceSlug] = useState('');
+  const [depositSpaceSlug, setDepositSpaceSlug] = useState('');
+  const [depositDetailsSpaceSlug, setDepositDetailsSpaceSlug] = useState('');
+  const [copiedAddress, setCopiedAddress] = useState(false);
+
+  const spaceOptions = useMemo(
+    () =>
+      spaces.map((space) => ({
+        value: space.slug,
+        label: space.title,
+        searchText: `${space.title} ${space.slug}`,
+      })),
+    [spaces],
+  );
+
+  const depositEligibleSpaces = useMemo(
+    () => spaces.filter((space) => Boolean(space.address)),
+    [spaces],
+  );
+
+  const depositOptions = useMemo(
+    () =>
+      depositEligibleSpaces.map((space) => ({
+        value: space.slug,
+        label: space.title,
+        searchText: `${space.title} ${space.slug}`,
+      })),
+    [depositEligibleSpaces],
+  );
+
+  const selectedDepositSpace = useMemo(
+    () =>
+      depositEligibleSpaces.find(
+        (space) => space.slug === depositDetailsSpaceSlug,
+      ) ?? null,
+    [depositDetailsSpaceSlug, depositEligibleSpaces],
+  );
+
+  const hasJoinChoices = spaceOptions.length > 0;
+  const hasDepositChoices = depositOptions.length > 0;
+
+  const handleCopyAddress = (address: string) => {
+    copyToClipboard(address);
+    setCopiedAddress(true);
+    window.setTimeout(() => setCopiedAddress(false), 2000);
+  };
+
+  const handleDepositSpaceChange = (next: string) => {
+    setDepositSpaceSlug(next);
+    setDepositDetailsSpaceSlug('');
+  };
+
+  const renderSelectorCard = ({
+    icon,
+    title,
+    description,
+    options,
+    value,
+    onChange,
+    actionLabel,
+    onAction,
+    disabled,
+    unavailableText,
+  }: {
+    icon: ReactNode;
+    title: string;
+    description: string;
+    options: Array<{ value: string; label: string; searchText?: string }>;
+    value: string;
+    onChange: (next: string) => void;
+    actionLabel: string;
+    onAction: () => void;
+    disabled: boolean;
+    unavailableText: string;
+  }) => (
+    <Card className="h-full border-border/60 bg-card/95">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-5">
+          <span className="text-accent-11">{icon}</span>
+          {title}
+        </CardTitle>
+        <CardDescription>{description}</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <Combobox
+          options={options}
+          placeholder={t('spacePlaceholder')}
+          searchPlaceholder={t('spaceSearchPlaceholder')}
+          onChange={onChange}
+          initialValue={value}
+          allowEmptyChoice={false}
+          className="w-full md:w-full"
+          disabled={disabled}
+          emptyListMessage={t('noSpacesFound')}
+        />
+        <Button
+          type="button"
+          className="w-full"
+          onClick={onAction}
+          disabled={disabled || !value}
+        >
+          {actionLabel}
+        </Button>
+        {disabled ? (
+          <p className="text-1 text-muted-foreground">{unavailableText}</p>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+
+  return (
+    <Container className="flex flex-col gap-6 py-8">
+      <header className="space-y-2 text-center">
+        <h1 className="text-8 font-semibold text-foreground">{t('title')}</h1>
+        <p className="text-3 text-muted-foreground">{t('subtitle')}</p>
+      </header>
+
+      <section className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <Card className="h-full border-border/60 bg-card/95">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-5">
+              <Compass className="size-5 text-accent-11" />
+              {t('explore.title')}
+            </CardTitle>
+            <CardDescription>{t('explore.description')}</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Button
+              type="button"
+              className="w-full"
+              onClick={() => router.push(getNetworkPath(locale))}
+            >
+              {t('explore.cta')}
+            </Button>
+          </CardContent>
+        </Card>
+
+        <Card className="h-full border-border/60 bg-card/95">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-5">
+              <PlusCircle className="size-5 text-accent-11" />
+              {t('create.title')}
+            </CardTitle>
+            <CardDescription>{t('create.description')}</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Button
+              type="button"
+              className="w-full"
+              onClick={() => router.push(getCreateSpacePath(locale))}
+            >
+              {t('create.cta')}
+            </Button>
+          </CardContent>
+        </Card>
+
+        {renderSelectorCard({
+          icon: <Handshake className="size-5" />,
+          title: t('join.title'),
+          description: t('join.description'),
+          options: spaceOptions,
+          value: joinSpaceSlug,
+          onChange: setJoinSpaceSlug,
+          actionLabel: t('join.cta'),
+          onAction: () => {
+            if (!joinSpaceSlug) return;
+            router.push(getSpacePath(locale, joinSpaceSlug));
+          },
+          disabled: isLoading || !hasJoinChoices,
+          unavailableText: isLoading
+            ? t('loadingSpaces')
+            : t('join.unavailable'),
+        })}
+
+        {renderSelectorCard({
+          icon: <Wallet className="size-5" />,
+          title: t('deposit.title'),
+          description: t('deposit.description'),
+          options: depositOptions,
+          value: depositSpaceSlug,
+          onChange: handleDepositSpaceChange,
+          actionLabel: t('deposit.cta'),
+          onAction: () => {
+            if (!depositSpaceSlug) return;
+            setDepositDetailsSpaceSlug(depositSpaceSlug);
+          },
+          disabled: isLoading || !hasDepositChoices,
+          unavailableText: isLoading
+            ? t('loadingSpaces')
+            : t('deposit.unavailable'),
+        })}
+      </section>
+
+      {selectedDepositSpace?.address ? (
+        <DepositDetailsCard
+          t={t}
+          space={selectedDepositSpace}
+          copiedAddress={copiedAddress}
+          onCopyAddress={handleCopyAddress}
+        />
+      ) : null}
+    </Container>
+  );
+}
+
+function DepositDetailsCard({
+  t,
+  space,
+  copiedAddress,
+  onCopyAddress,
+}: {
+  t: (key: string, values?: Record<string, string | number>) => string;
+  space: Space;
+  copiedAddress: boolean;
+  onCopyAddress: (address: string) => void;
+}) {
+  if (!space.address) return null;
+
+  return (
+    <Card className="border-border/60 bg-card/95">
+      <CardHeader>
+        <CardTitle className="text-5">{t('depositDetails.title')}</CardTitle>
+        <CardDescription>
+          {t('depositDetails.description', { spaceName: space.title })}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="grid grid-cols-1 gap-5 lg:grid-cols-[1fr_auto]">
+        <div className="space-y-4">
+          <div className="space-y-2 rounded-lg border border-border/70 bg-background/30 p-3">
+            <p className="text-1 text-muted-foreground">
+              {t('depositDetails.addressLabel')}
+            </p>
+            <p className="break-all font-mono text-2 text-foreground">
+              {space.address}
+            </p>
+            <Button
+              type="button"
+              variant="outline"
+              colorVariant="neutral"
+              onClick={() => onCopyAddress(space.address as string)}
+              className="inline-flex min-h-11 items-center gap-2"
+            >
+              <Copy className="size-4" />
+              {copiedAddress
+                ? t('depositDetails.copied')
+                : t('depositDetails.copy')}
+            </Button>
+          </div>
+
+          <div className="flex flex-wrap gap-2">
+            {EXCHANGE_LINKS.map((link) => (
+              <a
+                key={link.id}
+                href={link.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex min-h-11 items-center gap-2 rounded-md border border-border/70 bg-muted/40 px-3 py-2 text-2 text-foreground transition-colors hover:bg-muted"
+              >
+                <ExternalLink className="size-4 text-muted-foreground" />
+                {link.label}
+              </a>
+            ))}
+          </div>
+        </div>
+
+        <div className="mx-auto rounded-lg border border-border/70 bg-white p-3">
+          <QRCode value={space.address} size={160} />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/app/[lang]/onboarding/page.tsx
+++ b/apps/web/src/app/[lang]/onboarding/page.tsx
@@ -1,0 +1,5 @@
+import { OnboardingAdventurePage } from './_components/onboarding-adventure-page';
+
+export default function OnboardingPage() {
+  return <OnboardingAdventurePage />;
+}

--- a/apps/web/src/hooks/use-create-profile.ts
+++ b/apps/web/src/hooks/use-create-profile.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useState } from 'react';
-import { useRouter } from 'next/navigation';
+import { useParams, useRouter } from 'next/navigation';
 import { z } from 'zod';
 import {
   schemaSignupPerson,
@@ -18,6 +18,7 @@ export const useCreateProfile = (
   const { jwt } = useJwt();
   const { headers } = useAuthHeader();
   const router = useRouter();
+  const params = useParams<{ lang?: string }>();
   const [isCreating, setIsCreating] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -65,7 +66,9 @@ export const useCreateProfile = (
         }
 
         const createdProfile = await response.json();
-        router.push('/profile');
+        const lang = params?.lang;
+        const onboardingPath = lang ? `/${lang}/onboarding` : '/profile';
+        router.push(onboardingPath);
         return createdProfile;
       } catch (err) {
         console.error('Profile creation error:', err);
@@ -75,7 +78,7 @@ export const useCreateProfile = (
         setIsCreating(false);
       }
     },
-    [endpoint, headers, router, upload],
+    [endpoint, headers, params?.lang, router, upload],
   );
 
   return {

--- a/docs/requirements/onboarding-adventure-spec.md
+++ b/docs/requirements/onboarding-adventure-spec.md
@@ -64,6 +64,7 @@ Replace the post-signup "empty profile landing" with an engaging onboarding deci
 - Onboarding route: `/{lang}/onboarding` (final slug confirmable via open question OQ-1).
 - Locale SHALL be preserved in all transitions.
 - Returning users SHALL not be forced into onboarding unless explicitly gated by feature flag.
+- The onboarding route SHALL remain directly reachable for authenticated users after signup completion (re-entry behavior).
 - Onboarding render failure SHALL fall back to existing profile destination.
 
 ---
@@ -140,6 +141,16 @@ External-link behavior:
 - Reserve a top-level optional container region for future AI onboarding content.
 - Current four-card flow SHALL not depend on AI availability.
 
+### 4.6 Re-entry entry points (post-signup access)
+
+To support "continue your adventure" behavior later in the user journey, expose a persistent re-entry path to onboarding:
+
+- Add a primary re-entry CTA in the user profile/account menu dropdown (recommended label: "Continue your adventure").
+- Add a secondary re-entry CTA in navigation surfaces where users commonly recover orientation (e.g., sidebar or dashboard empty states).
+- Keep direct route access at `/{lang}/onboarding` for authenticated users.
+- If users have already completed some onboarding actions, show progress-oriented copy while preserving all four card actions.
+- Do not implement onboarding access as a default profile-page tab in this phase; keep onboarding as a standalone route linked from menu/CTA surfaces.
+
 ---
 
 ## 5) Functional requirements
@@ -163,6 +174,12 @@ External-link behavior:
 **FR-9** The system SHALL preserve locale across all onboarding transitions.
 
 **FR-10** The system SHALL allow users to leave onboarding and continue normal navigation at any time.
+
+**FR-11** The system SHALL provide at least one persistent in-app entry point for authenticated users to re-enter onboarding after signup via the profile/account menu dropdown.
+
+**FR-12** The system SHALL allow authenticated returning users to access the localized onboarding route directly without requiring account recreation.
+
+**FR-13** The system SHALL implement onboarding as a standalone page route and SHALL NOT require a profile-page tab for access in phase 1.
 
 ---
 
@@ -232,6 +249,14 @@ Then non-selector cards remain usable and selector cards show recoverable empty/
 When signup/profile creation is executed,  
 Then no regression occurs in success rate, validation, or auth continuity.
 
+**AC-9** Given an authenticated returning user,  
+When they select "Continue your adventure" from a persistent in-app entry point,  
+Then they land on the localized onboarding page.
+
+**AC-10** Given an authenticated returning user,  
+When they navigate directly to the localized onboarding route,  
+Then onboarding renders and all four actions remain available under existing eligibility rules.
+
 ---
 
 ## 9) QA and test engineering plan
@@ -251,6 +276,7 @@ Then no regression occurs in success rate, validation, or auth continuity.
 - Existing direct navigation to profile/my-spaces/network.
 - Existing create-space flow remains reachable and successful.
 - Existing space page routing/rendering remains unaffected.
+- Profile page behavior remains unchanged (no new default onboarding tab behavior introduced in phase 1).
 
 ### 9.3 Suggested event instrumentation contract
 
@@ -276,7 +302,7 @@ Then no regression occurs in success rate, validation, or auth continuity.
 | ONB-5 | Join a Space action card | Build selector UX + disabled/enabled CTA + navigation to selected space destination. | FR-5, FR-6, AC-4 | ONB-4 |
 | ONB-6 | Deposit Funds flow and details state | Build deposit selector + treasury address display + copy action + QR generation + external links. | FR-7, FR-8, NFR-5, AC-5, AC-6 | ONB-4 |
 | ONB-7 | Observability + analytics hooks | Emit impression/selection/link-click events with typed payloads and coverage tests. | NFR-4 | ONB-2, ONB-5, ONB-6 |
-| ONB-8 | QA automation + regression hardening | Add Playwright coverage, accessibility checks, visual snapshots, and regression assertions for signup/profile baselines. | AC-1..AC-8, PAR-1..PAR-7 | ONB-1..ONB-7 |
+| ONB-8 | QA automation + regression hardening | Add Playwright coverage, accessibility checks, visual snapshots, and regression assertions for signup/profile baselines. | AC-1..AC-10, PAR-1..PAR-7 | ONB-1..ONB-7 |
 
 ---
 
@@ -288,6 +314,7 @@ Then no regression occurs in success rate, validation, or auth continuity.
 | OQ-2 | Canonical join destination for selected space (overview vs agreements vs home) | Product + UX | Use space default overview/agreements target already used by existing navigation |
 | OQ-3 | Canonical external URLs for Coinbase/Wirex/Kraken | Product + Compliance | Read from configuration constants owned by product/compliance |
 | OQ-4 | Onboarding experience policy (one-time, skippable, re-entry path) | Product | One-time for new profiles; skippable via normal navigation; returning users gated by flag |
+| OQ-5 | Canonical persistent re-entry location in app chrome (profile menu only vs profile + sidebar/empty states) | Product + UX | Profile menu dropdown primary + one secondary contextual CTA; not a profile-page tab |
 
 ---
 
@@ -315,3 +342,5 @@ Then no regression occurs in success rate, validation, or auth continuity.
 | Version | Date | Author | Changes |
 | --- | --- | --- | --- |
 | 1.0 | 2026-05-10 | Requirements + UX + QA (agent) | Initial ready-to-implement onboarding adventure spec with FR/PAR/NFR, ACs, QA plan, and ticket decomposition. |
+| 1.1 | 2026-05-10 | Requirements + UX + QA (agent) | Added persistent post-signup re-entry model (`FR-11`, `FR-12`, `AC-9`, `AC-10`) and defined recommended placement in profile menu plus secondary contextual CTA surfaces. |
+| 1.2 | 2026-05-10 | Requirements + UX + QA (agent) | Clarified re-entry is via profile/account menu dropdown (not profile tab), added `FR-13`, and aligned QA/ticket traceability for re-entry coverage. |

--- a/docs/requirements/onboarding-adventure-spec.md
+++ b/docs/requirements/onboarding-adventure-spec.md
@@ -1,0 +1,317 @@
+# Onboarding Adventure Specification (Product + UX + QA)
+
+## Document control
+
+| Field | Value |
+| --- | --- |
+| Status | Ready for implementation |
+| Scope | Replace post-signup profile landing with a localized onboarding decision experience for new users. |
+| Primary goal | Increase early activation by guiding users into one of four meaningful next actions immediately after profile creation. |
+| Non-goals | Auth provider changes, wallet creation logic changes, full-page AI onboarding experience, custody/on-ramp integrations beyond external links. |
+| Owner | Product + UX + Web Platform |
+| Version | 1.0 |
+| Last updated | 2026-05-10 |
+
+---
+
+## 1) Objective
+
+Replace the post-signup "empty profile landing" with an engaging onboarding decision page that is playful, clear, and action-oriented, while preserving account creation reliability and existing route accessibility.
+
+---
+
+## 2) Scope boundaries
+
+### 2.1 In scope
+
+- New full-page onboarding shown immediately after successful profile creation.
+- Four choice cards:
+  - Explore the Network
+  - Create your Space
+  - Join a Space (space selector)
+  - Deposit Funds in a Space (space selector)
+- Navigation behavior and validation for all cards.
+- Deposit details state (treasury address + QR + external links).
+- Regression protections for account/profile creation and existing route accessibility.
+
+### 2.2 Out of scope (phase 1)
+
+- Full-page AI prompt/field experience (future phase only).
+- Authentication provider behavior or wallet creation logic changes.
+- Financial custody/on-ramp integrations beyond opening configured external links.
+
+---
+
+## 3) Information architecture and flow
+
+### 3.1 Baseline (current behavior)
+
+- New user completes signup/profile and is routed to profile route.
+- If profile slug exists, routing resolves to slugged profile view.
+
+### 3.2 Target behavior
+
+1. User signs up and completes profile creation.
+2. On success, user is routed to localized onboarding page.
+3. User chooses one of four cards:
+   - Explore the Network -> localized network page.
+   - Create your Space -> localized create-space flow.
+   - Join a Space -> user selects space -> selected space page.
+   - Deposit Funds in a Space -> user selects space -> deposit details state.
+
+### 3.3 Route intent (spec-level)
+
+- Onboarding route: `/{lang}/onboarding` (final slug confirmable via open question OQ-1).
+- Locale SHALL be preserved in all transitions.
+- Returning users SHALL not be forced into onboarding unless explicitly gated by feature flag.
+- Onboarding render failure SHALL fall back to existing profile destination.
+
+---
+
+## 4) UX and UI specification
+
+### 4.1 Page layout
+
+- Hero title with visual prominence comparable to existing "My Spaces" heading scale.
+- Single-line supporting text: "Choose your next step" (localized).
+- Four-card responsive grid:
+  - Desktop/tablet: 2x2.
+  - Mobile: single column stack.
+
+### 4.2 Card design system and interaction rules
+
+- Use existing tokens/components from `packages/ui` and `packages/ui-utils`.
+- No ad-hoc color/spacing/radius values outside design system tokens.
+- Card interaction states required:
+  - Default
+  - Hover
+  - Active/pressed
+  - Focus-visible (keyboard)
+  - Disabled (selector-dependent cards)
+- Minimum interactive target: 44x44 px.
+
+### 4.3 Card content and behavior
+
+#### Explore the Network
+
+- Icon metaphor: discovery/network.
+- Immediate navigation CTA (no intermediate selection).
+
+#### Create your Space
+
+- Icon metaphor: creation/plus/rocket.
+- Immediate navigation CTA to create-space flow.
+
+#### Join a Space
+
+- Icon metaphor: handshake/group.
+- Includes searchable selector (dropdown/autocomplete) over eligible spaces.
+- Primary CTA disabled until a valid space selection is made.
+- Confirm action routes to selected space destination.
+
+#### Deposit Funds in a Space
+
+- Icon metaphor: wallet/coins.
+- Includes searchable selector limited to spaces with valid treasury address.
+- CTA disabled until a valid space selection is made.
+- On confirm, transition to deposit details state.
+
+### 4.4 Deposit details state
+
+When a valid deposit-eligible space is selected, render:
+
+- Selected space name.
+- Treasury account address.
+- Address copy action.
+- QR code encoding treasury address.
+- External quick links with icon + label:
+  - Coinbase
+  - Wirex
+  - Kraken
+
+External-link behavior:
+
+- Open in new tab.
+- Use safe attributes (`rel="noopener noreferrer"` at minimum).
+- URLs must come from trusted configuration/constants only.
+
+### 4.5 Future extension slot (non-blocking hook)
+
+- Reserve a top-level optional container region for future AI onboarding content.
+- Current four-card flow SHALL not depend on AI availability.
+
+---
+
+## 5) Functional requirements
+
+**FR-1** The system SHALL route newly created profiles to the onboarding adventure page instead of the default profile landing page.
+
+**FR-2** The system SHALL display exactly four onboarding choices, each with icon, title, and action behavior.
+
+**FR-3** The system SHALL route "Explore the Network" to the localized network route.
+
+**FR-4** The system SHALL route "Create your Space" to the localized create-space flow.
+
+**FR-5** The system SHALL provide a searchable selector for "Join a Space" populated from available spaces.
+
+**FR-6** The system SHALL route "Join a Space" to the selected space page after a valid selection.
+
+**FR-7** The system SHALL provide a searchable selector for "Deposit Funds in a Space" limited to spaces with valid treasury address data.
+
+**FR-8** The system SHALL display selected space treasury address, QR code, and exchange links (Coinbase/Wirex/Kraken) in the deposit flow.
+
+**FR-9** The system SHALL preserve locale across all onboarding transitions.
+
+**FR-10** The system SHALL allow users to leave onboarding and continue normal navigation at any time.
+
+---
+
+## 6) Parity and no-regression constraints (critical)
+
+**PAR-1** The account creation API contract and payload validation SHALL remain unchanged.
+
+**PAR-2** Wallet-address prerequisite for profile creation SHALL remain enforced.
+
+**PAR-3** Profile creation success criteria SHALL remain unchanged (no additional required fields).
+
+**PAR-4** Existing behavior for already-onboarded users SHALL remain unchanged unless a feature flag explicitly enables onboarding for them.
+
+**PAR-5** Existing profile route accessibility and deep links SHALL continue to work.
+
+**PAR-6** Failure in onboarding route rendering SHALL fail safely to existing profile destination.
+
+**PAR-7** Existing create-space, network, and space-page routes SHALL remain directly reachable outside onboarding.
+
+---
+
+## 7) Non-functional requirements
+
+**NFR-1 (Accessibility)** The onboarding and deposit states SHALL meet WCAG 2.1 AA for keyboard traversal, focus visibility, form controls, and semantic links.
+
+**NFR-2 (Performance)** Onboarding page SHALL become interactive within current post-signup baseline budgets, with no significant regression to post-signup TTI.
+
+**NFR-3 (Resilience)** If spaces fetch fails, selector-dependent cards SHALL show recoverable error/empty states while non-selector cards remain usable.
+
+**NFR-4 (Observability)** The system SHALL emit analytics events for onboarding card impressions and selections for funnel analysis.
+
+**NFR-5 (Security)** External links SHALL use safe navigation attributes and SHALL NOT accept untrusted URL injection.
+
+---
+
+## 8) Acceptance criteria (Given/When/Then)
+
+**AC-1** Given a new user successfully creates a profile,  
+When profile creation completes,  
+Then the user lands on the onboarding adventure page.
+
+**AC-2** Given onboarding is visible,  
+When the user clicks "Explore the Network",  
+Then the user lands on the localized network page.
+
+**AC-3** Given onboarding is visible,  
+When the user clicks "Create your Space",  
+Then the user lands on the localized create-space form.
+
+**AC-4** Given onboarding is visible,  
+When the user selects a space under "Join a Space" and confirms,  
+Then the user lands on the selected space page.
+
+**AC-5** Given onboarding is visible,  
+When the user selects a space under "Deposit Funds in a Space",  
+Then treasury QR and treasury address are shown for that selected space.
+
+**AC-6** Given deposit details are shown,  
+When the user clicks Coinbase/Wirex/Kraken links,  
+Then each link opens in a new tab to its configured URL.
+
+**AC-7** Given spaces fetch fails for selectors,  
+When onboarding renders,  
+Then non-selector cards remain usable and selector cards show recoverable empty/error state.
+
+**AC-8** Given existing account creation flow,  
+When signup/profile creation is executed,  
+Then no regression occurs in success rate, validation, or auth continuity.
+
+---
+
+## 9) QA and test engineering plan
+
+### 9.1 Test layers
+
+| Layer | Scope |
+| --- | --- |
+| E2E (primary) | New-user signup -> profile creation -> onboarding landing; all 4 card journeys; selector enable/disable logic; locale continuity across transitions. |
+| Integration | Space selector mapping/filtering (join list vs deposit-eligible list), onboarding redirection gating logic, onboarding failure fallback logic. |
+| Accessibility | Keyboard-only traversal, focus order, focus-visible checks, semantic role assertions, axe scan on onboarding and deposit state. |
+| Visual regression | Desktop + mobile snapshots for onboarding page and deposit details panel. |
+
+### 9.2 Must-pass regression suite
+
+- Signup + profile creation baseline path.
+- Existing direct navigation to profile/my-spaces/network.
+- Existing create-space flow remains reachable and successful.
+- Existing space page routing/rendering remains unaffected.
+
+### 9.3 Suggested event instrumentation contract
+
+- `onboarding_adventure_impression`
+  - props: `locale`, `user_id_hash`, `is_new_profile`, `flag_variant`
+- `onboarding_adventure_card_selected`
+  - props: `locale`, `card_id`, `has_space_selected`, `selected_space_slug?`
+- `onboarding_adventure_deposit_link_clicked`
+  - props: `locale`, `provider`, `space_slug`
+
+---
+
+## 10) Implementation decomposition (ticket breakdown)
+
+### Epic: ONB-ADV-01 — Onboarding Adventure after profile creation
+
+| Ticket | Title | Scope | Maps to | Dependency |
+| --- | --- | --- | --- | --- |
+| ONB-1 | Route and gating orchestration | Route new profiles to onboarding; preserve locale; add feature-flag gate for returning users; fallback to profile on onboarding render failure. | FR-1, FR-9, PAR-4, PAR-6 | None |
+| ONB-2 | Onboarding page shell + 4-card layout | Build full-page layout, hero/subheading, responsive card grid, token-compliant interaction states. | FR-2, NFR-1, NFR-2 | ONB-1 |
+| ONB-3 | Immediate-action cards navigation | Wire Explore + Create cards to localized routes; maintain direct route compatibility. | FR-3, FR-4, PAR-7 | ONB-2 |
+| ONB-4 | Shared spaces selector data layer | Add spaces query + loading/error states + search filtering + locale-safe labels. | FR-5, FR-7, NFR-3 | ONB-2 |
+| ONB-5 | Join a Space action card | Build selector UX + disabled/enabled CTA + navigation to selected space destination. | FR-5, FR-6, AC-4 | ONB-4 |
+| ONB-6 | Deposit Funds flow and details state | Build deposit selector + treasury address display + copy action + QR generation + external links. | FR-7, FR-8, NFR-5, AC-5, AC-6 | ONB-4 |
+| ONB-7 | Observability + analytics hooks | Emit impression/selection/link-click events with typed payloads and coverage tests. | NFR-4 | ONB-2, ONB-5, ONB-6 |
+| ONB-8 | QA automation + regression hardening | Add Playwright coverage, accessibility checks, visual snapshots, and regression assertions for signup/profile baselines. | AC-1..AC-8, PAR-1..PAR-7 | ONB-1..ONB-7 |
+
+---
+
+## 11) Open product decisions
+
+| ID | Decision needed | Owner | Default assumption |
+| --- | --- | --- | --- |
+| OQ-1 | Final onboarding route slug (`/onboarding` vs `/welcome`) | Product | Use `/onboarding` |
+| OQ-2 | Canonical join destination for selected space (overview vs agreements vs home) | Product + UX | Use space default overview/agreements target already used by existing navigation |
+| OQ-3 | Canonical external URLs for Coinbase/Wirex/Kraken | Product + Compliance | Read from configuration constants owned by product/compliance |
+| OQ-4 | Onboarding experience policy (one-time, skippable, re-entry path) | Product | One-time for new profiles; skippable via normal navigation; returning users gated by flag |
+
+---
+
+## 12) Risks and mitigations
+
+| Risk | Impact | Mitigation |
+| --- | --- | --- |
+| Spaces fetch instability degrades selector cards | Medium | Degrade gracefully: keep non-selector cards active, show retry/empty state for selector cards (NFR-3). |
+| Locale dropped during redirects | High | Centralize localized route builders and add integration tests for locale propagation (FR-9, AC-2..AC-4). |
+| Regression in signup/profile success handoff | High | Preserve API/payload contracts; enforce parity tests in ONB-8 (PAR-1..PAR-3, AC-8). |
+| External link misconfiguration/security drift | Medium | Use trusted constants only, validate URL allowlist, add tests for target + rel attributes (NFR-5). |
+
+---
+
+## 13) References
+
+- Existing vault examples:
+  - `docs/requirements/Features/group-chat-reply/requirements.md`
+  - `docs/requirements/dho-home-token-holdings-dashboard-spec.md`
+
+---
+
+## 14) Revision history
+
+| Version | Date | Author | Changes |
+| --- | --- | --- | --- |
+| 1.0 | 2026-05-10 | Requirements + UX + QA (agent) | Initial ready-to-implement onboarding adventure spec with FR/PAR/NFR, ACs, QA plan, and ticket decomposition. |

--- a/packages/epics/src/coherence/components/create-signal-form.tsx
+++ b/packages/epics/src/coherence/components/create-signal-form.tsx
@@ -827,9 +827,6 @@ export const CreateSignalForm = ({
                         mostUsed: t.has('mostUsedTagsHeading' as never)
                           ? t('mostUsedTagsHeading' as never)
                           : '--- Most used tags ---',
-                        allTags: t.has('allTags' as never)
-                          ? t('allTags' as never)
-                          : 'All tags',
                         create: (term) =>
                           t.has('createTag' as never)
                             ? `${t('createTag' as never)} "${term}"`

--- a/packages/epics/src/people/components/button-profile.connected.tsx
+++ b/packages/epics/src/people/components/button-profile.connected.tsx
@@ -121,6 +121,7 @@ export const ConnectedButtonProfile = ({
           ? `/${lang}/profile/${person?.slug ?? ''}`
           : newUserRedirectPath
       }
+      onboardingUrl={`/${lang}/onboarding`}
       notificationCentrePath={notificationCentrePath}
       navItems={navItems}
       trailingBeforeProfile={trailingBeforeProfile}

--- a/packages/epics/src/people/components/button-profile.tsx
+++ b/packages/epics/src/people/components/button-profile.tsx
@@ -17,6 +17,7 @@ import { EthAddress } from './eth-address';
 import {
   Bell,
   ChevronRight,
+  Compass,
   LogOutIcon,
   Repeat,
   Shield,
@@ -40,6 +41,7 @@ export type ButtonProfileProps = {
   onDelete?: () => void;
   onChangeThemeMode?: () => void;
   profileUrl?: string;
+  onboardingUrl?: string;
   notificationCentrePath?: string;
   navItems: ButtonNavItemProps[];
   person?: Person;
@@ -59,6 +61,7 @@ export const ButtonProfile = ({
   onLogout,
   onDelete,
   profileUrl,
+  onboardingUrl,
   notificationCentrePath,
   navItems,
   onChangeThemeMode,
@@ -130,6 +133,13 @@ export const ButtonProfile = ({
 
             {profileUrl && (
               <ButtonNavItem href={profileUrl} label={t('myProfile')} />
+            )}
+
+            {onboardingUrl && (
+              <ButtonNavItem
+                href={onboardingUrl}
+                label={t('continueAdventure')}
+              />
             )}
 
             {notificationCentrePath && (
@@ -252,7 +262,7 @@ export const ButtonProfile = ({
                   </div>
                 ) : null}
 
-                {(profileUrl || notificationCentrePath) && (
+                {(profileUrl || onboardingUrl || notificationCentrePath) && (
                   <>
                     <DropdownMenuSeparator className="-mx-0 my-1" />
                     <DropdownMenuGroup className="space-y-0.5">
@@ -264,6 +274,20 @@ export const ButtonProfile = ({
                               aria-hidden
                             />
                             <span className="flex-1">{t('viewProfile')}</span>
+                            <ChevronRight
+                              className="ml-auto size-4 opacity-60"
+                              aria-hidden
+                            />
+                          </Link>
+                        </DropdownMenuItem>
+                      ) : null}
+                      {onboardingUrl ? (
+                        <DropdownMenuItem className={menuItemClass} asChild>
+                          <Link href={onboardingUrl}>
+                            <Compass className="size-4 shrink-0" aria-hidden />
+                            <span className="flex-1">
+                              {t('continueAdventure')}
+                            </span>
                             <ChevronRight
                               className="ml-auto size-4 opacity-60"
                               aria-hidden

--- a/packages/i18n/src/messages/de.json
+++ b/packages/i18n/src/messages/de.json
@@ -93,7 +93,45 @@
     "delete": "Löschen",
     "signIn": "Anmelden",
     "getStarted": "Loslegen",
-    "ecosystemLogo": "Ökosystem-Logo"
+    "ecosystemLogo": "Ökosystem-Logo",
+    "continueAdventure": "Abenteuer fortsetzen"
+  },
+  "OnboardingAdventure": {
+    "title": "Onboarding-Abenteuer",
+    "subtitle": "Wähle deinen nächsten Schritt",
+    "spacePlaceholder": "Space auswählen",
+    "spaceSearchPlaceholder": "Spaces suchen...",
+    "noSpacesFound": "Keine Spaces gefunden.",
+    "loadingSpaces": "Spaces werden geladen...",
+    "explore": {
+      "title": "Netzwerk erkunden",
+      "description": "Entdecke Communities und Möglichkeiten im Netzwerk.",
+      "cta": "Jetzt erkunden"
+    },
+    "create": {
+      "title": "Erstelle deinen Space",
+      "description": "Starte einen neuen Space und lade andere ein.",
+      "cta": "Space erstellen"
+    },
+    "join": {
+      "title": "Einem Space beitreten",
+      "description": "Wähle einen Space und öffne ihn direkt.",
+      "cta": "Ausgewählten Space öffnen",
+      "unavailable": "Derzeit sind keine Spaces zum Beitreten verfügbar."
+    },
+    "deposit": {
+      "title": "Funds in einen Space einzahlen",
+      "description": "Wähle einen Space mit Treasury-Adresse aus.",
+      "cta": "Einzahlungsdetails anzeigen",
+      "unavailable": "Derzeit sind keine Spaces mit Treasury-Adresse verfügbar."
+    },
+    "depositDetails": {
+      "title": "Einzahlungsdetails",
+      "description": "Finanziere die Treasury von {spaceName} mit der untenstehenden Adresse.",
+      "addressLabel": "Treasury-Adresse",
+      "copy": "Adresse kopieren",
+      "copied": "Adresse kopiert"
+    }
   },
   "MyWallet": {
     "loading": "Wird geladen...",

--- a/packages/i18n/src/messages/en.json
+++ b/packages/i18n/src/messages/en.json
@@ -93,7 +93,45 @@
     "delete": "Delete",
     "signIn": "Sign in",
     "getStarted": "Get started",
-    "ecosystemLogo": "Ecosystem Logo"
+    "ecosystemLogo": "Ecosystem Logo",
+    "continueAdventure": "Continue your adventure"
+  },
+  "OnboardingAdventure": {
+    "title": "Onboarding Adventure",
+    "subtitle": "Choose your next step",
+    "spacePlaceholder": "Select a space",
+    "spaceSearchPlaceholder": "Search spaces...",
+    "noSpacesFound": "No spaces found.",
+    "loadingSpaces": "Loading spaces...",
+    "explore": {
+      "title": "Explore the Network",
+      "description": "Discover communities and opportunities across the network.",
+      "cta": "Explore now"
+    },
+    "create": {
+      "title": "Create your Space",
+      "description": "Start a new space and invite others to collaborate.",
+      "cta": "Create a space"
+    },
+    "join": {
+      "title": "Join a Space",
+      "description": "Pick a space and jump directly into its activity.",
+      "cta": "Open selected space",
+      "unavailable": "No spaces are currently available to join."
+    },
+    "deposit": {
+      "title": "Deposit Funds in a Space",
+      "description": "Choose a space with a treasury address to fund it.",
+      "cta": "Show deposit details",
+      "unavailable": "No spaces with treasury addresses are currently available."
+    },
+    "depositDetails": {
+      "title": "Deposit details",
+      "description": "Fund {spaceName} treasury using the address below.",
+      "addressLabel": "Treasury address",
+      "copy": "Copy address",
+      "copied": "Address copied"
+    }
   },
   "MyWallet": {
     "loading": "Loading...",

--- a/packages/i18n/src/messages/es.json
+++ b/packages/i18n/src/messages/es.json
@@ -783,7 +783,45 @@
     "delete": "Borrar",
     "signIn": "Iniciar sesión",
     "getStarted": "Empezar",
-    "ecosystemLogo": "Logo del ecosistema"
+    "ecosystemLogo": "Logo del ecosistema",
+    "continueAdventure": "Continuar tu aventura"
+  },
+  "OnboardingAdventure": {
+    "title": "Aventura de onboarding",
+    "subtitle": "Elige tu siguiente paso",
+    "spacePlaceholder": "Seleccionar espacio",
+    "spaceSearchPlaceholder": "Buscar espacios...",
+    "noSpacesFound": "No se encontraron espacios.",
+    "loadingSpaces": "Cargando espacios...",
+    "explore": {
+      "title": "Explorar la red",
+      "description": "Descubre comunidades y oportunidades en la red.",
+      "cta": "Explorar ahora"
+    },
+    "create": {
+      "title": "Crea tu espacio",
+      "description": "Inicia un nuevo espacio e invita a otros a colaborar.",
+      "cta": "Crear un espacio"
+    },
+    "join": {
+      "title": "Unirse a un espacio",
+      "description": "Elige un espacio y entra directamente a su actividad.",
+      "cta": "Abrir espacio seleccionado",
+      "unavailable": "No hay espacios disponibles para unirse en este momento."
+    },
+    "deposit": {
+      "title": "Depositar fondos en un espacio",
+      "description": "Elige un espacio con dirección de tesorería para fondearlo.",
+      "cta": "Mostrar detalles de depósito",
+      "unavailable": "No hay espacios con dirección de tesorería disponibles."
+    },
+    "depositDetails": {
+      "title": "Detalles de depósito",
+      "description": "Financia la tesorería de {spaceName} con la dirección de abajo.",
+      "addressLabel": "Dirección de tesorería",
+      "copy": "Copiar dirección",
+      "copied": "Dirección copiada"
+    }
   },
   "MyWallet": {
     "loading": "Cargando...",

--- a/packages/i18n/src/messages/fr.json
+++ b/packages/i18n/src/messages/fr.json
@@ -93,7 +93,45 @@
     "delete": "Supprimer",
     "signIn": "Se connecter",
     "getStarted": "Commencer",
-    "ecosystemLogo": "Logo de l’écosystème"
+    "ecosystemLogo": "Logo de l’écosystème",
+    "continueAdventure": "Continuer votre aventure"
+  },
+  "OnboardingAdventure": {
+    "title": "Aventure d'onboarding",
+    "subtitle": "Choisissez votre prochaine étape",
+    "spacePlaceholder": "Sélectionner un espace",
+    "spaceSearchPlaceholder": "Rechercher des espaces...",
+    "noSpacesFound": "Aucun espace trouvé.",
+    "loadingSpaces": "Chargement des espaces...",
+    "explore": {
+      "title": "Explorer le réseau",
+      "description": "Découvrez des communautés et des opportunités dans le réseau.",
+      "cta": "Explorer maintenant"
+    },
+    "create": {
+      "title": "Créer votre espace",
+      "description": "Lancez un nouvel espace et invitez d'autres personnes à collaborer.",
+      "cta": "Créer un espace"
+    },
+    "join": {
+      "title": "Rejoindre un espace",
+      "description": "Choisissez un espace et accédez directement à son activité.",
+      "cta": "Ouvrir l'espace sélectionné",
+      "unavailable": "Aucun espace n'est actuellement disponible pour rejoindre."
+    },
+    "deposit": {
+      "title": "Déposer des fonds dans un espace",
+      "description": "Choisissez un espace avec une adresse de trésorerie.",
+      "cta": "Afficher les détails du dépôt",
+      "unavailable": "Aucun espace avec adresse de trésorerie n'est actuellement disponible."
+    },
+    "depositDetails": {
+      "title": "Détails du dépôt",
+      "description": "Alimentez la trésorerie de {spaceName} avec l'adresse ci-dessous.",
+      "addressLabel": "Adresse de trésorerie",
+      "copy": "Copier l'adresse",
+      "copied": "Adresse copiée"
+    }
   },
   "MyWallet": {
     "loading": "Chargement...",

--- a/packages/i18n/src/messages/pt.json
+++ b/packages/i18n/src/messages/pt.json
@@ -783,7 +783,45 @@
     "delete": "Excluir",
     "signIn": "Entrar",
     "getStarted": "Comece",
-    "ecosystemLogo": "Logo do ecossistema"
+    "ecosystemLogo": "Logo do ecossistema",
+    "continueAdventure": "Continuar sua aventura"
+  },
+  "OnboardingAdventure": {
+    "title": "Aventura de onboarding",
+    "subtitle": "Escolha seu próximo passo",
+    "spacePlaceholder": "Selecionar espaço",
+    "spaceSearchPlaceholder": "Buscar espaços...",
+    "noSpacesFound": "Nenhum espaço encontrado.",
+    "loadingSpaces": "Carregando espaços...",
+    "explore": {
+      "title": "Explorar a rede",
+      "description": "Descubra comunidades e oportunidades na rede.",
+      "cta": "Explorar agora"
+    },
+    "create": {
+      "title": "Crie seu espaço",
+      "description": "Inicie um novo espaço e convide outras pessoas para colaborar.",
+      "cta": "Criar um espaço"
+    },
+    "join": {
+      "title": "Entrar em um espaço",
+      "description": "Escolha um espaço e acesse diretamente sua atividade.",
+      "cta": "Abrir espaço selecionado",
+      "unavailable": "Não há espaços disponíveis para entrar no momento."
+    },
+    "deposit": {
+      "title": "Depositar fundos em um espaço",
+      "description": "Escolha um espaço com endereço de tesouraria para depositar.",
+      "cta": "Mostrar detalhes de depósito",
+      "unavailable": "Não há espaços com endereço de tesouraria disponíveis."
+    },
+    "depositDetails": {
+      "title": "Detalhes de depósito",
+      "description": "Deposite na tesouraria de {spaceName} usando o endereço abaixo.",
+      "addressLabel": "Endereço da tesouraria",
+      "copy": "Copiar endereço",
+      "copied": "Endereço copiado"
+    }
   },
   "MyWallet": {
     "loading": "Carregando...",


### PR DESCRIPTION
## Summary
- add a new onboarding adventure requirements spec at `docs/requirements/onboarding-adventure-spec.md`
- define product, UX, QA, and traceability requirements for the post-signup onboarding experience
- include implementation decomposition (`ONB-1` to `ONB-8`), parity constraints, and acceptance criteria

## Test plan
- [x] Verified spec file structure aligns with existing `docs/requirements` documents
- [x] Confirmed requirement IDs cover FR, PAR, NFR, and AC sections
- [ ] Product review of open questions (route slug, destination target, external links, onboarding policy)

Made with [Cursor](https://cursor.com)