### PR TITLE
feat(api): add mutual credit whitelist endpoint

### DIFF
--- a/apps/web/.env.template
+++ b/apps/web/.env.template
@@ -7,6 +7,10 @@ CHAIN_NAME=telos
 RPC_URL=https://mainnet.base.org
 DAO_SPACE_FACTORY_ADDRESS=0xff6006c67803a380Db25230F1aEc605790C405a1
 
+# Mutual credit whitelist API (server-only; set real values in Vercel env vars)
+MUTUAL_CREDIT_WHITELIST_API_KEY=
+MUTUAL_CREDIT_WHITELIST_SIGNER_PRIVATE_KEY=
+
 # Escrow proxy (EscrowImplementation) for Accept Investment — optional override (defaults to Base mainnet address in code, same batch as DAO proposals).
 # Set only if you deploy a different proxy: cd packages/storage-evm && npx hardhat run scripts/escrow-proxy.deploy.ts --network <network>
 NEXT_PUBLIC_ESCROW_IMPLEMENTATION_ADDRESS=

--- a/apps/web/src/app/api/v1/mutual-credit/whitelist/README.md
+++ b/apps/web/src/app/api/v1/mutual-credit/whitelist/README.md
@@ -1,0 +1,44 @@
+# Mutual Credit Whitelist API
+
+Endpoint:
+
+```txt
+POST /api/v1/mutual-credit/whitelist
+```
+
+Headers:
+
+```txt
+Authorization: Bearer <MUTUAL_CREDIT_WHITELIST_API_KEY>
+Content-Type: application/json
+```
+
+Body:
+
+```json
+{
+  "accounts": ["0x1234567890123456789012345678901234567890"],
+  "allowed": [true]
+}
+```
+
+Use `true` to whitelist an address for Mutual Credit, or `false` to remove it.
+
+Example:
+
+```bash
+curl -X POST "https://your-domain.com/api/v1/mutual-credit/whitelist" \
+  -H "Authorization: Bearer <MUTUAL_CREDIT_WHITELIST_API_KEY>" \
+  -H "Content-Type: application/json" \
+  -d '{"accounts":["0x1234567890123456789012345678901234567890"],"allowed":[true]}'
+```
+
+Required Vercel env vars:
+
+```txt
+MUTUAL_CREDIT_WHITELIST_API_KEY=<shared API key>
+MUTUAL_CREDIT_WHITELIST_SIGNER_PRIVATE_KEY=<server-only wallet private key>
+RPC_URL=<Base RPC URL>
+```
+
+The signer wallet must be the token contract owner or executor.

--- a/apps/web/src/app/api/v1/mutual-credit/whitelist/route.ts
+++ b/apps/web/src/app/api/v1/mutual-credit/whitelist/route.ts
@@ -1,4 +1,4 @@
-import { createHash, timingSafeEqual } from 'node:crypto';
+import { timingSafeEqual } from 'node:crypto';
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import {
@@ -8,7 +8,7 @@ import {
   http,
   isAddress,
 } from 'viem';
-import { privateKeyToAccount } from 'viem/accounts';
+import { nonceManager, privateKeyToAccount } from 'viem/accounts';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -16,6 +16,7 @@ export const maxDuration = 60;
 
 const regularSpaceTokenAddress = '0x0692C428864A3e2775C4d4Db3a84124435C7913D';
 const maxBatchSize = 100;
+const signerQueues = new Map<string, Promise<void>>();
 
 const baseChain = defineChain({
   id: 8453,
@@ -62,6 +63,21 @@ const requestSchema = z
         message: 'accounts and allowed must have the same length',
       });
     }
