### PR TITLE
fix(migrations): repair Drizzle meta snapshot chain collision

### DIFF
--- a/packages/storage-postgres/migrations/meta/0048_snapshot.json
+++ b/packages/storage-postgres/migrations/meta/0048_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "896b7c1a-1fdc-4b98-8287-0c2a4cbf127d",
-  "prevId": "d66b4696-2b41-46f4-92f0-cdd7fcaa1b0d",
+  "id": "a4b3c2d1-e5f6-4789-a0bc-1d2e3f4a5b6c",
+  "prevId": "2cf72e9c-79f1-4b88-8b4f-3c61c44575ec",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -407,6 +407,18 @@
           "primaryKey": false,
           "notNull": false
         },
+        "ecosystem_logo_url_light": {
+          "name": "ecosystem_logo_url_light",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ecosystem_logo_url_dark": {
+          "name": "ecosystem_logo_url_dark",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
         "lead_image": {
           "name": "lead_image",
           "type": "text",
@@ -477,6 +489,12 @@
           "primaryKey": false,
           "notNull": true,
           "default": "'[]'::jsonb"
+        },
+        "chat_room_id": {
+          "name": "chat_room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
         },
         "created_at": {
           "name": "created_at",
@@ -645,6 +663,13 @@
           "type": "text",
           "primaryKey": false,
           "notNull": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
         }
       },
       "indexes": {},
@@ -972,8 +997,8 @@
           "method": "btree",
           "with": {}
         },
-        "search_slug": {
-          "name": "search_slug",
+        "unique_slug": {
+          "name": "unique_slug",
           "columns": [
             {
               "expression": "slug",
@@ -982,7 +1007,7 @@
               "nulls": "last"
             }
           ],
-          "isUnique": false,
+          "isUnique": true,
           "concurrently": false,
           "method": "btree",
           "with": {}
@@ -1059,11 +1084,24 @@
           ],
           "isUnique": false,
           "concurrently": false,
-          "method": "btree",
+          "method": "gin",
           "with": {}
         }
       },
       "foreignKeys": {
+        "coherences_creator_id_people_id_fk": {
+          "name": "coherences_creator_id_people_id_fk",
+          "tableFrom": "coherences",
+          "tableTo": "people",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
         "coherences_space_id_spaces_id_fk": {
           "name": "coherences_space_id_spaces_id_fk",
           "tableFrom": "coherences",
@@ -1074,7 +1112,7 @@
           "columnsTo": [
             "id"
           ],
-          "onDelete": "no action",
+          "onDelete": "cascade",
           "onUpdate": "no action"
         }
       },
@@ -1096,7 +1134,8 @@
         },
         "environment": {
           "name": "environment",
-          "type": "text",
+          "type": "matrix_environment",
+          "typeSchema": "public",
           "primaryKey": false,
           "notNull": true
         },
@@ -1138,8 +1177,8 @@
           "notNull": true,
           "default": "now()"
         },
