### PR TITLE
fix(access): restore framework-based create access for delegates

### DIFF
--- a/packages/epics/src/coherence/components/signal-section.tsx
+++ b/packages/epics/src/coherence/components/signal-section.tsx
@@ -14,7 +14,10 @@ import Link from 'next/link';
 import React from 'react';
 import { useTranslations } from 'next-intl';
 import { SearchIcon } from 'lucide-react';
-import { useSpaceMember } from '../../spaces/hooks/use-space-member';
+import {
+  UserSpaceState,
+  useUserSpaceState,
+} from '../../spaces/hooks/use-user-space-state';
 import {
   SIGNAL_PROVISIONING_NOTICE_EVENT,
   SIGNAL_PROVISIONING_NOTICE_STORAGE_KEY,
@@ -108,9 +111,12 @@ export const SignalSection: FC<SignalSectionProps> = ({
   }, [provisioningNoticeLines]);
 
   const createSignalHref = `/${lang}/dho/${id}/coherence/new-signal`;
-  const { isMember, isMemberLoading } = useSpaceMember({
+  const { userState, isLoading: isUserStateLoading } = useUserSpaceState({
     spaceId: web3SpaceId,
+    spaceSlug: id,
   });
+  const canCreateSignal =
+    !isUserStateLoading && userState === UserSpaceState.LOGGED_IN_SPACE;
 
   return (
     <div className="flex w-full flex-col gap-4">
@@ -125,7 +131,7 @@ export const SignalSection: FC<SignalSectionProps> = ({
           className="w-full"
         />
         <div className="flex w-full items-center justify-end lg:w-auto">
-          {!isMemberLoading && isMember ? (
+          {canCreateSignal ? (
             <Button
               asChild
               variant="default"

--- a/packages/epics/src/governance/components/documents-sections.tsx
+++ b/packages/epics/src/governance/components/documents-sections.tsx
@@ -8,7 +8,10 @@ import { useFormatter, useTranslations } from 'next-intl';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@hypha-platform/ui';
 import Link from 'next/link';
 import { Button } from '@hypha-platform/ui';
-import { useSpaceMember } from '../../spaces/hooks/use-space-member';
+import {
+  UserSpaceState,
+  useUserSpaceState,
+} from '../../spaces/hooks/use-user-space-state';
 
 type DocumentsSectionsProps = {
   lang: string;
@@ -31,8 +34,9 @@ export function DocumentsSections({
     spaceSlug,
     order,
   });
-  const { isMember, isMemberLoading } = useSpaceMember({
+  const { userState, isLoading: isUserStateLoading } = useUserSpaceState({
     spaceId: web3SpaceId,
+    spaceSlug,
   });
   const onVotingCount = documents.onVoting.length;
   const acceptedCount = documents.accepted.length;
@@ -40,8 +44,10 @@ export function DocumentsSections({
 
   const basePath = `/${lang}/dho/${spaceSlug}/agreements`;
   const createProposalPath = `${basePath}/select-create-action`;
+  const canCreateProposal =
+    !isUserStateLoading && userState === UserSpaceState.LOGGED_IN_SPACE;
   const createProposalButton =
-    !isMemberLoading && isMember ? (
+    canCreateProposal ? (
       <Button asChild>
         <Link href={createProposalPath}>{t('newProposal')}</Link>
       </Button>

--- a/packages/epics/src/governance/components/documents-sections.tsx
+++ b/packages/epics/src/governance/components/documents-sections.tsx
@@ -46,14 +46,13 @@ export function DocumentsSections({
   const createProposalPath = `${basePath}/select-create-action`;
   const canCreateProposal =
     !isUserStateLoading && userState === UserSpaceState.LOGGED_IN_SPACE;
-  const createProposalButton =
-    canCreateProposal ? (
-      <Button asChild>
-        <Link href={createProposalPath}>{t('newProposal')}</Link>
-      </Button>
-    ) : (
-      <Button disabled>{t('newProposal')}</Button>
-    );
+  const createProposalButton = canCreateProposal ? (
+    <Button asChild>
+      <Link href={createProposalPath}>{t('newProposal')}</Link>
+    </Button>
+  ) : (
+    <Button disabled>{t('newProposal')}</Button>
+  );
 
   return (
     <Tabs


### PR DESCRIPTION
## Summary
- replace ad-hoc `useSpaceMember` checks on `New Proposal` and `New Signal` buttons with the shared user-space framework
- gate create actions via `useUserSpaceState(...)=LOGGED_IN_SPACE`, which preserves delegated member access (`isMember || isDelegate` path)
- keep non-space users read-only while removing the regression introduced in `acee84c23`

## Test plan
- [x] Run IDE lint diagnostics on updated files (`documents-sections.tsx`, `signal-section.tsx`)
- [ ] Validate manually as delegated space member: `New Proposal` enabled
- [ ] Validate manually as delegated space member: `New Signal` enabled
- [ ] Validate manually as non-member/non-delegate: both buttons remain disabled

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated the logic for enabling "new signal" and "new proposal" actions to use an improved permission determination mechanism.
  * Button states (enabled/disabled) now correctly reflect user authorization status in signal and governance sections.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hypha-dao/hypha-web/pull/2266?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->