### PR TITLE
feat(people): show Privy receive-funds modal after address copy

### DIFF
--- a/packages/epics/src/people/components/button-profile.tsx
+++ b/packages/epics/src/people/components/button-profile.tsx
@@ -95,6 +95,7 @@ export const ButtonProfile = ({
     address: safeWalletAddress,
     title: tCommon('receiveFundsTitle'),
     subtitle: tCommon('receiveFundsSubtitle'),
+    defaultFundingMethod: 'manual',
   });
 
   const handleAddressCopy = useCallback(

--- a/packages/epics/src/people/components/button-profile.tsx
+++ b/packages/epics/src/people/components/button-profile.tsx
@@ -32,7 +32,7 @@ import { Person } from '@hypha-platform/core/client';
 import { usePrivy, useMfaEnrollment } from '@privy-io/react-auth';
 import { useTranslations } from 'next-intl';
 import { usePathname } from 'next/navigation';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { cn, copyToClipboard } from '@hypha-platform/ui-utils';
 import { useFundWallet } from '../../treasury/hooks';
 
@@ -80,6 +80,9 @@ export const ButtonProfile = ({
   const tCommon = useTranslations('Common');
   const pathname = usePathname();
   const [profileMenuOpen, setProfileMenuOpen] = useState(false);
+  const fundWalletTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined,
+  );
   const { user } = usePrivy();
   const { showMfaEnrollmentModal } = useMfaEnrollment();
   const hasMfaMethods = user && user.mfaMethods && user.mfaMethods.length > 0;
@@ -93,7 +96,13 @@ export const ButtonProfile = ({
     (walletAddress: string) => {
       copyToClipboard(walletAddress);
       setProfileMenuOpen(false);
-      void fundWallet();
+      if (fundWalletTimeoutRef.current) {
+        clearTimeout(fundWalletTimeoutRef.current);
+      }
+      // Avoid colliding focus traps while sheet-like menus are closing.
+      fundWalletTimeoutRef.current = setTimeout(() => {
+        void fundWallet();
+      }, 300);
     },
     [fundWallet],
   );
@@ -104,6 +113,14 @@ export const ButtonProfile = ({
   useEffect(() => {
     setProfileMenuOpen(false);
   }, [pathname]);
+
+  useEffect(() => {
+    return () => {
+      if (fundWalletTimeoutRef.current) {
+        clearTimeout(fundWalletTimeoutRef.current);
+      }
+    };
+  }, []);
 
   if (compact) {
     if (!isConnected) {

--- a/packages/epics/src/people/components/button-profile.tsx
+++ b/packages/epics/src/people/components/button-profile.tsx
@@ -32,8 +32,9 @@ import { Person } from '@hypha-platform/core/client';
 import { usePrivy, useMfaEnrollment } from '@privy-io/react-auth';
 import { useTranslations } from 'next-intl';
 import { usePathname } from 'next/navigation';
-import { useEffect, useState } from 'react';
-import { cn } from '@hypha-platform/ui-utils';
+import { useCallback, useEffect, useState } from 'react';
+import { cn, copyToClipboard } from '@hypha-platform/ui-utils';
+import { useFundWallet } from '../../treasury/hooks';
 
 export type ButtonProfileProps = {
   address?: string;
@@ -82,6 +83,20 @@ export const ButtonProfile = ({
   const { user } = usePrivy();
   const { showMfaEnrollmentModal } = useMfaEnrollment();
   const hasMfaMethods = user && user.mfaMethods && user.mfaMethods.length > 0;
+  const { fundWallet } = useFundWallet({
+    address: address as `0x${string}` | undefined,
+    title: tCommon('receiveFundsTitle'),
+    subtitle: tCommon('receiveFundsSubtitle'),
+  });
+
+  const handleAddressCopy = useCallback(
+    (walletAddress: string) => {
+      copyToClipboard(walletAddress);
+      setProfileMenuOpen(false);
+      void fundWallet();
+    },
+    [fundWallet],
+  );
 
   const displayName = [person?.name, person?.surname].filter(Boolean).join(' ');
   const primaryLine = displayName.trim() || person?.nickname || t('myProfile');
@@ -155,7 +170,7 @@ export const ButtonProfile = ({
                 </div>
                 {address ? (
                   <div className="mt-3 w-full rounded-md border border-border/50 bg-muted/35 px-2 py-1.5 text-1 text-muted-foreground">
-                    <EthAddress address={address} />
+                    <EthAddress address={address} onClick={handleAddressCopy} />
                   </div>
                 ) : null}
               </div>
@@ -351,7 +366,7 @@ export const ButtonProfile = ({
               </div>
               {address ? (
                 <div className="w-full rounded-lg border border-border/60 bg-muted/40 px-3 py-2">
-                  <EthAddress address={address} />
+                  <EthAddress address={address} onClick={handleAddressCopy} />
                 </div>
               ) : null}
             </div>
@@ -496,7 +511,10 @@ export const ButtonProfile = ({
                         'text-1 text-muted-foreground',
                       )}
                     >
-                      <EthAddress address={address} />
+                      <EthAddress
+                        address={address}
+                        onClick={handleAddressCopy}
+                      />
                     </div>
                   </div>
                 ) : null}

--- a/packages/epics/src/people/components/button-profile.tsx
+++ b/packages/epics/src/people/components/button-profile.tsx
@@ -81,9 +81,9 @@ export const ButtonProfile = ({
   const tCommon = useTranslations('Common');
   const pathname = usePathname();
   const [profileMenuOpen, setProfileMenuOpen] = useState(false);
-  const fundWalletTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(
-    undefined,
-  );
+  const fundWalletTimeoutRef = useRef<
+    ReturnType<typeof setTimeout> | undefined
+  >(undefined);
   const safeWalletAddress =
     address && EVM_ADDRESS_REGEX.test(address)
       ? (address as `0x${string}`)

--- a/packages/epics/src/people/components/button-profile.tsx
+++ b/packages/epics/src/people/components/button-profile.tsx
@@ -59,6 +59,7 @@ const menuItemClass =
   'gap-2 px-2 py-2 text-2 [&_svg]:text-muted-foreground data-[highlighted]:[&_svg]:text-foreground';
 const compactSheetItemClass =
   'flex min-h-11 w-full items-center gap-3 rounded-md px-3 py-2 text-left text-2 text-foreground transition-colors hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring';
+const EVM_ADDRESS_REGEX = /^0x[a-fA-F0-9]{40}$/;
 
 export const ButtonProfile = ({
   person,
@@ -83,11 +84,15 @@ export const ButtonProfile = ({
   const fundWalletTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(
     undefined,
   );
+  const safeWalletAddress =
+    address && EVM_ADDRESS_REGEX.test(address)
+      ? (address as `0x${string}`)
+      : undefined;
   const { user } = usePrivy();
   const { showMfaEnrollmentModal } = useMfaEnrollment();
   const hasMfaMethods = user && user.mfaMethods && user.mfaMethods.length > 0;
   const { fundWallet } = useFundWallet({
-    address: address as `0x${string}` | undefined,
+    address: safeWalletAddress,
     title: tCommon('receiveFundsTitle'),
     subtitle: tCommon('receiveFundsSubtitle'),
   });

--- a/packages/epics/src/treasury/hooks/use-fund-wallet.ts
+++ b/packages/epics/src/treasury/hooks/use-fund-wallet.ts
@@ -4,6 +4,8 @@ import { useCallback } from 'react';
 import { useFundWallet as usePrivyFund } from '@privy-io/react-auth';
 import { base, Chain } from 'viem/chains';
 
+type DefaultFundingMethod = 'card' | 'exchange' | 'wallet' | 'manual';
+
 export interface UseFundWalletParams {
   /** When omitted, `fundWallet` is a no-op (safe for gated / loading UIs). */
   address?: `0x${string}`;
@@ -12,6 +14,8 @@ export interface UseFundWalletParams {
   title?: string;
   /** Localized modal subtitle; defaults to English fallback when omitted. */
   subtitle?: string;
+  /** Optional default funding route to skip the provider selection step. */
+  defaultFundingMethod?: DefaultFundingMethod;
 }
 
 export function useFundWallet({
@@ -20,6 +24,7 @@ export function useFundWallet({
   title = 'Receive Funds',
   subtitle = 'Share this QR code or wallet address to receive funds in this wallet.',
   chain = base,
+  defaultFundingMethod,
 }: UseFundWalletParams) {
   const { fundWallet: privyFundWallet } = usePrivyFund();
 
@@ -28,6 +33,7 @@ export function useFundWallet({
     try {
       await privyFundWallet(address, {
         chain,
+        defaultFundingMethod,
         uiConfig: {
           receiveFundsTitle: title,
           receiveFundsSubtitle: subtitle,
@@ -36,7 +42,7 @@ export function useFundWallet({
     } catch (e) {
       console.error('Funding a wallet failed:', e);
     }
-  }, [privyFundWallet, address, title, subtitle, chain]);
+  }, [privyFundWallet, address, title, subtitle, chain, defaultFundingMethod]);
 
   return { fundWallet };
 }

--- a/packages/epics/src/treasury/hooks/use-fund-wallet.ts
+++ b/packages/epics/src/treasury/hooks/use-fund-wallet.ts
@@ -8,12 +8,15 @@ export interface UseFundWalletParams {
   /** When omitted, `fundWallet` is a no-op (safe for gated / loading UIs). */
   address?: `0x${string}`;
   chain?: Chain;
+  /** Localized modal title; defaults to English fallback when omitted. */
   title?: string;
+  /** Localized modal subtitle; defaults to English fallback when omitted. */
   subtitle?: string;
 }
 
 export function useFundWallet({
   address,
+  // Keep English fallbacks for legacy callers; prefer passing localized copy.
   title = 'Receive Funds',
   subtitle = 'Share this QR code or wallet address to receive funds in this wallet.',
   chain = base,

--- a/packages/i18n/src/messages/de.json
+++ b/packages/i18n/src/messages/de.json
@@ -22,6 +22,8 @@
     "by": "von",
     "copyWalletAddress": "Wallet-Adresse kopieren",
     "walletAddressCopied": "Kopiert!",
+    "receiveFundsTitle": "Geld empfangen",
+    "receiveFundsSubtitle": "Teile diesen QR-Code oder die Wallet-Adresse, um Geld in diese Wallet zu empfangen.",
     "otherMembers": "+ {count} weitere Mitglieder",
     "exploreSpaces": "Spaces erkunden",
     "findCategory": "Kategorie suchen",

--- a/packages/i18n/src/messages/en.json
+++ b/packages/i18n/src/messages/en.json
@@ -22,6 +22,8 @@
     "by": "by",
     "copyWalletAddress": "Copy wallet address",
     "walletAddressCopied": "Copied!",
+    "receiveFundsTitle": "Receive Funds",
+    "receiveFundsSubtitle": "Share this QR code or wallet address to receive funds in this wallet.",
     "otherMembers": "+ other {count} members",
     "exploreSpaces": "Explore Spaces",
     "findCategory": "Find a Category",

--- a/packages/i18n/src/messages/es.json
+++ b/packages/i18n/src/messages/es.json
@@ -22,6 +22,8 @@
     "by": "por",
     "copyWalletAddress": "Copiar dirección de la billetera",
     "walletAddressCopied": "¡Copiado!",
+    "receiveFundsTitle": "Recibir fondos",
+    "receiveFundsSubtitle": "Comparte este código QR o dirección de billetera para recibir fondos en esta billetera.",
     "otherMembers": "+ {count} otros miembros",
     "exploreSpaces": "Explorar espacios",
     "findCategory": "Encuentra una categoría",

--- a/packages/i18n/src/messages/fr.json
+++ b/packages/i18n/src/messages/fr.json
@@ -22,6 +22,8 @@
     "by": "par",
     "copyWalletAddress": "Copier l’adresse du portefeuille",
     "walletAddressCopied": "Copié !",
+    "receiveFundsTitle": "Recevoir des fonds",
+    "receiveFundsSubtitle": "Partagez ce QR code ou l’adresse du portefeuille pour recevoir des fonds dans ce portefeuille.",
     "otherMembers": "+ {count} autres membres",
     "exploreSpaces": "Explorer les espaces",
     "findCategory": "Trouver une catégorie",

--- a/packages/i18n/src/messages/pt.json
+++ b/packages/i18n/src/messages/pt.json
@@ -22,6 +22,8 @@
     "by": "por",
     "copyWalletAddress": "Copiar endereço da carteira",
     "walletAddressCopied": "Copiado!",
+    "receiveFundsTitle": "Receber fundos",
+    "receiveFundsSubtitle": "Compartilhe este QR code ou endereço da carteira para receber fundos nesta carteira.",
     "otherMembers": "+ outros membros {count}",
     "exploreSpaces": "Explorar espaços",
     "findCategory": "Encontre uma categoria",


### PR DESCRIPTION
## Summary
- trigger Privy's receive-funds modal whenever the profile wallet address is copied
- keep the existing copy-to-clipboard UX while opening the QR-based funding flow on Base
- add localized receive-funds title/subtitle keys used by the modal

## Test plan
- [x] Open profile menu/sheet while signed in and click the wallet address
- [x] Confirm the wallet address is copied and "Copied!" feedback appears
- [x] Confirm the Privy receive-funds popup opens with QR code and Base network warning
- [x] Confirm behavior is consistent in desktop dropdown, compact sheet, and mobile profile panel

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Copy your wallet address directly from your profile menu with a single click, significantly streamlining the process of receiving funds.
  * New "Receive Funds" interface displays your QR code and wallet address for quick and easy sharing with others. Available in English, German, Spanish, French, and Portuguese.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hypha-dao/hypha-web/pull/2270?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->