+
+    const seenAccounts = new Set<string>();
+    accounts.forEach((account, index) => {
+      const normalizedAccount = account.toLowerCase();
+      if (seenAccounts.has(normalizedAccount)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['accounts', index],
+          message: 'duplicate account in request',
+        });
+        return;
+      }
+
+      seenAccounts.add(normalizedAccount);
+    });
   });
 
 function unauthorized() {
@@ -76,10 +92,14 @@ function getBearerToken(request: Request) {
 }
 
 function secureEquals(a: string, b: string) {
-  const aHash = createHash('sha256').update(a).digest();
-  const bHash = createHash('sha256').update(b).digest();
+  const aBuffer = Buffer.from(a);
+  const bBuffer = Buffer.from(b);
 
-  return timingSafeEqual(aHash, bHash);
+  if (aBuffer.length !== bBuffer.length) {
+    return false;
+  }
+
+  return timingSafeEqual(aBuffer, bBuffer);
 }
 
 function verifyApiKey(request: Request) {
@@ -124,6 +144,30 @@ function getSignerPrivateKey() {
   return (value.startsWith('0x') ? value : `0x${value}`) as `0x${string}`;
 }
 
+async function withSignerQueue<T>(
+  signerAddress: string,
+  task: () => Promise<T>,
+) {
+  const previousTask = signerQueues.get(signerAddress) ?? Promise.resolve();
+  let release!: () => void;
+  const currentTask = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const queuedTask = previousTask.then(() => currentTask);
+
+  signerQueues.set(signerAddress, queuedTask);
+
+  try {
+    await previousTask;
+    return await task();
+  } finally {
+    release();
+    if (signerQueues.get(signerAddress) === queuedTask) {
+      signerQueues.delete(signerAddress);
+    }
+  }
+}
+
 export async function POST(request: Request) {
   if (!verifyApiKey(request)) {
     return unauthorized();
@@ -146,7 +190,9 @@ export async function POST(request: Request) {
 
   try {
     const rpcUrl = getRpcUrl();
-    const account = privateKeyToAccount(getSignerPrivateKey());
+    const account = privateKeyToAccount(getSignerPrivateKey(), {
+      nonceManager,
+    });
     const transport = http(rpcUrl);
     const publicClient = createPublicClient({
       chain: baseChain,
@@ -158,14 +204,17 @@ export async function POST(request: Request) {
       transport,
     });
 
-    const { request: contractRequest } = await publicClient.simulateContract({
-      account,
-      address: regularSpaceTokenAddress,
-      abi: creditWhitelistAbi,
-      functionName: 'batchSetCreditWhitelistAddresses',
-      args: [parsed.data.accounts, parsed.data.allowed],
+    const transactionHash = await withSignerQueue(account.address, async () => {
+      const { request: contractRequest } = await publicClient.simulateContract({
+        account,
+        address: regularSpaceTokenAddress,
+        abi: creditWhitelistAbi,
+        functionName: 'batchSetCreditWhitelistAddresses',
+        args: [parsed.data.accounts, parsed.data.allowed],
+      });
+
+      return await walletClient.writeContract(contractRequest);
     });
-    const transactionHash = await walletClient.writeContract(contractRequest);
 
     return NextResponse.json({
       transactionHash,

--- a/apps/web/src/app/api/v1/mutual-credit/whitelist/route.ts
+++ b/apps/web/src/app/api/v1/mutual-credit/whitelist/route.ts
@@ -1,0 +1,185 @@
+import { createHash, timingSafeEqual } from 'node:crypto';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import {
+  createPublicClient,
+  createWalletClient,
+  defineChain,
+  http,
+  isAddress,
+} from 'viem';
+import { privateKeyToAccount } from 'viem/accounts';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const maxDuration = 60;
+
+const regularSpaceTokenAddress = '0x0692C428864A3e2775C4d4Db3a84124435C7913D';
+const maxBatchSize = 100;
+
+const baseChain = defineChain({
+  id: 8453,
+  name: 'Base',
+  nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
+  rpcUrls: {
+    default: {
+      http: ['https://mainnet.base.org'],
+    },
+  },
+});
+
+const creditWhitelistAbi = [
+  {
+    type: 'function',
+    name: 'batchSetCreditWhitelistAddresses',
+    stateMutability: 'nonpayable',
+    inputs: [
+      { name: 'accounts', type: 'address[]', internalType: 'address[]' },
+      { name: 'allowed', type: 'bool[]', internalType: 'bool[]' },
+    ],
+    outputs: [],
+  },
+] as const;
+
+const addressSchema = z
+  .string()
+  .trim()
+  .refine((value) => isAddress(value), {
+    message: 'Invalid EVM address',
+  })
+  .transform((value) => value as `0x${string}`);
+
+const requestSchema = z
+  .object({
+    accounts: z.array(addressSchema).min(1).max(maxBatchSize),
+    allowed: z.array(z.boolean()).min(1).max(maxBatchSize),
+  })
+  .superRefine(({ accounts, allowed }, ctx) => {
+    if (accounts.length !== allowed.length) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['allowed'],
+        message: 'accounts and allowed must have the same length',
+      });
+    }
+  });
+
+function unauthorized() {
+  return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+}
+
+function getBearerToken(request: Request) {
+  const header = request.headers.get('authorization') ?? '';
+  const [scheme, token] = header.split(' ');
+
+  return scheme?.toLowerCase() === 'bearer' ? token : undefined;
+}
+
+function secureEquals(a: string, b: string) {
+  const aHash = createHash('sha256').update(a).digest();
+  const bHash = createHash('sha256').update(b).digest();
+
+  return timingSafeEqual(aHash, bHash);
+}
+
+function verifyApiKey(request: Request) {
+  const expectedApiKey = process.env.MUTUAL_CREDIT_WHITELIST_API_KEY;
+
+  if (!expectedApiKey) {
+    console.error('Missing MUTUAL_CREDIT_WHITELIST_API_KEY');
+    return false;
+  }
+
+  const providedApiKey =
+    request.headers.get('x-api-key') ?? getBearerToken(request);
+
+  return providedApiKey ? secureEquals(providedApiKey, expectedApiKey) : false;
+}
+
+function getRequiredEnv(name: string) {
+  const value = process.env[name];
+
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+
+  return value;
+}
+
+function getRpcUrl() {
+  const rpcUrl = process.env.RPC_URL ?? process.env.NEXT_PUBLIC_RPC_URL;
+
+  if (!rpcUrl) {
+    throw new Error('Missing required environment variable: RPC_URL');
+  }
+
+  return rpcUrl;
+}
+
+function getSignerPrivateKey() {
+  const value = getRequiredEnv(
+    'MUTUAL_CREDIT_WHITELIST_SIGNER_PRIVATE_KEY',
+  ).trim();
+
+  return (value.startsWith('0x') ? value : `0x${value}`) as `0x${string}`;
+}
+
+export async function POST(request: Request) {
+  if (!verifyApiKey(request)) {
+    return unauthorized();
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const parsed = requestSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'Validation failed', details: parsed.error.flatten() },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const rpcUrl = getRpcUrl();
+    const account = privateKeyToAccount(getSignerPrivateKey());
+    const transport = http(rpcUrl);
+    const publicClient = createPublicClient({
+      chain: baseChain,
+      transport,
+    });
+    const walletClient = createWalletClient({
+      account,
+      chain: baseChain,
+      transport,
+    });
+
+    const { request: contractRequest } = await publicClient.simulateContract({
+      account,
+      address: regularSpaceTokenAddress,
+      abi: creditWhitelistAbi,
+      functionName: 'batchSetCreditWhitelistAddresses',
+      args: [parsed.data.accounts, parsed.data.allowed],
+    });
+    const transactionHash = await walletClient.writeContract(contractRequest);
+
+    return NextResponse.json({
+      transactionHash,
+      contractAddress: regularSpaceTokenAddress,
+      accountCount: parsed.data.accounts.length,
+    });
+  } catch (error) {
+    console.error('Failed to update mutual credit whitelist:', {
+      message: error instanceof Error ? error.message : String(error),
+    });
+
+    return NextResponse.json(
+      { error: 'Failed to update mutual credit whitelist' },
+      { status: 500 },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Add a secured Next.js route for updating the RegularSpaceToken mutual credit address whitelist.
- Authenticate calls with a server-side API key and keep signer private key access server-only.
- Document endpoint usage and required Vercel environment variables.

## Test plan
- pnpm --filter web check-types


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an API endpoint for batch mutual credit whitelist updates, with API key authentication, account address validation, on-chain transaction execution, and response confirmation details.

* **Documentation**
  * Provided endpoint documentation including authentication methods, request specifications, expected responses, and usage examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hypha-dao/hypha-web/pull/2253?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->