### PR TITLE
fix: make left menu click-only and align panel widths

### DIFF
--- a/packages/epics/src/common/ai-left-panel.tsx
+++ b/packages/epics/src/common/ai-left-panel.tsx
@@ -14,6 +14,7 @@ import {
   FileCheck2,
   House,
   Orbit,
+  Navigation,
   Menu,
   PanelLeftClose,
   Radio,
@@ -188,7 +189,7 @@ export function AiLeftPanel({ enableSpaceMemory = false }: AiLeftPanelProps) {
       {
         key: 'ecosystem-navigation',
         label: tSelectNavigation('ecosystem'),
-        icon: Orbit,
+        icon: Navigation,
         href: `/${lang}/dho/${spaceSlug}/ecosystem-navigation`,
         active: isSectionActive('ecosystem-navigation'),
       },

--- a/packages/epics/src/common/ai-left-panel.tsx
+++ b/packages/epics/src/common/ai-left-panel.tsx
@@ -88,7 +88,7 @@ const DEBUG = process.env.NEXT_PUBLIC_CHAT_DEBUG === 'true';
 const MENU_BUTTON_CLASS =
   'h-10 w-full rounded-lg border border-transparent p-0 text-sm font-medium text-muted-foreground transition-colors hover:border-border/70 hover:bg-muted/80 hover:text-foreground data-[active=true]:border-accent-9/40 data-[active=true]:bg-accent-9/18 data-[active=true]:text-foreground group-data-[collapsible=icon]:!h-10 group-data-[collapsible=icon]:!w-full group-data-[collapsible=icon]:!rounded-lg group-data-[collapsible=icon]:!p-0';
 const ICON_COLUMN_CLASS = 'flex h-10 w-10 shrink-0 items-center justify-center';
-const MENU_ROW_LINK_BASE_CLASS = 'flex w-full min-w-0 items-center';
+const MENU_ROW_LINK_BASE_CLASS = 'flex h-full w-full min-w-0 items-center';
 const MENU_ROW_LINK_EXPANDED_CLASS = 'pl-1.5';
 const MENU_ROW_LINK_COLLAPSED_CLASS = 'justify-center';
 const MENU_TRIGGER_CANVAS_CLASS =

--- a/packages/epics/src/common/ai-left-panel.tsx
+++ b/packages/epics/src/common/ai-left-panel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback, useMemo, useEffect, useRef } from 'react';
+import { useState, useCallback, useMemo, useEffect } from 'react';
 import { useChat } from '@ai-sdk/react';
 import { DefaultChatTransport } from 'ai';
 import { useAuthentication } from '@hypha-platform/authentication';
@@ -138,7 +138,6 @@ export function AiLeftPanel({ enableSpaceMemory = false }: AiLeftPanelProps) {
   const [recentSpaceSlugs, setRecentSpaceSlugs] = useState<string[]>(() =>
     readRecentSpaceSlugs(),
   );
-  const [isHoverOpenLocked, setIsHoverOpenLocked] = useState(false);
   const recentSpaceLookupSlugs = useMemo(
     () =>
       recentSpaceSlugs
@@ -533,34 +532,10 @@ export function AiLeftPanel({ enableSpaceMemory = false }: AiLeftPanelProps) {
     },
     [sendMessage, buildMessageOptions],
   );
-  const handleHeaderIconMouseEnter = useCallback(() => {
-    if (isHoverOpenLocked) return;
-    if (!overlayVisible) {
-      showAiOverlay();
-    }
-  }, [isHoverOpenLocked, overlayVisible, showAiOverlay]);
-
-  const handleExpandedRegionMouseEnter = useCallback(() => {
-    if (isHoverOpenLocked) return;
-    if (overlayVisible) {
-      showAiOverlay();
-    }
-  }, [isHoverOpenLocked, overlayVisible, showAiOverlay]);
-
-  const handleCollapsedRegionMouseEnter = useCallback(() => {
-    if (isHoverOpenLocked) return;
-    showAiOverlay();
-  }, [isHoverOpenLocked, showAiOverlay]);
-
-  const handleOverlayMouseLeave = useCallback(() => {
-    setIsHoverOpenLocked(false);
-    hideAiOverlay();
-  }, [hideAiOverlay]);
-
   const handleOverlayClose = useCallback(() => {
-    setIsHoverOpenLocked(true);
+    hideAiOverlay();
     closeAiPanel();
-  }, [closeAiPanel]);
+  }, [closeAiPanel, hideAiOverlay]);
 
   const handleTriggerClick = useCallback(() => {
     if (isAiOpen || overlayVisible) {
@@ -597,22 +572,14 @@ export function AiLeftPanel({ enableSpaceMemory = false }: AiLeftPanelProps) {
     if (overlayVisible) {
       return (
         <>
-          <SidebarHeader
-            className="bg-background-2 p-0"
-            onMouseEnter={handleExpandedRegionMouseEnter}
-            onMouseLeave={handleOverlayMouseLeave}
-          >
+          <SidebarHeader className="bg-background-2 p-0">
             <AiPanelHeader
               showCloseButton={false}
               leftSlot={triggerButton}
               rightSlot={closeButton}
             />
           </SidebarHeader>
-          <SidebarContent
-            className="bg-background-2"
-            onMouseEnter={handleExpandedRegionMouseEnter}
-            onMouseLeave={handleOverlayMouseLeave}
-          >
+          <SidebarContent className="bg-background-2">
             <SidebarGroup className="p-2 pt-4">
               <SidebarGroupContent>
                 <SidebarMenu className="gap-2">
@@ -651,11 +618,7 @@ export function AiLeftPanel({ enableSpaceMemory = false }: AiLeftPanelProps) {
             {triggerButton}
           </div>
         </SidebarHeader>
-        <SidebarContent
-          className="relative overflow-visible bg-background-2"
-          onMouseEnter={handleCollapsedRegionMouseEnter}
-          onMouseLeave={handleOverlayMouseLeave}
-        >
+        <SidebarContent className="relative overflow-visible bg-background-2">
           <SidebarGroup className="p-2 pt-4">
             <SidebarGroupContent>
               <SidebarMenu className="gap-2">

--- a/packages/epics/src/common/ai-left-panel.tsx
+++ b/packages/epics/src/common/ai-left-panel.tsx
@@ -17,6 +17,7 @@ import {
   Menu,
   PanelLeftClose,
   Radio,
+  Settings,
   SlidersHorizontal,
   Sparkles,
   UsersRound,
@@ -260,7 +261,7 @@ export function AiLeftPanel({ enableSpaceMemory = false }: AiLeftPanelProps) {
     return {
       key: 'space-settings',
       label: tModalAside('spaceSettings'),
-      icon: SlidersHorizontal,
+      icon: Settings,
       href: `/${lang}/dho/${spaceSlug}/agreements/select-settings-action`,
       active: isSpaceSettingsActive,
     };

--- a/packages/epics/src/common/ai-left-panel.tsx
+++ b/packages/epics/src/common/ai-left-panel.tsx
@@ -164,7 +164,8 @@ export function AiLeftPanel({ enableSpaceMemory = false }: AiLeftPanelProps) {
       if (
         section === 'agreements' &&
         pathname.includes(`/dho/${spaceSlug}/`) &&
-        pathname.includes('/space-configuration')
+        (pathname.includes('/space-configuration') ||
+          pathname.includes('/select-settings-action'))
       ) {
         return false;
       }

--- a/packages/epics/src/common/ai-left-panel.tsx
+++ b/packages/epics/src/common/ai-left-panel.tsx
@@ -434,9 +434,11 @@ export function AiLeftPanel({ enableSpaceMemory = false }: AiLeftPanelProps) {
             spaceSettingsItem ? 'p-2 pb-4 pt-2' : 'mt-auto p-2 pb-4'
           }`}
         >
-          <SidebarGroupLabel>
-            {tSpaces('recentlyVisitedSpacesLabel')}
-          </SidebarGroupLabel>
+          {mode === 'expanded' ? (
+            <SidebarGroupLabel className="pointer-events-none">
+              {tSpaces('recentlyVisitedSpacesLabel')}
+            </SidebarGroupLabel>
+          ) : null}
           <SidebarGroupContent>
             <SidebarMenu className="gap-2">
               {recentSpaces.map((space, index) =>

--- a/packages/epics/src/common/ai-left-panel.tsx
+++ b/packages/epics/src/common/ai-left-panel.tsx
@@ -13,13 +13,11 @@ import {
   Coins,
   FileCheck2,
   House,
-  Orbit,
   Navigation,
   Menu,
   PanelLeftClose,
   Radio,
   Settings,
-  SlidersHorizontal,
   Sparkles,
   UsersRound,
 } from 'lucide-react';

--- a/packages/epics/src/common/panel-main-column-scroll-bridge.tsx
+++ b/packages/epics/src/common/panel-main-column-scroll-bridge.tsx
@@ -12,9 +12,8 @@ import { setMainColumnScrollRoot } from './main-column-scroll';
 
 type Props = {
   leftOpen: boolean;
+  leftSidebarWidth: string;
   onLeftOpenChange: (open: boolean) => void;
-  onLeftMouseEnter?: () => void;
-  onLeftMouseLeave?: () => void;
   rightOpen: boolean;
   onRightOpenChange: (open: boolean) => void;
   rightSidebarWidth: string;
@@ -31,9 +30,8 @@ type Props = {
  */
 export function PanelDualSidebarScrollBridge({
   leftOpen,
+  leftSidebarWidth,
   onLeftOpenChange,
-  onLeftMouseEnter,
-  onLeftMouseLeave,
   rightOpen,
   onRightOpenChange,
   rightSidebarWidth,
@@ -52,7 +50,7 @@ export function PanelDualSidebarScrollBridge({
       onOpenChange={onLeftOpenChange}
       style={
         {
-          '--sidebar-width': '320px',
+          '--sidebar-width': leftSidebarWidth,
           '--sidebar-width-icon': '72px',
         } as React.CSSProperties
       }
@@ -62,8 +60,6 @@ export function PanelDualSidebarScrollBridge({
         variant="sidebar"
         collapsible="icon"
         className="z-[50] overflow-visible"
-        onMouseEnter={onLeftMouseEnter}
-        onMouseLeave={onLeftMouseLeave}
       >
         {leftContent}
         <SidebarResizeHandle />

--- a/packages/epics/src/common/panel-wrap-layout.tsx
+++ b/packages/epics/src/common/panel-wrap-layout.tsx
@@ -246,8 +246,6 @@ export function PanelWrapLayout({
     overlayVisible: leftOverlayVisible,
     openAiPanel,
     closeAiPanel,
-    showAiOverlay,
-    hideAiOverlay,
   } = useAiPanel();
   const { open: rightOpen, toggle: toggleRight } = useHumanChatPanel();
   const isSpace = useIsSpaceContext();
@@ -271,12 +269,14 @@ export function PanelWrapLayout({
   const rightSidebarWidth = isMobileViewport
     ? 'calc(100vw - var(--sidebar-left-width, 0px))'
     : '320px';
+  const leftExpandedSidebarWidth =
+    rightOpen && effectiveRight ? 'var(--sidebar-right-width, 320px)' : '320px';
 
   const wrapperRef = useRef<HTMLDivElement | null>(null);
   const leftExpanded = Boolean(leftOpen || leftOverlayVisible);
   const fallbackSidebarLeftPx = effectiveLeft
     ? leftExpanded
-      ? '320px'
+      ? leftExpandedSidebarWidth
       : LEFT_SIDEBAR_ICON_WIDTH
     : '0px';
   const fallbackSidebarRightPx =
@@ -364,6 +364,7 @@ export function PanelWrapLayout({
     content = (
       <PanelDualSidebarScrollBridge
         leftOpen={leftExpanded}
+        leftSidebarWidth={leftExpandedSidebarWidth}
         onLeftOpenChange={(open) => {
           if (open === leftExpanded) return;
           if (open) {
@@ -372,8 +373,6 @@ export function PanelWrapLayout({
           }
           closeAiPanel();
         }}
-        onLeftMouseEnter={showAiOverlay}
-        onLeftMouseLeave={hideAiOverlay}
         rightOpen={rightOpen}
         onRightOpenChange={(open) => {
           if (open !== rightOpen) toggleRight();
@@ -428,7 +427,7 @@ export function PanelWrapLayout({
         }}
         style={
           {
-            '--sidebar-width': '320px',
+            '--sidebar-width': leftExpandedSidebarWidth,
             '--sidebar-width-icon': LEFT_SIDEBAR_ICON_WIDTH,
           } as React.CSSProperties
         }

--- a/packages/i18n/src/messages/de.json
+++ b/packages/i18n/src/messages/de.json
@@ -784,7 +784,7 @@
   },
   "Network": {
     "manySpaces": "Viele Spaces,",
-    "oneVibrantNetwork": "Ein lebendiges Netzwerk",
+    "oneVibrantNetwork": "Ein Netzwerk",
     "findASpace": "Einen Space finden",
     "createSpace": "Space erstellen",
     "mostMembers": "Meiste Mitglieder",

--- a/packages/i18n/src/messages/en.json
+++ b/packages/i18n/src/messages/en.json
@@ -783,7 +783,7 @@
   },
   "Network": {
     "manySpaces": "Many Spaces,",
-    "oneVibrantNetwork": "One Vibrant Network",
+    "oneVibrantNetwork": "One Network",
     "findASpace": "Find a Space",
     "createSpace": "Create Space",
     "mostMembers": "Most Members",

--- a/packages/i18n/src/messages/es.json
+++ b/packages/i18n/src/messages/es.json
@@ -1474,7 +1474,7 @@
   },
   "Network": {
     "manySpaces": "Muchos espacios,",
-    "oneVibrantNetwork": "Una red vibrante",
+    "oneVibrantNetwork": "Una red",
     "findASpace": "Encuentra un espacio",
     "createSpace": "Crear espacio",
     "mostMembers": "La mayoría de los miembros",

--- a/packages/i18n/src/messages/fr.json
+++ b/packages/i18n/src/messages/fr.json
@@ -784,7 +784,7 @@
   },
   "Network": {
     "manySpaces": "De nombreux espaces,",
-    "oneVibrantNetwork": "Un réseau dynamique",
+    "oneVibrantNetwork": "Un réseau",
     "findASpace": "Trouver un espace",
     "createSpace": "Créer un espace",
     "mostMembers": "Le plus de membres",

--- a/packages/i18n/src/messages/pt.json
+++ b/packages/i18n/src/messages/pt.json
@@ -1474,7 +1474,7 @@
   },
   "Network": {
     "manySpaces": "Muitos espaços,",
-    "oneVibrantNetwork": "Uma rede vibrante",
+    "oneVibrantNetwork": "Uma rede",
     "findASpace": "Encontre um espaço",
     "createSpace": "Criar espaço",
     "mostMembers": "A maioria dos membros",


### PR DESCRIPTION
## Summary
- remove hover-triggered expansion from the left sidebar so it only opens/closes via hamburger click
- keep collapsed sidebar icon links clickable for direct navigation without expanding the menu
- align expanded left sidebar width with the right panel width source for consistent panel sizing

## Test plan
- [x] run `pnpm run format:fix`
- [x] check lints for edited files
- [ ] manually verify hover over hamburger/icons does not open the left menu
- [ ] manually verify hamburger click toggles left menu open/close
- [ ] manually verify collapsed icon clicks navigate to expected screens
- [ ] manually verify expanded left width matches right panel width


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved overlay panel interaction behavior

* **Style**
  * Updated navigation section icons (Ecosystem and Settings)
  * Simplified Network branding text across all supported languages

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hypha-dao/hypha-web/pull/2243)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->