-        "refresh_token": {
-          "name": "refresh_token",
+        "encrypted_refresh_token": {
+          "name": "encrypted_refresh_token",
           "type": "text",
           "primaryKey": false,
           "notNull": false
@@ -1152,24 +1191,15 @@
         }
       },
       "indexes": {
-        "search_environment": {
-          "name": "search_environment",
+        "matrix_user_links_env_privy_unique": {
+          "name": "matrix_user_links_env_privy_unique",
           "columns": [
             {
               "expression": "environment",
               "isExpression": false,
               "asc": true,
               "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "search_privy_user_id": {
-          "name": "search_privy_user_id",
-          "columns": [
+            },
             {
               "expression": "privy_user_id",
               "isExpression": false,
@@ -1177,14 +1207,20 @@
               "nulls": "last"
             }
           ],
-          "isUnique": false,
+          "isUnique": true,
           "concurrently": false,
           "method": "btree",
           "with": {}
         },
-        "search_matrix_user_id": {
-          "name": "search_matrix_user_id",
+        "matrix_user_links_env_matrix_unique": {
+          "name": "matrix_user_links_env_matrix_unique",
           "columns": [
+            {
+              "expression": "environment",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
             {
               "expression": "matrix_user_id",
               "isExpression": false,
@@ -1192,67 +1228,7 @@
               "nulls": "last"
             }
           ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "search_encrypted_access_token": {
-          "name": "search_encrypted_access_token",
-          "columns": [
-            {
-              "expression": "encrypted_access_token",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "search_device_id": {
-          "name": "search_device_id",
-          "columns": [
-            {
-              "expression": "device_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "search_refresh_token": {
-          "name": "search_refresh_token",
-          "columns": [
-            {
-              "expression": "refresh_token",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "search_token_expires_at": {
-          "name": "search_token_expires_at",
-          "columns": [
-            {
-              "expression": "token_expires_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
+          "isUnique": true,
           "concurrently": false,
           "method": "btree",
           "with": {}
@@ -1264,9 +1240,107 @@
       "policies": {},
       "checkConstraints": {},
       "isRLSEnabled": false
+    },
+    "public.token_updates": {
+      "name": "token_updates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_address": {
+          "name": "token_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "token_updates_document_id_idx": {
+          "name": "token_updates_document_id_idx",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "token_updates_token_address_idx": {
+          "name": "token_updates_token_address_idx",
+          "columns": [
+            {
+              "expression": "token_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "token_updates_document_id_documents_id_fk": {
+          "name": "token_updates_document_id_documents_id_fk",
+          "tableFrom": "token_updates",
+          "tableTo": "documents",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
     }
   },
   "enums": {
+    "public.matrix_environment": {
+      "name": "matrix_environment",
+      "schema": "public",
+      "values": [
+        "development",
+        "preview",
+        "production"
+      ]
+    },
     "public.document_state": {
       "name": "document_state",
       "schema": "public",


### PR DESCRIPTION
# PR / Issue #2257 — Fix Drizzle meta snapshot chain collision

## Problem

Running `pnpm --filter @hypha-platform/storage-postgres run generate` on `main` fails with:

```
Error: [migrations\meta\0042_snapshot.json, migrations\meta\0045_snapshot.json] are pointing to a
parent snapshot: migrations\meta\0042_snapshot.json/snapshot.json which is a collision.
```

`drizzle-kit generate` is broken on `main` — no new migrations can be generated.

## Root cause

Two feature branches were independently cut from the same base snapshot (0041, id `d66b4696`):

- Branch A (commit `7fdcde7d0`): generated snapshots **0042** and **0043**
- Branch B (commit `e18994256`, Apr 1 2026): generated snapshot **0045** with `prevId` still pointing at 0041, unaware of 0042/0043

When both merged into `main`, the snapshot chain forked. Additionally, snapshots for 0044, 0046, 0047, and 0048 were never committed to `meta/`.

## What this PR changes

**Only two files in `migrations/meta/`:**

- Deletes `0045_snapshot.json` (the forked snapshot causing the collision)
- Adds `0048_snapshot.json` (a correct single tip, chaining from 0043, reflecting the current schema state)

**No SQL migration file is added. `_journal.json` is unchanged.**

## Production database impact: zero

This is the critical point. The production database is touched exclusively through `drizzle-kit migrate`, which reads two things: `_journal.json` and the `migrations/*.sql` files. The `meta/` snapshot files are internal bookkeeping used only by `drizzle-kit generate` — `migrate` never reads them.

Since this PR adds no new SQL file and does not modify `_journal.json`, **`drizzle-kit migrate` will find nothing new to run when this PR merges. The production database is completely unaffected.**

## What this unblocks

Once merged, `drizzle-kit generate` works again on `main`. Any PR that needs a new migration (e.g. adding a new table) can generate it cleanly and include the resulting SQL file — which is the only thing that will then touch the DB when that PR merges.

## Verification

```bash
git checkout rozagerardo/fix/drizzle-meta-snapshot-collision
pnpm --filter @hypha-platform/storage-postgres run generate
# Expected: "No schema changes, nothing to migrate"
```

## Side note: coherences schema drift (pre-existing, unrelated)

During this investigation we noticed that `coherence.ts` was updated at some point (unique slug index, GIN tags, creator FK, cascade on space_id) without a migration ever being generated — likely because `generate` was already broken at that time. This drift predates this PR and is not introduced or worsened by it. Flagging here for awareness; it should be assessed separately by someone with DB access who can confirm the actual state and generate a corrective migration if needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for ecosystem logo customization in spaces with light and dark theme variants.
  * Enabled chat room integration for improved collaboration.
  * Introduced token archival capability for better token management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hypha-dao/hypha-web/pull/2258?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->