### PR TITLE
cherry-pick voice announcements and thread summaries

### DIFF
--- a/apps/web/src/app/api/v1/ops/space-memory/refresh-thread-summaries/route.ts
+++ b/apps/web/src/app/api/v1/ops/space-memory/refresh-thread-summaries/route.ts
@@ -1,0 +1,196 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import {
+  enqueueSignalEvaluationFromMemory,
+  listThreadSummariesDueForRefresh,
+  refreshThreadSummary,
+} from '@hypha-platform/core/server';
+import { db } from '@hypha-platform/storage-postgres';
+import { readOpsSecret } from '../../_lib/ops-auth';
+
+export const maxDuration = 300;
+
+const refreshPayloadSchema = z.object({
+  limit: z.number().int().min(1).max(500).optional().default(100),
+  dry_run: z.boolean().optional().default(false),
+});
+
+const REFRESH_CONCURRENCY = 4;
+const REFRESH_TIMEOUT_MS = 60_000;
+
+async function withTimeout<T>(
+  task: (signal: AbortSignal) => Promise<T>,
+  timeoutMs: number,
+  timeoutMessage: string,
+): Promise<T> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(
+    () => controller.abort(new Error(timeoutMessage)),
+    timeoutMs,
+  );
+  try {
+    return await task(controller.signal);
+  } catch (error) {
+    if (controller.signal.aborted) {
+      throw new Error(timeoutMessage);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const configuredSecret =
+    process.env.HYPHA_SPACE_MEMORY_OPS_SECRET?.trim() ?? '';
+  if (!configuredSecret) {
+    return NextResponse.json(
+      { error: 'HYPHA_SPACE_MEMORY_OPS_SECRET is not configured' },
+      { status: 503 },
+    );
+  }
+  if (readOpsSecret(request) !== configuredSecret) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  let parsedPayload: ReturnType<typeof refreshPayloadSchema.safeParse>;
+  try {
+    parsedPayload = refreshPayloadSchema.safeParse(await request.json());
+  } catch {
+    return NextResponse.json(
+      { error: 'Malformed JSON payload' },
+      { status: 400 },
+    );
+  }
+  if (!parsedPayload.success) {
+    return NextResponse.json(
+      { error: 'Invalid payload', details: parsedPayload.error.flatten() },
+      { status: 400 },
+    );
+  }
+  const payload = parsedPayload.data;
+
+  const targets = await listThreadSummariesDueForRefresh(
+    { limit: payload.limit },
+    { db },
+  );
+
+  if (payload.dry_run) {
+    return NextResponse.json({
+      ok: true,
+      dry_run: true,
+      target_count: targets.length,
+      targets,
+    });
+  }
+
+  type ResultRow = {
+    space_slug: string;
+    matrix_room_id: string;
+    ok: boolean;
+    skipped?: boolean;
+    reason?: string;
+    summary_id?: number;
+    error?: string;
+  };
+  const results: ResultRow[] = [];
+  const queue = [...targets];
+
+  const workers = Array.from({
+    length: Math.min(REFRESH_CONCURRENCY, queue.length || 1),
+  }).map(async () => {
+    while (true) {
+      const target = queue.shift();
+      if (!target) return;
+      try {
+        const result = await withTimeout(
+          (signal) =>
+            refreshThreadSummary(
+              {
+                spaceSlug: target.spaceSlug,
+                matrixRoomId: target.matrixRoomId,
+                signal,
+              },
+              { db },
+            ),
+          REFRESH_TIMEOUT_MS,
+          'Thread summary refresh timed out',
+        );
+        if (!result.ok) {
+          results.push({
+            space_slug: target.spaceSlug,
+            matrix_room_id: target.matrixRoomId,
+            ok: false,
+            error: result.error,
+          });
+          continue;
+        }
+        if (result.skipped) {
+          results.push({
+            space_slug: target.spaceSlug,
+            matrix_room_id: target.matrixRoomId,
+            ok: true,
+            skipped: true,
+            reason: result.reason,
+          });
+          continue;
+        }
+        try {
+          await enqueueSignalEvaluationFromMemory(
+            {
+              spaceSlug: target.spaceSlug,
+              triggerKind: 'thread_summary',
+              metadata: {
+                matrixRoomId: target.matrixRoomId,
+                threadSummaryId: result.summary.id,
+              },
+            },
+            { db },
+          );
+        } catch (enqueueError) {
+          console.error(
+            '[space-memory.refresh-thread-summaries] enqueue failed',
+            {
+              spaceSlug: target.spaceSlug,
+              error:
+                enqueueError instanceof Error
+                  ? enqueueError.message
+                  : String(enqueueError),
+            },
+          );
+        }
+        results.push({
+          space_slug: target.spaceSlug,
+          matrix_room_id: target.matrixRoomId,
+          ok: true,
+          summary_id: result.summary.id,
+        });
+      } catch (error) {
+        results.push({
+          space_slug: target.spaceSlug,
+          matrix_room_id: target.matrixRoomId,
+          ok: false,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+  });
+  await Promise.allSettled(workers);
+
+  const success_count = results.filter((r) => r.ok && !r.skipped).length;
+  const skipped_count = results.filter((r) => r.ok && r.skipped).length;
+  const failure_count = results.filter((r) => !r.ok).length;
+  const status = failure_count === 0 ? 200 : 207;
+
+  return NextResponse.json(
+    {
+      ok: failure_count === 0,
+      target_count: targets.length,
+      success_count,
+      skipped_count,
+      failure_count,
+      results,
+    },
+    { status },
+  );
+}

--- a/apps/web/src/app/api/v1/spaces/[spaceSlug]/thread-summary/activity/route.ts
+++ b/apps/web/src/app/api/v1/spaces/[spaceSlug]/thread-summary/activity/route.ts
@@ -1,0 +1,133 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { canConvertToBigInt } from '@hypha-platform/ui-utils';
+import {
+  enqueueSignalEvaluationFromMemory,
+  findSpaceBySlug,
+  recordThreadActivity,
+  refreshThreadSummary,
+} from '@hypha-platform/core/server';
+import { db } from '@hypha-platform/storage-postgres';
+import { checkSpaceAccess } from '@web/utils/check-space-access';
+
+const activitySchema = z.object({
+  matrixRoomId: z.string().trim().min(1),
+  threadKind: z.enum(['space', 'coherence']),
+  coherenceSlug: z.string().trim().min(1).optional().nullable(),
+  threadTitle: z.string().trim().min(1).optional().nullable(),
+  lastMessageEventId: z.string().trim().min(1),
+  lastMessageOriginServerTs: z.number().int().positive(),
+});
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ spaceSlug: string }> },
+) {
+  const { spaceSlug } = await params;
+  const space = await findSpaceBySlug({ slug: spaceSlug }, { db });
+  if (!space) {
+    return NextResponse.json({ error: 'Space not found' }, { status: 404 });
+  }
+
+  if (space.web3SpaceId != null) {
+    if (!canConvertToBigInt(space.web3SpaceId)) {
+      return NextResponse.json(
+        { error: 'Space has an invalid on-chain space id' },
+        { status: 403 },
+      );
+    }
+    const spaceId = Number(space.web3SpaceId);
+    if (!Number.isFinite(spaceId)) {
+      return NextResponse.json(
+        { error: 'Space has an invalid on-chain space id' },
+        { status: 403 },
+      );
+    }
+    const { hasAccess, response } = await checkSpaceAccess(request, spaceId);
+    if (!hasAccess) {
+      return (
+        response ?? NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+      );
+    }
+  }
+
+  let parsed: ReturnType<typeof activitySchema.safeParse>;
+  try {
+    parsed = activitySchema.safeParse(await request.json());
+  } catch {
+    return NextResponse.json(
+      { error: 'Malformed JSON payload' },
+      { status: 400 },
+    );
+  }
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'Invalid payload', details: parsed.error.flatten() },
+      { status: 400 },
+    );
+  }
+
+  const authHeader = request.headers.get('authorization');
+  const bearerMatch = authHeader?.match(/^Bearer\s+(.+)$/i);
+  const bearer = bearerMatch?.[1]?.trim() || undefined;
+
+  const payload = parsed.data;
+  const recorded = await recordThreadActivity(
+    {
+      spaceSlug,
+      matrixRoomId: payload.matrixRoomId,
+      threadKind: payload.threadKind,
+      coherenceSlug: payload.coherenceSlug,
+      threadTitle: payload.threadTitle,
+      lastMessageEventId: payload.lastMessageEventId,
+      lastMessageOriginServerTs: payload.lastMessageOriginServerTs,
+    },
+    { db },
+  );
+  if (!recorded.ok) {
+    return NextResponse.json({ error: recorded.error }, { status: 400 });
+  }
+
+  void refreshThreadSummary(
+    {
+      spaceSlug,
+      matrixRoomId: payload.matrixRoomId,
+      authToken: bearer,
+      requestUrlForSessionMatrix: request.url,
+    },
+    { db },
+  )
+    .then(async (result) => {
+      if (result.ok && !result.skipped) {
+        try {
+          await enqueueSignalEvaluationFromMemory(
+            {
+              spaceSlug,
+              triggerKind: 'thread_summary',
+              metadata: {
+                matrixRoomId: payload.matrixRoomId,
+                threadSummaryId: result.summary.id,
+              },
+            },
+            { db },
+          );
+        } catch (enqueueError) {
+          console.error('[thread-summary.activity] enqueue failed', {
+            spaceSlug,
+            error:
+              enqueueError instanceof Error
+                ? enqueueError.message
+                : String(enqueueError),
+          });
+        }
+      }
+    })
+    .catch((error) => {
+      console.error('[thread-summary.activity] refresh failed', {
+        spaceSlug,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
+
+  return NextResponse.json({ ok: true });
+}

--- a/apps/web/src/app/api/v1/spaces/[spaceSlug]/thread-summary/route.ts
+++ b/apps/web/src/app/api/v1/spaces/[spaceSlug]/thread-summary/route.ts
@@ -1,0 +1,143 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { canConvertToBigInt } from '@hypha-platform/ui-utils';
+import {
+  findSpaceBySlug,
+  getThreadSummaryForRoom,
+  refreshThreadSummary,
+} from '@hypha-platform/core/server';
+import { db } from '@hypha-platform/storage-postgres';
+import { checkSpaceAccess } from '@web/utils/check-space-access';
+
+async function authorizeSpace(
+  request: NextRequest,
+  spaceSlug: string,
+): Promise<
+  { ok: true; bearer?: string } | { ok: false; response: NextResponse }
+> {
+  const space = await findSpaceBySlug({ slug: spaceSlug }, { db });
+  if (!space) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: 'Space not found' },
+        { status: 404 },
+      ),
+    };
+  }
+  if (space.web3SpaceId != null) {
+    if (!canConvertToBigInt(space.web3SpaceId)) {
+      return {
+        ok: false,
+        response: NextResponse.json(
+          { error: 'Space has an invalid on-chain space id' },
+          { status: 403 },
+        ),
+      };
+    }
+    const spaceId = Number(space.web3SpaceId);
+    if (!Number.isFinite(spaceId)) {
+      return {
+        ok: false,
+        response: NextResponse.json(
+          { error: 'Space has an invalid on-chain space id' },
+          { status: 403 },
+        ),
+      };
+    }
+    const { hasAccess, response } = await checkSpaceAccess(request, spaceId);
+    if (!hasAccess) {
+      return {
+        ok: false,
+        response:
+          response ??
+          NextResponse.json({ error: 'Forbidden' }, { status: 403 }),
+      };
+    }
+  }
+  const authHeader = request.headers.get('authorization');
+  const bearerMatch = authHeader?.match(/^Bearer\s+(.+)$/i);
+  return { ok: true, bearer: bearerMatch?.[1]?.trim() || undefined };
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ spaceSlug: string }> },
+) {
+  const { spaceSlug } = await params;
+  const matrixRoomId = request.nextUrl.searchParams.get('matrixRoomId')?.trim();
+  if (!matrixRoomId) {
+    return NextResponse.json(
+      { error: 'matrixRoomId query parameter is required' },
+      { status: 400 },
+    );
+  }
+
+  const auth = await authorizeSpace(request, spaceSlug);
+  if (!auth.ok) return auth.response;
+
+  const summary = await getThreadSummaryForRoom(
+    { spaceSlug, matrixRoomId },
+    { db },
+  );
+  return NextResponse.json({ summary });
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ spaceSlug: string }> },
+) {
+  const { spaceSlug } = await params;
+  const auth = await authorizeSpace(request, spaceSlug);
+  if (!auth.ok) return auth.response;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: 'Malformed JSON payload' },
+      { status: 400 },
+    );
+  }
+
+  const matrixRoomId =
+    typeof body === 'object' &&
+    body &&
+    'matrixRoomId' in body &&
+    typeof (body as { matrixRoomId?: unknown }).matrixRoomId === 'string'
+      ? (body as { matrixRoomId: string }).matrixRoomId.trim()
+      : '';
+  if (!matrixRoomId) {
+    return NextResponse.json(
+      { error: 'matrixRoomId is required' },
+      { status: 400 },
+    );
+  }
+
+  const refreshResult = await refreshThreadSummary(
+    {
+      spaceSlug,
+      matrixRoomId,
+      authToken: auth.bearer,
+      requestUrlForSessionMatrix: request.url,
+      force: false,
+    },
+    { db },
+  );
+
+  if (!refreshResult.ok) {
+    return NextResponse.json({ error: refreshResult.error }, { status: 400 });
+  }
+  if (refreshResult.skipped) {
+    const summary = await getThreadSummaryForRoom(
+      { spaceSlug, matrixRoomId },
+      { db },
+    );
+    return NextResponse.json({
+      skipped: true,
+      reason: refreshResult.reason,
+      summary,
+    });
+  }
+  return NextResponse.json({ summary: refreshResult.summary });
+}

--- a/docs/operations/space-memory-production-checklist.md
+++ b/docs/operations/space-memory-production-checklist.md
@@ -1,0 +1,148 @@
+# Space Memory Production Checklist
+
+This checklist is for running Space Memory in production with reliable ingestion,
+scheduled refresh, and actionable monitoring.
+
+## 1) Required Environment Variables
+
+Set these on the web deployment:
+
+- `HYPHA_SPACE_MEMORY_OPS_SECRET`
+  - Shared secret for ops endpoints:
+    - `GET /api/v1/ops/space-memory/health`
+    - `POST /api/v1/ops/space-memory/refresh-discussions`
+    - `POST /api/v1/ops/space-memory/refresh-thread-summaries`
+- `HYPHA_CALL_ARTIFACT_INGEST_SECRET`
+  - Shared secret for call artifact ingestion endpoint:
+    - `POST /api/v1/spaces/[spaceSlug]/call-artifacts`
+- `NEXT_PUBLIC_MATRIX_HOMESERVER_URL`
+  - Required for Matrix timeline/media fetch and discussion summaries.
+- `HYPHA_MATRIX_ORG_MEMORY_ACCESS_TOKEN`
+  - Recommended bot/service token for unattended summary refresh jobs.
+
+Optional but useful:
+
+- `OPENROUTER_API_KEY`
+  - Enables LLM-backed living thread summaries (falls back to heuristics when unset).
+- `OPENROUTER_THREAD_SUMMARY_MODEL`
+  - Optional model override for thread summary generation.
+- `NEXT_PUBLIC_ENABLE_SPACE_MEMORY=true`
+  - Explicitly pins Space Memory to enabled (even though default now enables it).
+- `HYPHA_MCP_AUTH_TOKEN`
+- `HYPHA_MCP_MATRIX_REQUEST_URL` (or `VERCEL_URL`)
+
+## 2) Ingestion Pipeline (Recordings + Transcripts)
+
+Your recorder/STT worker must call:
+
+- `POST /api/v1/spaces/{spaceSlug}/call-artifacts`
+- Header:
+  - `x-hypha-ingest-secret: $HYPHA_CALL_ARTIFACT_INGEST_SECRET`
+
+Minimum payload:
+
+```json
+{
+  "call_session_id": "room-2026-05-16T00:00:00Z",
+  "transcript": { "text": "..." }
+}
+```
+
+Recommended payload includes both `recording` and `transcript`.
+
+## 3) Scheduled Thread Summary Refresh (Automation)
+
+Living thread summaries refresh when chat activity is recorded and via a scheduled
+sweep for rows that are due (≥30 minutes since last refresh and ≥1 new message).
+
+- `POST /api/v1/ops/space-memory/refresh-thread-summaries`
+- Header:
+  - `x-hypha-ops-secret: $HYPHA_SPACE_MEMORY_OPS_SECRET`
+
+Example body:
+
+```json
+{
+  "limit": 100
+}
+```
+
+Dry run:
+
+```json
+{
+  "dry_run": true,
+  "limit": 50
+}
+```
+
+### Suggested schedule
+
+- Every 30 minutes alongside discussion refresh for active orgs.
+
+## 4) Scheduled Discussion Refresh (Automation)
+
+Use the new ops endpoint:
+
+- `POST /api/v1/ops/space-memory/refresh-discussions`
+- Header:
+  - `x-hypha-ops-secret: $HYPHA_SPACE_MEMORY_OPS_SECRET`
+
+Example body:
+
+```json
+{
+  "limit": 100,
+  "include_archived": false
+}
+```
+
+Dry run:
+
+```json
+{
+  "dry_run": true,
+  "limit": 50
+}
+```
+
+### Suggested schedule
+
+- Every 30 minutes for active orgs.
+- Every 2-4 hours for low-activity environments.
+
+## 5) Health + Alerting
+
+Use the new health endpoint:
+
+- `GET /api/v1/ops/space-memory/health`
+- Header:
+  - `x-hypha-ops-secret: $HYPHA_SPACE_MEMORY_OPS_SECRET`
+
+The response includes:
+
+- `status`: `ok` | `warn` | `critical`
+- `readiness`: env/token readiness
+- `metrics`: recent ingestion/summaries
+- `alerts`: machine-readable warnings/critical issues
+
+### Suggested alert rules
+
+- Page on `status = critical`.
+- Warn if `alerts` contains `missing_matrix_bot_token`.
+- Warn if `alerts` contains `no_recent_summaries` for > 24h.
+
+## 6) Pagination Discipline for “Everything”
+
+When querying memory via AI/MCP, always paginate until completion:
+
+- `assets_pagination.has_next_page === false`
+- Document/member pagination likewise.
+
+## 7) Operational Verification (Go-Live)
+
+1. Call `/api/v1/ops/space-memory/health` and confirm no critical alerts.
+2. Run refresh dry-run and verify expected target spaces.
+3. Run real refresh and confirm `success_count > 0`.
+4. Ingest one synthetic transcript and verify it appears in org memory.
+5. Ask AI for “everything this space remembers” and validate multi-page retrieval.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,7 +20,11 @@
     "@privy-io/node": "^0.12.0",
     "@wagmi/cli": "^2.2.0",
     "matrix-js-sdk": "^40.0.0",
-    "pdf-parse": "^1.1.1"
+    "pdf-parse": "^1.1.1",
+    "@openrouter/ai-sdk-provider": "^2.3.3",
+    "ai": "^6.0.105",
+    "zod": "^3.24.2",
+    "server-only": "^0.0.1"
   },
   "exports": {
     "./client": "./src/client.ts",

--- a/packages/core/src/coherence/server/signal-orchestrator.ts
+++ b/packages/core/src/coherence/server/signal-orchestrator.ts
@@ -1,0 +1,1017 @@
+import 'server-only';
+
+import { and, eq, gt, gte, inArray, lt, lte, sql } from 'drizzle-orm';
+import {
+  signalOrchestratorCooldowns,
+  signalOrchestratorDispatches,
+  signalOrchestratorQueue,
+} from '@hypha-platform/storage-postgres';
+import type { DbConfig } from '../../server';
+import { COHERENCE_TAGS } from '../coherence-tags';
+import type { OrgMemoryAsset } from '../../governance/server/get-org-memory-by-space-slug';
+import { getOrgMemoryBySpaceSlug } from '../../governance/server/get-org-memory-by-space-slug';
+import { findAllCoherences } from './queries';
+import {
+  findAllOrganizationSpacesForNodeById,
+  findSpaceById,
+  findSpaceBySlug,
+} from '../../space/server/queries';
+import {
+  createAiSignalForSpaceBySlug,
+  getSpacePaymentEligibility,
+  relayAiSignalToEcosystemSpace,
+  toPaymentReason,
+  type SignalPriority,
+  type SignalType,
+} from './ai-signal-actions';
+
+function parseEnvNumber(
+  value: string | undefined,
+  fallback: number,
+  options?: { int?: boolean; min?: number; max?: number },
+): number {
+  const raw = Number(value ?? '');
+  let parsed = Number.isFinite(raw) ? raw : fallback;
+  if (options?.int) parsed = Math.trunc(parsed);
+  if (typeof options?.min === 'number') parsed = Math.max(options.min, parsed);
+  if (typeof options?.max === 'number') parsed = Math.min(options.max, parsed);
+  return parsed;
+}
+
+const WINDOW_MINUTES = parseEnvNumber(
+  process.env.HYPHA_SIGNAL_ORCHESTRATOR_WINDOW_MINUTES,
+  20,
+  { int: true, min: 1, max: 240 },
+);
+const MAX_ATTEMPTS = parseEnvNumber(
+  process.env.HYPHA_SIGNAL_ORCHESTRATOR_MAX_ATTEMPTS,
+  5,
+  { int: true, min: 1, max: 20 },
+);
+const MIN_RELEVANCE = parseEnvNumber(
+  process.env.HYPHA_SIGNAL_ORCHESTRATOR_MIN_RELEVANCE,
+  68,
+  { min: 0, max: 100 },
+);
+const MIN_CONFIDENCE = parseEnvNumber(
+  process.env.HYPHA_SIGNAL_ORCHESTRATOR_MIN_CONFIDENCE,
+  66,
+  { min: 0, max: 100 },
+);
+const MIN_NOVELTY = parseEnvNumber(
+  process.env.HYPHA_SIGNAL_ORCHESTRATOR_MIN_NOVELTY,
+  45,
+  { min: 0, max: 100 },
+);
+const RELAY_MIN_RELEVANCE = parseEnvNumber(
+  process.env.HYPHA_SIGNAL_ORCHESTRATOR_RELAY_MIN_RELEVANCE,
+  78,
+  { min: 0, max: 100 },
+);
+const RELAY_MIN_CONFIDENCE = parseEnvNumber(
+  process.env.HYPHA_SIGNAL_ORCHESTRATOR_RELAY_MIN_CONFIDENCE,
+  76,
+  { min: 0, max: 100 },
+);
+const DAILY_SPACE_LIMIT = parseEnvNumber(
+  process.env.HYPHA_SIGNAL_ORCHESTRATOR_SPACE_DAILY_LIMIT,
+  3,
+  { int: true, min: 1, max: 100 },
+);
+const DAILY_RELAY_LIMIT = parseEnvNumber(
+  process.env.HYPHA_SIGNAL_ORCHESTRATOR_RELAY_DAILY_LIMIT,
+  2,
+  { int: true, min: 1, max: 100 },
+);
+const TAG_COOLDOWN_HOURS = parseEnvNumber(
+  process.env.HYPHA_SIGNAL_ORCHESTRATOR_TAG_COOLDOWN_HOURS,
+  18,
+  { min: 1, max: 168 },
+);
+const SPACE_COOLDOWN_HOURS = parseEnvNumber(
+  process.env.HYPHA_SIGNAL_ORCHESTRATOR_SPACE_COOLDOWN_HOURS,
+  6,
+  { min: 1, max: 168 },
+);
+
+const SOURCE_TO_TAGS: Record<string, string[]> = {
+  call_recording: ['Learning', 'Knowledge'],
+  call_transcript: ['Learning', 'Feedback Loop', 'Knowledge'],
+  discussion_summary: ['Feedback Loop', 'Processes', 'Rhythms'],
+  thread_summary: ['Feedback Loop', 'Processes', 'Knowledge'],
+  matrix_chat: ['Feedback Loop', 'Communities'],
+  proposal_upload: ['Strategy', 'Milestones', 'Governance'],
+};
+
+type EnqueueInput = {
+  spaceSlug: string;
+  triggerKind:
+    | 'memory_ingest'
+    | 'discussion_summary'
+    | 'thread_summary'
+    | 'ops_refresh'
+    | 'manual'
+    | 'unknown';
+  sourceAssetKeys?: string[];
+  metadata?: Record<string, unknown>;
+};
+
+type ProcessBatchInput = {
+  limit?: number;
+  authToken?: string;
+  requestUrlForSessionMatrix?: string;
+  dryRun?: boolean;
+};
+
+type Candidate = {
+  type: SignalType;
+  priority: SignalPriority;
+  title: string;
+  description: string;
+  summary: string;
+  tags: string[];
+  relevance: number;
+  novelty: number;
+  actionability: number;
+  confidence: number;
+  rationale: string;
+};
+
+function clampScore(n: number): number {
+  return Math.max(0, Math.min(100, Math.round(n)));
+}
+
+function words(value: string | null | undefined): Set<string> {
+  return new Set(
+    (value ?? '')
+      .toLowerCase()
+      .replace(/[^a-z0-9\s]/g, ' ')
+      .split(/\s+/)
+      .filter((w) => w.length >= 4),
+  );
+}
+
+function overlap(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 || b.size === 0) return 0;
+  let c = 0;
+  for (const x of a) if (b.has(x)) c += 1;
+  return c / Math.max(1, Math.min(a.size, b.size));
+}
+
+function extractSourceAssetKeys(
+  payload: Record<string, unknown> | null | undefined,
+): string[] {
+  const value = payload?.source_asset_keys;
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === 'string');
+}
+
+function summarizeSources(assets: OrgMemoryAsset[]) {
+  const map = new Map<string, number>();
+  for (const a of assets) map.set(a.source, (map.get(a.source) ?? 0) + 1);
+  return [...map.entries()]
+    .map(([source, count]) => ({ source, count }))
+    .sort((a, b) => b.count - a.count);
+}
+
+function inferTags(assets: OrgMemoryAsset[], existingTags: string[]) {
+  const fromSources = assets.flatMap((a) => SOURCE_TO_TAGS[a.source] ?? []);
+  const merged = [...fromSources, ...existingTags].filter((tag, idx, arr) => {
+    if (!COHERENCE_TAGS.includes(tag as (typeof COHERENCE_TAGS)[number]))
+      return false;
+    return arr.indexOf(tag) === idx;
+  });
+  return merged.slice(0, 5);
+}
+
+function buildCandidate({
+  spaceTitle,
+  spacePurpose,
+  assets,
+  existingTitles,
+  existingTags,
+  eventCount,
+}: {
+  spaceTitle: string;
+  spacePurpose: string | null;
+  assets: OrgMemoryAsset[];
+  existingTitles: string[];
+  existingTags: string[];
+  eventCount: number;
+}): Candidate {
+  const sourceSummary = summarizeSources(assets);
+  const top = sourceSummary.slice(0, 3);
+  const relevance = clampScore(
+    35 +
+      Math.min(30, assets.length * 3) +
+      Math.min(25, eventCount * 5) +
+      (top.length >= 2 ? 10 : top.length === 1 ? 5 : 0) +
+      (spacePurpose?.trim() ? 10 : 0),
+  );
+  const title = `${spaceTitle}: high-signal ${(
+    top[0]?.source ?? 'activity'
+  ).replace(/_/g, ' ')} update`;
+  const titleSet = words(title);
+  const novelty = clampScore(
+    100 -
+      existingTitles.reduce(
+        (max, existing) => Math.max(max, overlap(titleSet, words(existing))),
+        0,
+      ) *
+        100,
+  );
+  const actionability = clampScore(
+    45 +
+      (top.some((s) => s.source === 'discussion_summary') ? 20 : 0) +
+      (top.some((s) => s.source === 'proposal_upload') ? 18 : 0) +
+      (top.some((s) => s.source === 'call_transcript') ? 15 : 0),
+  );
+  const confidence = clampScore(
+    relevance * 0.4 + novelty * 0.3 + actionability * 0.3,
+  );
+  const type: SignalType = top.some((s) => s.source === 'proposal_upload')
+    ? 'Proposal'
+    : top.some((s) => s.source === 'matrix_chat')
+    ? 'Opportunity'
+    : 'Insight';
+  const priority: SignalPriority =
+    relevance >= 85 && confidence >= 82
+      ? 'high'
+      : relevance >= 76 && confidence >= 72
+      ? 'medium'
+      : 'low';
+  const tags = inferTags(assets, existingTags);
+  const summary =
+    top.length > 0
+      ? top.map((s) => `${s.source.replace(/_/g, ' ')}:${s.count}`).join(', ')
+      : 'limited activity';
+  const description = [
+    'Recent space-memory activity indicates a coordination opportunity.',
+    `Observed signals: ${summary}.`,
+    spacePurpose?.trim()
+      ? `Purpose alignment: this supports "${spacePurpose.trim()}".`
+      : 'Purpose alignment should be confirmed explicitly in next team check-in.',
+    'Proposed next step: run a focused discussion to convert this activity into one concrete decision and owner.',
+  ].join('\n');
+  return {
+    type,
+    priority,
+    title,
+    description,
+    summary,
+    tags,
+    relevance,
+    novelty,
+    actionability,
+    confidence,
+    rationale: `relevance=${relevance}, novelty=${novelty}, actionability=${actionability}, confidence=${confidence}`,
+  };
+}
+
+async function recentDispatchCount({
+  spaceId,
+  mode,
+  db,
+}: {
+  spaceId: number;
+  mode: 'space' | 'relay';
+  db: DbConfig['db'];
+}) {
+  const since = new Date(Date.now() - 24 * 60 * 60 * 1000);
+  const [row] = await db
+    .select({ count: sql<number>`count(*)` })
+    .from(signalOrchestratorDispatches)
+    .where(
+      and(
+        eq(signalOrchestratorDispatches.sourceSpaceId, spaceId),
+        eq(signalOrchestratorDispatches.mode, mode),
+        eq(signalOrchestratorDispatches.decision, 'emitted'),
+        gte(signalOrchestratorDispatches.createdAt, since),
+      ),
+    );
+  return Number(row?.count ?? 0);
+}
+
+async function activeCooldowns(
+  spaceId: number,
+  keys: string[],
+  { db }: DbConfig,
+) {
+  if (keys.length === 0) return new Set<string>();
+  const rows = await db
+    .select({ key: signalOrchestratorCooldowns.key })
+    .from(signalOrchestratorCooldowns)
+    .where(
+      and(
+        eq(signalOrchestratorCooldowns.spaceId, spaceId),
+        inArray(signalOrchestratorCooldowns.key, keys),
+        gt(signalOrchestratorCooldowns.cooldownUntil, new Date()),
+      ),
+    );
+  return new Set(rows.map((r) => r.key));
+}
+
+async function saveCooldowns(
+  spaceId: number,
+  keys: string[],
+  reason: string,
+  hours: number,
+  { db }: DbConfig,
+) {
+  const until = new Date(Date.now() + hours * 60 * 60 * 1000);
+  for (const key of keys) {
+    await db
+      .insert(signalOrchestratorCooldowns)
+      .values({ spaceId, key, cooldownUntil: until, reason })
+      .onConflictDoUpdate({
+        target: [
+          signalOrchestratorCooldowns.spaceId,
+          signalOrchestratorCooldowns.key,
+        ],
+        set: { cooldownUntil: until, reason, updatedAt: new Date() },
+      });
+  }
+}
+
+async function saveDispatch(
+  {
+    queueId,
+    sourceSpaceId,
+    candidate,
+    mode,
+    decision,
+    rationale,
+    targetSpaceId,
+    emittedSignalId,
+    metadata,
+  }: {
+    queueId: number;
+    sourceSpaceId: number;
+    candidate: Candidate;
+    mode: 'space' | 'relay';
+    decision: 'emitted' | 'suppressed' | 'error' | 'discarded';
+    rationale: string;
+    targetSpaceId?: number;
+    emittedSignalId?: number;
+    metadata?: Record<string, unknown>;
+  },
+  { db }: DbConfig,
+) {
+  await db.insert(signalOrchestratorDispatches).values({
+    queueId,
+    sourceSpaceId,
+    targetSpaceId: targetSpaceId ?? null,
+    emittedSignalId: emittedSignalId ?? null,
+    mode,
+    decision,
+    relevanceScore: candidate.relevance,
+    noveltyScore: candidate.novelty,
+    actionabilityScore: candidate.actionability,
+    confidenceScore: candidate.confidence,
+    rationale,
+    tags: candidate.tags,
+    metadata: metadata ?? {},
+  });
+}
+
+export async function enqueueSignalEvaluationFromMemory(
+  input: EnqueueInput,
+  { db }: DbConfig,
+) {
+  const slug = input.spaceSlug.trim();
+  if (!slug) return { ok: false as const, error: 'spaceSlug is required' };
+  const host = await findSpaceBySlug({ slug }, { db });
+  if (!host) return { ok: false as const, error: 'Space not found' };
+  const dueAt = new Date(Date.now() + Math.max(5, WINDOW_MINUTES) * 60 * 1000);
+
+  const payload: Record<string, unknown> = {
+    trigger_kind: input.triggerKind,
+    source_asset_keys: input.sourceAssetKeys ?? [],
+    metadata: input.metadata ?? {},
+  };
+  return db.transaction(async (tx) => {
+    // Serialize enqueue per space to avoid duplicate pending rows under contention.
+    await tx.execute(sql`select pg_advisory_xact_lock(${host.id})`);
+
+    const pending = await tx.query.signalOrchestratorQueue.findFirst({
+      where: (q, { and, eq }) =>
+        and(eq(q.spaceId, host.id), eq(q.state, 'pending')),
+    });
+
+    if (pending) {
+      const prevKeys = extractSourceAssetKeys(pending.payload);
+      await tx
+        .update(signalOrchestratorQueue)
+        .set({
+          eventCount: pending.eventCount + 1,
+          dueAt,
+          triggerKind: input.triggerKind,
+          payload: {
+            ...pending.payload,
+            ...payload,
+            source_asset_keys: Array.from(
+              new Set([...(input.sourceAssetKeys ?? []), ...prevKeys]),
+            ).slice(0, 30),
+          },
+          updatedAt: new Date(),
+        })
+        .where(eq(signalOrchestratorQueue.id, pending.id));
+      return { ok: true as const, queueId: pending.id, deduped: true };
+    }
+
+    const [inserted] = await tx
+      .insert(signalOrchestratorQueue)
+      .values({
+        spaceId: host.id,
+        state: 'pending',
+        triggerKind: input.triggerKind,
+        eventCount: 1,
+        dueAt,
+        payload,
+      })
+      .returning();
+    return {
+      ok: true as const,
+      queueId: inserted?.id ?? null,
+      deduped: false,
+    };
+  });
+}
+
+export async function processSignalOrchestratorBatch(
+  {
+    limit = 20,
+    authToken,
+    requestUrlForSessionMatrix,
+    dryRun = false,
+  }: ProcessBatchInput,
+  { db }: DbConfig,
+) {
+  const rows = await db
+    .select()
+    .from(signalOrchestratorQueue)
+    .where(
+      and(
+        eq(signalOrchestratorQueue.state, 'pending'),
+        lte(signalOrchestratorQueue.dueAt, new Date()),
+      ),
+    )
+    .orderBy(signalOrchestratorQueue.dueAt)
+    .limit(Math.max(1, Math.min(100, limit)));
+
+  const systemAuthToken =
+    authToken?.trim() ||
+    process.env.HYPHA_SIGNAL_ORCHESTRATOR_AUTH_TOKEN?.trim() ||
+    process.env.HYPHA_MCP_AUTH_TOKEN?.trim();
+  const results: Array<{ queue_id: number; status: string; message: string }> =
+    [];
+
+  for (const row of rows) {
+    const [lock] = await db
+      .update(signalOrchestratorQueue)
+      .set({
+        state: 'processing',
+        attempts: row.attempts + 1,
+        processingStartedAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(signalOrchestratorQueue.id, row.id),
+          eq(signalOrchestratorQueue.state, 'pending'),
+        ),
+      )
+      .returning();
+    if (!lock) continue;
+
+    try {
+      if (lock.attempts > MAX_ATTEMPTS) {
+        await db
+          .update(signalOrchestratorQueue)
+          .set({
+            state: 'discarded',
+            lastError: 'Max attempts exceeded',
+            updatedAt: new Date(),
+          })
+          .where(eq(signalOrchestratorQueue.id, lock.id));
+        results.push({
+          queue_id: lock.id,
+          status: 'discarded',
+          message: 'Max attempts exceeded',
+        });
+        continue;
+      }
+
+      const host = await findSpaceById({ id: lock.spaceId }, { db });
+      if (!host) {
+        await db
+          .update(signalOrchestratorQueue)
+          .set({
+            state: 'discarded',
+            lastError: 'Space no longer exists',
+            updatedAt: new Date(),
+          })
+          .where(eq(signalOrchestratorQueue.id, lock.id));
+        results.push({
+          queue_id: lock.id,
+          status: 'discarded',
+          message: 'Space no longer exists',
+        });
+        continue;
+      }
+
+      const payment = await getSpacePaymentEligibility(host.web3SpaceId);
+      const paymentReason = toPaymentReason(payment);
+      if (paymentReason) {
+        await db
+          .update(signalOrchestratorQueue)
+          .set({
+            state: 'discarded',
+            lastError: paymentReason,
+            updatedAt: new Date(),
+          })
+          .where(eq(signalOrchestratorQueue.id, lock.id));
+        results.push({
+          queue_id: lock.id,
+          status: 'discarded',
+          message: paymentReason,
+        });
+        continue;
+      }
+
+      const [orgMemory, existingSignals] = await Promise.all([
+        getOrgMemoryBySpaceSlug(
+          {
+            spaceSlug: host.slug,
+            assetsPage: 1,
+            assetsPageSize: 40,
+            requestUrlForSessionMatrix,
+            assetView: 'signal',
+          },
+          { db, authToken: systemAuthToken },
+        ),
+        findAllCoherences(
+          { db },
+          { spaceId: host.id, includeArchived: false, orderBy: 'mostrecent' },
+        ),
+      ]);
+
+      if (orgMemory.access === 'denied' || !orgMemory.result.found) {
+        const msg =
+          orgMemory.access === 'denied'
+            ? orgMemory.message
+            : 'Org memory unavailable';
+        await db
+          .update(signalOrchestratorQueue)
+          .set({ state: 'failed', lastError: msg, updatedAt: new Date() })
+          .where(eq(signalOrchestratorQueue.id, lock.id));
+        results.push({ queue_id: lock.id, status: 'error', message: msg });
+        continue;
+      }
+
+      const candidate = buildCandidate({
+        spaceTitle: host.title,
+        spacePurpose: host.description ?? null,
+        assets: orgMemory.result.org_memory_assets,
+        existingTitles: existingSignals.map((s) => s.title),
+        existingTags: existingSignals.flatMap((s) => s.tags ?? []),
+        eventCount: lock.eventCount,
+      });
+
+      const recentSpaceSignals = await recentDispatchCount({
+        spaceId: host.id,
+        mode: 'space',
+        db,
+      });
+      const cooldownSet = await activeCooldowns(
+        host.id,
+        [`space:${host.id}`, ...candidate.tags.map((tag) => `tag:${tag}`)],
+        { db },
+      );
+      const suppress =
+        candidate.relevance < MIN_RELEVANCE ||
+        candidate.confidence < MIN_CONFIDENCE ||
+        candidate.novelty < MIN_NOVELTY ||
+        recentSpaceSignals >= DAILY_SPACE_LIMIT ||
+        cooldownSet.size > 0;
+
+      if (suppress || dryRun) {
+        if (dryRun) {
+          await db
+            .update(signalOrchestratorQueue)
+            .set({
+              state: 'pending',
+              processingStartedAt: null,
+              updatedAt: new Date(),
+            })
+            .where(eq(signalOrchestratorQueue.id, lock.id));
+        } else {
+          await saveDispatch(
+            {
+              queueId: lock.id,
+              sourceSpaceId: host.id,
+              candidate,
+              mode: 'space',
+              decision: 'suppressed',
+              rationale: candidate.rationale,
+              metadata: {
+                dry_run: false,
+                active_cooldowns: [...cooldownSet],
+                recent_space_signals: recentSpaceSignals,
+              },
+            },
+            { db },
+          );
+          await db
+            .update(signalOrchestratorQueue)
+            .set({ state: 'done', lastError: null, updatedAt: new Date() })
+            .where(eq(signalOrchestratorQueue.id, lock.id));
+        }
+        results.push({
+          queue_id: lock.id,
+          status: 'suppressed',
+          message: dryRun
+            ? 'Dry run evaluation only'
+            : 'Suppressed by guardrails',
+        });
+        continue;
+      }
+
+      const local = await createAiSignalForSpaceBySlug(
+        {
+          spaceSlug: host.slug,
+          authToken: systemAuthToken,
+          title: candidate.title,
+          description: candidate.description,
+          type: candidate.type,
+          priority: candidate.priority,
+          tags: candidate.tags,
+        },
+        { db },
+      );
+      if (!local.ok) {
+        await saveDispatch(
+          {
+            queueId: lock.id,
+            sourceSpaceId: host.id,
+            candidate,
+            mode: 'space',
+            decision: 'error',
+            rationale: local.error,
+          },
+          { db },
+        );
+        await db
+          .update(signalOrchestratorQueue)
+          .set({
+            state: 'failed',
+            lastError: local.error,
+            updatedAt: new Date(),
+          })
+          .where(eq(signalOrchestratorQueue.id, lock.id));
+        results.push({
+          queue_id: lock.id,
+          status: 'error',
+          message: local.error,
+        });
+        continue;
+      }
+
+      await saveDispatch(
+        {
+          queueId: lock.id,
+          sourceSpaceId: host.id,
+          emittedSignalId: local.signalId,
+          candidate,
+          mode: 'space',
+          decision: 'emitted',
+          rationale: candidate.rationale,
+        },
+        { db },
+      );
+      await saveCooldowns(
+        host.id,
+        [`space:${host.id}`],
+        'space_signal_emitted',
+        SPACE_COOLDOWN_HOURS,
+        { db },
+      );
+      await saveCooldowns(
+        host.id,
+        candidate.tags.map((tag) => `tag:${tag}`),
+        'tag_signal_emitted',
+        TAG_COOLDOWN_HOURS,
+        { db },
+      );
+
+      let relayMessage = 'local signal emitted';
+      if (
+        candidate.confidence >= RELAY_MIN_CONFIDENCE &&
+        candidate.relevance >= RELAY_MIN_RELEVANCE
+      ) {
+        const recentRelaySignals = await recentDispatchCount({
+          spaceId: host.id,
+          mode: 'relay',
+          db,
+        });
+        if (recentRelaySignals < DAILY_RELAY_LIMIT) {
+          const ecosystem = await findAllOrganizationSpacesForNodeById(
+            { id: host.id },
+            { db },
+          );
+          const targets = ecosystem
+            .filter(
+              (s) =>
+                s.id !== host.id &&
+                !s.flags?.includes('archived') &&
+                Boolean(s.slug),
+            )
+            .map((s) => ({
+              id: s.id,
+              slug: s.slug,
+              title: s.title,
+              description: s.description,
+            }));
+          const sourceWords = words(`${host.title} ${host.description ?? ''}`);
+          const best = targets
+            .map((t) => ({
+              ...t,
+              relevance: clampScore(
+                overlap(
+                  sourceWords,
+                  words(`${t.title} ${t.description ?? ''}`),
+                ) * 100,
+              ),
+            }))
+            .sort((a, b) => b.relevance - a.relevance)[0];
+
+          if (best && best.relevance >= 52) {
+            const relay = await relayAiSignalToEcosystemSpace(
+              {
+                sourceSpaceSlug: host.slug,
+                targetSpaceSlug: best.slug,
+                authToken: systemAuthToken,
+                title: `${host.title} -> ${best.title}: relevant signal`,
+                summary: `Local signal summary: ${candidate.summary}.`,
+                recommendedAction:
+                  'Review this signal in next coordination cycle and decide if shared workstream alignment is required.',
+                relevanceRationale: `Target overlap relevance score ${best.relevance}/100 from purpose-language alignment and ecosystem adjacency.`,
+                type: candidate.type,
+                priority: candidate.priority,
+                tags: candidate.tags,
+                sourceAssetKeys: extractSourceAssetKeys(lock.payload),
+              },
+              { db },
+            );
+
+            await saveDispatch(
+              {
+                queueId: lock.id,
+                sourceSpaceId: host.id,
+                targetSpaceId: best.id,
+                emittedSignalId: relay.ok ? relay.signalId : undefined,
+                candidate,
+                mode: 'relay',
+                decision: relay.ok ? 'emitted' : 'suppressed',
+                rationale: relay.ok
+                  ? `relay_score=${best.relevance}`
+                  : relay.error ?? 'relay suppressed',
+              },
+              { db },
+            );
+            if (relay.ok) relayMessage = `relay emitted to ${best.slug}`;
+          }
+        }
+      }
+
+      await db
+        .update(signalOrchestratorQueue)
+        .set({ state: 'done', lastError: null, updatedAt: new Date() })
+        .where(eq(signalOrchestratorQueue.id, lock.id));
+      results.push({
+        queue_id: lock.id,
+        status: relayMessage.startsWith('relay') ? 'relay_emitted' : 'emitted',
+        message: relayMessage,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      await db
+        .update(signalOrchestratorQueue)
+        .set({ state: 'failed', lastError: message, updatedAt: new Date() })
+        .where(eq(signalOrchestratorQueue.id, lock.id));
+      results.push({ queue_id: lock.id, status: 'error', message });
+    }
+  }
+
+  return {
+    ok: true as const,
+    scanned: rows.length,
+    processed: results.length,
+    results,
+  };
+}
+
+export async function getSignalOrchestratorMetrics({ db }: DbConfig) {
+  const since24h = new Date(Date.now() - 24 * 60 * 60 * 1000);
+  const [pending, failed, emitted, relays] = await Promise.all([
+    db
+      .select({ count: sql<number>`count(*)` })
+      .from(signalOrchestratorQueue)
+      .where(eq(signalOrchestratorQueue.state, 'pending')),
+    db
+      .select({ count: sql<number>`count(*)` })
+      .from(signalOrchestratorQueue)
+      .where(eq(signalOrchestratorQueue.state, 'failed')),
+    db
+      .select({ count: sql<number>`count(*)` })
+      .from(signalOrchestratorDispatches)
+      .where(
+        and(
+          eq(signalOrchestratorDispatches.mode, 'space'),
+          eq(signalOrchestratorDispatches.decision, 'emitted'),
+          gte(signalOrchestratorDispatches.createdAt, since24h),
+        ),
+      ),
+    db
+      .select({ count: sql<number>`count(*)` })
+      .from(signalOrchestratorDispatches)
+      .where(
+        and(
+          eq(signalOrchestratorDispatches.mode, 'relay'),
+          eq(signalOrchestratorDispatches.decision, 'emitted'),
+          gte(signalOrchestratorDispatches.createdAt, since24h),
+        ),
+      ),
+  ]);
+
+  const latestErrors = await db.query.signalOrchestratorQueue.findMany({
+    where: (q, { and, eq, isNotNull }) =>
+      and(eq(q.state, 'failed'), isNotNull(q.lastError)),
+    orderBy: (q, { desc }) => [desc(q.updatedAt)],
+    limit: 8,
+  });
+
+  return {
+    queue_pending: Number(pending[0]?.count ?? 0),
+    queue_failed: Number(failed[0]?.count ?? 0),
+    signals_emitted_last_24h: Number(emitted[0]?.count ?? 0),
+    relays_emitted_last_24h: Number(relays[0]?.count ?? 0),
+    latest_errors: latestErrors.map((row) => ({
+      queue_id: row.id,
+      space_id: row.spaceId,
+      error: row.lastError,
+      updated_at: row.updatedAt.toISOString(),
+    })),
+  };
+}
+
+function clampRetentionDays(
+  value: number | undefined,
+  fallback: number,
+): number {
+  const n = Math.trunc(Number(value));
+  if (!Number.isFinite(n)) return fallback;
+  return Math.max(1, Math.min(3650, n));
+}
+
+export async function cleanupSignalOrchestratorRetention(
+  {
+    dryRun = true,
+    queueTerminalRetentionDays = 30,
+    queueFailedRetentionDays = 45,
+    dispatchRetentionDays = 90,
+    cooldownGraceDays = 7,
+  }: {
+    dryRun?: boolean;
+    queueTerminalRetentionDays?: number;
+    queueFailedRetentionDays?: number;
+    dispatchRetentionDays?: number;
+    cooldownGraceDays?: number;
+  },
+  { db }: DbConfig,
+) {
+  const now = Date.now();
+  const effectiveQueueTerminalDays = clampRetentionDays(
+    queueTerminalRetentionDays,
+    30,
+  );
+  const effectiveQueueFailedDays = clampRetentionDays(
+    queueFailedRetentionDays,
+    45,
+  );
+  const effectiveDispatchDays = clampRetentionDays(dispatchRetentionDays, 90);
+  const effectiveCooldownGraceDays = clampRetentionDays(cooldownGraceDays, 7);
+
+  const queueTerminalCutoff = new Date(
+    now - effectiveQueueTerminalDays * 24 * 60 * 60 * 1000,
+  );
+  const queueFailedCutoff = new Date(
+    now - effectiveQueueFailedDays * 24 * 60 * 60 * 1000,
+  );
+  const dispatchCutoff = new Date(
+    now - effectiveDispatchDays * 24 * 60 * 60 * 1000,
+  );
+  const cooldownCutoff = new Date(
+    now - effectiveCooldownGraceDays * 24 * 60 * 60 * 1000,
+  );
+
+  if (dryRun) {
+    const [queueTerminal, queueFailed, dispatches, cooldowns] =
+      await Promise.all([
+        db
+          .select({ count: sql<number>`count(*)` })
+          .from(signalOrchestratorQueue)
+          .where(
+            and(
+              inArray(signalOrchestratorQueue.state, ['done', 'discarded']),
+              lt(signalOrchestratorQueue.updatedAt, queueTerminalCutoff),
+            ),
+          ),
+        db
+          .select({ count: sql<number>`count(*)` })
+          .from(signalOrchestratorQueue)
+          .where(
+            and(
+              eq(signalOrchestratorQueue.state, 'failed'),
+              lt(signalOrchestratorQueue.updatedAt, queueFailedCutoff),
+            ),
+          ),
+        db
+          .select({ count: sql<number>`count(*)` })
+          .from(signalOrchestratorDispatches)
+          .where(lt(signalOrchestratorDispatches.createdAt, dispatchCutoff)),
+        db
+          .select({ count: sql<number>`count(*)` })
+          .from(signalOrchestratorCooldowns)
+          .where(lt(signalOrchestratorCooldowns.cooldownUntil, cooldownCutoff)),
+      ]);
+
+    return {
+      ok: true as const,
+      dry_run: true,
+      cutoffs: {
+        queue_terminal_before: queueTerminalCutoff.toISOString(),
+        queue_failed_before: queueFailedCutoff.toISOString(),
+        dispatches_before: dispatchCutoff.toISOString(),
+        cooldowns_before: cooldownCutoff.toISOString(),
+      },
+      counts: {
+        queue_terminal: Number(queueTerminal[0]?.count ?? 0),
+        queue_failed: Number(queueFailed[0]?.count ?? 0),
+        dispatches: Number(dispatches[0]?.count ?? 0),
+        cooldowns: Number(cooldowns[0]?.count ?? 0),
+      },
+    };
+  }
+
+  const [
+    queueTerminalDeleted,
+    queueFailedDeleted,
+    dispatchDeleted,
+    cooldownDeleted,
+  ] = await Promise.all([
+    db
+      .delete(signalOrchestratorQueue)
+      .where(
+        and(
+          inArray(signalOrchestratorQueue.state, ['done', 'discarded']),
+          lt(signalOrchestratorQueue.updatedAt, queueTerminalCutoff),
+        ),
+      )
+      .returning(),
+    db
+      .delete(signalOrchestratorQueue)
+      .where(
+        and(
+          eq(signalOrchestratorQueue.state, 'failed'),
+          lt(signalOrchestratorQueue.updatedAt, queueFailedCutoff),
+        ),
+      )
+      .returning(),
+    db
+      .delete(signalOrchestratorDispatches)
+      .where(lt(signalOrchestratorDispatches.createdAt, dispatchCutoff))
+      .returning(),
+    db
+      .delete(signalOrchestratorCooldowns)
+      .where(lt(signalOrchestratorCooldowns.cooldownUntil, cooldownCutoff))
+      .returning(),
+  ]);
+
+  return {
+    ok: true as const,
+    dry_run: false,
+    cutoffs: {
+      queue_terminal_before: queueTerminalCutoff.toISOString(),
+      queue_failed_before: queueFailedCutoff.toISOString(),
+      dispatches_before: dispatchCutoff.toISOString(),
+      cooldowns_before: cooldownCutoff.toISOString(),
+    },
+    deleted: {
+      queue_terminal: queueTerminalDeleted.length,
+      queue_failed: queueFailedDeleted.length,
+      dispatches: dispatchDeleted.length,
+      cooldowns: cooldownDeleted.length,
+    },
+  };
+}

--- a/packages/core/src/governance/__tests__/thread-summaries-gates.test.ts
+++ b/packages/core/src/governance/__tests__/thread-summaries-gates.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import {
+  shouldRefreshThreadSummary,
+  THREAD_SUMMARY_REFRESH_INTERVAL_MS,
+} from '../server/thread-summaries-gates';
+
+describe('shouldRefreshThreadSummary', () => {
+  const now = 1_700_000_000_000;
+
+  it('requires new message activity', () => {
+    expect(
+      shouldRefreshThreadSummary({
+        lastMessageOriginServerTs: null,
+        lastSummarizedOriginServerTs: null,
+        lastRefreshedAt: null,
+        nowMs: now,
+      }),
+    ).toEqual({ ok: false, reason: 'no_thread_activity' });
+  });
+
+  it('skips when already summarized through latest message', () => {
+    expect(
+      shouldRefreshThreadSummary({
+        lastMessageOriginServerTs: 1000,
+        lastSummarizedOriginServerTs: 1000,
+        lastRefreshedAt: null,
+        nowMs: now,
+      }),
+    ).toEqual({ ok: false, reason: 'no_new_messages' });
+  });
+
+  it('rate limits refreshes to 30 minutes', () => {
+    expect(
+      shouldRefreshThreadSummary({
+        lastMessageOriginServerTs: 2000,
+        lastSummarizedOriginServerTs: 1000,
+        lastRefreshedAt: new Date(
+          now - THREAD_SUMMARY_REFRESH_INTERVAL_MS + 60_000,
+        ).toISOString(),
+        nowMs: now,
+      }),
+    ).toEqual({ ok: false, reason: 'rate_limited' });
+  });
+
+  it('allows refresh when activity is new and interval elapsed', () => {
+    expect(
+      shouldRefreshThreadSummary({
+        lastMessageOriginServerTs: 2000,
+        lastSummarizedOriginServerTs: 1000,
+        lastRefreshedAt: new Date(
+          now - THREAD_SUMMARY_REFRESH_INTERVAL_MS - 1,
+        ).toISOString(),
+        nowMs: now,
+      }),
+    ).toEqual({ ok: true });
+  });
+
+  it('supports force refresh', () => {
+    expect(
+      shouldRefreshThreadSummary({
+        lastMessageOriginServerTs: 1000,
+        lastSummarizedOriginServerTs: 1000,
+        lastRefreshedAt: new Date(now - 1000).toISOString(),
+        nowMs: now,
+        force: true,
+      }),
+    ).toEqual({ ok: true });
+  });
+});

--- a/packages/core/src/governance/server/fetch-org-memory-asset.ts
+++ b/packages/core/src/governance/server/fetch-org-memory-asset.ts
@@ -9,6 +9,13 @@ import { canConvertToBigInt } from '@hypha-platform/ui-utils';
 import { HYPHA_MEDIA_BUNDLE_FIELD } from '../../matrix/rich-reply';
 import { findAllDocumentsBySpaceSlugWithoutPagination } from './queries';
 import { parseOrgMemoryAssetKey } from '../../org-memory/org-memory-asset-key';
+import { getSpaceCallArtifactById } from './call-artifacts';
+import { getThreadSummaryById } from './thread-summaries';
+import type {
+  SpaceCallRecording,
+  SpaceCallTranscript,
+  SpaceDiscussionSummary,
+} from '@hypha-platform/storage-postgres';
 
 const DEFAULT_MAX_BYTES = 2 * 1024 * 1024; // 2 MiB
 const DEFAULT_FETCH_TIMEOUT_MS = 25_000;
@@ -559,7 +566,7 @@ export async function fetchOrgMemoryAsset(
     }
     fetchUrl = hit.url.trim();
     filename = hit.filename;
-  } else {
+  } else if (key.k === 'm') {
     const matrixRoomId = host.chatRoomId?.trim() ?? '';
     if (!matrixRoomId || key.r !== matrixRoomId) {
       return {
@@ -639,6 +646,191 @@ export async function fetchOrgMemoryAsset(
       mxcParsed.mediaId,
     );
     matrixAccessToken = tokenPack.token;
+  } else if (key.k === 'cr') {
+    const recording = (await getSpaceCallArtifactById(
+      { kind: 'recording', id: key.i, spaceId: host.id },
+      { db },
+    )) as SpaceCallRecording | null;
+    if (!recording) {
+      return {
+        access: 'ok',
+        result: {
+          ok: false,
+          error: 'Call recording not found for this space',
+          code: 'not_found',
+        },
+      };
+    }
+    filename =
+      recording.mediaUri.split('/').pop()?.trim() ||
+      `recording-${recording.callSessionId}.webm`;
+    const mxcParsed = parseMxc(recording.mediaUri);
+    if (mxcParsed) {
+      const homeserver = process.env.NEXT_PUBLIC_MATRIX_HOMESERVER_URL?.replace(
+        /\/?$/,
+        '',
+      );
+      if (!homeserver) {
+        return {
+          access: 'ok',
+          result: {
+            ok: false,
+            error: 'Matrix homeserver not configured',
+            code: 'matrix_auth',
+          },
+        };
+      }
+      const tokenPack = await resolveMatrixAccessToken(
+        authToken,
+        requestUrlForSessionMatrix,
+      );
+      if (!tokenPack) {
+        return {
+          access: 'ok',
+          result: {
+            ok: false,
+            error: 'No Matrix access token available for recording fetch',
+            code: 'matrix_auth',
+          },
+        };
+      }
+      fetchUrl = matrixMediaDownloadPath(
+        homeserver,
+        mxcParsed.serverName,
+        mxcParsed.mediaId,
+      );
+      matrixAccessToken = tokenPack.token;
+    } else {
+      fetchUrl = recording.mediaUri;
+    }
+  } else if (key.k === 'ct') {
+    const transcript = (await getSpaceCallArtifactById(
+      { kind: 'transcript', id: key.i, spaceId: host.id },
+      { db },
+    )) as SpaceCallTranscript | null;
+    if (!transcript) {
+      return {
+        access: 'ok',
+        result: {
+          ok: false,
+          error: 'Call transcript not found for this space',
+          code: 'not_found',
+        },
+      };
+    }
+    const textPayload = transcript.text;
+    const byteLength = Buffer.byteLength(textPayload, 'utf8');
+    if (byteLength > max_bytes) {
+      return {
+        access: 'ok',
+        result: {
+          ok: false,
+          error: `Response size ${byteLength} exceeds max_bytes`,
+          code: 'too_large',
+        },
+      };
+    }
+    const { text, truncated } = truncateText(textPayload, MAX_TEXT_CHARS);
+    return {
+      access: 'ok',
+      result: buildSuccessText(
+        `call-transcript-${transcript.callSessionId}.txt`,
+        'text/plain',
+        text,
+        truncated,
+        byteLength,
+      ),
+    };
+  } else if (key.k === 'ds') {
+    const summary = (await getSpaceCallArtifactById(
+      { kind: 'discussion_summary', id: key.i, spaceId: host.id },
+      { db },
+    )) as SpaceDiscussionSummary | null;
+    if (!summary) {
+      return {
+        access: 'ok',
+        result: {
+          ok: false,
+          error: 'Discussion summary not found for this space',
+          code: 'not_found',
+        },
+      };
+    }
+    const bullets = Array.isArray(summary.bullets)
+      ? summary.bullets.filter(
+          (b: unknown): b is string => typeof b === 'string',
+        )
+      : [];
+    const body = [summary.summary, ...bullets.map((b) => `- ${b}`)]
+      .join('\n')
+      .trim();
+    const byteLength = Buffer.byteLength(body, 'utf8');
+    if (byteLength > max_bytes) {
+      return {
+        access: 'ok',
+        result: {
+          ok: false,
+          error: `Response size ${byteLength} exceeds max_bytes`,
+          code: 'too_large',
+        },
+      };
+    }
+    const { text, truncated } = truncateText(body, MAX_TEXT_CHARS);
+    return {
+      access: 'ok',
+      result: buildSuccessText(
+        `discussion-summary-${summary.id}.md`,
+        'text/markdown',
+        text,
+        truncated,
+        byteLength,
+      ),
+    };
+  } else if (key.k === 'ts') {
+    const summary = await getThreadSummaryById(
+      { id: key.i, spaceId: host.id },
+      { db },
+    );
+    if (!summary) {
+      return {
+        access: 'ok',
+        result: {
+          ok: false,
+          error: 'Thread summary not found for this space',
+          code: 'not_found',
+        },
+      };
+    }
+    const bullets = Array.isArray(summary.bullets)
+      ? summary.bullets.filter(
+          (b: unknown): b is string => typeof b === 'string',
+        )
+      : [];
+    const body = [summary.summary, ...bullets.map((b) => `- ${b}`)]
+      .join('\n')
+      .trim();
+    const byteLength = Buffer.byteLength(body, 'utf8');
+    if (byteLength > max_bytes) {
+      return {
+        access: 'ok',
+        result: {
+          ok: false,
+          error: `Response size ${byteLength} exceeds max_bytes`,
+          code: 'too_large',
+        },
+      };
+    }
+    const { text, truncated } = truncateText(body, MAX_TEXT_CHARS);
+    return {
+      access: 'ok',
+      result: buildSuccessText(
+        `thread-summary-${summary.id}.md`,
+        'text/markdown',
+        text,
+        truncated,
+        byteLength,
+      ),
+    };
   }
 
   if (!fetchUrl) {

--- a/packages/core/src/governance/server/get-org-memory-by-space-slug.ts
+++ b/packages/core/src/governance/server/get-org-memory-by-space-slug.ts
@@ -1,7 +1,12 @@
 import 'server-only';
 
 import type { Document } from '../types';
-import { canConvertToBigInt } from '@hypha-platform/ui-utils';
+import {
+  canConvertToBigInt,
+  stripDescription,
+  stripMarkdown,
+} from '@hypha-platform/ui-utils';
+import { and, desc, eq } from 'drizzle-orm';
 import type { DbConfig } from '../../server';
 import { checkSpaceAccessForSpace } from '../../space/server/check-space-access-for-roster';
 import { findSpaceHostFieldsBySlug } from '../../space/server/queries';
@@ -19,11 +24,22 @@ import {
   HYPHA_MEDIA_BUNDLE_FIELD,
   type HyphaMediaBundleItemWire,
 } from '../../matrix/rich-reply';
+import { coherences } from '@hypha-platform/storage-postgres';
 import { withOrgMemoryAssetKeys } from '../../org-memory/with-org-memory-asset-keys';
+import { listSpaceCallArtifactsBySpaceId } from './call-artifacts';
+import { listThreadSummariesBySpaceId } from './thread-summaries';
+import { isMemoryDocument } from '../space-memory-document-label';
 
 /** Aligned with MCP §8.1 / architecture org memory rows. */
 export type OrgMemoryAsset = {
-  source: 'proposal_upload' | 'matrix_chat';
+  source:
+    | 'proposal_upload'
+    | 'memory'
+    | 'matrix_chat'
+    | 'call_recording'
+    | 'call_transcript'
+    | 'discussion_summary'
+    | 'thread_summary';
   filename: string;
   /** Opaque key for `fetch_org_memory_asset` (MCP / Chat). */
   asset_key?: string;
@@ -38,6 +54,12 @@ export type OrgMemoryAsset = {
   document_state?: Document['state'];
   document_slug?: string;
   document_label?: string;
+  call_session_id?: string;
+  call_recording_id?: number;
+  call_transcript_id?: number;
+  discussion_summary_id?: number;
+  thread_summary_id?: number;
+  text_excerpt?: string;
   occurred_at: string;
 };
 
@@ -58,6 +80,11 @@ export type GetOrgMemoryBySpaceSlugInput = {
    * (Space Memory / browser API parity with Human Chat).
    */
   requestUrlForSessionMatrix?: string;
+  /**
+   * `full` — user-facing Space Memory (no signal compaction).
+   * `signal` — coherence / signal orchestrator digest (applies compaction).
+   */
+  assetView?: 'full' | 'signal';
 };
 
 /** Why Matrix-backed rows may be empty (MCP / debugging — no secrets). */
@@ -201,6 +228,75 @@ function normalizeAttachment(
   };
 }
 
+function memoryDocumentExcerpt(description?: string | null): string {
+  return stripMarkdown(stripDescription(description ?? ''), {
+    extraNewlines: true,
+  }).trim();
+}
+
+function normalizeMemoryAttachment(
+  doc: Document,
+  raw: string | { name: string; url: string },
+  index: number,
+): OrgMemoryAsset | null {
+  const url = typeof raw === 'string' ? raw : raw.url;
+  const filename =
+    typeof raw === 'string'
+      ? url.split('/').pop() || `attachment-${index + 1}`
+      : raw.name || url.split('/').pop() || `attachment-${index + 1}`;
+  if (!url?.trim()) return null;
+  return {
+    source: 'memory',
+    filename,
+    app_url: url,
+    document_id: doc.id,
+    occurred_at: doc.updatedAt.toISOString(),
+    text_excerpt:
+      memoryDocumentExcerpt(doc.description).slice(0, 500) || undefined,
+    ...proposalDocContextFields(doc),
+  };
+}
+
+function collectMemoryDocumentAssets(
+  documents: Array<
+    Document & { creator?: Document['creator']; status?: Document['status'] }
+  >,
+): OrgMemoryAsset[] {
+  const out: OrgMemoryAsset[] = [];
+  const seen = new Set<string>();
+
+  for (const doc of documents) {
+    if (!isMemoryDocument(doc)) continue;
+
+    const title = doc.title?.trim() || 'Memory';
+    const excerpt = memoryDocumentExcerpt(doc.description);
+    const bodyKey = `memory:${doc.id}:body`;
+    if (!seen.has(bodyKey)) {
+      seen.add(bodyKey);
+      out.push({
+        source: 'memory',
+        filename: title,
+        document_id: doc.id,
+        occurred_at: doc.updatedAt.toISOString(),
+        text_excerpt: excerpt.slice(0, 500) || undefined,
+        ...proposalDocContextFields(doc),
+      });
+    }
+
+    const attachments = doc.attachments ?? [];
+    attachments.forEach((a, i) => {
+      const row = normalizeMemoryAttachment(doc, a, i);
+      if (!row?.app_url) return;
+      const key = `memory:${doc.id}:att:${row.app_url}`;
+      if (seen.has(key)) return;
+      seen.add(key);
+      out.push(row);
+    });
+  }
+
+  return out;
+}
+
 function collectProposalAssets(
   documents: Array<
     Document & { creator?: Document['creator']; status?: Document['status'] }
@@ -209,21 +305,6 @@ function collectProposalAssets(
   const out: OrgMemoryAsset[] = [];
   const seen = new Set<string>();
   for (const doc of documents) {
-    if (doc.leadImage?.trim()) {
-      const url = doc.leadImage;
-      const key = `doc:${doc.id}:lead`;
-      if (!seen.has(key)) {
-        seen.add(key);
-        out.push({
-          source: 'proposal_upload',
-          filename: url.split('/').pop() || 'lead-image',
-          app_url: url,
-          document_id: doc.id,
-          occurred_at: doc.updatedAt.toISOString(),
-          ...proposalDocContextFields(doc),
-        });
-      }
-    }
     const attachments = doc.attachments ?? [];
     attachments.forEach((a, i) => {
       const row = normalizeAttachment(doc, a, i);
@@ -233,6 +314,37 @@ function collectProposalAssets(
       seen.add(key);
       out.push(row);
     });
+  }
+  return out;
+}
+
+async function listSpaceMatrixRoomIds(
+  {
+    spaceId,
+    primaryRoomId,
+  }: {
+    spaceId: number;
+    primaryRoomId: string | null;
+  },
+  { db }: DbConfig,
+): Promise<string[]> {
+  const rows = await db
+    .select({ roomId: coherences.roomId })
+    .from(coherences)
+    .where(and(eq(coherences.spaceId, spaceId), eq(coherences.archived, false)))
+    .orderBy(desc(coherences.updatedAt))
+    .limit(200);
+  const seen = new Set<string>();
+  const out: string[] = [];
+  const push = (roomId: string | null | undefined) => {
+    const trimmed = roomId?.trim();
+    if (!trimmed || seen.has(trimmed)) return;
+    seen.add(trimmed);
+    out.push(trimmed);
+  };
+  push(primaryRoomId);
+  for (const row of rows) {
+    push(row.roomId);
   }
   return out;
 }
@@ -572,14 +684,143 @@ function filterAssetsBySearch(
   return assets.filter(
     (a) =>
       a.filename.toLowerCase().includes(q) ||
+      (a.text_excerpt?.toLowerCase().includes(q) ?? false) ||
       (a.app_url?.toLowerCase().includes(q) ?? false) ||
       (a.mxc_uri?.toLowerCase().includes(q) ?? false),
   );
 }
 
+function inferAssetKindForSignal(asset: OrgMemoryAsset) {
+  const name = asset.filename.toLowerCase();
+  const target = `${asset.filename} ${
+    asset.app_url ?? asset.mxc_uri ?? ''
+  }`.toLowerCase();
+  if (/\.(png|jpe?g|gif|webp|svg|avif)(\?|#|$)/i.test(target)) return 'image';
+  if (/\.(mp4|webm|mov|mkv|m4v)(\?|#|$)/i.test(target)) return 'video';
+  if (/\.(pdf|doc|docx|txt|md|csv|xls|xlsx|ppt|pptx|zip)(\?|#|$)/i.test(target))
+    return 'document';
+  if ((asset.mime ?? '').toLowerCase().startsWith('image/')) return 'image';
+  if ((asset.mime ?? '').toLowerCase().startsWith('video/')) return 'video';
+  if (
+    name.endsWith('.pdf') ||
+    name.endsWith('.doc') ||
+    name.endsWith('.docx') ||
+    name.endsWith('.txt') ||
+    name.endsWith('.md')
+  ) {
+    return 'document';
+  }
+  return 'other';
+}
+
+function looksOpaqueNoiseFilename(filename: string): boolean {
+  const raw = filename.trim();
+  if (!raw) return true;
+  const lower = raw.toLowerCase();
+  const hasExtension = /\.[a-z0-9]{2,5}(\?|#|$)/i.test(raw);
+  const alphaNumOnly = /^[a-z0-9_-]+$/i.test(raw);
+  const hashLike = alphaNumOnly && raw.length >= 28 && !hasExtension;
+  const uuidLike =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+      raw,
+    );
+  const genericScreenshot =
+    /(screenshot|screen shot|image)[\s_-]*\d*/i.test(lower) &&
+    !/(architecture|roadmap|proposal|budget|decision|minutes|plan|spec)/i.test(
+      lower,
+    );
+  return hashLike || uuidLike || genericScreenshot;
+}
+
+function orgMemoryAssetStableId(asset: OrgMemoryAsset): string {
+  const uniqueLocator =
+    asset.app_url ??
+    asset.mxc_uri ??
+    (asset.call_recording_id != null
+      ? `call-recording:${asset.call_recording_id}`
+      : null) ??
+    (asset.call_transcript_id != null
+      ? `call-transcript:${asset.call_transcript_id}`
+      : null) ??
+    (asset.discussion_summary_id != null
+      ? `discussion-summary:${asset.discussion_summary_id}`
+      : null) ??
+    (asset.thread_summary_id != null
+      ? `thread-summary:${asset.thread_summary_id}`
+      : null) ??
+    (asset.document_id != null && asset.source === 'memory' && !asset.app_url
+      ? `memory-body:${asset.document_id}`
+      : null) ??
+    `${asset.filename}:${asset.occurred_at}`;
+  return `${asset.source}:${uniqueLocator}`;
+}
+
+function compareOrgMemoryAssetsStable(
+  a: OrgMemoryAsset,
+  b: OrgMemoryAsset,
+): number {
+  const tb = Date.parse(b.occurred_at);
+  const ta = Date.parse(a.occurred_at);
+  const tbd = Number.isFinite(tb) ? tb : 0;
+  const tad = Number.isFinite(ta) ? ta : 0;
+  if (tbd !== tad) return tbd - tad;
+  return orgMemoryAssetStableId(a).localeCompare(orgMemoryAssetStableId(b));
+}
+
+function compactOrgMemoryAssetsForSignal(
+  assets: OrgMemoryAsset[],
+): OrgMemoryAsset[] {
+  const dedupeKeys = new Set<string>();
+  const imageQuotaByDocument = new Map<number, number>();
+  const compacted: OrgMemoryAsset[] = [];
+
+  for (const asset of assets) {
+    const uniqueLocator =
+      asset.app_url ??
+      asset.mxc_uri ??
+      (asset.call_recording_id != null
+        ? `call-recording:${asset.call_recording_id}`
+        : null) ??
+      (asset.call_transcript_id != null
+        ? `call-transcript:${asset.call_transcript_id}`
+        : null) ??
+      (asset.discussion_summary_id != null
+        ? `discussion-summary:${asset.discussion_summary_id}`
+        : null) ??
+      (asset.thread_summary_id != null
+        ? `thread-summary:${asset.thread_summary_id}`
+        : null) ??
+      `${asset.filename}:${asset.occurred_at}`;
+    const dedupeKey = `${asset.source}:${uniqueLocator}`;
+    if (dedupeKeys.has(dedupeKey)) continue;
+    dedupeKeys.add(dedupeKey);
+
+    const kind = inferAssetKindForSignal(asset);
+    const lowSignalName = looksOpaqueNoiseFilename(asset.filename);
+
+    if (asset.source === 'proposal_upload') {
+      if (kind === 'other' && lowSignalName) {
+        continue;
+      }
+      if (kind === 'image' && lowSignalName) {
+        continue;
+      }
+      if (kind === 'image' && asset.document_id != null) {
+        const used = imageQuotaByDocument.get(asset.document_id) ?? 0;
+        if (used >= 1) continue;
+        imageQuotaByDocument.set(asset.document_id, used + 1);
+      }
+    }
+
+    compacted.push(asset);
+  }
+
+  return compacted;
+}
+
 /**
  * Organisation memory for a space: member roster (same as `getSpaceMembersRoster`)
- * plus `org_memory_assets` from proposal document attachments/lead images and,
+ * plus `org_memory_assets` from proposal document attachments and,
  * when `NEXT_PUBLIC_MATRIX_HOMESERVER_URL` is set and either
  * `HYPHA_MATRIX_ORG_MEMORY_ACCESS_TOKEN` **or** (for HTTP with Privy JWT)
  * the caller passes `requestUrlForSessionMatrix` so the user's Matrix token
@@ -596,6 +837,7 @@ export async function getOrgMemoryBySpaceSlug(
     assetsPageSize = 50,
     assetsSearch,
     requestUrlForSessionMatrix,
+    assetView = 'full',
   }: GetOrgMemoryBySpaceSlugInput,
   { db, authToken }: DbConfig & { authToken?: string },
 ): Promise<
@@ -696,36 +938,141 @@ export async function getOrgMemoryBySpaceSlug(
     attachProposalStatusToDocument(d, proposalOutcomes),
   );
 
-  const proposalAssets = collectProposalAssets(docsWithStatus);
-
-  const matrixRoomId = host.chatRoomId?.trim() ?? '';
-  const { assets: matrixAssets, meta: matrixFetchMeta } =
-    matrixRoomId.length > 0
-      ? await fetchMatrixChatAssets(matrixRoomId, {
-          authToken,
-          requestUrlForSessionMatrix,
-        })
-      : {
-          assets: [] as OrgMemoryAsset[],
-          meta: {
-            attempted: false,
-            skipped_reason: 'missing_chat_room_id' as const,
-            chat_room_id: null,
-            ...matrixEnvFlags(),
-            used_bot_access_token: false,
-            used_session_matrix_token: false,
-            session_matrix_token_unavailable: false,
-            http_status: null,
-            events_in_chunk: 0,
-            media_events_yielded: 0,
-            hypha_media_bundle_slots: 0,
-            error: null,
-          } satisfies MatrixOrgMemoryFetchMeta,
-        };
-
-  let combined = [...proposalAssets, ...matrixAssets].sort((a, b) =>
-    a.occurred_at < b.occurred_at ? 1 : a.occurred_at > b.occurred_at ? -1 : 0,
+  const proposalAssets = collectProposalAssets(
+    docsWithStatus.filter((doc) => !isMemoryDocument(doc)),
   );
+  const memoryAssets = collectMemoryDocumentAssets(docsWithStatus);
+
+  const matrixRoomIds = await listSpaceMatrixRoomIds(
+    {
+      spaceId: host.id,
+      primaryRoomId: host.chatRoomId ?? null,
+    },
+    { db },
+  );
+  const matrixResults =
+    matrixRoomIds.length > 0
+      ? await Promise.all(
+          matrixRoomIds.map((roomId) =>
+            fetchMatrixChatAssets(roomId, {
+              authToken,
+              requestUrlForSessionMatrix,
+            }),
+          ),
+        )
+      : [];
+  const matrixAssets = matrixResults.flatMap((result) => result.assets);
+  const matrixMetaFallback: MatrixOrgMemoryFetchMeta = {
+    attempted: false,
+    skipped_reason: 'missing_chat_room_id',
+    chat_room_id: null,
+    ...matrixEnvFlags(),
+    used_bot_access_token: false,
+    used_session_matrix_token: false,
+    session_matrix_token_unavailable: false,
+    http_status: null,
+    events_in_chunk: 0,
+    media_events_yielded: 0,
+    hypha_media_bundle_slots: 0,
+    error: null,
+  };
+  const matrixFetchMeta = matrixResults.reduce<MatrixOrgMemoryFetchMeta>(
+    (aggregate, current) => {
+      aggregate.attempted = aggregate.attempted || current.meta.attempted;
+      aggregate.used_bot_access_token =
+        aggregate.used_bot_access_token || current.meta.used_bot_access_token;
+      aggregate.used_session_matrix_token =
+        aggregate.used_session_matrix_token ||
+        current.meta.used_session_matrix_token;
+      aggregate.session_matrix_token_unavailable =
+        aggregate.session_matrix_token_unavailable ||
+        current.meta.session_matrix_token_unavailable;
+      aggregate.events_in_chunk += current.meta.events_in_chunk;
+      aggregate.media_events_yielded += current.meta.media_events_yielded;
+      aggregate.hypha_media_bundle_slots +=
+        current.meta.hypha_media_bundle_slots;
+      if (current.meta.http_status != null) {
+        aggregate.http_status = current.meta.http_status;
+      }
+      if (current.meta.error) {
+        aggregate.error = aggregate.error
+          ? `${aggregate.error} | ${current.meta.error}`
+          : current.meta.error;
+      }
+      return aggregate;
+    },
+    {
+      ...matrixMetaFallback,
+      chat_room_id: matrixRoomIds[0] ?? null,
+      skipped_reason: matrixRoomIds.length > 0 ? null : 'missing_chat_room_id',
+    },
+  );
+
+  const callArtifacts = await listSpaceCallArtifactsBySpaceId(host.id, { db });
+  const recordingAssets: OrgMemoryAsset[] = callArtifacts.recordings.map(
+    (r) => {
+      const mediaUri = r.mediaUri.trim();
+      const isMxc = mediaUri.startsWith('mxc://');
+      return {
+        source: 'call_recording',
+        filename:
+          mediaUri.split('/').pop()?.trim() ||
+          `call-recording-${r.callSessionId}.webm`,
+        ...(isMxc ? { mxc_uri: mediaUri } : { app_url: mediaUri }),
+        mime: r.mimeType,
+        occurred_at: r.createdAt.toISOString(),
+        call_session_id: r.callSessionId,
+        call_recording_id: r.id,
+      };
+    },
+  );
+  const transcriptAssets: OrgMemoryAsset[] = callArtifacts.transcripts.map(
+    (t) => ({
+      source: 'call_transcript',
+      filename: `call-transcript-${t.callSessionId}.txt`,
+      mime: 'text/plain',
+      occurred_at: t.createdAt.toISOString(),
+      call_session_id: t.callSessionId,
+      call_transcript_id: t.id,
+      text_excerpt: t.summary ?? t.text.slice(0, 240),
+    }),
+  );
+  const discussionSummaryAssets: OrgMemoryAsset[] = callArtifacts.summaries.map(
+    (s) => ({
+      source: 'discussion_summary',
+      filename: `discussion-summary-${s.id}.md`,
+      mime: 'text/markdown',
+      occurred_at: s.createdAt.toISOString(),
+      discussion_summary_id: s.id,
+      text_excerpt: s.summary,
+    }),
+  );
+  const threadSummaryRows = await listThreadSummariesBySpaceId(host.id, { db });
+  const threadSummaryAssets: OrgMemoryAsset[] = threadSummaryRows.map((s) => ({
+    source: 'thread_summary',
+    filename: `thread-summary-${s.id}.md`,
+    mime: 'text/markdown',
+    matrix_room_id: s.matrixRoomId,
+    occurred_at:
+      s.updatedAt instanceof Date
+        ? s.updatedAt.toISOString()
+        : String(s.updatedAt),
+    thread_summary_id: s.id,
+    text_excerpt: s.summary,
+  }));
+
+  let combined = [
+    ...proposalAssets,
+    ...memoryAssets,
+    ...matrixAssets,
+    ...recordingAssets,
+    ...transcriptAssets,
+    ...discussionSummaryAssets,
+    ...threadSummaryAssets,
+  ].sort(compareOrgMemoryAssetsStable);
+  if (assetView === 'signal') {
+    combined = compactOrgMemoryAssetsForSignal(combined);
+  }
   combined = filterAssetsBySearch(combined, assetsSearch);
 
   const total = combined.length;

--- a/packages/core/src/governance/server/index.ts
+++ b/packages/core/src/governance/server/index.ts
@@ -5,3 +5,5 @@ export * from './get-org-memory-by-space-slug';
 export * from './get-token-holdings-by-space-slug';
 export * from './fetch-org-memory-asset';
 export * from './resolve-document-proposal-status';
+export * from './call-artifacts';
+export * from './thread-summaries';

--- a/packages/core/src/governance/server/thread-summaries-gates.ts
+++ b/packages/core/src/governance/server/thread-summaries-gates.ts
@@ -1,0 +1,33 @@
+export const THREAD_SUMMARY_REFRESH_INTERVAL_MS = 30 * 60 * 1000;
+export const THREAD_SUMMARY_MIN_MESSAGES = 3;
+export const THREAD_SUMMARY_MATRIX_MAX_PAGES = 8;
+
+export function shouldRefreshThreadSummary(params: {
+  lastMessageOriginServerTs: number | null | undefined;
+  lastSummarizedOriginServerTs: number | null | undefined;
+  lastRefreshedAt: string | null | undefined;
+  nowMs?: number;
+  force?: boolean;
+}): { ok: true } | { ok: false; reason: string } {
+  if (params.force) return { ok: true };
+  const lastMessageTs = params.lastMessageOriginServerTs ?? null;
+  if (lastMessageTs == null || lastMessageTs <= 0) {
+    return { ok: false, reason: 'no_thread_activity' };
+  }
+  const lastSummarizedTs = params.lastSummarizedOriginServerTs ?? null;
+  if (lastSummarizedTs != null && lastSummarizedTs >= lastMessageTs) {
+    return { ok: false, reason: 'no_new_messages' };
+  }
+  const lastRefreshedAt = params.lastRefreshedAt?.trim();
+  if (lastRefreshedAt) {
+    const refreshedMs = Date.parse(lastRefreshedAt);
+    if (
+      Number.isFinite(refreshedMs) &&
+      (params.nowMs ?? Date.now()) - refreshedMs <
+        THREAD_SUMMARY_REFRESH_INTERVAL_MS
+    ) {
+      return { ok: false, reason: 'rate_limited' };
+    }
+  }
+  return { ok: true };
+}

--- a/packages/core/src/governance/server/thread-summaries.ts
+++ b/packages/core/src/governance/server/thread-summaries.ts
@@ -1,0 +1,541 @@
+import 'server-only';
+
+import { and, desc, eq, isNotNull, isNull, lt, or, sql } from 'drizzle-orm';
+import { spaces, threadSummaries } from '@hypha-platform/storage-postgres';
+import type { DbConfig } from '../../server';
+import { findSpaceHostFieldsBySlug } from '../../space/server/queries';
+import {
+  generateThreadLivingSummaryWithLlm,
+  type ThreadSummaryMessageLine,
+} from './thread-summary-llm';
+
+import {
+  shouldRefreshThreadSummary,
+  THREAD_SUMMARY_MATRIX_MAX_PAGES,
+  THREAD_SUMMARY_MIN_MESSAGES,
+  THREAD_SUMMARY_REFRESH_INTERVAL_MS,
+} from './thread-summaries-gates';
+
+export {
+  shouldRefreshThreadSummary,
+  THREAD_SUMMARY_MATRIX_MAX_PAGES,
+  THREAD_SUMMARY_MIN_MESSAGES,
+  THREAD_SUMMARY_REFRESH_INTERVAL_MS,
+} from './thread-summaries-gates';
+
+type MatrixTimelineEvent = {
+  event_id?: string;
+  type?: string;
+  sender?: string;
+  content?: Record<string, unknown>;
+  origin_server_ts?: number;
+};
+
+type MatrixChunkResponse = {
+  chunk?: MatrixTimelineEvent[];
+  end?: string;
+};
+
+export type ThreadSummaryKind = 'space' | 'coherence';
+
+export type ThreadSummaryView = {
+  id: number;
+  spaceId: number;
+  matrixRoomId: string;
+  threadKind: ThreadSummaryKind;
+  coherenceSlug: string | null;
+  threadTitle: string | null;
+  summary: string;
+  bullets: string[];
+  messageCount: number;
+  participantCount: number;
+  updatedAt: string;
+  lastRefreshedAt: string | null;
+};
+
+function extractPlainMessageText(
+  content: Record<string, unknown> | undefined,
+): string | null {
+  if (!content) return null;
+  const msgtype = content.msgtype;
+  if (msgtype !== 'm.text' && msgtype !== 'm.notice') return null;
+  const body = content.body;
+  if (typeof body !== 'string') return null;
+  const cleaned = body.replace(/\s+/g, ' ').trim();
+  return cleaned.length > 0 ? cleaned : null;
+}
+
+function senderLabel(sender: string | undefined): string {
+  const value = sender?.trim();
+  if (!value) return 'Someone';
+  const local = value.split(':')[0]?.replace(/^@/, '');
+  return local || value;
+}
+
+async function resolveMatrixAccessToken(
+  authToken: string | undefined,
+  requestUrlForSessionMatrix: string | undefined,
+) {
+  const botToken = process.env.HYPHA_MATRIX_ORG_MEMORY_ACCESS_TOKEN?.trim();
+  if (botToken) return botToken;
+  const sessionAuth = authToken?.trim();
+  const sessionReqUrl = requestUrlForSessionMatrix?.trim();
+  if (!sessionAuth || !sessionReqUrl) return null;
+  const { resolveUserMatrixAccessTokenForOrgMemory } = await import(
+    './resolve-user-matrix-access-token-for-org-memory'
+  );
+  return (
+    (await resolveUserMatrixAccessTokenForOrgMemory(
+      sessionAuth,
+      sessionReqUrl,
+    )) ?? null
+  );
+}
+
+export async function fetchRoomThreadTimeline(
+  roomId: string,
+  authToken: string | undefined,
+  requestUrlForSessionMatrix: string | undefined,
+  signal?: AbortSignal,
+  maxPages = THREAD_SUMMARY_MATRIX_MAX_PAGES,
+): Promise<{
+  lines: Array<{
+    eventId: string;
+    sender: string;
+    text: string;
+    originServerTs: number;
+  }>;
+  participantIds: string[];
+}> {
+  const homeserver = process.env.NEXT_PUBLIC_MATRIX_HOMESERVER_URL?.replace(
+    /\/?$/,
+    '',
+  );
+  if (!homeserver) return { lines: [], participantIds: [] };
+  const accessToken = await resolveMatrixAccessToken(
+    authToken,
+    requestUrlForSessionMatrix,
+  );
+  if (!accessToken) return { lines: [], participantIds: [] };
+
+  const senders = new Set<string>();
+  const lines: Array<{
+    eventId: string;
+    sender: string;
+    text: string;
+    originServerTs: number;
+  }> = [];
+  let fromToken: string | undefined;
+
+  for (let i = 0; i < maxPages; i++) {
+    if (signal?.aborted) {
+      throw new Error('Thread summary fetch aborted');
+    }
+    const params = new URLSearchParams({ dir: 'b', limit: '100' });
+    if (fromToken) params.set('from', fromToken);
+    const url = `${homeserver}/_matrix/client/v3/rooms/${encodeURIComponent(
+      roomId,
+    )}/messages?${params.toString()}`;
+    const res = await fetch(url, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+      signal,
+    });
+    if (!res.ok) break;
+    const body = (await res.json()) as MatrixChunkResponse;
+    const chunk = Array.isArray(body.chunk) ? body.chunk : [];
+    for (const ev of chunk) {
+      if (ev.type !== 'm.room.message') continue;
+      const text = extractPlainMessageText(ev.content);
+      if (!text) continue;
+      if (ev.sender) senders.add(ev.sender);
+      lines.push({
+        eventId: ev.event_id?.trim() || `${ev.origin_server_ts ?? i}`,
+        sender: senderLabel(ev.sender),
+        text,
+        originServerTs: ev.origin_server_ts ?? 0,
+      });
+    }
+    const next = typeof body.end === 'string' ? body.end : undefined;
+    if (!next || chunk.length === 0) break;
+    fromToken = next;
+  }
+
+  return {
+    lines: lines.reverse(),
+    participantIds: [...senders],
+  };
+}
+
+function rowToView(
+  row: typeof threadSummaries.$inferSelect,
+): ThreadSummaryView {
+  return {
+    id: row.id,
+    spaceId: row.spaceId,
+    matrixRoomId: row.matrixRoomId,
+    threadKind: row.threadKind as ThreadSummaryKind,
+    coherenceSlug: row.coherenceSlug,
+    threadTitle: row.threadTitle,
+    summary: row.summary,
+    bullets: Array.isArray(row.bullets) ? row.bullets : [],
+    messageCount: row.messageCount,
+    participantCount: row.participantCount,
+    updatedAt:
+      row.updatedAt instanceof Date
+        ? row.updatedAt.toISOString()
+        : String(row.updatedAt),
+    lastRefreshedAt: row.lastRefreshedAt,
+  };
+}
+
+export async function getThreadSummaryForRoom(
+  {
+    spaceSlug,
+    matrixRoomId,
+  }: {
+    spaceSlug: string;
+    matrixRoomId: string;
+  },
+  { db }: DbConfig,
+): Promise<ThreadSummaryView | null> {
+  const host = await findSpaceHostFieldsBySlug({ slug: spaceSlug }, { db });
+  if (!host) return null;
+  const roomId = matrixRoomId.trim();
+  if (!roomId) return null;
+  const [row] = await db
+    .select()
+    .from(threadSummaries)
+    .where(
+      and(
+        eq(threadSummaries.spaceId, host.id),
+        eq(threadSummaries.matrixRoomId, roomId),
+      ),
+    )
+    .limit(1);
+  return row ? rowToView(row) : null;
+}
+
+export async function recordThreadActivity(
+  {
+    spaceSlug,
+    matrixRoomId,
+    threadKind,
+    coherenceSlug,
+    threadTitle,
+    lastMessageEventId,
+    lastMessageOriginServerTs,
+  }: {
+    spaceSlug: string;
+    matrixRoomId: string;
+    threadKind: ThreadSummaryKind;
+    coherenceSlug?: string | null;
+    threadTitle?: string | null;
+    lastMessageEventId: string;
+    lastMessageOriginServerTs: number;
+  },
+  { db }: DbConfig,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const host = await findSpaceHostFieldsBySlug({ slug: spaceSlug }, { db });
+  if (!host) return { ok: false, error: 'Space not found' };
+  const roomId = matrixRoomId.trim();
+  const eventId = lastMessageEventId.trim();
+  if (!roomId || !eventId) {
+    return { ok: false, error: 'matrixRoomId and lastMessageEventId required' };
+  }
+  if (
+    !Number.isFinite(lastMessageOriginServerTs) ||
+    lastMessageOriginServerTs <= 0
+  ) {
+    return { ok: false, error: 'Invalid lastMessageOriginServerTs' };
+  }
+
+  const [existing] = await db
+    .select()
+    .from(threadSummaries)
+    .where(
+      and(
+        eq(threadSummaries.spaceId, host.id),
+        eq(threadSummaries.matrixRoomId, roomId),
+      ),
+    )
+    .limit(1);
+
+  if (
+    existing?.lastMessageOriginServerTs != null &&
+    existing.lastMessageOriginServerTs >= lastMessageOriginServerTs
+  ) {
+    return { ok: true };
+  }
+
+  const now = new Date();
+  if (existing) {
+    await db
+      .update(threadSummaries)
+      .set({
+        threadKind,
+        coherenceSlug: coherenceSlug?.trim() || null,
+        threadTitle: threadTitle?.trim() || existing.threadTitle,
+        lastMessageEventId: eventId,
+        lastMessageOriginServerTs: lastMessageOriginServerTs,
+        updatedAt: now,
+      })
+      .where(eq(threadSummaries.id, existing.id));
+    return { ok: true };
+  }
+
+  await db.insert(threadSummaries).values({
+    spaceId: host.id,
+    matrixRoomId: roomId,
+    threadKind,
+    coherenceSlug: coherenceSlug?.trim() || null,
+    threadTitle: threadTitle?.trim() || null,
+    summary: '',
+    bullets: [],
+    lastMessageEventId: eventId,
+    lastMessageOriginServerTs: lastMessageOriginServerTs,
+    updatedAt: now,
+  });
+  return { ok: true };
+}
+
+export async function refreshThreadSummary(
+  {
+    spaceSlug,
+    matrixRoomId,
+    authToken,
+    requestUrlForSessionMatrix,
+    force = false,
+    signal,
+  }: {
+    spaceSlug: string;
+    matrixRoomId: string;
+    authToken?: string;
+    requestUrlForSessionMatrix?: string;
+    force?: boolean;
+    signal?: AbortSignal;
+  },
+  { db }: DbConfig,
+): Promise<
+  | { ok: true; summary: ThreadSummaryView; skipped?: false }
+  | { ok: true; skipped: true; reason: string }
+  | { ok: false; error: string }
+> {
+  const host = await findSpaceHostFieldsBySlug({ slug: spaceSlug }, { db });
+  if (!host) return { ok: false, error: 'Space not found' };
+  const roomId = matrixRoomId.trim();
+  if (!roomId) return { ok: false, error: 'matrixRoomId required' };
+
+  const [existing] = await db
+    .select()
+    .from(threadSummaries)
+    .where(
+      and(
+        eq(threadSummaries.spaceId, host.id),
+        eq(threadSummaries.matrixRoomId, roomId),
+      ),
+    )
+    .limit(1);
+
+  const gate = shouldRefreshThreadSummary({
+    lastMessageOriginServerTs: existing?.lastMessageOriginServerTs,
+    lastSummarizedOriginServerTs: existing?.lastSummarizedOriginServerTs,
+    lastRefreshedAt: existing?.lastRefreshedAt,
+    force,
+  });
+  if (!gate.ok) {
+    return { ok: true, skipped: true, reason: gate.reason };
+  }
+
+  const timeline = await fetchRoomThreadTimeline(
+    roomId,
+    authToken,
+    requestUrlForSessionMatrix,
+    signal,
+  );
+  if (timeline.lines.length < THREAD_SUMMARY_MIN_MESSAGES) {
+    return {
+      ok: true,
+      skipped: true,
+      reason: 'insufficient_messages',
+    };
+  }
+
+  const llmMessages: ThreadSummaryMessageLine[] = timeline.lines.map(
+    (line) => ({
+      sender: line.sender,
+      text: line.text,
+    }),
+  );
+
+  let summaryText = '';
+  let bullets: string[] = [];
+  let source = 'llm';
+
+  try {
+    const llm = await generateThreadLivingSummaryWithLlm({
+      threadTitle: existing?.threadTitle,
+      previousSummary: existing?.summary,
+      messages: llmMessages,
+      signal,
+    });
+    if (llm) {
+      summaryText = llm.summary.trim();
+      bullets = llm.bullets.map((b) => b.trim()).filter(Boolean);
+    }
+  } catch (error) {
+    console.error('[thread-summary] LLM generation failed', {
+      spaceSlug,
+      matrixRoomId: roomId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  if (!summaryText) {
+    const joined = llmMessages.map((m) => m.text).join(' ');
+    summaryText =
+      joined.length <= 320 ? joined : `${joined.slice(0, 317).trim()}...`;
+    bullets = llmMessages.slice(-3).map((m) => m.text);
+    source = 'heuristic_fallback';
+  }
+
+  const lastLine = timeline.lines[timeline.lines.length - 1];
+  const now = new Date();
+  const refreshedAt = now.toISOString();
+  const values = {
+    summary: summaryText,
+    bullets,
+    messageCount: timeline.lines.length,
+    participantCount: timeline.participantIds.length,
+    lastSummarizedEventId: lastLine?.eventId ?? null,
+    lastSummarizedOriginServerTs: lastLine?.originServerTs ?? null,
+    lastRefreshedAt: refreshedAt,
+    source,
+    updatedAt: now,
+    metadata: {
+      refreshedAt,
+      messageWindow: timeline.lines.length,
+    },
+  };
+
+  let row: typeof threadSummaries.$inferSelect;
+  if (existing) {
+    const [updated] = await db
+      .update(threadSummaries)
+      .set(values)
+      .where(eq(threadSummaries.id, existing.id))
+      .returning();
+    if (!updated)
+      return { ok: false, error: 'Failed to update thread summary' };
+    row = updated;
+  } else {
+    const [inserted] = await db
+      .insert(threadSummaries)
+      .values({
+        spaceId: host.id,
+        matrixRoomId: roomId,
+        threadKind: 'space',
+        summary: values.summary,
+        bullets: values.bullets,
+        messageCount: values.messageCount,
+        participantCount: values.participantCount,
+        lastSummarizedEventId: values.lastSummarizedEventId,
+        lastSummarizedOriginServerTs: values.lastSummarizedOriginServerTs,
+        lastMessageEventId: values.lastSummarizedEventId,
+        lastMessageOriginServerTs: values.lastSummarizedOriginServerTs,
+        lastRefreshedAt: values.lastRefreshedAt,
+        source: values.source,
+        metadata: values.metadata,
+        updatedAt: values.updatedAt,
+      })
+      .returning();
+    if (!inserted) {
+      return { ok: false, error: 'Failed to create thread summary' };
+    }
+    row = inserted;
+  }
+
+  return { ok: true, summary: rowToView(row) };
+}
+
+export async function listThreadSummariesDueForRefresh(
+  { limit = 100 }: { limit?: number },
+  { db }: DbConfig,
+): Promise<
+  Array<{
+    spaceSlug: string;
+    matrixRoomId: string;
+    threadKind: ThreadSummaryKind;
+    coherenceSlug: string | null;
+  }>
+> {
+  const cutoff = new Date(
+    Date.now() - THREAD_SUMMARY_REFRESH_INTERVAL_MS,
+  ).toISOString();
+
+  const rows = await db
+    .select({
+      slug: spaces.slug,
+      matrixRoomId: threadSummaries.matrixRoomId,
+      threadKind: threadSummaries.threadKind,
+      coherenceSlug: threadSummaries.coherenceSlug,
+    })
+    .from(threadSummaries)
+    .innerJoin(spaces, eq(threadSummaries.spaceId, spaces.id))
+    .where(
+      and(
+        isNotNull(threadSummaries.lastMessageOriginServerTs),
+        or(
+          isNull(threadSummaries.lastSummarizedOriginServerTs),
+          lt(
+            threadSummaries.lastSummarizedOriginServerTs,
+            threadSummaries.lastMessageOriginServerTs,
+          ),
+        ),
+        or(
+          sql`${threadSummaries.lastRefreshedAt} IS NULL`,
+          lt(threadSummaries.lastRefreshedAt, cutoff),
+        ),
+      ),
+    )
+    .orderBy(desc(threadSummaries.updatedAt))
+    .limit(limit);
+
+  return rows.map((row) => ({
+    spaceSlug: row.slug,
+    matrixRoomId: row.matrixRoomId,
+    threadKind: row.threadKind as ThreadSummaryKind,
+    coherenceSlug: row.coherenceSlug,
+  }));
+}
+
+export async function listThreadSummariesBySpaceId(
+  spaceId: number,
+  { db }: DbConfig,
+  limit = 50,
+): Promise<Array<typeof threadSummaries.$inferSelect>> {
+  return db
+    .select()
+    .from(threadSummaries)
+    .where(
+      and(
+        eq(threadSummaries.spaceId, spaceId),
+        sql`${threadSummaries.summary} <> ''`,
+      ),
+    )
+    .orderBy(desc(threadSummaries.updatedAt))
+    .limit(limit);
+}
+
+export async function getThreadSummaryById(
+  { id, spaceId }: { id: number; spaceId: number },
+  { db }: DbConfig,
+): Promise<typeof threadSummaries.$inferSelect | null> {
+  const [row] = await db
+    .select()
+    .from(threadSummaries)
+    .where(
+      and(eq(threadSummaries.id, id), eq(threadSummaries.spaceId, spaceId)),
+    )
+    .limit(1);
+  return row ?? null;
+}

--- a/packages/core/src/governance/server/thread-summary-llm.ts
+++ b/packages/core/src/governance/server/thread-summary-llm.ts
@@ -1,0 +1,94 @@
+import 'server-only';
+
+import { generateObject } from 'ai';
+import { createOpenRouter } from '@openrouter/ai-sdk-provider';
+import { z } from 'zod';
+
+const threadSummarySchema = z.object({
+  summary: z
+    .string()
+    .min(1)
+    .describe('2-4 sentence overview of the thread for catch-up'),
+  bullets: z
+    .array(z.string().min(1))
+    .min(1)
+    .max(8)
+    .describe('Key points, decisions, and open questions'),
+});
+
+export type ThreadSummaryLlmResult = z.infer<typeof threadSummarySchema>;
+
+export type ThreadSummaryMessageLine = {
+  sender: string;
+  text: string;
+};
+
+function buildOpenRouterAppHeaders(): Record<string, string> {
+  const referer =
+    process.env.OPENROUTER_HTTP_REFERER?.trim() ||
+    process.env.NEXT_PUBLIC_APP_URL?.trim() ||
+    (process.env.VERCEL_URL?.trim()
+      ? `https://${process.env.VERCEL_URL.replace(/^https?:\/\//, '')}`
+      : '') ||
+    'https://hypha.earth';
+  const title = process.env.OPENROUTER_APP_TITLE?.trim() || 'Hypha Platform';
+  return { 'HTTP-Referer': referer, 'X-Title': title };
+}
+
+const DEFAULT_MODEL = 'openai/gpt-4o-mini';
+
+function resolveModelId(): string {
+  const fromEnv = process.env.OPENROUTER_THREAD_SUMMARY_MODEL?.trim();
+  if (fromEnv) return fromEnv;
+  const chatModel = process.env.OPENROUTER_CHAT_MODEL?.trim();
+  if (chatModel && !chatModel.toLowerCase().includes('openrouter/auto')) {
+    return chatModel;
+  }
+  return DEFAULT_MODEL;
+}
+
+export async function generateThreadLivingSummaryWithLlm(params: {
+  threadTitle?: string | null;
+  previousSummary?: string | null;
+  messages: ThreadSummaryMessageLine[];
+  signal?: AbortSignal;
+}): Promise<ThreadSummaryLlmResult | null> {
+  const apiKey = process.env.OPENROUTER_API_KEY?.trim();
+  if (!apiKey) return null;
+
+  const transcript = params.messages
+    .map((line) => `${line.sender}: ${line.text}`)
+    .join('\n');
+  if (!transcript.trim()) return null;
+
+  const openrouter = createOpenRouter({
+    apiKey,
+    compatibility: 'strict',
+    headers: buildOpenRouterAppHeaders(),
+  });
+
+  const title = params.threadTitle?.trim() || 'Conversation thread';
+  const prior = params.previousSummary?.trim();
+
+  const { object } = await generateObject({
+    model: openrouter(resolveModelId()),
+    schema: threadSummarySchema,
+    abortSignal: params.signal,
+    prompt: [
+      'You summarize an ongoing team chat thread as a living document.',
+      'Write for members catching up and for institutional memory.',
+      'Be factual, neutral, and concise. Do not invent decisions.',
+      'If the thread is mostly social or inconclusive, say so plainly.',
+      '',
+      `Thread title: ${title}`,
+      prior ? `Previous summary (update and supersede):\n${prior}` : '',
+      '',
+      'Recent messages (oldest to newest):',
+      transcript,
+    ]
+      .filter(Boolean)
+      .join('\n'),
+  });
+
+  return object;
+}

--- a/packages/core/src/matrix/__tests__/call-capture-voice-announcement.test.ts
+++ b/packages/core/src/matrix/__tests__/call-capture-voice-announcement.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { speakCallCaptureVoiceAnnouncement } from '../client/hooks/call-capture-voice-announcement';
+
+describe('call-capture-voice-announcement', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('speaks trimmed announcement text when speech synthesis is available', () => {
+    const speak = vi.fn();
+    const cancel = vi.fn();
+    const getVoices = vi.fn(() => [
+      {
+        name: 'Samantha',
+        lang: 'en-US',
+        localService: true,
+      },
+    ]);
+
+    class MockSpeechSynthesisUtterance {
+      text = '';
+      lang = '';
+      rate = 1;
+      pitch = 1;
+      volume = 1;
+      voice: SpeechSynthesisVoice | null = null;
+
+      constructor(message: string) {
+        this.text = message;
+      }
+    }
+
+    vi.stubGlobal('SpeechSynthesisUtterance', MockSpeechSynthesisUtterance);
+    vi.stubGlobal('window', {
+      speechSynthesis: {
+        speak,
+        cancel,
+        getVoices,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      },
+    });
+
+    speakCallCaptureVoiceAnnouncement('  Recording has started.  ', 'en-US');
+
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(speak).toHaveBeenCalledTimes(1);
+    const utterance = speak.mock.calls[0]?.[0] as MockSpeechSynthesisUtterance;
+    expect(utterance.text).toBe('Recording has started.');
+    expect(utterance.lang).toBe('en-US');
+    expect(utterance.rate).toBeCloseTo(0.93);
+    expect(utterance.voice?.name).toBe('Samantha');
+  });
+
+  it('ignores empty announcements', () => {
+    const speak = vi.fn();
+    vi.stubGlobal('window', {
+      speechSynthesis: {
+        speak,
+        cancel: vi.fn(),
+        getVoices: vi.fn(() => []),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      },
+    });
+
+    speakCallCaptureVoiceAnnouncement('   ');
+
+    expect(speak).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/matrix/client/hooks/call-capture-voice-announcement.ts
+++ b/packages/core/src/matrix/client/hooks/call-capture-voice-announcement.ts
@@ -1,0 +1,123 @@
+import type { SpaceGroupCallCaptureMode } from './space-group-call-state';
+
+export type CallCaptureVoiceAction = 'started' | 'stopped';
+
+export type CallCaptureVoiceAnnouncementParams = {
+  action: CallCaptureVoiceAction;
+  mode: Exclude<SpaceGroupCallCaptureMode, 'none'>;
+};
+
+export type GetCallCaptureVoiceAnnouncement = (
+  params: CallCaptureVoiceAnnouncementParams,
+) => string | null | undefined;
+
+const PREFERRED_VOICE_NAME_PARTS = [
+  'samantha',
+  'karen',
+  'victoria',
+  'google uk english female',
+  'google us english',
+  'microsoft zira',
+  'microsoft aria',
+  'moira',
+  'fiona',
+  'tessa',
+  'amelie',
+  'anna',
+  'helena',
+  'paulina',
+];
+
+function resolveAnnouncementLanguage(): string {
+  if (typeof document !== 'undefined') {
+    const lang = document.documentElement.lang?.trim();
+    if (lang) return lang;
+  }
+  if (typeof navigator !== 'undefined') {
+    return navigator.language?.trim() || 'en';
+  }
+  return 'en';
+}
+
+function voiceMatchesLanguage(
+  voice: SpeechSynthesisVoice,
+  lang: string,
+): boolean {
+  const target = lang.toLowerCase();
+  const voiceLang = voice.lang.toLowerCase();
+  return (
+    voiceLang === target || voiceLang.startsWith(`${target.split('-')[0]}-`)
+  );
+}
+
+function pickAnnouncementVoice(
+  lang: string,
+  voices: SpeechSynthesisVoice[],
+): SpeechSynthesisVoice | null {
+  if (voices.length === 0) return null;
+  const langMatches = voices.filter((voice) =>
+    voiceMatchesLanguage(voice, lang),
+  );
+  const pool = langMatches.length > 0 ? langMatches : voices;
+  const ranked = [...pool].sort((a, b) => {
+    const score = (voice: SpeechSynthesisVoice) => {
+      const name = voice.name.toLowerCase();
+      let value = 0;
+      for (let i = 0; i < PREFERRED_VOICE_NAME_PARTS.length; i += 1) {
+        if (name.includes(PREFERRED_VOICE_NAME_PARTS[i]!)) {
+          value += 100 - i;
+        }
+      }
+      if (voice.localService) value += 5;
+      if (name.includes('female')) value += 3;
+      return value;
+    };
+    return score(b) - score(a);
+  });
+  return ranked[0] ?? null;
+}
+
+/** Short spoken notice when call capture starts or stops (Zoom-style compliance cue). */
+export function speakCallCaptureVoiceAnnouncement(
+  text: string | null | undefined,
+  lang = resolveAnnouncementLanguage(),
+) {
+  if (
+    typeof window === 'undefined' ||
+    typeof window.speechSynthesis === 'undefined'
+  ) {
+    return;
+  }
+  const message = text?.trim();
+  if (!message) return;
+
+  const speak = () => {
+    window.speechSynthesis.cancel();
+    const utterance = new SpeechSynthesisUtterance(message);
+    utterance.lang = lang;
+    utterance.rate = 0.93;
+    utterance.pitch = 1.02;
+    utterance.volume = 0.92;
+    const voice = pickAnnouncementVoice(
+      lang,
+      window.speechSynthesis.getVoices(),
+    );
+    if (voice) utterance.voice = voice;
+    window.speechSynthesis.speak(utterance);
+  };
+
+  const voices = window.speechSynthesis.getVoices();
+  if (voices.length > 0) {
+    speak();
+    return;
+  }
+
+  const onVoicesChanged = () => {
+    window.speechSynthesis.removeEventListener(
+      'voiceschanged',
+      onVoicesChanged,
+    );
+    speak();
+  };
+  window.speechSynthesis.addEventListener('voiceschanged', onVoicesChanged);
+}

--- a/packages/core/src/matrix/client/hooks/index.ts
+++ b/packages/core/src/matrix/client/hooks/index.ts
@@ -2,7 +2,28 @@ export * from './use-matrix-token';
 export * from './use-user-privy-id-by-matrix-id';
 export * from './use-matrix-user-ids-by-privy-subs';
 export * from './use-space-group-call';
-export { getCallControlsPhase } from './space-group-call-state';
-export { isPermissionLikeGroupCallError } from './space-group-call-utils';
+export {
+  getCallControlsPhase,
+  type SpaceGroupCallCaptureMode,
+  type SpaceGroupCallRecordingStatus,
+} from './space-group-call-state';
+export {
+  CALL_CAPTURE_NOTICE_TYPE,
+  resolveActiveRoomCaptureFromEvents,
+  resolveCaptureConsent,
+  resolveLocalCaptureConsent,
+  type SpaceGroupCallCaptureConsent,
+} from './call-capture-consent';
+export {
+  speakCallCaptureVoiceAnnouncement,
+  type CallCaptureVoiceAction,
+  type CallCaptureVoiceAnnouncementParams,
+  type GetCallCaptureVoiceAnnouncement,
+} from './call-capture-voice-announcement';
+export {
+  isMatrixRateLimitedError,
+  isPermissionLikeGroupCallError,
+  shouldIgnoreGroupCallErrorDuringCapture,
+} from './space-group-call-utils';
 export { logSpaceGroupCallEvent } from './space-group-call-telemetry';
 export type { SpaceGroupCallTelemetryEvent } from './space-group-call-telemetry';

--- a/packages/core/src/matrix/client/hooks/use-space-group-call.ts
+++ b/packages/core/src/matrix/client/hooks/use-space-group-call.ts
@@ -2,19 +2,48 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import * as MatrixSdk from 'matrix-js-sdk';
-import { ClientEvent, RoomStateEvent } from 'matrix-js-sdk';
+import { ClientEvent, RoomEvent, RoomStateEvent } from 'matrix-js-sdk';
+import type { RoomMessageEventContent } from 'matrix-js-sdk/lib/@types/events';
 import { GroupCallEventHandlerEvent } from 'matrix-js-sdk/lib/webrtc/groupCallEventHandler';
 import { useMatrix } from '../providers/matrix-provider';
-import { isPermissionLikeGroupCallError } from './space-group-call-utils';
+import {
+  isPermissionLikeGroupCallError,
+  shouldIgnoreGroupCallErrorDuringCapture,
+} from './space-group-call-utils';
 import { logSpaceGroupCallEvent } from './space-group-call-telemetry';
 import { matrixGroupCallSummaryStatsMsFromEnv } from '../matrix-webrtc-env';
 import {
   attachGroupCallWebRtcDiagnostics,
   probeMatrixTurnServerReadiness,
 } from './group-call-webrtc-diagnostics';
-import type { SpaceGroupCallState } from './space-group-call-state';
-
+import {
+  startBrowserCallTranscription,
+  startGroupCallRecording,
+  uploadRecordedCallArtifact,
+} from './call-recording';
+import type {
+  SpaceGroupCallCaptureMode,
+  SpaceGroupCallRecordingStatus,
+  SpaceGroupCallState,
+} from './space-group-call-state';
+import {
+  CALL_CAPTURE_NOTICE_TYPE,
+  resolveActiveRoomCaptureFromEvents,
+  resolveCaptureConsent,
+  resolveLocalCaptureConsent,
+  type SpaceGroupCallCaptureConsent,
+} from './call-capture-consent';
+import {
+  speakCallCaptureVoiceAnnouncement,
+  type GetCallCaptureVoiceAnnouncement,
+} from './call-capture-voice-announcement';
 export type { SpaceGroupCallState } from './space-group-call-state';
+export type {
+  SpaceGroupCallCaptureMode,
+  SpaceGroupCallRecordingStatus,
+} from './space-group-call-state';
+export type { SpaceGroupCallCaptureConsent } from './call-capture-consent';
+export type { GetCallCaptureVoiceAnnouncement } from './call-capture-voice-announcement';
 
 export type SpaceGroupCallErrorCode =
   | 'NO_CLIENT'
@@ -27,6 +56,16 @@ export type SpaceGroupCallErrorCode =
 
 const { GroupCallEvent, GroupCallIntent, GroupCallType, GroupCallState } =
   MatrixSdk;
+
+const CAPTURE_START_STALL_MS = 8_000;
+
+function isCaptureEligibleCallState(state: SpaceGroupCallState): boolean {
+  return (
+    state === 'connected' ||
+    state === 'awaiting_media' ||
+    state === 'connecting'
+  );
+}
 
 /** Abort `gc.enter()` hang (SFU/TURN stuck) — user-recoverable via Retry. */
 const CONNECT_STALL_ABORT_MS = 90_000;
@@ -49,10 +88,15 @@ const PLACE_OUTGOING_DELAYED_MS = 600;
 const PLACE_OUTGOING_RETRY_MS = [1500, 4000, 8000] as const;
 const ROOM_CALL_PERMISSION_REPAIR_TIMEOUT_MS = 30_000;
 const VOICE_PROCESSING_PRESET_KEY = 'hypha-group-call-voice-processing-v1';
+const CALL_CAPTURE_NOTICE_BODY = 'Hypha call capture notice';
 
 export type SpaceGroupCallOptions = {
   authToken?: string | null;
   spaceSlug?: string | null;
+  /** Fired after call recording/transcript artifacts are persisted successfully. */
+  onCallArtifactsUploaded?: (params: { spaceSlug: string }) => void;
+  /** Localized spoken notice when capture starts or stops (Zoom-style compliance cue). */
+  getCaptureVoiceAnnouncement?: GetCallCaptureVoiceAnnouncement;
 };
 export type SpaceGroupCallVoiceProcessingPreset =
   | 'standard'
@@ -195,7 +239,19 @@ export function useSpaceGroupCall(
   options: SpaceGroupCallOptions = {},
 ) {
   const { client } = useMatrix();
-  const { authToken = null, spaceSlug = null } = options;
+  const {
+    authToken = null,
+    spaceSlug = null,
+    onCallArtifactsUploaded,
+    getCaptureVoiceAnnouncement,
+  } = options;
+  const latestAuthTokenRef = useRef<string | null>(authToken?.trim() || null);
+  const latestSpaceSlugRef = useRef<string | null>(spaceSlug?.trim() || null);
+  const onCallArtifactsUploadedRef = useRef(onCallArtifactsUploaded);
+  const getCaptureVoiceAnnouncementRef = useRef(getCaptureVoiceAnnouncement);
+  const prevActiveRoomCaptureRef = useRef<SpaceGroupCallCaptureConsent | null>(
+    null,
+  );
 
   const [callState, setCallState] = useState<SpaceGroupCallState>('idle');
   const [errorCode, setErrorCode] = useState<SpaceGroupCallErrorCode | null>(
@@ -223,6 +279,18 @@ export function useSpaceGroupCall(
   /** Screenshare-only failure (does not end the call). */
   const [screenshareErrorCode, setScreenshareErrorCode] =
     useState<SpaceGroupCallErrorCode | null>(null);
+  const [recordingStatus, setRecordingStatus] =
+    useState<SpaceGroupCallRecordingStatus>('idle');
+  const [recordingError, setRecordingError] = useState<string | null>(null);
+  const [capturePreference, setCapturePreference] = useState<
+    Exclude<SpaceGroupCallCaptureMode, 'none'>
+  >('recording_with_transcript');
+  const [capturePreferenceSelected, setCapturePreferenceSelected] =
+    useState(false);
+  const [captureMode, setCaptureMode] =
+    useState<SpaceGroupCallCaptureMode>('none');
+  const [activeRoomCapture, setActiveRoomCapture] =
+    useState<SpaceGroupCallCaptureConsent | null>(null);
 
   const groupCallRef = useRef<MatrixSdk.GroupCall | null>(null);
   /**
@@ -268,6 +336,23 @@ export function useSpaceGroupCall(
   const remoteMediaRecoverRequestedRef = useRef(false);
   const remoteMediaRecoverAttemptedRef = useRef(false);
   const remoteMediaRecoverInFlightRef = useRef(false);
+  const recordingGenerationRef = useRef(0);
+  const recordingFinalizeInFlightRef = useRef(false);
+  const recordingFinalizeGenerationRef = useRef<number | null>(null);
+  const recordingRuntimeRef = useRef<{
+    generation: number;
+    mode: SpaceGroupCallCaptureMode;
+    pauseRecorder?: () => void;
+    resumeRecorder?: () => void;
+    stopRecorder?: () => Promise<Blob>;
+    pauseTranscript?: () => Promise<void> | void;
+    resumeTranscript?: () => void;
+    stopTranscript: () => Promise<string> | string;
+    mimeType?: string;
+    startedAt: string;
+    recordedRoomId: string;
+  } | null>(null);
+  const captureModeRef = useRef<SpaceGroupCallCaptureMode>('none');
   const [remoteMediaRecoverNonce, setRemoteMediaRecoverNonce] = useState(0);
   const [remoteMediaStall, setRemoteMediaStall] = useState(false);
 
@@ -284,6 +369,37 @@ export function useSpaceGroupCall(
    */
   const [idleRoomParticipantCount, setIdleRoomParticipantCount] = useState(0);
   const [idleInCallUserIds, setIdleInCallUserIds] = useState<string[]>([]);
+
+  useEffect(() => {
+    latestAuthTokenRef.current = authToken?.trim() || null;
+  }, [authToken]);
+
+  useEffect(() => {
+    latestSpaceSlugRef.current = spaceSlug?.trim() || null;
+  }, [spaceSlug]);
+
+  useEffect(() => {
+    onCallArtifactsUploadedRef.current = onCallArtifactsUploaded;
+  }, [onCallArtifactsUploaded]);
+
+  useEffect(() => {
+    getCaptureVoiceAnnouncementRef.current = getCaptureVoiceAnnouncement;
+  }, [getCaptureVoiceAnnouncement]);
+
+  const playCaptureVoiceAnnouncement = useCallback(
+    (
+      action: 'started' | 'stopped',
+      mode: Exclude<SpaceGroupCallCaptureMode, 'none'>,
+    ) => {
+      const text = getCaptureVoiceAnnouncementRef.current?.({ action, mode });
+      speakCallCaptureVoiceAnnouncement(text);
+    },
+    [],
+  );
+
+  useEffect(() => {
+    captureModeRef.current = captureMode;
+  }, [captureMode]);
 
   const setActiveKeyFromGroupCall = useCallback((gc: MatrixSdk.GroupCall) => {
     const f = gc.activeSpeaker;
@@ -316,7 +432,191 @@ export function useSpaceGroupCall(
     }
   }, []);
 
+  const announceCaptureNotice = useCallback(
+    async (
+      action: 'started' | 'stopped',
+      mode: Exclude<SpaceGroupCallCaptureMode, 'none'>,
+    ) => {
+      const activeRoomId = roomId?.trim();
+      if (!client || !activeRoomId) return;
+      const noticeId = `${Date.now()}-${Math.random()
+        .toString(36)
+        .slice(2, 8)}`;
+      try {
+        const noticePayload = {
+          msgtype: MatrixSdk.MsgType.Notice,
+          body: CALL_CAPTURE_NOTICE_BODY,
+          [CALL_CAPTURE_NOTICE_TYPE]: true,
+          notice_id: noticeId,
+          action,
+          mode,
+          sent_at: new Date().toISOString(),
+        } as RoomMessageEventContent;
+        await client.sendEvent(
+          activeRoomId,
+          MatrixSdk.EventType.RoomMessage,
+          noticePayload,
+        );
+      } catch {
+        // best effort; recording can continue without room-wide notice
+      }
+    },
+    [client, roomId],
+  );
+
+  const finalizeRecording = useCallback(() => {
+    const runtime = recordingRuntimeRef.current;
+    const runtimeGeneration = runtime?.generation ?? null;
+    if (
+      recordingFinalizeInFlightRef.current &&
+      runtimeGeneration != null &&
+      recordingFinalizeGenerationRef.current === runtimeGeneration
+    ) {
+      return;
+    }
+
+    const token = latestAuthTokenRef.current;
+    const slug = latestSpaceSlugRef.current;
+    const activeRoomId = runtime?.recordedRoomId?.trim() || roomId?.trim();
+    if (!runtime) {
+      recordingRuntimeRef.current = null;
+      if (!recordingFinalizeInFlightRef.current) {
+        setRecordingStatus('idle');
+      }
+      return;
+    }
+    if (!token || !activeRoomId) {
+      recordingRuntimeRef.current = null;
+      void (async () => {
+        try {
+          if (runtime.stopRecorder) {
+            await runtime.stopRecorder();
+          }
+        } catch {
+          // ignore recorder stop errors during teardown-only cleanup
+        }
+        try {
+          await runtime.stopTranscript();
+        } catch {
+          // ignore transcript stop errors during teardown-only cleanup
+        }
+        if (!recordingFinalizeInFlightRef.current) {
+          setRecordingStatus('error');
+          setRecordingError(
+            !token
+              ? 'recording upload skipped: missing auth token'
+              : 'recording upload skipped: missing room context',
+          );
+        }
+      })();
+      return;
+    }
+    if (!slug) {
+      recordingRuntimeRef.current = null;
+      void (async () => {
+        try {
+          if (runtime.stopRecorder) {
+            await runtime.stopRecorder();
+          }
+        } catch {
+          // ignore recorder stop errors during teardown-only cleanup
+        }
+        try {
+          await runtime.stopTranscript();
+        } catch {
+          // ignore transcript stop errors during teardown-only cleanup
+        }
+        if (!recordingFinalizeInFlightRef.current) {
+          setRecordingStatus('error');
+          setRecordingError('recording upload skipped: missing space slug');
+        }
+      })();
+      return;
+    }
+
+    const cleanupGeneration = runtime.generation;
+    recordingFinalizeInFlightRef.current = true;
+    recordingFinalizeGenerationRef.current = cleanupGeneration;
+    recordingRuntimeRef.current = null;
+    setRecordingStatus('uploading');
+    if (
+      runtime.mode === 'recording_with_transcript' ||
+      runtime.mode === 'transcript_only'
+    ) {
+      void announceCaptureNotice('stopped', runtime.mode);
+      playCaptureVoiceAnnouncement('stopped', runtime.mode);
+    }
+    void (async () => {
+      try {
+        const endedAt = new Date().toISOString();
+        const transcriptText = await runtime.stopTranscript();
+        const sessionId = callSessionId ?? newCallSessionId();
+        const normalizedTranscript = transcriptText.trim();
+        const uploadTranscriptOnly = async () => {
+          if (!normalizedTranscript) {
+            throw new Error(
+              'Nothing was captured to save. Keep capture running for a few seconds, speak into your mic, and ensure call audio/video is connected before stopping.',
+            );
+          }
+          await uploadRecordedCallArtifact({
+            authToken: token,
+            spaceSlug: slug,
+            roomId: activeRoomId,
+            callSessionId: sessionId,
+            transcriptText: normalizedTranscript,
+            startedAt: runtime.startedAt,
+            endedAt,
+          });
+        };
+        if (runtime.mode === 'transcript_only') {
+          await uploadTranscriptOnly();
+        } else if (runtime.mode === 'recording_with_transcript') {
+          if (!runtime.stopRecorder || !runtime.mimeType) {
+            await uploadTranscriptOnly();
+          } else {
+            const blob = await runtime.stopRecorder();
+            if (blob.size === 0) {
+              await uploadTranscriptOnly();
+            } else {
+              await uploadRecordedCallArtifact({
+                authToken: token,
+                spaceSlug: slug,
+                roomId: activeRoomId,
+                callSessionId: sessionId,
+                blob,
+                mimeType: runtime.mimeType,
+                transcriptText: normalizedTranscript,
+                startedAt: runtime.startedAt,
+                endedAt,
+              });
+            }
+          }
+        }
+        if (recordingFinalizeGenerationRef.current === cleanupGeneration) {
+          setRecordingStatus('idle');
+          setRecordingError(null);
+          onCallArtifactsUploadedRef.current?.({ spaceSlug: slug });
+        }
+      } catch (error) {
+        if (recordingFinalizeGenerationRef.current === cleanupGeneration) {
+          setRecordingStatus('error');
+          setRecordingError(
+            error instanceof Error ? error.message : String(error),
+          );
+        }
+      } finally {
+        if (recordingFinalizeGenerationRef.current === cleanupGeneration) {
+          recordingFinalizeInFlightRef.current = false;
+          recordingFinalizeGenerationRef.current = null;
+        }
+      }
+    })();
+  }, [announceCaptureNotice, callSessionId, playCaptureVoiceAnnouncement, roomId]);
+
   const runCleanup = useCallback(() => {
+    finalizeRecording();
+    setCaptureMode('none');
+
     clearConnectingStallTimer();
     clearMediaDebugInterval();
     if (placeOutgoingNudgeTimerRef.current != null) {
@@ -390,9 +690,14 @@ export function useSpaceGroupCall(
     setActiveSpeakerKey(null);
     setCallSessionId(null);
     setScreenshareErrorCode(null);
+    setCapturePreferenceSelected(false);
+    if (!recordingFinalizeInFlightRef.current) {
+      setRecordingStatus('idle');
+      setRecordingError(null);
+    }
     loggedStatsForGroupCallIdRef.current = null;
     lastRoomIdForTelemetryRef.current = null;
-  }, [clearConnectingStallTimer, clearMediaDebugInterval]);
+  }, [clearConnectingStallTimer, clearMediaDebugInterval, finalizeRecording]);
 
   const refreshLocalPreview = useCallback(() => {
     const gc = groupCallRef.current;
@@ -626,6 +931,27 @@ export function useSpaceGroupCall(
       groupCallListenerCleanupRef.current = null;
 
       const onError = (err: unknown) => {
+        const captureActive =
+          captureModeRef.current !== 'none' ||
+          recordingRuntimeRef.current != null ||
+          recordingFinalizeInFlightRef.current;
+        if (shouldIgnoreGroupCallErrorDuringCapture(err, captureActive)) {
+          if (roomId) {
+            logSpaceGroupCallEvent({
+              name: 'hypha.group_call.error_ignored',
+              roomId,
+              kind: lastJoinKindRef.current ?? undefined,
+              errorCode: 'WEBRTC_FAILED',
+            });
+          }
+          if (process.env.NODE_ENV === 'development') {
+            console.warn(
+              '[hypha.group_call] Ignoring transient group call error during capture',
+              err,
+            );
+          }
+          return;
+        }
         const isPerm = isPermissionLikeGroupCallError(err);
         const code: SpaceGroupCallErrorCode = isPerm
           ? 'PERMISSION_DENIED'
@@ -1372,6 +1698,210 @@ export function useSpaceGroupCall(
   }, []);
 
   useEffect(() => {
+    if (!isCaptureEligibleCallState(callState)) return;
+    if (recordingRuntimeRef.current) return;
+    if (recordingFinalizeInFlightRef.current) return;
+    if (captureMode === 'none') {
+      if (!recordingFinalizeInFlightRef.current) {
+        setRecordingStatus('idle');
+        setRecordingError(null);
+      }
+      return;
+    }
+    const gc = groupCallRef.current;
+    const sessionId = callSessionId?.trim();
+    const activeRoom = roomId?.trim();
+    if (!gc || !sessionId || !activeRoom) return;
+
+    const transcript = startBrowserCallTranscription({
+      onError: () => {
+        // recording continues even if speech recognition fails
+      },
+    });
+    if (captureMode === 'transcript_only' && transcript.supported === false) {
+      setRecordingStatus('error');
+      setRecordingError('transcript capture is not supported in this browser');
+      setCaptureMode('none');
+      return;
+    }
+    let recorder: ReturnType<typeof startGroupCallRecording> | null = null;
+    if (captureMode === 'recording_with_transcript') {
+      recorder = startGroupCallRecording(gc);
+      if (!recorder) {
+        void transcript.stop();
+        setRecordingStatus('error');
+        setRecordingError('recording not supported by this browser');
+        setCaptureMode('none');
+        return;
+      }
+    }
+    const generation = recordingGenerationRef.current + 1;
+    recordingGenerationRef.current = generation;
+    recordingRuntimeRef.current = {
+      generation,
+      mode: captureMode,
+      pauseRecorder: recorder?.pause,
+      resumeRecorder: recorder?.resume,
+      stopRecorder: recorder?.stop,
+      pauseTranscript: transcript.pause,
+      resumeTranscript: transcript.resume,
+      stopTranscript: transcript.stop,
+      mimeType: recorder?.mimeType,
+      startedAt: new Date().toISOString(),
+      recordedRoomId: activeRoom,
+    };
+    setRecordingStatus('recording');
+    setRecordingError(null);
+    void announceCaptureNotice('started', captureMode);
+    playCaptureVoiceAnnouncement('started', captureMode);
+  }, [
+    announceCaptureNotice,
+    callSessionId,
+    callState,
+    captureMode,
+    feedVersion,
+    groupCall,
+    playCaptureVoiceAnnouncement,
+    roomId,
+  ]);
+
+  useEffect(() => {
+    if (captureMode === 'none') return;
+    if (recordingRuntimeRef.current) return;
+    if (recordingFinalizeInFlightRef.current) return;
+    if (recordingStatus !== 'idle') return;
+    if (!isCaptureEligibleCallState(callState)) return;
+
+    const timer = window.setTimeout(() => {
+      if (captureModeRef.current === 'none') return;
+      if (recordingRuntimeRef.current) return;
+      if (recordingFinalizeInFlightRef.current) return;
+      setRecordingStatus('error');
+      setRecordingError(
+        'Call capture could not start. Stop capture and try again, or leave and rejoin the call.',
+      );
+      setCaptureMode('none');
+    }, CAPTURE_START_STALL_MS);
+
+    return () => {
+      window.clearTimeout(timer);
+    };
+  }, [
+    callState,
+    captureMode,
+    callSessionId,
+    groupCall,
+    recordingStatus,
+    roomId,
+  ]);
+
+  const startCapture = useCallback(
+    (mode?: Exclude<SpaceGroupCallCaptureMode, 'none'>) => {
+      if (recordingFinalizeInFlightRef.current) return;
+      const nextMode = mode ?? capturePreference;
+      setCapturePreference(nextMode);
+      setCapturePreferenceSelected(true);
+      if (recordingRuntimeRef.current) return;
+      setCaptureMode(nextMode);
+    },
+    [capturePreference],
+  );
+
+  const stopCapture = useCallback(() => {
+    const pendingMode = captureModeRef.current;
+    if (recordingRuntimeRef.current || recordingFinalizeInFlightRef.current) {
+      finalizeRecording();
+    } else if (
+      pendingMode === 'recording_with_transcript' ||
+      pendingMode === 'transcript_only'
+    ) {
+      setRecordingStatus('idle');
+      setRecordingError(null);
+      void announceCaptureNotice('stopped', pendingMode);
+    } else {
+      setRecordingStatus('idle');
+      setRecordingError(null);
+    }
+    setCaptureMode('none');
+  }, [announceCaptureNotice, finalizeRecording]);
+
+  const pauseCapture = useCallback(() => {
+    const runtime = recordingRuntimeRef.current;
+    if (!runtime) return;
+    if (recordingStatus === 'paused' || recordingStatus === 'uploading') return;
+    runtime.pauseRecorder?.();
+    void Promise.resolve(runtime.pauseTranscript?.()).finally(() => {
+      setRecordingStatus('paused');
+    });
+  }, [recordingStatus]);
+
+  const resumeCapture = useCallback(() => {
+    const runtime = recordingRuntimeRef.current;
+    if (!runtime) return;
+    if (recordingStatus !== 'paused') return;
+    runtime.resumeRecorder?.();
+    runtime.resumeTranscript?.();
+    setRecordingStatus('recording');
+  }, [recordingStatus]);
+
+  useEffect(() => {
+    if (!client || !roomId?.trim()) {
+      setActiveRoomCapture(null);
+      return;
+    }
+    const activeRoomId = roomId.trim();
+    const room = client.getRoom(activeRoomId);
+    if (!room) {
+      setActiveRoomCapture(null);
+      return;
+    }
+    const localUserId = client.getUserId() ?? null;
+    const syncFromTimeline = () => {
+      const recent = room.getLiveTimeline()?.getEvents()?.slice().reverse();
+      if (!recent?.length) {
+        setActiveRoomCapture(null);
+        return;
+      }
+      setActiveRoomCapture(
+        resolveActiveRoomCaptureFromEvents(
+          recent,
+          (senderId) => room.getMember(senderId)?.name || senderId,
+          localUserId,
+        ),
+      );
+    };
+
+    syncFromTimeline();
+    const onTimeline = () => {
+      syncFromTimeline();
+    };
+    room.on(RoomEvent.Timeline, onTimeline);
+    return () => {
+      room.off(RoomEvent.Timeline, onTimeline);
+    };
+  }, [client, roomId]);
+
+  const captureConsent = useMemo(() => {
+    const localCapture = resolveLocalCaptureConsent({
+      captureMode,
+      recordingStatus,
+    });
+    return resolveCaptureConsent(activeRoomCapture, localCapture);
+  }, [activeRoomCapture, captureMode, recordingStatus]);
+
+  useEffect(() => {
+    const prev = prevActiveRoomCaptureRef.current;
+    const next = activeRoomCapture;
+    prevActiveRoomCaptureRef.current = next;
+
+    if (next && !prev && !next.isLocalInitiator) {
+      playCaptureVoiceAnnouncement('started', next.mode);
+    } else if (!next && prev && !prev.isLocalInitiator) {
+      playCaptureVoiceAnnouncement('stopped', prev.mode);
+    }
+  }, [activeRoomCapture, playCaptureVoiceAnnouncement]);
+
+  useEffect(() => {
     if (!groupCallRef.current) return;
     if (activeGroupCallRoomIdRef.current === roomId) return;
     if (lastRoomIdForTelemetryRef.current) {
@@ -1639,6 +2169,14 @@ export function useSpaceGroupCall(
     setScreenshareErrorCode(null);
   }, []);
 
+  useEffect(() => {
+    if (!recordingRuntimeRef.current) return;
+    if (callState === 'idle' || callState === 'error') {
+      finalizeRecording();
+      setCaptureMode('none');
+    }
+  }, [callState, finalizeRecording]);
+
   const dismissCallError = useCallback(() => {
     if (callState !== 'error') return;
     setErrorCode(null);
@@ -1647,6 +2185,13 @@ export function useSpaceGroupCall(
     setThreadContext(null);
     isJoiningRef.current = false;
   }, [callState]);
+
+  const updateCapturePreference = useCallback(
+    (mode: Exclude<SpaceGroupCallCaptureMode, 'none'>) => {
+      setCapturePreference(mode);
+    },
+    [],
+  );
 
   const retryFromError = useCallback(() => {
     if (callState !== 'error') return;
@@ -1697,6 +2242,18 @@ export function useSpaceGroupCall(
     callSessionId,
     errorCode,
     screenshareErrorCode,
+    recordingStatus,
+    recordingError,
+    captureMode,
+    setCaptureMode,
+    capturePreference,
+    capturePreferenceSelected,
+    setCapturePreference: updateCapturePreference,
+    startCapture,
+    pauseCapture,
+    resumeCapture,
+    stopCapture,
+    captureConsent,
     dismissScreenshareError,
     dismissCallError,
     retryFromError,

--- a/packages/core/src/matrix/client/hooks/use-space-group-call.ts
+++ b/packages/core/src/matrix/client/hooks/use-space-group-call.ts
@@ -611,7 +611,12 @@ export function useSpaceGroupCall(
         }
       }
     })();
-  }, [announceCaptureNotice, callSessionId, playCaptureVoiceAnnouncement, roomId]);
+  }, [
+    announceCaptureNotice,
+    callSessionId,
+    playCaptureVoiceAnnouncement,
+    roomId,
+  ]);
 
   const runCleanup = useCallback(() => {
     finalizeRecording();

--- a/packages/core/src/org-memory/build-space-memory-items.ts
+++ b/packages/core/src/org-memory/build-space-memory-items.ts
@@ -1,7 +1,16 @@
 import type { Attachment, Document } from '../governance/types';
 import { DocumentState } from '../governance/types';
+import { isMemoryDocument } from '../governance/space-memory-document-label';
+import { stripDescription, stripMarkdown } from '@hypha-platform/ui-utils';
 
-export type SpaceMemorySource = 'proposal_upload' | 'matrix_chat';
+export type SpaceMemorySource =
+  | 'proposal_upload'
+  | 'memory'
+  | 'matrix_chat'
+  | 'call_recording'
+  | 'call_transcript'
+  | 'discussion_summary'
+  | 'thread_summary';
 
 export type SpaceMemoryAssetKind = 'document' | 'image' | 'video' | 'other';
 
@@ -19,12 +28,20 @@ export type SpaceMemoryItem = {
     documentSlug?: string;
     documentLabel?: string;
     matrixEventId?: string;
+    textExcerpt?: string;
   };
 };
 
 /** JSON shape of `org_memory_assets[]` from `/api/v1/spaces/.../org-memory` (dates are ISO strings). */
 export type OrgMemoryAssetWire = {
-  source: 'proposal_upload' | 'matrix_chat';
+  source:
+    | 'proposal_upload'
+    | 'memory'
+    | 'matrix_chat'
+    | 'call_recording'
+    | 'call_transcript'
+    | 'discussion_summary'
+    | 'thread_summary';
   filename: string;
   asset_key?: string;
   mime?: string;
@@ -37,6 +54,10 @@ export type OrgMemoryAssetWire = {
   document_state?: string;
   document_slug?: string;
   document_label?: string;
+  call_session_id?: string;
+  discussion_summary_id?: number;
+  thread_summary_id?: number;
+  text_excerpt?: string;
   occurred_at: string;
 };
 
@@ -97,6 +118,14 @@ function normalizeHttpUrl(raw: string): string | null {
   }
 }
 
+function resolveOrgMemoryMxcUri(asset: OrgMemoryAssetWire): string | null {
+  const fromField = asset.mxc_uri?.trim();
+  if (fromField?.startsWith('mxc://')) return fromField;
+  const fromAppUrl = asset.app_url?.trim();
+  if (fromAppUrl?.startsWith('mxc://')) return fromAppUrl;
+  return null;
+}
+
 function inferKind(name: string, url: string): SpaceMemoryAssetKind {
   const has = (value: string, exts: string) =>
     new RegExp(`\\.(${exts})(\\?|$)`, 'i').test(value);
@@ -142,13 +171,20 @@ function documentActivityIso(doc: Document): string {
   return new Date(0).toISOString();
 }
 
+function memoryDocumentExcerpt(description?: string | null): string {
+  return stripMarkdown(stripDescription(description ?? ''), {
+    extraNewlines: true,
+  }).trim();
+}
+
 export function documentStateForContext(
   state: Document['state'],
 ): DocumentState {
   if (
     state === DocumentState.DISCUSSION ||
     state === DocumentState.PROPOSAL ||
-    state === DocumentState.AGREEMENT
+    state === DocumentState.AGREEMENT ||
+    state === DocumentState.MEMORY
   ) {
     return state;
   }
@@ -156,6 +192,7 @@ export function documentStateForContext(
   if (s === DocumentState.DISCUSSION) return DocumentState.DISCUSSION;
   if (s === DocumentState.PROPOSAL) return DocumentState.PROPOSAL;
   if (s === DocumentState.AGREEMENT) return DocumentState.AGREEMENT;
+  if (s === DocumentState.MEMORY) return DocumentState.MEMORY;
   return DocumentState.PROPOSAL;
 }
 
@@ -170,7 +207,6 @@ export function buildSpaceMemoryItemsFromDocuments(
 
   for (const doc of documents) {
     const activityIso = documentActivityIso(doc);
-    const attachmentUrls = new Set<string>();
     const docTitle = doc.title?.trim() || '';
     const stateEnum = documentStateForContext(doc.state);
     const baseContext = {
@@ -181,36 +217,46 @@ export function buildSpaceMemoryItemsFromDocuments(
       documentLabel: doc.label?.trim() || undefined,
     };
 
+    if (isMemoryDocument(doc)) {
+      const excerpt = memoryDocumentExcerpt(doc.description);
+      items.push({
+        id: `${doc.id}:memory`,
+        name: docTitle || 'Memory',
+        url: `memory://document/${doc.id}`,
+        kind: 'document',
+        source: 'memory',
+        uploadedAt: activityIso,
+        context: {
+          ...baseContext,
+          documentState: DocumentState.MEMORY,
+          textExcerpt: excerpt || undefined,
+        },
+      });
+    }
+
+    const uploadSource: SpaceMemorySource = isMemoryDocument(doc)
+      ? 'memory'
+      : 'proposal_upload';
+
     const attachments = doc.attachments ?? [];
     attachments.forEach((raw, index) => {
       const { name, url } = normalizeAttachment(raw);
       const safeUrl = normalizeHttpUrl(url);
       if (!safeUrl) return;
-      attachmentUrls.add(safeUrl);
       items.push({
         id: `${doc.id}:attachment:${index}`,
         name,
         url: safeUrl,
         kind: inferKind(name, safeUrl),
-        source: 'proposal_upload',
+        source: uploadSource,
         uploadedAt: activityIso,
         context: { ...baseContext },
       });
     });
 
-    const lead = doc.leadImage ? normalizeHttpUrl(doc.leadImage) : null;
-    if (lead && !attachmentUrls.has(lead)) {
-      const name = fileNameFromUrl(lead);
-      items.push({
-        id: `${doc.id}:lead`,
-        name,
-        url: lead,
-        kind: inferKind(name, lead),
-        source: 'proposal_upload',
-        uploadedAt: activityIso,
-        context: { ...baseContext },
-      });
-    }
+    // Proposal/document leadImage is a decorative header banner (often auto-copied
+    // from the space hero). Real uploads live in `attachments` — omit leadImage
+    // from Space Memory / org_memory_assets.
   }
 
   items.sort((a, b) => {
@@ -280,6 +326,49 @@ export function buildSpaceMemoryItemsFromOrgMemoryPayload(
       continue;
     }
 
+    if (a.source === 'memory') {
+      const docId = a.document_id ?? 0;
+      const title = a.document_title?.trim() || a.filename?.trim() || 'Memory';
+      const excerpt = a.text_excerpt?.trim() || '';
+      const safeUrl = a.app_url ? normalizeHttpUrl(a.app_url) : null;
+      if (safeUrl) {
+        items.push({
+          id: `memory:${docId}:${safeUrl}`,
+          name: a.filename?.trim() ? a.filename : fileNameFromUrl(safeUrl),
+          url: safeUrl,
+          kind: inferKindFromMime(a.mime, a.filename, safeUrl),
+          source: 'memory',
+          uploadedAt,
+          context: {
+            documentId: docId,
+            documentTitle: title,
+            documentState: DocumentState.MEMORY,
+            documentSlug: a.document_slug,
+            documentLabel: a.document_label?.trim() || undefined,
+            textExcerpt: excerpt || undefined,
+          },
+        });
+        continue;
+      }
+      items.push({
+        id: `memory:${docId}:body`,
+        name: title,
+        url: `memory://document/${docId}`,
+        kind: 'document',
+        source: 'memory',
+        uploadedAt,
+        context: {
+          documentId: docId,
+          documentTitle: title,
+          documentState: DocumentState.MEMORY,
+          documentSlug: a.document_slug,
+          documentLabel: a.document_label?.trim() || undefined,
+          textExcerpt: excerpt || undefined,
+        },
+      });
+      continue;
+    }
+
     if (a.source === 'matrix_chat') {
       const mxc = a.mxc_uri?.trim() ?? '';
       const room = a.matrix_room_id?.trim() ?? '';
@@ -302,6 +391,63 @@ export function buildSpaceMemoryItemsFromOrgMemoryPayload(
           documentTitle: '',
           documentState: DocumentState.PROPOSAL,
           matrixEventId: ev || undefined,
+        },
+      });
+      continue;
+    }
+
+    if (a.source === 'call_recording') {
+      const mxc = resolveOrgMemoryMxcUri(a);
+      const safeUrl = !mxc && a.app_url ? normalizeHttpUrl(a.app_url) : null;
+      const sessionId = a.call_session_id ?? a.filename;
+      items.push({
+        id: `call-recording:${sessionId}`,
+        name: a.filename?.trim() ? a.filename : 'Call recording',
+        url: mxc ?? safeUrl ?? `memory://call-recording/${sessionId}`,
+        kind: inferKindFromMime(
+          a.mime,
+          a.filename,
+          mxc ?? a.app_url ?? safeUrl ?? '',
+        ),
+        source: 'call_recording',
+        uploadedAt,
+        context: {
+          documentId: 0,
+          documentTitle: a.call_session_id ?? '',
+          documentState: DocumentState.PROPOSAL,
+        },
+      });
+      continue;
+    }
+
+    if (
+      a.source === 'call_transcript' ||
+      a.source === 'discussion_summary' ||
+      a.source === 'thread_summary'
+    ) {
+      const syntheticId =
+        a.source === 'discussion_summary'
+          ? String(a.discussion_summary_id ?? a.filename)
+          : a.source === 'thread_summary'
+          ? String(a.thread_summary_id ?? a.filename)
+          : String(a.call_session_id ?? a.filename);
+      items.push({
+        id: `${a.source}:${syntheticId}`,
+        name: a.filename?.trim()
+          ? a.filename
+          : a.source === 'discussion_summary'
+          ? 'Discussion summary'
+          : a.source === 'thread_summary'
+          ? 'Thread summary'
+          : 'Call transcript',
+        url: `memory://${a.source}/${syntheticId}`,
+        kind: 'document',
+        source: a.source,
+        uploadedAt,
+        context: {
+          documentId: 0,
+          documentTitle: a.text_excerpt ?? '',
+          documentState: DocumentState.PROPOSAL,
         },
       });
     }

--- a/packages/core/src/org-memory/org-memory-asset-key.ts
+++ b/packages/core/src/org-memory/org-memory-asset-key.ts
@@ -4,7 +4,12 @@
  */
 export type OrgMemoryAssetKeyPayload =
   | { k: 'p'; d: number; u: string }
-  | { k: 'm'; r: string; e: string; x: string };
+  | { k: 'mem'; d: number; u?: string }
+  | { k: 'm'; r: string; e: string; x: string }
+  | { k: 'cr'; i: number }
+  | { k: 'ct'; i: number }
+  | { k: 'ds'; i: number }
+  | { k: 'ts'; i: number };
 
 function uint8ToBinaryString(bytes: Uint8Array): string {
   const chunk = 0x8000;
@@ -58,6 +63,11 @@ export function parseOrgMemoryAssetKey(
   if (o.k === 'p' && typeof o.d === 'number' && typeof o.u === 'string') {
     return { k: 'p', d: o.d, u: o.u };
   }
+  if (o.k === 'mem' && typeof o.d === 'number') {
+    return typeof o.u === 'string' && o.u.trim()
+      ? { k: 'mem', d: o.d, u: o.u }
+      : { k: 'mem', d: o.d };
+  }
   if (
     o.k === 'm' &&
     typeof o.r === 'string' &&
@@ -65,6 +75,38 @@ export function parseOrgMemoryAssetKey(
     typeof o.x === 'string'
   ) {
     return { k: 'm', r: o.r, e: o.e, x: o.x };
+  }
+  if (
+    o.k === 'cr' &&
+    typeof o.i === 'number' &&
+    Number.isInteger(o.i) &&
+    o.i > 0
+  ) {
+    return { k: 'cr', i: o.i };
+  }
+  if (
+    o.k === 'ct' &&
+    typeof o.i === 'number' &&
+    Number.isInteger(o.i) &&
+    o.i > 0
+  ) {
+    return { k: 'ct', i: o.i };
+  }
+  if (
+    o.k === 'ds' &&
+    typeof o.i === 'number' &&
+    Number.isInteger(o.i) &&
+    o.i > 0
+  ) {
+    return { k: 'ds', i: o.i };
+  }
+  if (
+    o.k === 'ts' &&
+    typeof o.i === 'number' &&
+    Number.isInteger(o.i) &&
+    o.i > 0
+  ) {
+    return { k: 'ts', i: o.i };
   }
   return null;
 }

--- a/packages/core/src/org-memory/with-org-memory-asset-keys.ts
+++ b/packages/core/src/org-memory/with-org-memory-asset-keys.ts
@@ -5,12 +5,25 @@ import {
 
 /** Minimal shape for attaching stable fetch keys (matches org_memory_assets JSON). */
 export type OrgMemoryAssetLike = {
-  source: 'proposal_upload' | 'matrix_chat';
+  source:
+    | 'proposal_upload'
+    | 'memory'
+    | 'matrix_chat'
+    | 'call_recording'
+    | 'call_transcript'
+    | 'discussion_summary'
+    | 'thread_summary';
   app_url?: string;
   document_id?: number;
   matrix_room_id?: string;
   matrix_event_id?: string;
   mxc_uri?: string;
+  call_session_id?: string;
+  call_recording_id?: number;
+  call_transcript_id?: number;
+  discussion_summary_id?: number;
+  thread_summary_id?: number;
+  text_excerpt?: string;
 };
 
 export function withOrgMemoryAssetKeys<T extends OrgMemoryAssetLike>(
@@ -20,6 +33,11 @@ export function withOrgMemoryAssetKeys<T extends OrgMemoryAssetLike>(
     let payload: OrgMemoryAssetKeyPayload;
     if (a.source === 'proposal_upload' && a.app_url && a.document_id != null) {
       payload = { k: 'p', d: a.document_id, u: a.app_url.trim() };
+    } else if (a.source === 'memory' && a.document_id != null) {
+      const url = a.app_url?.trim();
+      payload = url
+        ? { k: 'mem', d: a.document_id, u: url }
+        : { k: 'mem', d: a.document_id };
     } else if (
       a.source === 'matrix_chat' &&
       a.matrix_room_id &&
@@ -32,6 +50,24 @@ export function withOrgMemoryAssetKeys<T extends OrgMemoryAssetLike>(
         e: a.matrix_event_id,
         x: a.mxc_uri.trim(),
       };
+    } else if (a.source === 'call_recording' && a.call_recording_id != null) {
+      payload = { k: 'cr', i: a.call_recording_id };
+    } else if (a.source === 'call_transcript' && a.call_transcript_id != null) {
+      payload = { k: 'ct', i: a.call_transcript_id };
+    } else if (
+      a.source === 'discussion_summary' &&
+      a.discussion_summary_id != null
+    ) {
+      payload = { k: 'ds', i: a.discussion_summary_id };
+    } else if (a.source === 'thread_summary' && a.thread_summary_id != null) {
+      payload = { k: 'ts', i: a.thread_summary_id };
+    } else if (
+      a.source === 'call_recording' ||
+      a.source === 'call_transcript' ||
+      a.source === 'discussion_summary' ||
+      a.source === 'thread_summary'
+    ) {
+      throw new Error(`Missing artifact id for source "${a.source}"`);
     } else {
       payload = { k: 'p', d: a.document_id ?? 0, u: a.app_url?.trim() ?? '' };
     }

--- a/packages/epics/src/coherence/components/space-memory-section.tsx
+++ b/packages/epics/src/coherence/components/space-memory-section.tsx
@@ -8,20 +8,17 @@ import React from 'react';
 import { useTranslations } from 'next-intl';
 import {
   DocumentState,
-  EventType,
-  RoomEvent,
+  SpaceMemoryItem,
   filterSpaceMemoryItems,
-  useMatrix,
-  useSpaceBySlug,
 } from '@hypha-platform/core/client';
-import type { MatrixEvent, Room } from 'matrix-js-sdk';
 import { useSpaceMemoryOrg } from '../hooks/use-space-memory-org';
-import { SpaceMemoryTimelineItem } from './space-memory-timeline-item';
+import {
+  SpaceMemoryTimelineItem,
+  humanizeAssetName,
+} from './space-memory-timeline-item';
 import { MemoryFilterValue, MemoryFilters } from './memory-filters';
 import { useParams } from 'next/navigation';
 import { Locale } from '@hypha-platform/i18n';
-
-const MATRIX_SPACE_MEMORY_REFRESH_DEBOUNCE_MS = 1_800;
 
 type SpaceMemorySectionProps = {
   spaceSlug: string;
@@ -31,8 +28,6 @@ export const SpaceMemorySection: FC<SpaceMemorySectionProps> = ({
   spaceSlug,
 }) => {
   const t = useTranslations('CoherenceTab');
-  const { space } = useSpaceBySlug(spaceSlug);
-  const { client, isMatrixAvailable } = useMatrix();
   const {
     items,
     totalCount,
@@ -57,55 +52,61 @@ export const SpaceMemorySection: FC<SpaceMemorySectionProps> = ({
     [],
   );
 
-  const refreshTimeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(
-    null,
+  const isConversationItem = React.useCallback(
+    (row: SpaceMemoryItem) =>
+      row.source === 'matrix_chat' ||
+      row.source === 'discussion_summary' ||
+      row.source === 'thread_summary',
+    [],
   );
 
-  React.useEffect(() => {
-    const chatRoomId = space?.chatRoomId?.trim();
-    if (!chatRoomId || !client || !isMatrixAvailable) return;
+  const isCallItem = React.useCallback(
+    (row: SpaceMemoryItem) =>
+      row.source === 'call_recording' || row.source === 'call_transcript',
+    [],
+  );
 
-    const scheduleRefresh = () => {
-      if (refreshTimeoutRef.current) {
-        clearTimeout(refreshTimeoutRef.current);
+  const stateLabel = React.useCallback(
+    (state: DocumentState) =>
+      t(
+        `documentStates.${state}` as
+          | 'documentStates.discussion'
+          | 'documentStates.proposal'
+          | 'documentStates.agreement'
+          | 'documentStates.memory',
+      ),
+    [t],
+  );
+
+  const contextLineForItem = React.useCallback(
+    (row: SpaceMemoryItem) => {
+      if (row.source === 'memory') {
+        return t('spaceMemoryContextMemory', {
+          title: row.context.documentTitle || t('untitledDocument'),
+        });
       }
-      refreshTimeoutRef.current = setTimeout(() => {
-        refreshTimeoutRef.current = null;
-        void refresh();
-      }, MATRIX_SPACE_MEMORY_REFRESH_DEBOUNCE_MS);
-    };
-
-    const onTimeline = (
-      event: MatrixEvent,
-      room: Room | undefined,
-      _toStart: boolean | undefined,
-      removed: boolean,
-      data: { liveEvent?: boolean },
-    ) => {
-      if (room?.roomId !== chatRoomId) return;
-      if (removed) return;
-      if (data?.liveEvent === false) return;
-      if (event.getType() !== EventType.RoomMessage) return;
-      scheduleRefresh();
-    };
-
-    client.on(RoomEvent.Timeline, onTimeline);
-    return () => {
-      client.removeListener(RoomEvent.Timeline, onTimeline);
-      if (refreshTimeoutRef.current) {
-        clearTimeout(refreshTimeoutRef.current);
-        refreshTimeoutRef.current = null;
+      if (row.source === 'matrix_chat') {
+        return t('spaceMemoryContextMatrix');
       }
-    };
-  }, [space?.chatRoomId, client, isMatrixAvailable, refresh]);
-
-  const stateLabel = (state: DocumentState) =>
-    t(
-      `documentStates.${state}` as
-        | 'documentStates.discussion'
-        | 'documentStates.proposal'
-        | 'documentStates.agreement',
-    );
+      if (
+        row.source === 'discussion_summary' ||
+        row.source === 'thread_summary'
+      ) {
+        return humanizeAssetName(row.name);
+      }
+      if (row.source === 'call_transcript') {
+        return t('spaceMemoryContextCallTranscript');
+      }
+      if (row.source === 'call_recording') {
+        return t('spaceMemoryContextCallRecording');
+      }
+      return t('spaceMemoryContext', {
+        title: row.context.documentTitle || t('untitledDocument'),
+        state: stateLabel(row.context.documentState),
+      });
+    },
+    [stateLabel, t],
+  );
 
   const counts = React.useMemo(
     () =>
@@ -116,11 +117,11 @@ export const SpaceMemorySection: FC<SpaceMemorySectionProps> = ({
             row.source === 'proposal_upload' &&
             row.context.documentState === DocumentState.PROPOSAL,
         ).length,
-        conversations: items.filter((row) => row.source === 'matrix_chat')
-          .length,
+        conversations: items.filter((row) => isConversationItem(row)).length,
+        calls: items.filter((row) => isCallItem(row)).length,
         'ai-chat': items.filter((row) => isAiChatItem(row)).length,
       } satisfies Record<MemoryFilterValue, number>),
-    [isAiChatItem, items],
+    [isAiChatItem, isCallItem, isConversationItem, items],
   );
 
   const filteredItems = React.useMemo(() => {
@@ -135,7 +136,10 @@ export const SpaceMemorySection: FC<SpaceMemorySectionProps> = ({
         );
       }
       if (activeFilter === 'conversations') {
-        return row.source === 'matrix_chat';
+        return isConversationItem(row);
+      }
+      if (activeFilter === 'calls') {
+        return isCallItem(row);
       }
       if (activeFilter === 'ai-chat') {
         return isAiChatItem(row);
@@ -144,15 +148,14 @@ export const SpaceMemorySection: FC<SpaceMemorySectionProps> = ({
     });
 
     return filterSpaceMemoryItems(byFilter, searchTerm);
-  }, [activeFilter, isAiChatItem, items, searchTerm]);
-
-  const showAiChatTab = counts['ai-chat'] > 0;
-
-  React.useEffect(() => {
-    if (!showAiChatTab && activeFilter === 'ai-chat') {
-      setActiveFilter('general');
-    }
-  }, [activeFilter, showAiChatTab]);
+  }, [
+    activeFilter,
+    isAiChatItem,
+    isCallItem,
+    isConversationItem,
+    items,
+    searchTerm,
+  ]);
 
   const newMemoryHref = `/${lang}/dho/${id}/memory/new-memory`;
 
@@ -161,14 +164,16 @@ export const SpaceMemorySection: FC<SpaceMemorySectionProps> = ({
       className="flex w-full flex-col gap-4 py-2"
       aria-label={t('spaceMemory')}
     >
-      <h1 className="text-7 font-semibold tracking-tight text-foreground">
-        {t('spaceMemory')}
-        {typeof totalCount === 'number' ? (
-          <span className="ml-2 text-5 font-medium text-muted-foreground">
-            | {Intl.NumberFormat().format(totalCount)}
-          </span>
-        ) : null}
-      </h1>
+      <header className="flex flex-wrap items-end justify-between gap-2">
+        <h1 className="text-7 font-semibold tracking-tight text-foreground">
+          {t('spaceMemory')}
+          {typeof totalCount === 'number' ? (
+            <span className="ml-2 text-5 font-medium text-muted-foreground">
+              | {Intl.NumberFormat(lang).format(totalCount)}
+            </span>
+          ) : null}
+        </h1>
+      </header>
       <MemoryFilters
         activeFilter={activeFilter}
         onFilterChange={setActiveFilter}
@@ -176,7 +181,6 @@ export const SpaceMemorySection: FC<SpaceMemorySectionProps> = ({
         onSearchChange={setSearchTerm}
         newMemoryHref={newMemoryHref}
         counts={counts}
-        showAiChatTab={showAiChatTab}
       />
 
       {error ? (
@@ -202,6 +206,8 @@ export const SpaceMemorySection: FC<SpaceMemorySectionProps> = ({
               ? t('spaceMemoryEmptySearch')
               : activeFilter === 'ai-chat'
               ? t('spaceMemoryAiChatEmpty')
+              : activeFilter === 'calls'
+              ? t('spaceMemoryCallsEmpty')
               : activeFilter === 'general'
               ? t('spaceMemoryEmpty')
               : t('spaceMemoryEmptyTab')}
@@ -210,23 +216,17 @@ export const SpaceMemorySection: FC<SpaceMemorySectionProps> = ({
       ) : (
         <>
           <ul
-            className="m-0 flex w-full list-none flex-wrap justify-start gap-x-6 gap-y-10 p-0"
-            aria-label={t('spaceMemoryTimelineLabel')}
+            className="m-0 grid w-full list-none grid-cols-1 gap-4 p-0 md:grid-cols-2 xl:grid-cols-3"
+            aria-label={t('spaceMemory')}
           >
             {filteredItems.map((row) => (
               <SpaceMemoryTimelineItem
                 key={row.id}
                 item={row}
-                contextLine={
-                  row.source === 'matrix_chat'
-                    ? t('spaceMemoryContextMatrix')
-                    : t('spaceMemoryContext', {
-                        title:
-                          row.context.documentTitle || t('untitledDocument'),
-                        state: stateLabel(row.context.documentState),
-                      })
-                }
-                openLabel={t('spaceMemoryOpenAsset', { name: row.name })}
+                contextLine={contextLineForItem(row)}
+                openLabel={t('spaceMemoryOpenAsset', {
+                  name: humanizeAssetName(row.name),
+                })}
               />
             ))}
           </ul>

--- a/packages/epics/src/coherence/components/space-memory-timeline-item.tsx
+++ b/packages/epics/src/coherence/components/space-memory-timeline-item.tsx
@@ -8,9 +8,9 @@ import { formatDate } from '@hypha-platform/ui-utils';
 import React, { useMemo } from 'react';
 import { useTranslations } from 'next-intl';
 
-/** Matches Human Chat image slot: `rounded-lg border border-border bg-muted/30` + object-contain preview */
+/** Matches Human Chat image slot: rounded shell with safe media preview. */
 const THUMB_SHELL =
-  'relative flex h-44 w-44 max-w-full shrink-0 items-center justify-center overflow-hidden rounded-lg border border-border bg-muted/30';
+  'relative flex min-h-[160px] w-full items-center justify-center overflow-hidden rounded-lg border border-border bg-muted/30';
 
 function isSafeAssetUrl(url: string): boolean {
   try {
@@ -27,6 +27,160 @@ function isMxcUrl(url: string): boolean {
 
 function looksLikePdf(name: string, url: string): boolean {
   return /\.pdf(\?|#|$)/i.test(name) || /\.pdf(\?|#|$)/i.test(url);
+}
+
+let didConfigurePdfWorker = false;
+
+async function loadPdfJsWithWorker() {
+  const pdfJs = await import('pdfjs-dist/legacy/build/pdf.mjs');
+  if (!didConfigurePdfWorker) {
+    try {
+      const workerUrl = new URL(
+        'pdfjs-dist/legacy/build/pdf.worker.mjs',
+        import.meta.url,
+      ).toString();
+      pdfJs.GlobalWorkerOptions.workerSrc = workerUrl;
+    } catch {
+      // Keep default worker resolution if URL construction fails.
+    }
+    didConfigurePdfWorker = true;
+  }
+  return pdfJs;
+}
+
+export function humanizeAssetName(name: string): string {
+  const trimmed = name.trim();
+  if (!trimmed) return name;
+  const sanitized = trimmed
+    .replace(/[_-]+/g, ' ')
+    .replace(/[^\p{L}\p{N}\s.()]/gu, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return sanitized || name;
+}
+
+function PdfPreview({
+  src,
+  fallbackLabel,
+  unavailableLabel,
+}: {
+  src: string;
+  fallbackLabel: string;
+  unavailableLabel: string;
+}) {
+  const canvasRef = React.useRef<HTMLCanvasElement | null>(null);
+  const [renderState, setRenderState] = React.useState<
+    'loading' | 'ready' | 'embed' | 'error'
+  >('loading');
+
+  React.useEffect(() => {
+    let cancelled = false;
+    let loadingTask: { destroy: () => void } | null = null;
+    let pdf: { destroy: () => Promise<void> } | null = null;
+
+    async function renderFirstPage(): Promise<void> {
+      try {
+        setRenderState('loading');
+        const pdfJs = await loadPdfJsWithWorker();
+        const request: Parameters<typeof pdfJs.getDocument>[0] = {
+          url: src,
+          verbosity: 0,
+        };
+        const task = pdfJs.getDocument(request);
+        loadingTask = task;
+        const loadedPdf = await task.promise;
+        pdf = loadedPdf;
+        const page = await loadedPdf.getPage(1);
+
+        const baseViewport = page.getViewport({ scale: 1 });
+        const scale = Math.min(2, Math.max(0.6, 900 / baseViewport.width));
+        const viewport = page.getViewport({ scale });
+        const pixelRatio = window.devicePixelRatio || 1;
+        const canvas = canvasRef.current;
+        const context = canvas?.getContext('2d');
+
+        if (!canvas || !context || cancelled) return;
+
+        canvas.width = Math.max(1, Math.floor(viewport.width * pixelRatio));
+        canvas.height = Math.max(1, Math.floor(viewport.height * pixelRatio));
+        canvas.style.width = `${Math.max(1, Math.floor(viewport.width))}px`;
+        canvas.style.height = `${Math.max(1, Math.floor(viewport.height))}px`;
+        context.setTransform(pixelRatio, 0, 0, pixelRatio, 0, 0);
+
+        await page.render({ canvas, canvasContext: context, viewport }).promise;
+
+        if (!cancelled) {
+          setRenderState('ready');
+        }
+      } catch {
+        if (!cancelled) {
+          // Fallback to native PDF embed if canvas pipeline fails.
+          setRenderState('embed');
+        }
+      } finally {
+        await pdf?.destroy().catch(() => undefined);
+      }
+    }
+
+    void renderFirstPage();
+    return () => {
+      cancelled = true;
+      loadingTask?.destroy?.();
+    };
+  }, [src]);
+
+  if (renderState === 'embed') {
+    return (
+      <object
+        data={src}
+        type="application/pdf"
+        aria-label={fallbackLabel}
+        className="h-full w-full"
+      >
+        <div className="flex min-h-[120px] w-full flex-col items-center justify-center gap-2 px-2 text-muted-foreground">
+          <FileIcon className="h-8 w-8 opacity-70" strokeWidth={1.25} />
+          <span className="line-clamp-2 text-center text-[10px]">
+            {unavailableLabel}
+          </span>
+        </div>
+      </object>
+    );
+  }
+
+  if (renderState === 'error') {
+    return (
+      <div className="flex min-h-[120px] w-full flex-col items-center justify-center gap-2 px-2 text-muted-foreground">
+        <FileIcon className="h-8 w-8 opacity-70" strokeWidth={1.25} />
+        <span className="line-clamp-2 text-center text-[10px]">
+          {unavailableLabel}
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative flex h-full w-full items-center justify-center overflow-hidden">
+      <canvas
+        ref={canvasRef}
+        aria-label={fallbackLabel}
+        className={cn(
+          'max-h-full max-w-full object-contain',
+          renderState === 'ready' ? 'opacity-100' : 'opacity-0',
+        )}
+      />
+      {renderState === 'loading' ? (
+        <div className="absolute inset-0 flex min-h-[120px] w-full flex-col items-center justify-center gap-2 px-2 text-muted-foreground">
+          <FileIcon
+            className="h-8 w-8 animate-pulse opacity-70"
+            strokeWidth={1.25}
+          />
+          <span className="line-clamp-2 text-center text-[10px]">
+            {fallbackLabel}
+          </span>
+        </div>
+      ) : null}
+    </div>
+  );
 }
 
 type MatrixClientLike = NonNullable<ReturnType<typeof useMatrix>['client']>;
@@ -71,6 +225,7 @@ export function SpaceMemoryTimelineItem({
   const t = useTranslations('CoherenceTab');
   const { client, isMatrixAvailable } = useMatrix();
   const uploaded = formatDate(new Date(item.uploadedAt), true);
+  const displayName = useMemo(() => humanizeAssetName(item.name), [item.name]);
   const [imageFailed, setImageFailed] = React.useState(false);
   /** After a scaled thumbnail fails, retry full media (Synapse sometimes fails thumbnailing only). */
   const [matrixImagePhase, setMatrixImagePhase] = React.useState<
@@ -101,16 +256,50 @@ export function SpaceMemoryTimelineItem({
         : mxcDownload
       : null;
   const videoSrcForMatrix = item.kind === 'video' ? mxcDownload : null;
+  const pdfSrc =
+    looksLikePdf(item.name, item.url) && (mxc ? mxcDownload : httpSafe)
+      ? mxc
+        ? mxcDownload
+        : item.url
+      : null;
   const openHref = mxc ? mxcDownload : item.url;
-  const canOpen = Boolean(openHref && isSafeAssetUrl(openHref));
+  const isMemoryBody =
+    item.source === 'memory' && item.url.startsWith('memory://document/');
+  const isCallTranscriptBody =
+    item.source === 'call_transcript' &&
+    item.url.startsWith('memory://call_transcript/');
+  const canOpen = Boolean(
+    !isMemoryBody &&
+      !isCallTranscriptBody &&
+      openHref &&
+      isSafeAssetUrl(openHref),
+  );
+  const cardTitle =
+    isCallTranscriptBody && item.context.documentTitle?.trim()
+      ? item.context.documentTitle.trim()
+      : displayName;
 
   const thumbPreview = (() => {
+    if (isMemoryBody || isCallTranscriptBody) {
+      const excerpt =
+        item.context.textExcerpt?.trim() ||
+        item.context.documentTitle?.trim() ||
+        displayName;
+      return (
+        <div className="flex min-h-[120px] w-full flex-col justify-start gap-2 overflow-y-auto px-3 py-3 text-left">
+          <p className="line-clamp-8 whitespace-pre-wrap text-sm leading-relaxed text-card-foreground">
+            {excerpt}
+          </p>
+        </div>
+      );
+    }
     if (mxc) {
-      if (looksLikePdf(item.name, item.url)) {
+      if (looksLikePdf(item.name, item.url) && pdfSrc) {
         return (
-          <FileIcon
-            className="h-12 w-12 text-muted-foreground"
-            strokeWidth={1.25}
+          <PdfPreview
+            src={pdfSrc}
+            fallbackLabel={displayName}
+            unavailableLabel={t('spaceMemoryPdfPreviewUnavailable')}
           />
         );
       }
@@ -160,7 +349,7 @@ export function SpaceMemoryTimelineItem({
           <div className="flex min-h-[120px] w-full flex-col items-center justify-center gap-2 px-2 text-muted-foreground">
             <ImageIcon className="h-8 w-8 opacity-70" strokeWidth={1.25} />
             <span className="line-clamp-2 text-center text-[10px]">
-              {item.name}
+              {displayName}
             </span>
           </div>
         );
@@ -213,7 +402,13 @@ export function SpaceMemoryTimelineItem({
     }
     if (item.kind === 'image' && !imageFailed) {
       if (looksLikePdf(item.name, item.url)) {
-        return (
+        return pdfSrc ? (
+          <PdfPreview
+            src={pdfSrc}
+            fallbackLabel={displayName}
+            unavailableLabel={t('spaceMemoryPdfPreviewUnavailable')}
+          />
+        ) : (
           <FileIcon
             className="h-12 w-12 text-muted-foreground"
             strokeWidth={1.25}
@@ -235,7 +430,7 @@ export function SpaceMemoryTimelineItem({
         <div className="flex min-h-[120px] w-full flex-col items-center justify-center gap-2 px-2 text-muted-foreground">
           <ImageIcon className="h-8 w-8 opacity-70" strokeWidth={1.25} />
           <span className="line-clamp-2 text-center text-[10px]">
-            {item.name}
+            {displayName}
           </span>
         </div>
       );
@@ -254,7 +449,13 @@ export function SpaceMemoryTimelineItem({
       );
     }
     if (item.kind === 'document' && looksLikePdf(item.name, item.url)) {
-      return (
+      return pdfSrc ? (
+        <PdfPreview
+          src={pdfSrc}
+          fallbackLabel={displayName}
+          unavailableLabel={t('spaceMemoryPdfPreviewUnavailable')}
+        />
+      ) : (
         <FileIcon
           className="h-12 w-12 text-muted-foreground"
           strokeWidth={1.25}
@@ -272,25 +473,44 @@ export function SpaceMemoryTimelineItem({
   const linkClass =
     'group flex flex-col gap-2 rounded-lg outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2';
   const filenameRowClass =
-    'inline-flex items-start gap-1 text-xs font-medium leading-snug text-foreground underline-offset-2 group-hover:text-primary group-hover:underline';
+    'inline-flex items-center gap-1 text-xs font-medium uppercase tracking-wide text-muted-foreground underline-offset-2 group-hover:text-primary group-hover:underline';
+
+  const sourceLabel = (() => {
+    if (item.source === 'memory') return t('spaceMemory');
+    if (item.source === 'proposal_upload') return t('spaceMemoryProposals');
+    if (item.source === 'matrix_chat') return t('spaceMemoryConversations');
+    if (
+      item.source === 'discussion_summary' ||
+      item.source === 'thread_summary'
+    )
+      return t('spaceMemoryConversations');
+    if (item.source === 'call_transcript')
+      return t('spaceMemoryCallTranscriptExcerpt');
+    if (item.source === 'call_recording') return t('spaceMemoryCalls');
+    return t('spaceMemory');
+  })();
 
   return (
-    <li className="flex w-44 shrink-0 flex-col items-stretch">
-      <span
-        className="mb-1.5 h-2 w-2 shrink-0 self-center rounded-full border-2 border-background bg-accent-9 shadow-sm ring-1 ring-border"
-        aria-hidden
-      />
-      <time
-        dateTime={item.uploadedAt}
-        className="text-center text-[10px] font-medium leading-tight text-muted-foreground"
-      >
-        {uploaded}
-      </time>
-      <p className="mt-0.5 line-clamp-2 text-center text-[10px] leading-tight text-muted-foreground">
+    <li className="flex h-full w-full flex-col rounded-lg border border-border bg-card p-3">
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <span className="inline-flex items-center rounded-md bg-accent-9 px-2 py-0.5 text-[11px] font-semibold text-accent-contrast">
+          {sourceLabel}
+        </span>
+        <time
+          dateTime={item.uploadedAt}
+          className="text-[10px] font-medium leading-tight text-muted-foreground"
+        >
+          {uploaded}
+        </time>
+      </div>
+      <p className="line-clamp-2 text-xs leading-tight text-muted-foreground">
         {contextLine}
       </p>
+      <p className="mt-1 line-clamp-2 text-sm font-medium leading-snug text-card-foreground">
+        {cardTitle}
+      </p>
 
-      <div className="mt-2 flex flex-col gap-2">
+      <div className="mt-3 flex flex-1 flex-col gap-2">
         {canOpen ? (
           <a
             href={openHref!}
@@ -299,11 +519,11 @@ export function SpaceMemoryTimelineItem({
             className={linkClass}
             aria-label={openLabel}
           >
-            <div className={cn(THUMB_SHELL, 'min-h-[120px]')}>
+            <div className={cn(THUMB_SHELL, 'aspect-[16/10]')}>
               {thumbPreview}
             </div>
             <span className={filenameRowClass}>
-              <span className="line-clamp-3 break-words">{item.name}</span>
+              <span>{t('openDocument')}</span>
               <ExternalLink className="mt-0.5 h-3 w-3 shrink-0 opacity-60" />
             </span>
           </a>
@@ -312,12 +532,9 @@ export function SpaceMemoryTimelineItem({
             className="flex flex-col gap-2 rounded-lg"
             title={mxc && !canOpen ? t('spaceMemoryMatrixOpenHint') : undefined}
           >
-            <div className={cn(THUMB_SHELL, 'min-h-[120px]')}>
+            <div className={cn(THUMB_SHELL, 'aspect-[16/10]')}>
               {thumbPreview}
             </div>
-            <span className="line-clamp-3 break-words text-xs font-medium text-foreground">
-              {item.name}
-            </span>
           </div>
         )}
       </div>

--- a/packages/epics/src/common/global-call-dock-context.tsx
+++ b/packages/epics/src/common/global-call-dock-context.tsx
@@ -1,7 +1,12 @@
 'use client';
 
 import React from 'react';
-import { useSpaceGroupCall } from '@hypha-platform/core/client';
+import { useTranslations } from 'next-intl';
+import {
+  useSpaceGroupCall,
+  type GetCallCaptureVoiceAnnouncement,
+} from '@hypha-platform/core/client';
+import { revalidateSpaceMemoryOrg } from '../coherence/hooks/use-space-memory-org';
 
 type PendingJoin = {
   kind: 'audio' | 'video';
@@ -108,6 +113,7 @@ const GlobalCallDockContext =
   React.createContext<GlobalCallDockContextValue | null>(null);
 
 function useGlobalCallDockValue() {
+  const t = useTranslations('HumanChatPanel');
   const [boundRoomId, setBoundRoomId] = React.useState<string | null>(null);
   const [boundSpaceSlug, setBoundSpaceSlug] = React.useState<string | null>(
     null,
@@ -131,9 +137,33 @@ function useGlobalCallDockValue() {
   const restoreInProgressRef = React.useRef(false);
   const restoreTimerRef = React.useRef<number | null>(null);
 
+  const onCallArtifactsUploaded = React.useCallback(
+    ({ spaceSlug: slug }: { spaceSlug: string }) => {
+      void revalidateSpaceMemoryOrg(slug);
+    },
+    [],
+  );
+
+  const getCaptureVoiceAnnouncement =
+    React.useCallback<GetCallCaptureVoiceAnnouncement>(
+      ({ action, mode }) => {
+        if (mode === 'recording_with_transcript') {
+          return action === 'started'
+            ? t('callCaptureVoiceStartedRecordingTranscript')
+            : t('callCaptureVoiceStoppedRecordingTranscript');
+        }
+        return action === 'started'
+          ? t('callCaptureVoiceStartedTranscript')
+          : t('callCaptureVoiceStoppedTranscript');
+      },
+      [t],
+    );
+
   const call = useSpaceGroupCall(activeRoomId, {
     authToken: activeAuthToken,
     spaceSlug: activeSpaceSlug,
+    onCallArtifactsUploaded,
+    getCaptureVoiceAnnouncement,
   });
 
   const inSession =
@@ -179,6 +209,23 @@ function useGlobalCallDockValue() {
       setActiveAuthToken(boundAuthToken);
     }
   }, [inSession, boundAuthToken, boundRoomId, boundSpaceSlug]);
+
+  React.useEffect(() => {
+    if (!activeRoomId || !boundRoomId || activeRoomId !== boundRoomId) return;
+    if (activeSpaceSlug !== boundSpaceSlug) {
+      setActiveSpaceSlug(boundSpaceSlug);
+    }
+    if (activeAuthToken !== boundAuthToken) {
+      setActiveAuthToken(boundAuthToken);
+    }
+  }, [
+    activeAuthToken,
+    activeRoomId,
+    activeSpaceSlug,
+    boundAuthToken,
+    boundRoomId,
+    boundSpaceSlug,
+  ]);
 
   React.useEffect(() => {
     if (call.callState === 'idle') {

--- a/packages/epics/src/common/human-chat-panel/human-chat-panel-thread-summary.tsx
+++ b/packages/epics/src/common/human-chat-panel/human-chat-panel-thread-summary.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import { ChevronDown, ChevronUp, Sparkles } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { useMemo, useState } from 'react';
+import { cn } from '@hypha-platform/ui-utils';
+import type { ThreadSummaryPayload } from './use-thread-summary';
+
+type HumanChatPanelThreadSummaryProps = {
+  summary: ThreadSummaryPayload | null;
+  isLoading?: boolean;
+  threadTitle?: string | null;
+  className?: string;
+};
+
+function formatUpdatedAt(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const ms = Date.parse(value);
+  if (!Number.isFinite(ms)) return null;
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(new Date(ms));
+}
+
+export function HumanChatPanelThreadSummary({
+  summary,
+  isLoading = false,
+  threadTitle,
+  className,
+}: HumanChatPanelThreadSummaryProps) {
+  const t = useTranslations('HumanChatPanel');
+  const [expanded, setExpanded] = useState(true);
+  const updatedLabel = useMemo(
+    () =>
+      formatUpdatedAt(summary?.lastRefreshedAt ?? summary?.updatedAt ?? null),
+    [summary?.lastRefreshedAt, summary?.updatedAt],
+  );
+
+  if (isLoading && !summary?.summary?.trim()) {
+    return (
+      <div
+        className={cn(
+          'border-b border-border/60 bg-muted/20 px-3 py-2 text-xs text-muted-foreground',
+          className,
+        )}
+      >
+        {t('threadSummaryLoading')}
+      </div>
+    );
+  }
+
+  if (!summary?.summary?.trim()) return null;
+
+  return (
+    <section
+      className={cn(
+        'border-b border-border/60 bg-muted/20 px-3 py-2',
+        className,
+      )}
+      aria-label={t('threadSummaryLabel')}
+    >
+      <div className="flex items-start gap-2">
+        <Sparkles
+          className="mt-0.5 h-3.5 w-3.5 shrink-0 text-primary"
+          aria-hidden
+        />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-start gap-2">
+            <div className="min-w-0 flex-1">
+              <p className="text-xs font-medium text-foreground">
+                {t('threadSummaryTitle')}
+                {threadTitle?.trim() ? (
+                  <span className="font-normal text-muted-foreground">
+                    {' '}
+                    · {threadTitle.trim()}
+                  </span>
+                ) : null}
+              </p>
+              {updatedLabel ? (
+                <p className="text-[11px] text-muted-foreground">
+                  {t('threadSummaryUpdated', { when: updatedLabel })}
+                </p>
+              ) : null}
+            </div>
+            <button
+              type="button"
+              onClick={() => setExpanded((v) => !v)}
+              className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-muted/80 hover:text-foreground"
+              aria-expanded={expanded}
+              aria-label={
+                expanded ? t('threadSummaryCollapse') : t('threadSummaryExpand')
+              }
+            >
+              {expanded ? (
+                <ChevronUp className="h-3.5 w-3.5" />
+              ) : (
+                <ChevronDown className="h-3.5 w-3.5" />
+              )}
+            </button>
+          </div>
+          {expanded ? (
+            <div className="mt-1.5 space-y-1.5">
+              <p className="text-xs leading-relaxed text-foreground/90">
+                {summary.summary}
+              </p>
+              {summary.bullets.length > 0 ? (
+                <ul className="list-disc space-y-0.5 ps-4 text-xs text-foreground/85">
+                  {summary.bullets.map((bullet) => (
+                    <li key={bullet}>{bullet}</li>
+                  ))}
+                </ul>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/packages/epics/src/common/human-chat-panel/use-thread-summary.ts
+++ b/packages/epics/src/common/human-chat-panel/use-thread-summary.ts
@@ -1,0 +1,94 @@
+'use client';
+
+import useSWR from 'swr';
+import { useAuthentication } from '@hypha-platform/authentication';
+
+export type ThreadSummaryPayload = {
+  id: number;
+  matrixRoomId: string;
+  threadKind: 'space' | 'coherence';
+  coherenceSlug: string | null;
+  threadTitle: string | null;
+  summary: string;
+  bullets: string[];
+  messageCount: number;
+  participantCount: number;
+  updatedAt: string;
+  lastRefreshedAt: string | null;
+};
+
+type ThreadSummaryResponse = {
+  summary: ThreadSummaryPayload | null;
+};
+
+export function useThreadSummary(
+  spaceSlug: string | null | undefined,
+  matrixRoomId: string | null | undefined,
+) {
+  const { getAccessToken } = useAuthentication();
+  const slug = spaceSlug?.trim();
+  const roomId = matrixRoomId?.trim();
+
+  const { data, error, isLoading, mutate } = useSWR<ThreadSummaryResponse>(
+    slug && roomId ? ['thread-summary', slug, roomId] : null,
+    async () => {
+      const token = await getAccessToken();
+      const headers: HeadersInit = {};
+      if (token) headers.Authorization = `Bearer ${token}`;
+      const qs = new URLSearchParams({ matrixRoomId: roomId! });
+      const res = await fetch(
+        `/api/v1/spaces/${encodeURIComponent(
+          slug!,
+        )}/thread-summary?${qs.toString()}`,
+        { headers },
+      );
+      if (!res.ok) {
+        throw new Error(`Failed to load thread summary (${res.status})`);
+      }
+      return (await res.json()) as ThreadSummaryResponse;
+    },
+    {
+      refreshInterval: 60_000,
+      revalidateOnFocus: true,
+    },
+  );
+
+  return {
+    summary: data?.summary ?? null,
+    isLoading,
+    error,
+    refresh: mutate,
+  };
+}
+
+export async function recordThreadSummaryActivity(params: {
+  spaceSlug: string;
+  matrixRoomId: string;
+  threadKind: 'space' | 'coherence';
+  coherenceSlug?: string | null;
+  threadTitle?: string | null;
+  lastMessageEventId: string;
+  lastMessageOriginServerTs: number;
+  getAccessToken: () => Promise<string | null | undefined>;
+}) {
+  const token = await params.getAccessToken();
+  const headers: HeadersInit = { 'Content-Type': 'application/json' };
+  if (token) headers.Authorization = `Bearer ${token}`;
+  await fetch(
+    `/api/v1/spaces/${encodeURIComponent(
+      params.spaceSlug,
+    )}/thread-summary/activity`,
+    {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        matrixRoomId: params.matrixRoomId,
+        threadKind: params.threadKind,
+        coherenceSlug: params.coherenceSlug ?? null,
+        threadTitle: params.threadTitle ?? null,
+        lastMessageEventId: params.lastMessageEventId,
+        lastMessageOriginServerTs: params.lastMessageOriginServerTs,
+      }),
+    },
+  );
+}

--- a/packages/epics/src/common/human-right-panel.tsx
+++ b/packages/epics/src/common/human-right-panel.tsx
@@ -8,6 +8,8 @@ import {
   type MatrixEvent,
   type Room,
 } from 'matrix-js-sdk';
+import type { RoomMessageEventContent } from 'matrix-js-sdk/lib/@types/events';
+import { Check, Plus } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import {
   useParams,
@@ -21,11 +23,13 @@ import {
   SidebarFooter,
   useSidebar,
   Button,
+  Skeleton,
 } from '@hypha-platform/ui';
 import { useAuthentication } from '@hypha-platform/authentication';
 import {
   useMatrix,
   useCoherenceMutationsWeb2Rsc,
+  useHookRegistry,
   useJwt,
   useMatrixUserIdsByPrivySubs,
   useMe,
@@ -36,6 +40,7 @@ import {
   stripMatrixReplyFallback,
   RoomEvent,
   EventType,
+  MsgType,
   MatrixUploadTimeoutError,
   SendMessageCancelledError,
   SendMessagePartialFailureError,
@@ -71,8 +76,16 @@ import {
   type ChatMentionCandidate,
   type ChatPanelAttachmentMedia,
 } from './human-chat-panel';
+import {
+  type MentionPickCandidate,
+  useResolvedMentionCandidateLabel,
+} from './human-chat-panel/use-resolved-mention-candidate-label';
 import type { ChatPanelTab } from './human-chat-panel';
-import { useHumanChatPanel } from './human-chat-panel-context';
+import {
+  recordThreadSummaryActivity,
+  useThreadSummary,
+} from './human-chat-panel/use-thread-summary';
+import { HumanChatPanelThreadSummary } from './human-chat-panel/human-chat-panel-thread-summary';
 import {
   computeAggregateUnreadMentionCount,
   computeHumanChatUnreadState,
@@ -80,6 +93,7 @@ import {
 import {
   looksLikeTechnicalMatrixDisplayName,
   matrixMemberDisplayLabel,
+  matrixUserIdToCanonicalPrivySub,
   shortenMatrixIdForDisplay,
 } from './human-chat-panel/matrix-room-member-display';
 import { getActiveTabFromPath } from './get-active-tab-from-path';
@@ -106,6 +120,49 @@ function disposeDraftAttachmentUrls(drafts: ChatDraftAttachment[]) {
       URL.revokeObjectURL(a.previewUrl);
     }
   }
+}
+
+function SignalTeamResolvedMemberLabel({
+  candidate,
+  fallbackLabel,
+  isOwner = false,
+  unknownMemberLabel,
+}: {
+  candidate: MentionPickCandidate;
+  fallbackLabel: string;
+  isOwner?: boolean;
+  unknownMemberLabel: string;
+}) {
+  const { resolvedLabel, busy } = useResolvedMentionCandidateLabel(candidate);
+  const syncFallback = looksLikeTechnicalMatrixDisplayName(
+    fallbackLabel,
+    candidate.userId,
+  )
+    ? ''
+    : fallbackLabel.trim();
+  const finalLabel = resolvedLabel?.trim() || syncFallback;
+  const showSkeleton =
+    busy ||
+    !finalLabel ||
+    looksLikeTechnicalMatrixDisplayName(finalLabel, candidate.userId);
+
+  if (showSkeleton) {
+    return (
+      <Skeleton
+        className="inline-block align-baseline"
+        loading
+        width={140}
+        height={16}
+      />
+    );
+  }
+
+  return (
+    <span className="truncate">
+      {finalLabel || unknownMemberLabel}
+      {isOwner ? ' 👑' : ''}
+    </span>
+  );
 }
 
 /** Sanitized labels shared by multiple members need a disambiguated composer token + map key. */
@@ -189,6 +246,8 @@ type ReplyDraft = {
   messageId: string;
   authorLabel: string;
   excerpt: string;
+  sourceUserId?: string;
+  isYou?: boolean;
 };
 
 type EditDraft = {
@@ -201,12 +260,155 @@ type EditDraft = {
 const ROOM_STORAGE_KEY = 'hypha-chat-room-';
 
 const SESSION_ROOM_TO_SPACE_PREFIX = 'hypha-room-to-space-';
+const SESSION_ROOM_TO_COHERENCE_SLUG_PREFIX = 'hypha-room-to-coherence-slug-';
+const SESSION_ROOM_TO_COHERENCE_TITLE_PREFIX = 'hypha-room-to-coherence-title-';
 const CHAT_HISTORY_SESSION_PREFIX = 'hypha-chat-history-v1-';
 const CHAT_HISTORY_MAX_ITEMS = 250;
+const SIGNAL_TEAM_EVENT_KIND = 'io.hypha.signal.team.v1';
+const SIGNAL_TEAM_REQUEST_EVENT_KIND = 'io.hypha.signal.team.request.v1';
+const SIGNAL_TEAM_EVENT_BODY_MARKER = '[hypha:signal-team]';
+const SIGNAL_TEAM_REQUEST_EVENT_BODY_MARKER = '[hypha:signal-team-request]';
+
+function toUserFriendlySignalSystemBody(body: string): string {
+  const trimmed = body.trim();
+  const withoutMarker = trimmed
+    .replace(SIGNAL_TEAM_EVENT_BODY_MARKER, '')
+    .replace(SIGNAL_TEAM_REQUEST_EVENT_BODY_MARKER, '')
+    .trim();
+  if (!withoutMarker) return 'Signal team updated';
+  if (withoutMarker === 'signal team members updated') {
+    return 'Signal team updated';
+  }
+  if (withoutMarker === 'signal team access requested') {
+    return 'Signal team access requested';
+  }
+  if (withoutMarker === 'signal team access approved') {
+    return 'Signal team access approved';
+  }
+  return withoutMarker;
+}
 
 type PersistedUIMessage = Omit<UIMessage, 'timestamp'> & {
   timestamp?: string;
 };
+
+type SignalTeamTimelineState = {
+  memberMatrixUserIds: string[];
+  pendingRequesterIds: string[];
+  ownerMatrixUserId: string | null;
+};
+
+type SignalTeamEventContent = {
+  msgtype: RoomMessageEventContent['msgtype'];
+  body: RoomMessageEventContent['body'];
+  coherenceSlug: string | null;
+  memberMatrixUserIds?: string[];
+  ownerMatrixUserId?: string | null;
+  requesterMatrixUserId?: string;
+  status?: 'pending' | 'approved';
+  addedMemberMatrixUserIds?: string[];
+  removedMemberMatrixUserIds?: string[];
+  updatedAt: string;
+} & RoomMessageEventContent;
+
+function normalizeMatrixUserIds(ids: unknown): string[] {
+  if (!Array.isArray(ids)) return [];
+  return [...new Set(ids.map((id) => String(id).trim()).filter(Boolean))];
+}
+
+function roomPowerLevelForUser(
+  room: Room | undefined,
+  userId: string | null,
+): number {
+  if (!room || !userId) return 0;
+  const powerLevels = room.currentState.getStateEvents(
+    EventType.RoomPowerLevels,
+    '',
+  );
+  const content = (powerLevels?.getContent() ?? {}) as {
+    users?: Record<string, number>;
+    users_default?: number;
+  };
+  const perUser = content.users?.[userId];
+  if (typeof perUser === 'number') return perUser;
+  const fromMember = room.getMember(userId)?.powerLevel;
+  if (typeof fromMember === 'number') return fromMember;
+  return typeof content.users_default === 'number' ? content.users_default : 0;
+}
+
+function deriveSignalTeamStateFromEvents(
+  events: MatrixEvent[],
+  coherenceSlug?: string | null,
+  room?: Room,
+): SignalTeamTimelineState {
+  let memberMatrixUserIds: string[] = [];
+  const pending = new Set<string>();
+  let ownerMatrixUserId: string | null = null;
+  const targetSlug = coherenceSlug?.trim() || null;
+
+  for (const ev of events) {
+    const eventType = ev.getType();
+    if (eventType !== EventType.RoomMessage) continue;
+    const content = ev.getContent() as Record<string, unknown> | null;
+    if (!content || typeof content !== 'object') continue;
+    const msgtype =
+      typeof content.msgtype === 'string' ? content.msgtype.trim() : '';
+    const body = typeof content.body === 'string' ? content.body.trim() : '';
+    const eventKind = body.startsWith(SIGNAL_TEAM_EVENT_BODY_MARKER)
+      ? SIGNAL_TEAM_EVENT_KIND
+      : body.startsWith(SIGNAL_TEAM_REQUEST_EVENT_BODY_MARKER)
+      ? SIGNAL_TEAM_REQUEST_EVENT_KIND
+      : msgtype;
+    const eventSlug =
+      typeof content.coherenceSlug === 'string'
+        ? content.coherenceSlug.trim()
+        : '';
+    if (targetSlug && eventSlug && eventSlug !== targetSlug) continue;
+    const senderId = ev.getSender()?.trim() || null;
+    const isKnownTrustedSender = Boolean(
+      senderId &&
+        (senderId === ownerMatrixUserId ||
+          memberMatrixUserIds.includes(senderId)),
+    );
+    const hasElevatedRoomPower = roomPowerLevelForUser(room, senderId) >= 50;
+    const isTrustedActor = isKnownTrustedSender || hasElevatedRoomPower;
+
+    if (eventKind === SIGNAL_TEAM_EVENT_KIND) {
+      if (!isTrustedActor) continue;
+      memberMatrixUserIds = normalizeMatrixUserIds(content.memberMatrixUserIds);
+      const nextOwnerId =
+        typeof content.ownerMatrixUserId === 'string'
+          ? content.ownerMatrixUserId.trim()
+          : '';
+      if (nextOwnerId) {
+        ownerMatrixUserId = nextOwnerId;
+      }
+      continue;
+    }
+
+    if (eventKind !== SIGNAL_TEAM_REQUEST_EVENT_KIND) continue;
+    const requesterId =
+      typeof content.requesterMatrixUserId === 'string'
+        ? content.requesterMatrixUserId.trim()
+        : '';
+    if (!requesterId) continue;
+    const status =
+      typeof content.status === 'string' ? content.status.trim() : 'pending';
+    const requesterIsSender = senderId === requesterId;
+    if (!requesterIsSender && !isTrustedActor) continue;
+    if (status === 'pending') {
+      pending.add(requesterId);
+    } else {
+      pending.delete(requesterId);
+    }
+  }
+
+  return {
+    memberMatrixUserIds,
+    pendingRequesterIds: [...pending],
+    ownerMatrixUserId,
+  };
+}
 
 function readPersistedChatHistory(roomId: string): UIMessage[] {
   if (typeof window === 'undefined') return [];
@@ -275,6 +477,49 @@ function rememberRoomToSpaceSlugSession(roomId: string, slug: string): void {
     );
   } catch {
     // ignore
+  }
+}
+
+function rememberRoomToCoherenceSession(
+  roomId: string,
+  slug: string,
+  title?: string | null,
+): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.sessionStorage.setItem(
+      `${SESSION_ROOM_TO_COHERENCE_SLUG_PREFIX}${roomId}`,
+      slug,
+    );
+    if (title?.trim()) {
+      window.sessionStorage.setItem(
+        `${SESSION_ROOM_TO_COHERENCE_TITLE_PREFIX}${roomId}`,
+        title.trim(),
+      );
+    }
+  } catch {
+    // ignore
+  }
+}
+
+function readRoomToCoherenceSession(roomId: string): {
+  slug: string | null;
+  title: string | null;
+} {
+  if (typeof window === 'undefined') return { slug: null, title: null };
+  try {
+    const slug = window.sessionStorage
+      .getItem(`${SESSION_ROOM_TO_COHERENCE_SLUG_PREFIX}${roomId}`)
+      ?.trim();
+    const title = window.sessionStorage
+      .getItem(`${SESSION_ROOM_TO_COHERENCE_TITLE_PREFIX}${roomId}`)
+      ?.trim();
+    return {
+      slug: slug || null,
+      title: title || null,
+    };
+  } catch {
+    return { slug: null, title: null };
   }
 }
 
@@ -427,6 +672,9 @@ function toUIMessage(
       : undefined;
 
   const media = mediaSingle;
+  const normalizedTextContent = isMedia
+    ? msg.content
+    : toUserFriendlySignalSystemBody(msg.content);
 
   const memberAvatar =
     !isCurrentUser && msg.sender ? resolveAvatarForUser(msg.sender) : undefined;
@@ -439,7 +687,7 @@ function toUIMessage(
       ? captionForMedia
         ? [{ type: 'text', text: captionForMedia }]
         : []
-      : [{ type: 'text', text: msg.content }],
+      : [{ type: 'text', text: normalizedTextContent }],
     media,
     mediaSlots,
     formattedContentHtml:
@@ -579,6 +827,8 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
     openHumanChatPanel,
   } = useHumanChatPanel();
   const { jwt: authToken } = useJwt();
+  const { useSendNotifications } = useHookRegistry();
+  const { notifyChatMention } = useSendNotifications({ authToken });
   const { person: me } = useMe();
   const { persons: spaceMembersResult } = useMembers({
     spaceSlug,
@@ -612,6 +862,7 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
     isAuthenticated,
     isLoading: isAuthLoading,
     login,
+    getAccessToken,
   } = useAuthentication();
 
   const currentUserAvatarUrl = me?.avatarUrl;
@@ -644,10 +895,21 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
   const editDraftRef = useRef(editDraft);
   editDraftRef.current = editDraft;
   const [roomId, setRoomId] = useState<string | null>(null);
+  const {
+    summary: threadSummary,
+    isLoading: threadSummaryLoading,
+    refresh: refreshThreadSummaryView,
+  } = useThreadSummary(spaceSlug, roomId);
 
   useEffect(() => {
     setMentionDisplayOverride({});
   }, [roomId]);
+
+  useEffect(() => {
+    if (mode !== 'coherence') {
+      setSignalTeamPanelOpen(false);
+    }
+  }, [mode]);
 
   const [isJoining, setIsJoining] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -656,6 +918,9 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
   const [deleteError, setDeleteError] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<ChatPanelTab>('chat');
   const [scrollToEventId, setScrollToEventId] = useState<string | null>(null);
+  const [mentionNavigationNotice, setMentionNavigationNotice] = useState<
+    string | null
+  >(null);
   /** Shown in timeline after a short delay while large attachment sends run. */
   const [sendingPending, setSendingPending] = useState<null | {
     id: string;
@@ -667,6 +932,18 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
   const [unreadBump, setUnreadBump] = useState(0);
   const [aggregateMentionBump, setAggregateMentionBump] = useState(0);
   const lastAutoMarkReadAtRef = useRef(0);
+  const [signalTeamMemberIds, setSignalTeamMemberIds] = useState<string[]>([]);
+  const [signalTeamOwnerId, setSignalTeamOwnerId] = useState<string | null>(
+    null,
+  );
+  const [signalTeamPendingRequesterIds, setSignalTeamPendingRequesterIds] =
+    useState<string[]>([]);
+  const [signalTeamPanelOpen, setSignalTeamPanelOpen] = useState(false);
+  const [signalTeamDraftMemberIds, setSignalTeamDraftMemberIds] = useState<
+    string[] | null
+  >(null);
+  const [signalTeamBusy, setSignalTeamBusy] = useState(false);
+  const signalTeamAutoSeededRoomIdsRef = useRef<Set<string>>(new Set());
 
   const currentUserId = client?.getUserId?.() ?? null;
   const currentUserIdRef = useRef(currentUserId);
@@ -728,6 +1005,17 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
     groupCall: spaceGroupCall,
     feedVersion: spaceCallFeedVersion,
     screenshareErrorCode: spaceCallScreenshareError,
+    captureMode: spaceCallCaptureMode,
+    capturePreference: spaceCallCapturePreference,
+    capturePreferenceSelected: spaceCallCapturePreferenceSelected,
+    setCapturePreference: setSpaceCallCapturePreference,
+    startCapture: startSpaceCallCapture,
+    pauseCapture: pauseSpaceCallCapture,
+    resumeCapture: resumeSpaceCallCapture,
+    stopCapture: stopSpaceCallCapture,
+    recordingStatus: spaceCallRecordingStatus,
+    recordingError: spaceCallRecordingError,
+    captureConsent: spaceCallCaptureConsent,
     dismissScreenshareError: dismissSpaceCallScreenshareError,
     activeSpeakerKey: spaceCallActiveSpeakerKey,
     setScreensharingEnabled: setSpaceCallScreensharing,
@@ -742,30 +1030,28 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
   } = useGlobalCallDock();
 
   useEffect(() => {
-    if (mode === 'space') {
-      bindRoomContext(roomId, spaceSlug ?? null, authToken ?? null);
+    const activeRoomId = roomId?.trim() || null;
+    const activeSpaceSlug = spaceSlug?.trim() || null;
+    const activeAuthToken = authToken?.trim() || null;
+
+    if (activeRoomId) {
+      bindRoomContext(activeRoomId, activeSpaceSlug, activeAuthToken);
     } else {
-      bindRoomContext(null, null);
+      bindRoomContext(null, null, null);
     }
+
     return () => {
-      bindRoomContext(null, null);
+      bindRoomContext(null, null, null);
     };
-  }, [authToken, bindRoomContext, mode, roomId, spaceSlug]);
+  }, [authToken, bindRoomContext, roomId, spaceSlug]);
 
   const callUiEnabled = useMemo(
     () =>
-      mode === 'space' &&
       Boolean(roomId) &&
       isMatrixAvailable &&
       isMatrixAuthenticated &&
       hasSpaceChatAccess,
-    [
-      mode,
-      roomId,
-      isMatrixAvailable,
-      isMatrixAuthenticated,
-      hasSpaceChatAccess,
-    ],
+    [roomId, isMatrixAvailable, isMatrixAuthenticated, hasSpaceChatAccess],
   );
 
   const inSpaceCall =
@@ -890,6 +1176,11 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
 
   /** Bumps when Matrix room membership changes so `@` mention candidates + button state refresh without reload. */
   const [mentionMembershipEpoch, setMentionMembershipEpoch] = useState(0);
+  const [matrixProfileLabelByUserId, setMatrixProfileLabelByUserId] = useState<
+    Record<string, string>
+  >({});
+  const profileLookupInFlightRef = useRef<Set<string>>(new Set());
+  const profileLookupAttemptedRef = useRef<Set<string>>(new Set());
 
   const rosterSubs = useMemo(
     () =>
@@ -916,6 +1207,24 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
     return m;
   }, [spaceMembers, subToMatrixUserId, t]);
 
+  /** Fallback roster lookup using Matrix localpart == Privy sub (same `useMembers` roster source as chat Members tab). */
+  const personLabelByPrivySub = useMemo(() => {
+    const m = new Map<string, string>();
+    for (const p of spaceMembers) {
+      const sub = p.sub?.trim();
+      if (!sub) continue;
+      m.set(sub, personRosterLabel(p, t('unknownMember')));
+    }
+    return m;
+  }, [spaceMembers, t]);
+
+  const matrixLocalpartToPrivySub = useCallback(
+    (userId: string): string | null => {
+      return matrixUserIdToCanonicalPrivySub(userId);
+    },
+    [],
+  );
+
   const resolveMemberLabel = useCallback(
     (userId: string | undefined) => {
       if (!userId) return t('unknownMember');
@@ -925,6 +1234,13 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
       }
       const rosterLabel = matrixUserIdToPersonLabel.get(userId)?.trim();
       if (rosterLabel) return rosterLabel;
+      const localpartSub = matrixLocalpartToPrivySub(userId);
+      if (localpartSub) {
+        const rosterBySub = personLabelByPrivySub.get(localpartSub)?.trim();
+        if (rosterBySub) return rosterBySub;
+      }
+      const profileLabel = matrixProfileLabelByUserId[userId]?.trim();
+      if (profileLabel) return profileLabel;
       if (roomId && client) {
         const room = client.getRoom(roomId);
         const member = room?.getMember(userId);
@@ -940,39 +1256,68 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
     [
       client,
       currentUserId,
+      matrixLocalpartToPrivySub,
+      matrixProfileLabelByUserId,
       matrixUserIdToPersonLabel,
       me?.name,
       me?.surname,
+      personLabelByPrivySub,
       roomId,
       t,
     ],
   );
 
-  const mentionCandidates = useMemo((): ChatMentionCandidate[] => {
-    if (!client || !roomId) return [];
-    const room = client.getRoom(roomId);
-    if (!room) return [];
+  const mentionCandidateRoomIds = useMemo(() => {
+    const ids = new Set<string>();
+    if (roomId?.trim()) {
+      ids.add(roomId.trim());
+    }
+    if (mode === 'coherence' && space?.chatRoomId?.trim()) {
+      ids.add(space.chatRoomId.trim());
+    }
+    return [...ids];
+  }, [roomId, mode, space?.chatRoomId]);
+
+  const rawMentionCandidates = useMemo((): ChatMentionCandidate[] => {
+    if (!client || mentionCandidateRoomIds.length === 0) return [];
 
     const byUserId = new Map<
       string,
       { displayLabel: string; avatarUrl?: string; privySub?: string }
     >();
 
-    for (const member of room.getJoinedMembers()) {
-      const userId = member.userId;
-      if (!userId) continue;
-      if (currentUserId && userId === currentUserId) continue;
-      byUserId.set(userId, {
-        displayLabel: matrixMemberDisplayLabel(member, userId),
-        avatarUrl: matrixMemberAvatarSquare(client, roomId, userId, 64),
-      });
+    for (const candidateRoomId of mentionCandidateRoomIds) {
+      const room = client.getRoom(candidateRoomId);
+      if (!room) continue;
+      for (const member of room.getJoinedMembers()) {
+        const userId = member.userId;
+        if (!userId) continue;
+        if (currentUserId && userId === currentUserId) continue;
+        byUserId.set(userId, {
+          displayLabel: matrixMemberDisplayLabel(member, userId),
+          avatarUrl: matrixMemberAvatarSquare(
+            client,
+            candidateRoomId,
+            userId,
+            64,
+          ),
+        });
+      }
     }
 
     /** Same names as Members tab — overrides Matrix-only technical displaynames. */
     for (const p of spaceMembers) {
       const sub = p.sub?.trim();
       if (!sub) continue;
-      const mxid = subToMatrixUserId[sub];
+      let mxid = subToMatrixUserId[sub];
+      if (!mxid) {
+        for (const userId of byUserId.keys()) {
+          if (matrixUserIdToCanonicalPrivySub(userId) === sub) {
+            mxid = userId;
+            break;
+          }
+        }
+      }
       if (!mxid) continue;
       if (currentUserId && mxid === currentUserId) continue;
       const prev = byUserId.get(mxid);
@@ -1001,12 +1346,65 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
     return list;
   }, [
     client,
-    roomId,
+    mentionCandidateRoomIds,
     currentUserId,
     spaceMembers,
     subToMatrixUserId,
     t,
     mentionMembershipEpoch,
+  ]);
+
+  useEffect(() => {
+    if (!client || rawMentionCandidates.length === 0) return;
+    const unresolved = rawMentionCandidates.filter((candidate) => {
+      if (profileLookupAttemptedRef.current.has(candidate.userId)) return false;
+      if (matrixProfileLabelByUserId[candidate.userId]) return false;
+      if (matrixUserIdToCanonicalPrivySub(candidate.userId)) return false;
+      if (matrixUserIdToPersonLabel.has(candidate.userId)) return false;
+      return looksLikeTechnicalMatrixDisplayName(
+        candidate.displayLabel,
+        candidate.userId,
+      );
+    });
+    if (unresolved.length === 0) return;
+
+    const batch = unresolved.slice(0, 3);
+    for (const candidate of batch) {
+      const userId = candidate.userId;
+      if (profileLookupInFlightRef.current.has(userId)) continue;
+      if (profileLookupAttemptedRef.current.has(userId)) continue;
+      profileLookupInFlightRef.current.add(userId);
+      profileLookupAttemptedRef.current.add(userId);
+      void client
+        .getProfileInfo(userId)
+        .then((profile) => {
+          const displayName =
+            typeof profile?.displayname === 'string'
+              ? profile.displayname.trim()
+              : '';
+          if (
+            !displayName ||
+            looksLikeTechnicalMatrixDisplayName(displayName, userId)
+          ) {
+            return;
+          }
+          setMatrixProfileLabelByUserId((prev) => {
+            if (prev[userId] === displayName) return prev;
+            return { ...prev, [userId]: displayName };
+          });
+        })
+        .catch(() => {
+          // Best-effort lookup; keep existing fallback when unavailable.
+        })
+        .finally(() => {
+          profileLookupInFlightRef.current.delete(userId);
+        });
+    }
+  }, [
+    client,
+    rawMentionCandidates,
+    matrixProfileLabelByUserId,
+    matrixUserIdToPersonLabel,
   ]);
 
   const mergeMentionDisplayLabel = useCallback(
@@ -1021,6 +1419,27 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
     [],
   );
 
+  const isSignalThread = mode === 'coherence' && Boolean(coherenceSlug?.trim());
+  const hasSignalTeamPolicy = isSignalThread && signalTeamMemberIds.length > 0;
+  const signalTeamMemberIdSet = useMemo(
+    () => new Set(signalTeamMemberIds),
+    [signalTeamMemberIds],
+  );
+  const isCurrentUserSignalTeamMember = Boolean(
+    currentUserId && signalTeamMemberIdSet.has(currentUserId),
+  );
+  const canInteractWithSignalThread =
+    !isSignalThread || !hasSignalTeamPolicy || isCurrentUserSignalTeamMember;
+  const canJoinSignalThreadCall =
+    !isSignalThread || !hasSignalTeamPolicy || isCurrentUserSignalTeamMember;
+
+  const mentionCandidates = useMemo((): ChatMentionCandidate[] => {
+    if (!isSignalThread) return rawMentionCandidates;
+    return rawMentionCandidates.filter((candidate) =>
+      signalTeamMemberIdSet.has(candidate.userId),
+    );
+  }, [isSignalThread, rawMentionCandidates, signalTeamMemberIdSet]);
+
   const mentionLabelByUserId = useMemo(
     () =>
       new Map(
@@ -1028,11 +1447,11 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
           const o = mentionDisplayOverride[candidate.userId];
           return [
             candidate.userId,
-            o?.trim() ? o : candidate.displayLabel,
+            o?.trim() ? o : resolveMemberLabel(candidate.userId),
           ] as const;
         }),
       ),
-    [mentionCandidates, mentionDisplayOverride],
+    [mentionCandidates, mentionDisplayOverride, resolveMemberLabel],
   );
 
   const duplicateSanitizedDisplayKeys = useMemo(
@@ -1076,7 +1495,18 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
     (userId: string | undefined) => {
       const id = userId?.trim();
       if (!id) return t('unknownMember');
-      return mentionLabelByUserId.get(id) ?? resolveMemberLabel(id);
+      const mentionLabel = mentionLabelByUserId.get(id)?.trim();
+      const resolved = resolveMemberLabel(id);
+      if (
+        mentionLabel &&
+        !looksLikeTechnicalMatrixDisplayName(mentionLabel, id)
+      ) {
+        return mentionLabel;
+      }
+      if (!looksLikeTechnicalMatrixDisplayName(resolved, id)) {
+        return resolved;
+      }
+      return mentionLabel || resolved;
     },
     [mentionLabelByUserId, resolveMemberLabel, t],
   );
@@ -1092,16 +1522,264 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
   );
 
   /** `@` when there is anyone to mention (joined members and/or roster-linked MXIDs). */
-  const mentionPickerEnabled = mentionCandidates.length > 0;
+  const mentionPickerEnabled =
+    canInteractWithSignalThread && mentionCandidates.length > 0;
+  const signalTeamSelectableMembers = useMemo((): ChatMentionCandidate[] => {
+    const byUserId = new Map<string, ChatMentionCandidate>();
+    for (const member of rawMentionCandidates) {
+      byUserId.set(member.userId, member);
+    }
+    if (currentUserId) {
+      const currentUserLabel =
+        [me?.name, me?.surname].filter(Boolean).join(' ').trim() ||
+        me?.nickname?.trim() ||
+        t('you');
+      if (!byUserId.has(currentUserId)) {
+        byUserId.set(currentUserId, {
+          userId: currentUserId,
+          displayLabel: currentUserLabel,
+          avatarUrl: me?.avatarUrl,
+        });
+      }
+    }
+    return [...byUserId.values()].sort((a, b) =>
+      resolveMentionMemberLabel(a.userId).localeCompare(
+        resolveMentionMemberLabel(b.userId),
+        undefined,
+        {
+          sensitivity: 'base',
+        },
+      ),
+    );
+  }, [
+    rawMentionCandidates,
+    currentUserId,
+    me?.name,
+    me?.surname,
+    me?.nickname,
+    me?.avatarUrl,
+    resolveMentionMemberLabel,
+    t,
+  ]);
+  const effectiveSignalTeamMemberIds = useMemo(
+    () =>
+      isSignalThread
+        ? signalTeamMemberIds
+        : signalTeamSelectableMembers.map((member) => member.userId),
+    [isSignalThread, signalTeamMemberIds, signalTeamSelectableMembers],
+  );
+  const signalTeamEditorMemberIds = useMemo(
+    () =>
+      signalTeamDraftMemberIds != null
+        ? signalTeamDraftMemberIds
+        : effectiveSignalTeamMemberIds,
+    [signalTeamDraftMemberIds, effectiveSignalTeamMemberIds],
+  );
+  const canManageSignalTeam =
+    isSignalThread && (!hasSignalTeamPolicy || isCurrentUserSignalTeamMember);
+  const currentUserPendingSignalTeamRequest = Boolean(
+    currentUserId && signalTeamPendingRequesterIds.includes(currentUserId),
+  );
+
+  const publishSignalTeamMembers = useCallback(
+    async (
+      nextMemberIds: string[],
+      options?: {
+        addedMemberMatrixUserIds?: string[];
+        removedMemberMatrixUserIds?: string[];
+      },
+    ) => {
+      if (!client || !roomId || !isSignalThread) return;
+      try {
+        const ownerId =
+          signalTeamOwnerId?.trim() || currentUserId?.trim() || null;
+        const actorId = currentUserId?.trim() || null;
+        const deduped = normalizeMatrixUserIds([
+          ...nextMemberIds,
+          ...(ownerId ? [ownerId] : []),
+          ...(actorId ? [actorId] : []),
+        ]);
+        const added = normalizeMatrixUserIds(options?.addedMemberMatrixUserIds);
+        const removed = normalizeMatrixUserIds(
+          options?.removedMemberMatrixUserIds,
+        );
+        const addedLabels = added.map((id) => resolveMentionMemberLabel(id));
+        const removedLabels = removed.map((id) =>
+          resolveMentionMemberLabel(id),
+        );
+        const summaryParts: string[] = [];
+        if (addedLabels.length > 0) {
+          summaryParts.push(`added ${addedLabels.join(', ')}`);
+        }
+        if (removedLabels.length > 0) {
+          summaryParts.push(`removed ${removedLabels.join(', ')}`);
+        }
+        const summaryText =
+          summaryParts.length > 0 ? `: ${summaryParts.join('; ')}` : '';
+        await client.sendEvent(roomId, EventType.RoomMessage, {
+          msgtype: MsgType.Notice,
+          body: `${SIGNAL_TEAM_EVENT_BODY_MARKER} signal team updated${summaryText}`,
+          coherenceSlug: coherenceSlug?.trim() || null,
+          memberMatrixUserIds: deduped,
+          ownerMatrixUserId: ownerId,
+          addedMemberMatrixUserIds: added,
+          removedMemberMatrixUserIds: removed,
+          updatedAt: new Date().toISOString(),
+        } as SignalTeamEventContent);
+        setSignalTeamMemberIds(deduped);
+        if (ownerId && !signalTeamOwnerId) {
+          setSignalTeamOwnerId(ownerId);
+        }
+        setSignalTeamPendingRequesterIds((prev) =>
+          prev.filter((id) => !deduped.includes(id)),
+        );
+      } catch (error) {
+        console.error(
+          '[HumanRightPanel] publishSignalTeamMembers failed',
+          error,
+        );
+        setComposerError(t('sendFailed'));
+      }
+    },
+    [
+      client,
+      roomId,
+      isSignalThread,
+      coherenceSlug,
+      currentUserId,
+      signalTeamOwnerId,
+      resolveMentionMemberLabel,
+      t,
+    ],
+  );
+
+  const commitSignalTeamDraft = useCallback(async () => {
+    if (!signalTeamPanelOpen) return;
+    const draftIds = signalTeamDraftMemberIds;
+    setSignalTeamPanelOpen(false);
+    if (!draftIds) return;
+
+    const currentIds = normalizeMatrixUserIds(effectiveSignalTeamMemberIds);
+    const nextIds = normalizeMatrixUserIds(draftIds);
+    const addedMemberMatrixUserIds = nextIds.filter(
+      (id) => !currentIds.includes(id),
+    );
+    const removedMemberMatrixUserIds = currentIds.filter(
+      (id) => !nextIds.includes(id),
+    );
+    setSignalTeamDraftMemberIds(null);
+    if (
+      addedMemberMatrixUserIds.length === 0 &&
+      removedMemberMatrixUserIds.length === 0
+    ) {
+      return;
+    }
+    await publishSignalTeamMembers(nextIds, {
+      addedMemberMatrixUserIds,
+      removedMemberMatrixUserIds,
+    });
+  }, [
+    signalTeamPanelOpen,
+    signalTeamDraftMemberIds,
+    effectiveSignalTeamMemberIds,
+    publishSignalTeamMembers,
+  ]);
+
+  const requestSignalTeamAccess = useCallback(async () => {
+    if (!client || !roomId || !isSignalThread || !currentUserId) return;
+    setSignalTeamBusy(true);
+    try {
+      await client.sendEvent(roomId, EventType.RoomMessage, {
+        msgtype: MsgType.Notice,
+        body: `${SIGNAL_TEAM_REQUEST_EVENT_BODY_MARKER} signal team access requested`,
+        coherenceSlug: coherenceSlug?.trim() || null,
+        requesterMatrixUserId: currentUserId,
+        status: 'pending',
+        updatedAt: new Date().toISOString(),
+      } as SignalTeamEventContent);
+      setSignalTeamPendingRequesterIds((prev) =>
+        prev.includes(currentUserId) ? prev : [...prev, currentUserId],
+      );
+    } catch (error) {
+      console.error('[HumanRightPanel] requestSignalTeamAccess failed', error);
+      setComposerError(t('sendFailed'));
+    } finally {
+      setSignalTeamBusy(false);
+    }
+  }, [client, roomId, isSignalThread, currentUserId, coherenceSlug, t]);
+
+  const approveSignalTeamRequester = useCallback(
+    async (requesterMatrixUserId: string) => {
+      if (!client || !roomId || !isSignalThread) return;
+      const requesterId = requesterMatrixUserId.trim();
+      if (!requesterId) return;
+      setSignalTeamBusy(true);
+      try {
+        const ownerId =
+          signalTeamOwnerId?.trim() || currentUserId?.trim() || null;
+        const actorId = currentUserId?.trim() || null;
+        const nextMembers = normalizeMatrixUserIds([
+          ...effectiveSignalTeamMemberIds,
+          requesterId,
+          ...(ownerId ? [ownerId] : []),
+          ...(actorId ? [actorId] : []),
+        ]);
+        await Promise.all([
+          client.sendEvent(roomId, EventType.RoomMessage, {
+            msgtype: MsgType.Notice,
+            body: `${SIGNAL_TEAM_REQUEST_EVENT_BODY_MARKER} signal team access approved`,
+            coherenceSlug: coherenceSlug?.trim() || null,
+            requesterMatrixUserId: requesterId,
+            status: 'approved',
+            updatedAt: new Date().toISOString(),
+          } as SignalTeamEventContent),
+          client.sendEvent(roomId, EventType.RoomMessage, {
+            msgtype: MsgType.Notice,
+            body: `${SIGNAL_TEAM_EVENT_BODY_MARKER} signal team members updated`,
+            coherenceSlug: coherenceSlug?.trim() || null,
+            memberMatrixUserIds: nextMembers,
+            ownerMatrixUserId: ownerId,
+            updatedAt: new Date().toISOString(),
+          } as SignalTeamEventContent),
+        ]);
+        setSignalTeamMemberIds(nextMembers);
+        setSignalTeamPendingRequesterIds((prev) =>
+          prev.filter((id) => id !== requesterId),
+        );
+      } catch (error) {
+        console.error(
+          '[HumanRightPanel] approveSignalTeamRequester failed',
+          error,
+        );
+        setComposerError(t('sendFailed'));
+      } finally {
+        setSignalTeamBusy(false);
+      }
+    },
+    [
+      client,
+      roomId,
+      isSignalThread,
+      coherenceSlug,
+      effectiveSignalTeamMemberIds,
+      currentUserId,
+      signalTeamOwnerId,
+      t,
+    ],
+  );
 
   useEffect(() => {
     if (!client || !roomId) return;
     const room = client.getRoom(roomId);
     if (!room) return;
+    const parentRoomId =
+      mode === 'coherence' ? space?.chatRoomId?.trim() : undefined;
 
     const bumpMembership = (...args: unknown[]) => {
       const state = args[1] as { roomId?: string } | undefined;
-      if (state?.roomId !== roomId) return;
+      const changedRoomId = state?.roomId?.trim();
+      if (!changedRoomId) return;
+      if (changedRoomId !== roomId && changedRoomId !== parentRoomId) return;
       setMentionMembershipEpoch((n) => n + 1);
     };
 
@@ -1112,7 +1790,7 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
       client.off(RoomStateEvent.Members, bumpMembership);
       client.off(RoomStateEvent.NewMember, bumpMembership);
     };
-  }, [client, roomId]);
+  }, [client, mode, roomId, space?.chatRoomId]);
 
   const resolveMemberLabelRef = useRef(resolveMemberLabel);
   resolveMemberLabelRef.current = resolveMemberLabel;
@@ -1762,6 +2440,7 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
 
   const handleSelectMentionFromInbox = useCallback(
     (eventId: string, fromRoomId?: string) => {
+      setMentionNavigationNotice(null);
       const targetRoom = fromRoomId?.trim();
       const current = roomId?.trim();
       const langMatch = pathname.match(/^\/([^/]+)\//);
@@ -1791,6 +2470,20 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
           setActiveTab('chat');
           return;
         }
+
+        const coherence = readRoomToCoherenceSession(targetRoom);
+        if (coherence.slug) {
+          openCoherenceChat(
+            targetRoom,
+            coherence.title || 'Conversation',
+            coherence.slug,
+          );
+          openHumanChatPanel();
+          setActiveTab('chat');
+          setScrollToEventId(eventId);
+          return;
+        }
+        setMentionNavigationNotice(t('mentionOpenFallbackRoom'));
       }
 
       setActiveTab('chat');
@@ -1800,15 +2493,25 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
       roomId,
       pathname,
       router,
+      openCoherenceChat,
       openHumanChatPanel,
       space?.chatRoomId,
       spaceSlug,
+      t,
     ],
   );
 
   const handleConsumedScrollTarget = useCallback(() => {
     setScrollToEventId(null);
   }, []);
+
+  const handleScrollTargetNotFound = useCallback(
+    (_eventId: string) => {
+      setMentionNavigationNotice(t('mentionOpenFallbackMissingMessage'));
+      setScrollToEventId(null);
+    },
+    [t],
+  );
 
   const mergedMessages = useMemo(() => {
     if (!sendingPending) return messages;
@@ -1826,6 +2529,47 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
     };
     return [...messages, pendingRow];
   }, [messages, sendingPending, currentUserAvatarUrl]);
+
+  const reportThreadSummaryActivity = useCallback(
+    (eventId: string, originServerTs: number) => {
+      const slug = spaceSlug?.trim();
+      const activeRoomId = roomId?.trim();
+      if (!slug || !activeRoomId || !eventId.trim()) return;
+      void recordThreadSummaryActivity({
+        spaceSlug: slug,
+        matrixRoomId: activeRoomId,
+        threadKind: mode === 'coherence' ? 'coherence' : 'space',
+        coherenceSlug: mode === 'coherence' ? coherenceSlug : null,
+        threadTitle: mode === 'coherence' ? coherenceTitle : null,
+        lastMessageEventId: eventId,
+        lastMessageOriginServerTs: originServerTs,
+        getAccessToken,
+      }).then(() => {
+        void refreshThreadSummaryView();
+      });
+    },
+    [
+      coherenceSlug,
+      coherenceTitle,
+      getAccessToken,
+      mode,
+      refreshThreadSummaryView,
+      roomId,
+      spaceSlug,
+    ],
+  );
+
+  useEffect(() => {
+    if (!roomId || !spaceSlug?.trim()) return;
+    const latest = [...messages]
+      .reverse()
+      .find((m) => !m.isSynthetic && !m.sendPending && m.id.trim());
+    if (!latest?.timestamp) return;
+    const timer = window.setTimeout(() => {
+      reportThreadSummaryActivity(latest.id, latest.timestamp!.getTime());
+    }, 2500);
+    return () => window.clearTimeout(timer);
+  }, [messages, reportThreadSummaryActivity, roomId, spaceSlug]);
 
   useEffect(() => {
     if (!client || !roomId) return;
@@ -1875,6 +2619,20 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
       rememberRoomToSpaceSlugSession(rid, pathSlug);
     }
   }, [pathname, roomId, mode]);
+
+  useEffect(() => {
+    const rid = roomId?.trim() ?? null;
+    const slug = coherenceSlug?.trim() ?? null;
+    if (
+      !rid ||
+      !slug ||
+      mode !== 'coherence' ||
+      typeof window === 'undefined'
+    ) {
+      return;
+    }
+    rememberRoomToCoherenceSession(rid, slug, coherenceTitle);
+  }, [roomId, coherenceSlug, coherenceTitle, mode]);
 
   /**
    * Global mention badge: avoid listening to `ClientEvent.Room` — it fires on almost every
@@ -2103,13 +2861,19 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
       const authorLabel =
         target.role === 'user'
           ? t('you')
-          : target.senderName ?? resolveMemberLabel(target.senderMatrixId);
+          : target.role === 'member' && target.senderMatrixId
+          ? resolveMemberLabel(target.senderMatrixId)
+          : target.senderName ?? t('unknownMember');
       const excerpt = firstLineForReplyPreview(getMessagePlainText(target));
       setEditDraft(null);
       setReplyDraft({
         messageId,
         authorLabel,
         excerpt,
+        ...(target.role === 'user' ? { isYou: true } : {}),
+        ...(target.role === 'member' && target.senderMatrixId
+          ? { sourceUserId: target.senderMatrixId }
+          : {}),
       });
     },
     [messages, resolveMemberLabel, t],
@@ -2199,6 +2963,10 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
 
   const handleSend = useCallback(async () => {
     if (!roomId) return;
+    if (!canInteractWithSignalThread) {
+      setComposerError(t('signalTeamInteractionRestricted'));
+      return;
+    }
     const trimmed = input.trim();
     if (!trimmed && draftAttachments.length === 0) return;
     const text = input;
@@ -2274,7 +3042,7 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
           });
         }
       } else {
-        await matrixRef.current.sendMessage({
+        const sendResult = await matrixRef.current.sendMessage({
           roomId,
           message: wirePlain,
           mentionUserIds,
@@ -2305,6 +3073,58 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
               }
             : {}),
         });
+        if (sendResult.eventId && spaceSlug?.trim()) {
+          reportThreadSummaryActivity(sendResult.eventId, Date.now());
+        }
+        const mentionTargets = mentionUserIds.filter((matrixId) => {
+          if (matrixId === currentUserIdRef.current) return false;
+          if (!hasSignalTeamPolicy) return true;
+          return signalTeamMemberIdSet.has(matrixId);
+        });
+        if (
+          mentionTargets.length > 0 &&
+          sendResult.eventId &&
+          mode === 'space'
+        ) {
+          const params = new URLSearchParams(
+            searchParams?.toString() ?? undefined,
+          );
+          params.set('msg', sendResult.eventId);
+          params.set('chat', roomId);
+          const query = params.toString();
+          const lang = getLocaleFromPath(pathname);
+          const mappedSpaceSlug = roomId
+            ? window.sessionStorage
+                .getItem(`${SESSION_ROOM_TO_SPACE_PREFIX}${roomId}`)
+                ?.trim() || readRoomIdToSpaceSlugFromStorage().get(roomId)
+            : null;
+          const canonicalSpaceSlug = spaceSlug?.trim() || mappedSpaceSlug;
+          const canonicalPath = canonicalSpaceSlug
+            ? `/${lang}/dho/${canonicalSpaceSlug}`
+            : pathname;
+          const deepLink =
+            typeof window !== 'undefined'
+              ? `${window.location.origin}${canonicalPath}${
+                  query ? `?${query}` : ''
+                }`
+              : canonicalPath;
+          const actorDisplayName =
+            [me?.name, me?.surname].filter(Boolean).join(' ').trim() ||
+            me?.nickname?.trim() ||
+            t('you');
+          void notifyChatMention({
+            actorSlug: me?.slug,
+            actorDisplayName,
+            mentionMatrixUserIds: mentionTargets,
+            messagePreview: wirePlain.trim().slice(0, 220),
+            url: deepLink,
+          }).catch((notifyErr) => {
+            console.warn(
+              '[HumanRightPanel] Mention notification dispatch failed:',
+              notifyErr,
+            );
+          });
+        }
       }
       setSendingPending(null);
       disposeDraftAttachmentUrls(savedAttachments);
@@ -2354,6 +3174,30 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
         setEditDraft(savedEditDraft);
         return;
       }
+      const isUnknownTokenError =
+        typeof err === 'object' &&
+        err !== null &&
+        ((err as { errcode?: string }).errcode === 'M_UNKNOWN_TOKEN' ||
+          (err as { data?: { errcode?: string } }).data?.errcode ===
+            'M_UNKNOWN_TOKEN' ||
+          `${(err as { message?: string }).message ?? ''}`
+            .toLowerCase()
+            .includes('unknown token'));
+      if (isUnknownTokenError) {
+        const recovered = await matrixRef.current
+          .refreshSession()
+          .catch(() => false);
+        setComposerError(
+          recovered
+            ? 'Chat session refreshed. Please send your message again.'
+            : 'Chat session expired. Please reload the page and try again.',
+        );
+        setInput(text);
+        setReplyDraft(savedDraft);
+        setEditDraft(savedEditDraft);
+        setDraftAttachments(savedAttachments);
+        return;
+      }
       const msg = isMatrixRateLimitedError(err)
         ? t('sendRateLimited')
         : err instanceof MatrixUploadTimeoutError
@@ -2370,10 +3214,22 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
   }, [
     input,
     roomId,
+    canInteractWithSignalThread,
     replyDraft,
     editDraft,
     draftAttachments,
     mentionSanitizedLabelToUserId,
+    mode,
+    searchParams,
+    pathname,
+    me?.name,
+    me?.surname,
+    me?.nickname,
+    me?.slug,
+    spaceSlug,
+    notifyChatMention,
+    hasSignalTeamPolicy,
+    signalTeamMemberIdSet,
     t,
   ]);
 
@@ -2423,8 +3279,20 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
                 onlyLocalInRoomCall={
                   spaceCallShowJoinStrip && spaceCallOtherMemberCount === 0
                 }
-                onAudio={handleCallAudio}
-                onVideo={handleCallVideo}
+                onAudio={() => {
+                  if (!canJoinSignalThreadCall && isSignalThread) {
+                    void requestSignalTeamAccess();
+                    return;
+                  }
+                  handleCallAudio();
+                }}
+                onVideo={() => {
+                  if (!canJoinSignalThreadCall && isSignalThread) {
+                    void requestSignalTeamAccess();
+                    return;
+                  }
+                  handleCallVideo();
+                }}
               />
             ) : null
           }
@@ -2437,8 +3305,21 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
               deviceCount={spaceCallRoomGroupDeviceCount}
               disabled={!callUiEnabled}
               busy={spaceCallBusyJoining}
-              onJoinAudio={handleCallAudio}
-              onJoinVideo={handleCallVideo}
+              captureConsent={spaceCallCaptureConsent}
+              onJoinAudio={() => {
+                if (!canJoinSignalThreadCall && isSignalThread) {
+                  void requestSignalTeamAccess();
+                  return;
+                }
+                handleCallAudio();
+              }}
+              onJoinVideo={() => {
+                if (!canJoinSignalThreadCall && isSignalThread) {
+                  void requestSignalTeamAccess();
+                  return;
+                }
+                handleCallVideo();
+              }}
             />
           )}
         {callUiEnabled &&
@@ -2466,6 +3347,18 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
               onVoiceProcessingPresetChange={
                 handleCallVoiceProcessingPresetChange
               }
+              captureMode={spaceCallCaptureMode}
+              capturePreference={spaceCallCapturePreference}
+              capturePreferenceSelected={spaceCallCapturePreferenceSelected}
+              onCapturePreferenceChange={setSpaceCallCapturePreference}
+              onStartCapture={startSpaceCallCapture}
+              onPauseCapture={pauseSpaceCallCapture}
+              onResumeCapture={resumeSpaceCallCapture}
+              onStopCapture={stopSpaceCallCapture}
+              recordingStatus={spaceCallRecordingStatus}
+              recordingError={spaceCallRecordingError}
+              captureConsent={spaceCallCaptureConsent}
+              controlsMode="leave_only"
               onDismissScreenshareError={dismissSpaceCallScreenshareError}
               onRetryCall={handleRetrySpaceCall}
               onDismissCallError={dismissSpaceCallError}
@@ -2518,6 +3411,7 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
                       groupCall={spaceGroupCall}
                       callKind={spaceCallKind}
                       isLocalVideoMuted={spaceCallVideoMuted}
+                      isMicrophoneMuted={spaceCallMicMuted}
                       isScreensharing={spaceCallScreensharing}
                       callState={spaceCallState}
                       feedVersion={spaceCallFeedVersion}
@@ -2533,7 +3427,7 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
                 {error && (
                   <div
                     role="alert"
-                    className="mx-3 mt-3 rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive"
+                    className="mt-0 w-full border-y border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive"
                   >
                     {error}
                   </div>
@@ -2541,15 +3435,187 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
                 {composerError && (
                   <div
                     role="alert"
-                    className="mx-3 mt-2 rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive"
+                    className="mt-0 w-full border-y border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive"
                   >
                     {composerError}
+                  </div>
+                )}
+                {mentionNavigationNotice && (
+                  <div
+                    role="status"
+                    className="mt-0 w-full border-y border-amber-500/30 bg-amber-500/10 px-3 py-2 text-sm text-amber-700 dark:text-amber-300"
+                  >
+                    {mentionNavigationNotice}
+                  </div>
+                )}
+                {isSignalThread &&
+                  hasSignalTeamPolicy &&
+                  !canInteractWithSignalThread && (
+                    <div className="mt-0 w-full border-y border-border/70 bg-muted/40 px-3 py-2 text-sm text-foreground">
+                      <p>{t('signalTeamBannerReadOnly')}</p>
+                      <div className="mt-2 flex items-center gap-2">
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant="outline"
+                          className="h-8 min-h-8 border-[color:var(--space-accent)] bg-background px-3 text-[color:var(--space-accent)] hover:bg-accent-3 disabled:border-[color:var(--space-accent)]/45 disabled:text-[color:var(--space-accent)]/55 disabled:opacity-100"
+                          disabled={
+                            currentUserPendingSignalTeamRequest ||
+                            signalTeamBusy
+                          }
+                          onClick={() => void requestSignalTeamAccess()}
+                        >
+                          {currentUserPendingSignalTeamRequest
+                            ? t('signalTeamRequestPending')
+                            : t('signalTeamRequestAccess')}
+                        </Button>
+                      </div>
+                    </div>
+                  )}
+                {isSignalThread &&
+                  canManageSignalTeam &&
+                  signalTeamPendingRequesterIds.length > 0 && (
+                    <div className="mt-0 w-full border-y border-border/70 bg-muted/40 px-3 py-2">
+                      <p className="text-xs font-medium text-foreground">
+                        {t('signalTeamPendingRequests')}
+                      </p>
+                      <div className="mt-2 space-y-1">
+                        {signalTeamPendingRequesterIds.map((requesterId) => (
+                          <div
+                            key={requesterId}
+                            className="flex items-center justify-between gap-2"
+                          >
+                            <span className="truncate text-xs text-muted-foreground">
+                              <SignalTeamResolvedMemberLabel
+                                candidate={{
+                                  userId: requesterId,
+                                  displayLabel:
+                                    resolveMentionMemberLabel(requesterId),
+                                }}
+                                fallbackLabel={resolveMentionMemberLabel(
+                                  requesterId,
+                                )}
+                                unknownMemberLabel={t('unknownMember')}
+                              />
+                            </span>
+                            <Button
+                              type="button"
+                              size="sm"
+                              variant="outline"
+                              disabled={signalTeamBusy}
+                              onClick={() =>
+                                void approveSignalTeamRequester(requesterId)
+                              }
+                            >
+                              {t('signalTeamApproveRequester')}
+                            </Button>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                {isSignalThread && canManageSignalTeam && (
+                  <div className="mt-0 w-full border-y border-border/70 bg-muted/40 px-3 py-2">
+                    <div className="flex items-center justify-between gap-3">
+                      <p className="text-sm font-medium text-foreground">
+                        {t('signalTeamManageTitle')}
+                      </p>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        colorVariant="accent"
+                        className="h-7 min-h-7 self-center border-[color:var(--space-accent)] px-2.5 py-0 text-xs font-semibold leading-none whitespace-nowrap text-[color:var(--space-accent)] hover:bg-accent-3"
+                        onClick={() => {
+                          if (signalTeamPanelOpen) {
+                            void commitSignalTeamDraft();
+                            return;
+                          }
+                          setSignalTeamDraftMemberIds(
+                            normalizeMatrixUserIds(
+                              effectiveSignalTeamMemberIds,
+                            ),
+                          );
+                          setSignalTeamPanelOpen(true);
+                        }}
+                      >
+                        {signalTeamPanelOpen
+                          ? t('signalTeamManageClose')
+                          : t('signalTeamManageOpen')}
+                      </Button>
+                    </div>
+                    {signalTeamPanelOpen && (
+                      <div className="mt-2 space-y-2">
+                        <p className="text-xs text-muted-foreground">
+                          {t('signalTeamMemberListHint')}
+                        </p>
+                        <div className="grid gap-1">
+                          {signalTeamSelectableMembers.map((member) => {
+                            const selected = signalTeamEditorMemberIds.includes(
+                              member.userId,
+                            );
+                            const isCurrentUser =
+                              member.userId === currentUserId;
+                            const isOwner = member.userId === signalTeamOwnerId;
+                            return (
+                              <button
+                                key={member.userId}
+                                type="button"
+                                className={`flex items-center justify-between rounded-md px-2 py-1 text-left text-sm ${
+                                  selected
+                                    ? 'border border-accent-8/55 bg-accent-3/28 ring-1 ring-accent-8/35'
+                                    : 'border border-transparent hover:bg-muted/70'
+                                }`}
+                                disabled={signalTeamBusy}
+                                onClick={() => {
+                                  if (isCurrentUser && selected) return;
+                                  if (isOwner && selected) return;
+                                  const next = selected
+                                    ? signalTeamEditorMemberIds.filter(
+                                        (id) => id !== member.userId,
+                                      )
+                                    : [
+                                        ...signalTeamEditorMemberIds,
+                                        member.userId,
+                                      ];
+                                  setSignalTeamDraftMemberIds(
+                                    normalizeMatrixUserIds(next),
+                                  );
+                                }}
+                              >
+                                <SignalTeamResolvedMemberLabel
+                                  candidate={{
+                                    userId: member.userId,
+                                    displayLabel: member.displayLabel,
+                                    privySub: member.privySub,
+                                  }}
+                                  fallbackLabel={member.displayLabel}
+                                  isOwner={isOwner}
+                                  unknownMemberLabel={t('unknownMember')}
+                                />
+                                <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
+                                  {isOwner ? null : selected ? (
+                                    <Check className="h-3.5 w-3.5 text-accent-11" />
+                                  ) : (
+                                    <Plus className="h-3.5 w-3.5" />
+                                  )}
+                                  {isOwner
+                                    ? 'Owner'
+                                    : selected
+                                    ? t('signalTeamRemoveMember')
+                                    : t('signalTeamAddMember')}
+                                </span>
+                              </button>
+                            );
+                          })}
+                        </div>
+                      </div>
+                    )}
                   </div>
                 )}
                 {reactionError && (
                   <div
                     role="alert"
-                    className="mx-3 mt-2 rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive"
+                    className="mt-0 w-full border-y border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive"
                   >
                     {reactionError}
                   </div>
@@ -2557,7 +3623,7 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
                 {deleteError && (
                   <div
                     role="alert"
-                    className="mx-3 mt-2 rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive"
+                    className="mt-0 w-full border-y border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive"
                   >
                     {deleteError}
                   </div>
@@ -2569,31 +3635,41 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
                     </div>
                   </div>
                 ) : (
-                  <HumanChatPanelMessages
-                    messages={mergedMessages}
-                    roomId={roomId}
-                    currentUserId={currentUserId}
-                    currentUserAvatarUrl={currentUserAvatarUrl}
-                    onReply={handleReplyToMessage}
-                    onEditMessage={handleEditMessage}
-                    onDeleteMessage={handleDeleteMessage}
-                    onToggleReaction={handleToggleReaction}
-                    resolveReactionReactorLabel={(userId) =>
-                      resolveMemberLabel(userId)
-                    }
-                    resolveMatrixMemberLabel={resolveMentionMemberLabel}
-                    resolveSenderDisplayLabel={resolveSenderDisplayLabel}
-                    onCancelSendPending={cancelSendInFlight}
-                    firstUnreadMessageId={unreadChatState.firstUnreadMessageId}
-                    unreadNotificationCount={
-                      unreadChatState.unreadNotificationCount
-                    }
-                    unreadCountIsCapped={unreadChatState.unreadCountIsCapped}
-                    onReachedTimelineBottom={handleReachedTimelineBottom}
-                    onMarkAsReadFromBanner={handleMarkAsReadFromBanner}
-                    scrollTargetEventId={scrollToEventId}
-                    onConsumedScrollTarget={handleConsumedScrollTarget}
-                  />
+                  <>
+                    <HumanChatPanelThreadSummary
+                      summary={threadSummary}
+                      isLoading={threadSummaryLoading}
+                      threadTitle={mode === 'coherence' ? coherenceTitle : null}
+                    />
+                    <HumanChatPanelMessages
+                      messages={mergedMessages}
+                      roomId={roomId}
+                      currentUserId={currentUserId}
+                      currentUserAvatarUrl={currentUserAvatarUrl}
+                      onReply={handleReplyToMessage}
+                      onEditMessage={handleEditMessage}
+                      onDeleteMessage={handleDeleteMessage}
+                      onToggleReaction={handleToggleReaction}
+                      resolveReactionReactorLabel={(userId) =>
+                        resolveMemberLabel(userId)
+                      }
+                      resolveMatrixMemberLabel={resolveMentionMemberLabel}
+                      resolveSenderDisplayLabel={resolveSenderDisplayLabel}
+                      onCancelSendPending={cancelSendInFlight}
+                      firstUnreadMessageId={
+                        unreadChatState.firstUnreadMessageId
+                      }
+                      unreadNotificationCount={
+                        unreadChatState.unreadNotificationCount
+                      }
+                      unreadCountIsCapped={unreadChatState.unreadCountIsCapped}
+                      onReachedTimelineBottom={handleReachedTimelineBottom}
+                      onMarkAsReadFromBanner={handleMarkAsReadFromBanner}
+                      scrollTargetEventId={scrollToEventId}
+                      onConsumedScrollTarget={handleConsumedScrollTarget}
+                      onScrollTargetNotFound={handleScrollTargetNotFound}
+                    />
+                  </>
                 )}
               </div>
             )}
@@ -2645,6 +3721,8 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
               onSend={handleSend}
               mentionCandidates={mentionCandidates}
               mentionPickerEnabled={mentionPickerEnabled}
+              composerLocked={!canInteractWithSignalThread}
+              composerLockedMessage={t('signalTeamInteractionRestricted')}
               getMentionComposerLabel={getMentionComposerLabel}
               onMergeMentionDisplayLabel={mergeMentionDisplayLabel}
               draftAttachments={draftAttachments}
@@ -2654,6 +3732,8 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
                   ? {
                       authorLabel: replyDraft.authorLabel,
                       excerpt: replyDraft.excerpt,
+                      sourceUserId: replyDraft.sourceUserId,
+                      isYou: replyDraft.isYou,
                       onDismiss: () => setReplyDraft(null),
                     }
                   : undefined

--- a/packages/i18n/src/messages/de.json
+++ b/packages/i18n/src/messages/de.json
@@ -100,7 +100,43 @@
   },
   "OnboardingAdventure": {
     "title": "Dein Abenteuer beginnt hier.",
-    "subtitle": "Wähle deinen nächsten Schritt.",
+    "continueAdventure": "Dein Abenteuer geht hier weiter",
+    "subtitle": "Du hast eine kraftvolle Vision für die Welt, wir geben dir die Werkzeuge, sie umzusetzen.",
+    "aiHero": {
+      "title": "Build Anything, Together",
+      "description": "Sag Hypha AI, was du aufbauen willst, und sie führt dich Schritt für Schritt durch das Setup.",
+      "placeholder": "Space erstellen, bestehendem Space beitreten, Netzwerk erkunden oder Treasury finanzieren - beschreibe dein Ziel, und AI führt dich.",
+      "rotating": {
+        "createSpace": "Frag Hypha AI, einen Space für deine Mission zu erstellen...",
+        "governance": "Frag Hypha AI, Governance für deine Community zu entwerfen...",
+        "joinSpace": "Frag Hypha AI, dir beim Beitritt zum passenden Space zu helfen...",
+        "treasury": "Frag Hypha AI, einen treasury-fähigen Space einzurichten...",
+        "explore": "Frag Hypha AI, Chancen im Netzwerk zu finden..."
+      },
+      "cta": "Mit AI starten",
+      "starting": "Wird gestartet...",
+      "openingAi": "AI-Panel wird geöffnet...",
+      "sending": "Dein Prompt wird an die AI gesendet...",
+      "handoffFailed": "AI-Konversation konnte nicht gestartet werden. Bitte erneut versuchen.",
+      "handoffTimeout": "Die AI-Übergabe dauert länger als erwartet. Bitte erneut versuchen.",
+      "sendFailed": "Prompt konnte nicht an die AI gesendet werden. Bitte erneut versuchen.",
+      "helper": "Die AI schlägt jede Aktion vor und fragt vor Erstellung oder Änderung immer nach Bestätigung.",
+      "unavailable": "AI-Onboarding ist in dieser Bereitstellung derzeit nicht verfügbar.",
+      "ariaLabel": "AI-Onboarding-Prompt",
+      "flow": {
+        "badge": "Simple. Powerful. By design.",
+        "reviewingTitle": "Deine Anfrage wird analysiert",
+        "reviewingDescription": "Die AI plant gerade den besten Weg für dein Ziel.",
+        "reviewingDescriptionPersonalized": "{firstName}, die AI plant gerade den besten Weg für dein Ziel.",
+        "confirmingTitle": "Eine klare Bestätigung wird vorbereitet",
+        "confirmingDescription": "Vor jeder Schreibaktion bekommst du eine fokussierte Auswahl.",
+        "executingTitle": "Die gewählte Aktion wird ausgeführt",
+        "executingDescription": "Die AI erstellt, verbindet oder navigiert jetzt basierend auf deiner Wahl.",
+        "routingTitle": "Du wirst zum richtigen Ziel geführt",
+        "routingDescription": "Navigation zu deinem Space oder der gewählten Ansicht wird abgeschlossen.",
+        "confirmationHint": "Du behältst die Kontrolle: Vor jedem Erstellen oder Aktualisieren fragt die AI nach Bestätigung."
+      }
+    },
     "spacePlaceholder": "Space auswählen",
     "spaceSearchPlaceholder": "Spaces suchen...",
     "searchToSeeSpaces": "Beginne zu tippen, um passende Spaces zu sehen.",
@@ -165,7 +201,8 @@
       "browserNotifications": "Browser-Benachrichtigungen (früher „Desktop-Pop-up-Benachrichtigungen“)",
       "yes": "Ja",
       "no": "Nein",
-      "emailNotificationsWithEmail": "E-Mail-Benachrichtigungen ({email})"
+      "emailNotificationsWithEmail": "E-Mail-Benachrichtigungen ({email})",
+      "mentionConsent": "Einwilligung für Erwähnungsbenachrichtigungen"
     },
     "subscriptions": {
       "title": "Benachrichtigen, wenn...",
@@ -178,7 +215,11 @@
         "title": "Ein Vorschlag wird angenommen oder abgelehnt",
         "description": "In allen Spaces, in denen Sie Mitglied sind."
       },
-      "labelWithComingSoon": "{title} ({comingSoon})"
+      "labelWithComingSoon": "{title} ({comingSoon})",
+      "mentionOnChatMessage": {
+        "title": "Sie werden in einer Chat-Nachricht erwähnt",
+        "description": "In jedem Thread oder Chat, in dem Erwähnungen für Sie aktiviert sind."
+      }
     },
     "actions": {
       "retry": "Erneut versuchen",
@@ -493,7 +534,10 @@
         "selectMember": "Bitte wählen Sie ein Mitglied aus",
         "selectSpace": "Bitte wählen Sie einen Space aus"
       }
-    }
+    },
+    "aiAgents": "KI-Agenten",
+    "aiAgentsEmptyState": "Noch keine KI-Agenten mobilisiert. Stelle strategische Fragen, um sie zu aktivieren.",
+    "aiAgentsMobilizedCount": "{count, plural, one {# Mal mobilisiert} other {# Mal mobilisiert}}"
   },
   "TreasuryTab": {
     "balance": "Kontostand",
@@ -968,6 +1012,8 @@
     "rootSpaceDescription": "Wenn Sie diesen Space als Root-Space markieren, wird er unabhängig. Er ist dann nicht mehr mit der aktuellen Organisation verknüpft, und alle mit ihm verknüpften Spaces werden mitverschoben.",
     "uploadEcosystemLogoLight": "Ökosystem-Logo hochladen (hell)",
     "uploadEcosystemLogoDark": "Ökosystem-Logo hochladen (dunkel)",
+    "ecosystemLogoPlaceholder": "{spaceName}-Ökosystemlogo hochladen",
+    "ecosystemLogoPlaceholderFallback": "diesen Space",
     "ecosystemLogoLightDescription": "Laden Sie ein helles Logo für Ihr Ökosystem hoch (PNG, JPG, GIF oder WEBP).",
     "ecosystemLogoDarkDescription": "Laden Sie ein dunkles Logo für Ihr Ökosystem hoch (PNG, JPG, GIF oder WEBP).",
     "search": "Suchen...",
@@ -994,6 +1040,7 @@
       "votingMethod": "Abstimmungsmethode",
       "entryMethod": "Beitrittsmethode",
       "membershipExit": "Mitgliedschaft beenden",
+      "spaceMemory": "Space Memory",
       "spaceToSpace": "Space-zu-Space",
       "issueNewToken": "Neuen Token ausgeben",
       "treasuryMinting": "Treasury Minting",
@@ -1936,7 +1983,13 @@
     "toolTokens": "{count} Token(s) für Space \"{slug}\" abgerufen.",
     "toolError": "Fehler: {message}",
     "streamError": "Beim Generieren der Antwort ist ein Fehler aufgetreten.",
-    "attachment": "Anhang"
+    "attachment": "Anhang",
+    "pendingAction": "Ausstehende Aktion",
+    "confirmWith": "Bestätigen mit:",
+    "confirm": "Bestätigen",
+    "cancel": "Abbrechen",
+    "showMore": "Mehr anzeigen",
+    "showLess": "Weniger anzeigen"
   },
   "HumanChatPanel": {
     "title": "Chat",
@@ -1992,6 +2045,7 @@
     "mentionNotAvailable": "Erwähnungen (demnächst)",
     "mentionNoMembers": "Noch keine Mitglieder geladen — kurz später erneut versuchen",
     "mentionListLabel": "Jemanden erwähnen",
+    "mentionListHintIncludesParentSpaceMembers": "Wähle ein Mitglied aus, das du erwähnen möchtest. Diese Liste kann auch Mitglieder aus dem übergeordneten Space enthalten.",
     "mentionInboxTitle": "Erwähnungen",
     "mentionInboxBellCallRingHint": "Klicke die Glocke, um Anruf-Töne stumm oder laut zu schalten. Den Menüpunkt „Erwähnungen“ öffnen, um @-Erwähnungen zu sehen.",
     "callJoinCallAlertsMutedShort": "Stumm",
@@ -2150,6 +2204,8 @@
     "callRemoteParticipant": "Teilnehmende/r",
     "callScreenShare": "Bildschirmfreigabe",
     "callScreenShareActive": "Bildschirmfreigabe ist aktiv",
+    "callYouAreSharingScreen": "Sie teilen Ihren Bildschirm",
+    "callYouAreSharingScreenHint": "Andere sehen Ihren Bildschirm. Ihre eigene Freigabe sehen Sie hier nicht.",
     "callFullView": "Vollansicht",
     "callFullViewDescription": "Größere Anzeige des Anrufs. Der Space-Anruf bleibt aktiv, wenn Sie dieses Fenster schließen.",
     "callFullViewClose": "Schließen",
@@ -2167,7 +2223,72 @@
     "callLeftBannerDismiss": "Schließen",
     "callPaneResizeSharePeople": "Bildschirmfreigabe und Personen skalieren",
     "callPaneResizeShareStrip": "Bildschirmfreigabe und Filmstreifen skalieren",
-    "callPaneResizeSpeakerShare": "Sprecher*in und Bildschirmfreigabe skalieren"
+    "callPaneResizeSpeakerShare": "Sprecher*in und Bildschirmfreigabe skalieren",
+    "callDockTitleWithMembers": "Anruf - {count, plural, one {# Mitglied} other {# Mitglieder}}",
+    "callDockOpenCallSpace": "Anrufraum öffnen",
+    "callDockSpaceLabel": "Space",
+    "callDockMinimize": "Anruf minimieren",
+    "callDockExpand": "Anruf erweitern",
+    "callDockFullscreen": "Vollbild",
+    "callDockExitFullscreen": "Vollbild beenden",
+    "callCaptureLabel": "Anrufaufzeichnung",
+    "callCaptureModeNone": "Aus",
+    "callCaptureModeTranscriptOnly": "Nur Transkript",
+    "callCaptureModeRecordingWithTranscript": "Aufzeichnung + Transkript",
+    "callCaptureStatusIdle": "Inaktiv",
+    "callCaptureStatusCapturing": "Aufnahme läuft",
+    "callCaptureStatusStarting": "Wird gestartet…",
+    "callCaptureStatusPaused": "Pausiert",
+    "callCaptureStatusSaving": "Wird gespeichert",
+    "callCaptureStop": "Aufzeichnung stoppen",
+    "callCapturePause": "Aufzeichnung pausieren",
+    "callCaptureResume": "Aufzeichnung fortsetzen",
+    "callCaptureConfirmStopRecordingTitle": "Cloud-Aufzeichnung beenden?",
+    "callCaptureConfirmStopRecording": "Die Aufzeichnung wird für alle Teilnehmenden dieses Anrufs beendet.",
+    "callCaptureConfirmStopRecordingAction": "Aufzeichnung stoppen",
+    "callCaptureConfirmStopTranscriptTitle": "Transkripterfassung beenden?",
+    "callCaptureConfirmStopTranscript": "Die Transkripterfassung ist noch aktiv. Jetzt beenden und speichern?",
+    "callCaptureConfirmStopTranscriptAction": "Transkript stoppen",
+    "callCaptureConfirmCancel": "Abbrechen",
+    "callCaptureStatusError": "Aufzeichnungsfehler",
+    "messageReadMore": "Mehr lesen",
+    "messageShowLess": "Weniger anzeigen",
+    "callCaptureOffHint": "Aufzeichnung ist aus. Für diesen Anruf werden weder Aufnahme noch Transkript gespeichert.",
+    "threadSummaryLabel": "Thread-Zusammenfassung",
+    "threadSummaryTitle": "Aktuelle Zusammenfassung",
+    "threadSummaryLoading": "Thread-Zusammenfassung wird aktualisiert…",
+    "threadSummaryUpdated": "Aktualisiert {when}",
+    "threadSummaryExpand": "Zusammenfassung erweitern",
+    "threadSummaryCollapse": "Zusammenfassung einklappen",
+    "callCaptureLeaveWarning": "Aufzeichnung ist aus. Zum Bestätigen erneut auf Verlassen klicken.",
+    "callCaptureConsentLocal": "Du zeichnest diesen Anruf auf ({mode}). Andere werden benachrichtigt.",
+    "callCaptureConsentRemote": "{actor} zeichnet diesen Anruf auf ({mode}).",
+    "callCaptureConsentJoin": "Dieser Anruf wird aufgezeichnet ({mode}) von {actor}. Beitritt gilt als Zustimmung.",
+    "callCaptureConsentLegalNote": "Aufzeichnung und Transkript können im Space-Gedächtnis gespeichert werden.",
+    "callCaptureConsentPausedSuffix": " Aufzeichnung ist pausiert.",
+    "callCaptureVoiceStartedRecordingTranscript": "Dieser Anruf wird jetzt aufgezeichnet und transkribiert.",
+    "callCaptureVoiceStoppedRecordingTranscript": "Aufzeichnung und Transkription wurden beendet.",
+    "callCaptureVoiceStartedTranscript": "Dieser Anruf wird jetzt transkribiert.",
+    "callCaptureVoiceStoppedTranscript": "Die Transkription wurde beendet.",
+    "callCaptureVoiceStartedRecordingTranscript": "Dieser Anruf wird jetzt aufgezeichnet und transkribiert.",
+    "callCaptureVoiceStoppedRecordingTranscript": "Aufzeichnung und Transkription wurden beendet.",
+    "callCaptureVoiceStartedTranscript": "Dieser Anruf wird jetzt transkribiert.",
+    "callCaptureVoiceStoppedTranscript": "Die Transkription wurde beendet.",
+    "composerLockedPlaceholder": "Nur ausgewählte Teammitglieder können in diesem Thread interagieren.",
+    "signalTeamInteractionRestricted": "Nur ausgewählte Teammitglieder können in diesem Thread Nachrichten senden und Erwähnungen nutzen.",
+    "signalTeamBannerReadOnly": "Dieser Thread ist teambezogen. Du kannst Updates lesen, aber nur ausgewählte Teammitglieder können interagieren.",
+    "signalTeamRequestAccess": "Anfrage zur Aufnahme",
+    "signalTeamRequestPending": "Anfrage ausstehend",
+    "signalTeamManageTitle": "Signal-Team",
+    "signalTeamManageOpen": "Verwalten",
+    "signalTeamManageClose": "Fertig",
+    "signalTeamMemberListHint": "Wähle Mitglieder aus, die Nachrichten senden, erwähnen und an Thread-Anrufen teilnehmen können.",
+    "signalTeamAddMember": "Hinzufügen",
+    "signalTeamRemoveMember": "Entfernen",
+    "signalTeamPendingRequests": "Ausstehende Anfragen",
+    "signalTeamApproveRequester": "Zum Team hinzufügen",
+    "mentionOpenFallbackRoom": "Dieser Raum konnte im lokalen Kontext nicht aufgelöst werden. Öffnen Sie den zugehörigen Space und versuchen Sie es erneut.",
+    "mentionOpenFallbackMissingMessage": "Diese Erwähnung ist in der geladenen Timeline noch nicht verfügbar. Bitte versuchen Sie es gleich noch einmal."
   },
   "CoherenceTab": {
     "signals": "Signale",
@@ -2195,6 +2316,7 @@
     "openConversation": "Gespräch öffnen",
     "saySomething": "Schreiben Sie etwas...",
     "proposeAgreement": "Vereinbarung vorschlagen",
+    "comingSoon": "Demnächst verfügbar",
     "errorOhSnap": "Hoppla! Ein Fehler ist aufgetreten",
     "reset": "Zurücksetzen",
     "creatingNewSignal": "Neues Signal wird erstellt",
@@ -2223,25 +2345,33 @@
     "spaceMemoryLoadMoreError": "Weitere Einträge konnten nicht geladen werden. Bitte erneut versuchen.",
     "spaceMemoryRetry": "Erneut versuchen",
     "spaceMemoryRefresh": "Aktualisieren",
-    "spaceMemoryTimelineLabel": "Space-Memory-Verlauf",
+    "openDocument": "Dokument öffnen",
     "spaceMemoryContext": "Aus «{title}» · {state}",
+    "spaceMemoryContextMemory": "Erinnerung · «{title}»",
     "spaceMemoryContextMatrix": "Aus Matrix-Chat",
     "spaceMemoryMatrixPreviewNeedsChat": "Vorschau braucht Human Chat (Matrix)",
     "spaceMemoryMatrixOpenHint": "Öffnen Sie Human Chat, um Matrix zu verbinden, aktualisieren Sie dann den Space Memory, um diese Datei zu öffnen.",
     "spaceMemoryMatrixVideoPlayHint": "Tippen für Vorschau",
+    "spaceMemoryPdfPreviewUnavailable": "PDF-Vorschau nicht verfügbar",
     "spaceMemoryOpenAsset": "{name} öffnen",
     "untitledDocument": "Unbenanntes Dokument",
     "spaceMemoryGeneral": "Allgemein",
     "spaceMemoryProposals": "Vorschläge",
     "spaceMemoryConversations": "Gespräche",
+    "spaceMemoryCalls": "Anrufe",
     "spaceMemoryAiChat": "AI-Chat",
+    "newMemoryUploadDocumentsTitle": "Dokumente hochladen",
+    "newMemoryUploadingFiles": "Space-Memories werden hochgeladen...",
+    "newMemoryAttachmentsRequired": "Bitte laden Sie mindestens ein Dokument für diese Erinnerung hoch.",
     "newMemory": "Neue Erinnerung",
     "spaceMemoryEmptyTab": "In dieser Ansicht wurden keine Einträge gefunden.",
     "spaceMemoryAiChatEmpty": "AI-Chat-Erinnerungen sind noch nicht verfügbar.",
+    "spaceMemoryCallsEmpty": "Noch keine Anrufaufzeichnungen oder Transkripte. Sie erscheinen hier, nachdem ein aufgezeichneter Gruppenanruf beendet wurde.",
     "documentStates": {
       "discussion": "Diskussion",
       "proposal": "Vorschlag",
-      "agreement": "Vereinbarung"
+      "agreement": "Vereinbarung",
+      "memory": "Erinnerung"
     },
     "types": {
       "Opportunity": "Chance",
@@ -2354,7 +2484,113 @@
     "spaceMemoryCallRecordingNoUrl": "Recording will be available when a media URL is ingested for this session.",
     "spaceMemoryCallTranscriptExcerpt": "Transcript",
     "spaceMemoryContextCallRecording": "Call recording (organizational memory)",
-    "spaceMemoryContextCallTranscript": "Call transcript (organizational memory)"
+    "spaceMemoryContextCallTranscript": "Call transcript (organizational memory)",
+    "aiAgentsCatalog": {
+      "purpose": {
+        "role": "Senior-Strateg:in",
+        "focus": "Mission klären, strategische Ausrichtung schärfen, Nordstern-Ergebnisse definieren und langfristige Richtung festlegen",
+        "roleDefinition": [
+          "Definiert die strategische Ausrichtung und verknüpft tägliche Entscheidungen mit langfristigen Missionsergebnissen.",
+          "Identifiziert strategische blinde Flecken, Zielkonflikte und Zweitrundeneffekte vor verbindlichen Zusagen.",
+          "Übersetzt Vision in messbare Prioritäten, Entscheidungskriterien und Erfolgsindikatoren."
+        ]
+      },
+      "governance": {
+        "role": "Governance-Architekt:in",
+        "focus": "Entscheidungsrechte, Verantwortungsmodelle, Qualität von Vorschlägen und kollektive Koordinationsmechanismen",
+        "roleDefinition": [
+          "Entwirft Governance-Abläufe, die Vorschläge klar, verantwortlich und umsetzbar halten.",
+          "Verbessert die Abstimmungsqualität, indem Annahmen, Stakeholder-Wirkungen und Entscheidungsreife sichtbar werden.",
+          "Empfiehlt schlanke Leitplanken, die Autonomie schützen und gleichzeitig Koordinationsaufwand reduzieren."
+        ]
+      },
+      "operations": {
+        "role": "Operations Lead",
+        "focus": "Umsetzungspläne, Liefer-Rhythmus, Abhängigkeitsmanagement und praktische Implementierungsdetails",
+        "roleDefinition": [
+          "Übersetzt Strategie in ausführbare Pläne mit Verantwortlichen, Meilensteinen und realistischen Zeitplänen.",
+          "Markiert Engpässe durch Abhängigkeiten frühzeitig und schlägt konkrete Sequenzierungsoptionen vor.",
+          "Erhöht die Lieferzuverlässigkeit mit klaren Arbeitsrhythmen und Feedback-Schleifen."
+        ]
+      },
+      "community": {
+        "role": "Community Builder",
+        "focus": "Mitglieder-Engagement, Qualität der Beteiligung, Onboarding und Gesundheit der Mitwirkenden",
+        "roleDefinition": [
+          "Stärkt die Beteiligungsqualität durch besseres Onboarding und klarere Rollen für Mitwirkende.",
+          "Erkennt Rückgänge beim Engagement und schlägt Maßnahmen für Bindung und Aktivierung vor.",
+          "Balanciert Offenheit mit gesunden Normen, Vertrauen und nachhaltiger Mitwirkenden-Erfahrung."
+        ]
+      },
+      "finance": {
+        "role": "Treasury- und Token-Analyst:in",
+        "focus": "Token-/Treasury-Auswirkungen, Verteilungseffekte, Nachhaltigkeit und Zielkonflikte bei der Kapitalallokation",
+        "roleDefinition": [
+          "Bewertet Treasury- und Token-Entscheidungen hinsichtlich Nachhaltigkeit, Konzentrationsrisiko und Runway-Auswirkungen.",
+          "Verknüpft Budgetentscheidungen mit strategischen Prioritäten und erwarteten Organisationsergebnissen.",
+          "Empfiehlt risikobewusste Allokationsoptionen mit klarer Upside-/Downside-Bewertung."
+        ]
+      },
+      "product": {
+        "role": "Produktstrateg:in",
+        "focus": "Nutzerwirkung, Produktpriorisierung, Experimentdesign und messbare Adoptions-Ergebnisse",
+        "roleDefinition": [
+          "Priorisiert Funktionen nach Nutzerwert, strategischem Fit und Umsetzungsvorteilen.",
+          "Entwirft Experimente, die Annahmen mit messbaren Lernergebnissen validieren.",
+          "Richtet Roadmap-Entscheidungen an Adoptions-, Retentions- und Verhaltensänderungsmetriken aus."
+        ]
+      },
+      "risk": {
+        "role": "Risk- und Compliance-Berater:in",
+        "focus": "Fehlermodi, Downside-Szenarien, Minderungspläne und Policy-/Compliance-Aspekte",
+        "roleDefinition": [
+          "Macht operative, Governance- und Sicherheits-Fehlermodi vor der Umsetzung sichtbar.",
+          "Empfiehlt praktische Gegenmaßnahmen mit klaren Verantwortlichkeiten und Auslösebedingungen.",
+          "Hält Vorschläge compliant und resilient, ohne die Umsetzung übermäßig zu bürokratisieren."
+        ]
+      },
+      "ecosystem": {
+        "role": "Ökosystem- und Partnerschaftsstrateg:in",
+        "focus": "Space-übergreifende Zusammenarbeit, Partnerschaften, Ökosystem-Abhängigkeiten und Hebel externer Koordination",
+        "roleDefinition": [
+          "Kartiert Ökosystem-Abhängigkeiten und identifiziert Partnerschaften mit hohem Hebel.",
+          "Entwirft Space-übergreifende Koordinationspläne mit klaren Verantwortlichkeiten und gemeinsamen Ergebnissen.",
+          "Verbessert externes Signal-Routing, damit umsetzbare Erkenntnisse schnell die richtigen Spaces erreichen."
+        ]
+      },
+      "learning": {
+        "role": "Learning- und Wissensarchitekt:in",
+        "focus": "Wissenssicherung, Lernschleifen, Evidenzqualität und Systeme zur kontinuierlichen Verbesserung",
+        "roleDefinition": [
+          "Macht Diskussionen und Experimente zu wiederverwendbarem organisationalem Wissen.",
+          "Entwirft Feedback-Schleifen, die die Entscheidungsqualität über Zeit verbessern.",
+          "Hebt Evidenzstandards an, indem Annahmen, Metriken und Learnings klarer werden."
+        ]
+      },
+      "reputation": {
+        "role": "Reputation- und Trust-Steward",
+        "focus": "Glaubwürdigkeitssignale, Stakeholder-Vertrauen, narrative Kohärenz und kommunikatives Risikomanagement",
+        "roleDefinition": [
+          "Schützt Vertrauen, indem öffentliches Narrativ mit tatsächlichem operativem Verhalten abgeglichen wird.",
+          "Macht Reputationsrisiken früh sichtbar und schlägt proaktive Minderungsmaßnahmen vor.",
+          "Verbessert die Qualität der Stakeholder-Kommunikation bei Veränderung, Konflikt und Unsicherheit."
+        ]
+      }
+    },
+    "createBoard": "Board erstellen",
+    "createBoardDescription": "Speichere einen Board-Filter nach Tag-Kategorie oder einzelnem Tag.",
+    "boardName": "Board-Name",
+    "boardNamePlaceholder": "z. B. Impact-Board",
+    "boardFilterBy": "Filtern nach",
+    "boardFilterCategory": "Tag-Kategorie",
+    "boardFilterTag": "Einzelner Tag",
+    "boardSelectCategory": "Kategorie",
+    "boardSelectTag": "Tag",
+    "boardCreateAction": "Board erstellen",
+    "boardCancelAction": "Abbrechen",
+    "boardAll": "Alle Signale",
+    "boardDelete": "Board {boardName} löschen",
+    "spaceMemoryTimelineLabel": "Space-Memory-Verlauf"
   },
   "GlobalCallDock": {
     "callTitle": "Anruf - {count, plural, one {# Mitglied} other {# Mitglieder}}",
@@ -2366,7 +2602,9 @@
     "exitFullscreenLabel": "Vollbild beenden",
     "unknownMember": "Unbekannt",
     "resizeTopRightLabel": "Anruffenster über die obere rechte Ecke skalieren",
-    "resizeBottomLeftLabel": "Anruffenster über die untere linke Ecke skalieren"
+    "resizeBottomLeftLabel": "Anruffenster über die untere linke Ecke skalieren",
+    "openFloatingWindowLabel": "Schwebendes Anruffenster öffnen",
+    "closeFloatingWindowLabel": "Schwebendes Anruffenster schließen"
   },
   "SignalCard": {
     "noConversationRoom": "Noch kein Gesprächsraum",

--- a/packages/i18n/src/messages/en.json
+++ b/packages/i18n/src/messages/en.json
@@ -100,7 +100,43 @@
   },
   "OnboardingAdventure": {
     "title": "Your Adventure starts here.",
-    "subtitle": "Pick your next move.",
+    "continueAdventure": "Your adventure continues here",
+    "subtitle": "You have a powerful vision for the world - we give you the tools to put it into action.",
+    "aiHero": {
+      "title": "Build Anything, Together",
+      "description": "Tell Hypha AI what you want to build, and it will guide setup step by step.",
+      "placeholder": "Create a space, join an existing one, explore the network, or fund a treasury - describe your goal and AI will guide you.",
+      "rotating": {
+        "createSpace": "Ask Hypha AI to create a space for your mission...",
+        "governance": "Ask Hypha AI to draft governance for your community...",
+        "joinSpace": "Ask Hypha AI to help you join the right space...",
+        "treasury": "Ask Hypha AI to set up a treasury-ready space...",
+        "explore": "Ask Hypha AI to find opportunities across the network..."
+      },
+      "cta": "Start with AI",
+      "starting": "Starting...",
+      "openingAi": "Opening AI panel...",
+      "sending": "Sending your prompt to AI...",
+      "handoffFailed": "Could not start AI conversation. Please try again.",
+      "handoffTimeout": "AI handoff is taking longer than expected. Please try again.",
+      "sendFailed": "Prompt could not be sent to AI. Please retry.",
+      "helper": "AI will propose each action and ask for confirmation before creating or updating anything.",
+      "unavailable": "AI onboarding is temporarily unavailable on this deployment.",
+      "ariaLabel": "AI onboarding prompt",
+      "flow": {
+        "badge": "Simple. Powerful. By design.",
+        "reviewingTitle": "Reviewing your request",
+        "reviewingDescription": "AI is mapping the best path for your goal.",
+        "reviewingDescriptionPersonalized": "{firstName}, AI is mapping the best path for your goal.",
+        "confirmingTitle": "Preparing one clear confirmation",
+        "confirmingDescription": "You will get a focused choice before any write action.",
+        "executingTitle": "Executing the selected action",
+        "executingDescription": "AI is now creating, joining, or routing based on your choice.",
+        "routingTitle": "Taking you to the right destination",
+        "routingDescription": "Finalizing navigation to your space or selected screen.",
+        "confirmationHint": "You stay in control: AI asks for confirmation before any create or update action."
+      }
+    },
     "spacePlaceholder": "Select a space",
     "spaceSearchPlaceholder": "Search spaces...",
     "searchToSeeSpaces": "Start typing to see matching spaces.",
@@ -164,7 +200,8 @@
       "browserNotifications": "Browser Notifications (formerly \"Desktop Pop-up Notifications\")",
       "yes": "Yes",
       "no": "No",
-      "emailNotificationsWithEmail": "Email Notifications ({email})"
+      "emailNotificationsWithEmail": "Email Notifications ({email})",
+      "mentionConsent": "Mention Notifications Consent"
     },
     "subscriptions": {
       "title": "Get Notified When...",
@@ -177,7 +214,11 @@
         "title": "A proposal is approved or rejected",
         "description": "In any of the spaces you're a member of."
       },
-      "labelWithComingSoon": "{title} ({comingSoon})"
+      "labelWithComingSoon": "{title} ({comingSoon})",
+      "mentionOnChatMessage": {
+        "title": "You are mentioned in a chat message",
+        "description": "In any thread or chat where mentions are enabled for you."
+      }
     },
     "actions": {
       "retry": "Retry",
@@ -492,7 +533,10 @@
         "selectMember": "Please select a member",
         "selectSpace": "Please select a space"
       }
-    }
+    },
+    "aiAgents": "AI Agents",
+    "aiAgentsEmptyState": "No AI agents mobilized yet. Ask strategic questions to activate them.",
+    "aiAgentsMobilizedCount": "Mobilized {count, plural, one {# time} other {# times}}"
   },
   "TreasuryTab": {
     "balance": "Balance",
@@ -967,6 +1011,8 @@
     "rootSpaceDescription": "Marking this space as a Root Space will make it independent. It will no longer be linked to the current organisation, and all of its linked spaces will move with it.",
     "uploadEcosystemLogoLight": "Upload Ecosystem Logo (Light)",
     "uploadEcosystemLogoDark": "Upload Ecosystem Logo (Dark)",
+    "ecosystemLogoPlaceholder": "Upload {spaceName} ecosystem logo",
+    "ecosystemLogoPlaceholderFallback": "this space",
     "ecosystemLogoLightDescription": "Upload a light-mode logo for your ecosystem (PNG, JPG, GIF, or WEBP).",
     "ecosystemLogoDarkDescription": "Upload a dark-mode logo for your ecosystem (PNG, JPG, GIF, or WEBP).",
     "search": "Search...",
@@ -993,6 +1039,7 @@
       "votingMethod": "Voting Method",
       "entryMethod": "Entry Method",
       "membershipExit": "Membership Exit",
+      "spaceMemory": "Space Memory",
       "spaceToSpace": "Space to Space",
       "issueNewToken": "Issue New Token",
       "treasuryMinting": "Treasury Minting",
@@ -1146,6 +1193,9 @@
       "addAttachmentLabel": "Add Attachment (JPEG, PNG, WebP, or PDF — max 4MB)",
       "proposalContent": "Proposal Content",
       "proposalContentPlaceholder": "Type your proposal content here...",
+      "errors": {
+        "memoryAttachmentsRequired": "Please upload at least one document for this memory."
+      },
       "editor": {
         "toolbar": {
           "blockTypes": {
@@ -1934,6 +1984,12 @@
     "toolNoSpace": "No space found for slug \"{slug}\"",
     "toolTokens": "Retrieved {count} token(s) for space \"{slug}\".",
     "toolError": "Error: {message}",
+    "pendingAction": "Pending action",
+    "confirmWith": "Confirm with:",
+    "confirm": "Confirm",
+    "cancel": "Cancel",
+    "showMore": "Read more",
+    "showLess": "Show less",
     "streamError": "An error occurred while generating the response.",
     "attachment": "Attachment"
   },
@@ -1992,6 +2048,7 @@
     "mentionNotAvailable": "Mentions (coming soon)",
     "mentionNoMembers": "No members loaded yet — try again in a moment",
     "mentionListLabel": "Mention someone",
+    "mentionListHintIncludesParentSpaceMembers": "Choose a member to mention. This list may include members from the parent space.",
     "mentionInboxTitle": "Mentions",
     "mentionInboxBellCallRingHint": "Click the bell to mute or unmute call ring alerts. Open the Mentions tab to see @ mentions.",
     "callJoinCallAlertsMutedShort": "Muted",
@@ -2149,6 +2206,8 @@
     "callRemoteParticipant": "Participant",
     "callScreenShare": "Screen share",
     "callScreenShareActive": "Screen share is on",
+    "callYouAreSharingScreen": "You're sharing your screen",
+    "callYouAreSharingScreenHint": "Others can see your screen. You won't see your own share here.",
     "callFullView": "Full view",
     "callFullViewDescription": "Larger view of the call. Your space call stays active when you close this window.",
     "callFullViewClose": "Close",
@@ -2166,7 +2225,68 @@
     "callLeftBannerDismiss": "Dismiss",
     "callPaneResizeSharePeople": "Resize screen share and people",
     "callPaneResizeShareStrip": "Resize screen share and filmstrip",
-    "callPaneResizeSpeakerShare": "Resize speaker and screen share"
+    "callPaneResizeSpeakerShare": "Resize speaker and screen share",
+    "callDockTitleWithMembers": "Call - {count, plural, one {# member} other {# members}}",
+    "callDockOpenCallSpace": "Open call space",
+    "callDockSpaceLabel": "Space",
+    "callDockMinimize": "Minimize call",
+    "callDockExpand": "Expand call",
+    "callDockFullscreen": "Fullscreen",
+    "callDockExitFullscreen": "Exit fullscreen",
+    "callCaptureLabel": "Call capture",
+    "callCaptureModeNone": "Off",
+    "callCaptureModeTranscriptOnly": "Transcript only",
+    "callCaptureModeRecordingWithTranscript": "Recording + transcript",
+    "callCaptureStatusIdle": "Idle",
+    "callCaptureStatusCapturing": "Capturing",
+    "callCaptureStatusStarting": "Starting…",
+    "callCaptureStatusPaused": "Paused",
+    "callCaptureStatusSaving": "Saving",
+    "callCaptureStop": "Stop recording",
+    "callCapturePause": "Pause recording",
+    "callCaptureResume": "Resume recording",
+    "callCaptureConfirmStopRecordingTitle": "Stop cloud recording?",
+    "callCaptureConfirmStopRecording": "Recording will end for everyone in this call.",
+    "callCaptureConfirmStopRecordingAction": "Stop recording",
+    "callCaptureConfirmStopTranscriptTitle": "Stop transcript capture?",
+    "callCaptureConfirmStopTranscript": "Transcript capture is still active. Stop and save the transcript now?",
+    "callCaptureConfirmStopTranscriptAction": "Stop transcript",
+    "callCaptureConfirmCancel": "Cancel",
+    "callCaptureStatusError": "Capture error",
+    "messageReadMore": "Read more",
+    "messageShowLess": "Show less",
+    "callCaptureOffHint": "Capture is off. No recording or transcript will be saved for this call.",
+    "threadSummaryLabel": "Thread summary",
+    "threadSummaryTitle": "Living summary",
+    "threadSummaryLoading": "Updating thread summary…",
+    "threadSummaryUpdated": "Updated {when}",
+    "threadSummaryExpand": "Expand summary",
+    "threadSummaryCollapse": "Collapse summary",
+    "callCaptureLeaveWarning": "Capture is off. Press Leave again to confirm leaving without a recording.",
+    "callCaptureConsentLocal": "You are capturing this call ({mode}). Others are notified.",
+    "callCaptureConsentRemote": "{actor} is capturing this call ({mode}).",
+    "callCaptureConsentJoin": "This call is being captured ({mode}) by {actor}. Joining indicates your consent.",
+    "callCaptureConsentLegalNote": "Recording and transcription may be stored in this space's memory.",
+    "callCaptureConsentPausedSuffix": " Capture is paused.",
+    "callCaptureVoiceStartedRecordingTranscript": "This call is now being recorded and transcribed.",
+    "callCaptureVoiceStoppedRecordingTranscript": "Recording and transcription have stopped.",
+    "callCaptureVoiceStartedTranscript": "This call is now being transcribed.",
+    "callCaptureVoiceStoppedTranscript": "Transcription has stopped.",
+    "composerLockedPlaceholder": "Only selected team members can interact in this thread.",
+    "signalTeamInteractionRestricted": "Only selected team members can send messages and mentions in this thread.",
+    "signalTeamBannerReadOnly": "This is a dedicated Signal team channel. Only selected team members can reply to keep it focused.",
+    "signalTeamRequestAccess": "Request to be included",
+    "signalTeamRequestPending": "Request pending",
+    "signalTeamManageTitle": "Signal Team",
+    "signalTeamManageOpen": "Manage",
+    "signalTeamManageClose": "Done",
+    "signalTeamMemberListHint": "Select members who can message, mention, and join thread calls.",
+    "signalTeamAddMember": "Add",
+    "signalTeamRemoveMember": "Remove",
+    "signalTeamPendingRequests": "Pending requests",
+    "signalTeamApproveRequester": "Add to team",
+    "mentionOpenFallbackRoom": "We could not resolve that room from your local context. Open the related space and try again.",
+    "mentionOpenFallbackMissingMessage": "That mention message is not available in the loaded timeline yet. Try again in a moment."
   },
   "CoherenceTab": {
     "signals": "Signals",
@@ -2194,6 +2314,7 @@
     "openConversation": "Open conversation",
     "saySomething": "Say something...",
     "proposeAgreement": "Propose Agreement",
+    "comingSoon": "Coming soon",
     "errorOhSnap": "Oh snap! There was an error",
     "reset": "Reset",
     "creatingNewSignal": "Creating new signal",
@@ -2222,8 +2343,9 @@
     "spaceMemoryLoadMoreError": "Could not load more items. Try again.",
     "spaceMemoryRetry": "Retry",
     "spaceMemoryRefresh": "Refresh",
-    "spaceMemoryTimelineLabel": "Space memory history",
+    "openDocument": "Open document",
     "spaceMemoryContext": "From «{title}» · {state}",
+    "spaceMemoryContextMemory": "Memory · «{title}»",
     "spaceMemoryContextMatrix": "From Matrix chat",
     "spaceMemoryContextCallTranscript": "Call transcript (organizational memory)",
     "spaceMemoryContextCallRecording": "Call recording (organizational memory)",
@@ -2233,19 +2355,118 @@
     "spaceMemoryMatrixPreviewNeedsChat": "Preview needs Human Chat (Matrix)",
     "spaceMemoryMatrixOpenHint": "Open Human Chat to connect Matrix, then refresh Space Memory to open this file.",
     "spaceMemoryMatrixVideoPlayHint": "Tap to play preview",
+    "spaceMemoryPdfPreviewUnavailable": "PDF preview unavailable",
     "spaceMemoryOpenAsset": "Open {name}",
     "untitledDocument": "Untitled document",
     "spaceMemoryGeneral": "General",
     "spaceMemoryProposals": "Proposals",
     "spaceMemoryConversations": "Conversations",
+    "spaceMemoryCalls": "Calls",
     "spaceMemoryAiChat": "AI Chat",
+    "newMemoryUploadDocumentsTitle": "Upload Documents",
+    "newMemoryUploadingFiles": "Uploading space memories...",
+    "newMemoryAttachmentsRequired": "Please upload at least one document for this memory.",
     "newMemory": "New memory",
+    "aiAgentsCatalog": {
+      "purpose": {
+        "role": "Senior Strategist",
+        "focus": "clarify mission, strategic alignment, north-star outcomes, and long-term direction",
+        "roleDefinition": [
+          "Defines strategic intent and links daily decisions to long-term mission outcomes.",
+          "Identifies strategic blindspots, trade-offs, and second-order effects before commitments.",
+          "Translates vision into measurable priorities, decision criteria, and success indicators."
+        ]
+      },
+      "governance": {
+        "role": "Governance Architect",
+        "focus": "decision rights, accountability models, proposal quality, and collective coordination mechanisms",
+        "roleDefinition": [
+          "Designs governance flows that keep proposals clear, accountable, and executable.",
+          "Improves voting quality by surfacing assumptions, stakeholder impact, and decision readiness.",
+          "Recommends lightweight policy guardrails that protect autonomy while reducing coordination drag."
+        ]
+      },
+      "operations": {
+        "role": "Operations Lead",
+        "focus": "execution plans, delivery cadence, dependency management, and practical implementation details",
+        "roleDefinition": [
+          "Turns strategy into executable plans with owners, milestones, and realistic timelines.",
+          "Flags dependency bottlenecks early and proposes concrete sequencing options.",
+          "Improves delivery reliability with clear operating rhythms and feedback loops."
+        ]
+      },
+      "community": {
+        "role": "Community Builder",
+        "focus": "member engagement, participation quality, onboarding, and contributor health",
+        "roleDefinition": [
+          "Strengthens participation quality by improving onboarding and contributor clarity.",
+          "Detects engagement drop-offs and proposes retention and activation interventions.",
+          "Balances openness with healthy norms, trust, and sustainable contributor experience."
+        ]
+      },
+      "finance": {
+        "role": "Treasury and Token Analyst",
+        "focus": "token/treasury implications, distribution effects, sustainability, and capital allocation trade-offs",
+        "roleDefinition": [
+          "Evaluates treasury and token decisions for sustainability, concentration risk, and runway impact.",
+          "Connects budget choices to strategic priorities and expected organizational outcomes.",
+          "Recommends risk-aware allocation options with explicit upside/downside framing."
+        ]
+      },
+      "product": {
+        "role": "Product Strategist",
+        "focus": "user impact, product prioritization, experimentation design, and measurable adoption outcomes",
+        "roleDefinition": [
+          "Prioritizes features by user value, strategic fit, and implementation leverage.",
+          "Designs experiments that validate assumptions with measurable learning outcomes.",
+          "Aligns roadmap choices with adoption, retention, and behavior-change metrics."
+        ]
+      },
+      "risk": {
+        "role": "Risk and Compliance Advisor",
+        "focus": "failure modes, downside scenarios, mitigation plans, and policy/compliance considerations",
+        "roleDefinition": [
+          "Surfaces operational, governance, and security failure modes before execution.",
+          "Recommends practical mitigations with clear ownership and trigger conditions.",
+          "Keeps proposals compliant and resilient without over-bureaucratizing execution."
+        ]
+      },
+      "ecosystem": {
+        "role": "Ecosystem and Partnerships Strategist",
+        "focus": "cross-space collaboration, partnerships, ecosystem dependencies, and external coordination leverage",
+        "roleDefinition": [
+          "Maps ecosystem dependencies and identifies high-leverage partnership opportunities.",
+          "Designs cross-space coordination plans with clear ownership and mutual outcomes.",
+          "Improves external signal routing so actionable insights reach the right spaces quickly."
+        ]
+      },
+      "learning": {
+        "role": "Learning and Knowledge Architect",
+        "focus": "knowledge capture, learning loops, evidence quality, and continuous improvement systems",
+        "roleDefinition": [
+          "Turns discussions and experiments into reusable organizational knowledge.",
+          "Designs feedback loops that improve decision quality over time.",
+          "Raises evidence standards by clarifying assumptions, metrics, and lessons learned."
+        ]
+      },
+      "reputation": {
+        "role": "Reputation and Trust Steward",
+        "focus": "credibility signals, stakeholder trust, narrative coherence, and communication risk management",
+        "roleDefinition": [
+          "Protects trust by aligning public narrative with actual operational behavior.",
+          "Surfaces reputation risks early and proposes proactive mitigation steps.",
+          "Improves stakeholder communication quality during change, conflict, and uncertainty."
+        ]
+      }
+    },
     "spaceMemoryEmptyTab": "No items found in this view.",
     "spaceMemoryAiChatEmpty": "AI chat memories are not available yet.",
+    "spaceMemoryCallsEmpty": "No call recordings or transcripts yet. They appear here after a recorded group call ends.",
     "documentStates": {
       "discussion": "Discussion",
       "proposal": "Proposal",
-      "agreement": "Agreement"
+      "agreement": "Agreement",
+      "memory": "Memory"
     },
     "types": {
       "Opportunity": "Opportunity",
@@ -2353,7 +2574,21 @@
       "needsResources": "Needs & Resources",
       "valueModel": "Value & Model",
       "evidenceImpact": "Evidence & Impact"
-    }
+    },
+    "createBoard": "Create board",
+    "createBoardDescription": "Save a board filter by tag category or individual tag.",
+    "boardName": "Board name",
+    "boardNamePlaceholder": "e.g. Impact board",
+    "boardFilterBy": "Filter by",
+    "boardFilterCategory": "Tag category",
+    "boardFilterTag": "Individual tag",
+    "boardSelectCategory": "Category",
+    "boardSelectTag": "Tag",
+    "boardCreateAction": "Create board",
+    "boardCancelAction": "Cancel",
+    "boardAll": "All signals",
+    "boardDelete": "Delete board {boardName}",
+    "spaceMemoryTimelineLabel": "Space memory history"
   },
   "GlobalCallDock": {
     "callTitle": "Call - {count, plural, one {# member} other {# members}}",
@@ -2365,7 +2600,9 @@
     "exitFullscreenLabel": "Exit fullscreen",
     "unknownMember": "Unknown",
     "resizeTopRightLabel": "Resize call window from top-right corner",
-    "resizeBottomLeftLabel": "Resize call window from bottom-left corner"
+    "resizeBottomLeftLabel": "Resize call window from bottom-left corner",
+    "openFloatingWindowLabel": "Open floating call window",
+    "closeFloatingWindowLabel": "Close floating call window"
   },
   "SignalCard": {
     "noConversationRoom": "No conversation room yet",

--- a/packages/i18n/src/messages/es.json
+++ b/packages/i18n/src/messages/es.json
@@ -604,6 +604,7 @@
       "votingMethod": "Método de votación",
       "entryMethod": "Método de entrada",
       "membershipExit": "Salida de membresía",
+      "spaceMemory": "Space Memory",
       "spaceToSpace": "Espacio al espacio",
       "issueNewToken": "Emitir nuevo token",
       "treasuryMinting": "Acuñación del Tesoro",
@@ -790,7 +791,43 @@
   },
   "OnboardingAdventure": {
     "title": "Tu aventura empieza aquí.",
-    "subtitle": "Elige tu próximo paso.",
+    "continueAdventure": "Tu aventura continúa aquí",
+    "subtitle": "Tienes una visión poderosa para el mundo; nosotros te damos las herramientas para hacerla realidad.",
+    "aiHero": {
+      "title": "Build Anything, Together",
+      "description": "Cuéntale a Hypha AI lo que quieres construir y te guiará paso a paso en la configuración.",
+      "placeholder": "Crear un espacio, unirte a uno existente, explorar la red o financiar una tesorería: describe tu objetivo y la AI te guía.",
+      "rotating": {
+        "createSpace": "Pídele a Hypha AI crear un espacio para tu misión...",
+        "governance": "Pídele a Hypha AI diseñar la gobernanza de tu comunidad...",
+        "joinSpace": "Pídele a Hypha AI ayudarte a unirte al espacio correcto...",
+        "treasury": "Pídele a Hypha AI preparar un espacio listo para tesorería...",
+        "explore": "Pídele a Hypha AI encontrar oportunidades en la red..."
+      },
+      "cta": "Empezar con AI",
+      "starting": "Iniciando...",
+      "openingAi": "Abriendo el panel de AI...",
+      "sending": "Enviando tu prompt a la AI...",
+      "handoffFailed": "No se pudo iniciar la conversación con la AI. Inténtalo de nuevo.",
+      "handoffTimeout": "El traspaso a la AI tarda más de lo esperado. Inténtalo de nuevo.",
+      "sendFailed": "No se pudo enviar el prompt a la AI. Reintenta.",
+      "helper": "La AI propondrá cada acción y pedirá confirmación antes de crear o actualizar cualquier cosa.",
+      "unavailable": "El onboarding con AI no está disponible temporalmente en este despliegue.",
+      "ariaLabel": "Prompt de onboarding con AI",
+      "flow": {
+        "badge": "Simple. Powerful. By design.",
+        "reviewingTitle": "Revisando tu solicitud",
+        "reviewingDescription": "La AI está trazando la mejor ruta para tu objetivo.",
+        "reviewingDescriptionPersonalized": "{firstName}, la AI está trazando la mejor ruta para tu objetivo.",
+        "confirmingTitle": "Preparando una confirmación clara",
+        "confirmingDescription": "Verás una sola decisión enfocada antes de cualquier acción de escritura.",
+        "executingTitle": "Ejecutando la acción seleccionada",
+        "executingDescription": "La AI ahora crea, te dirige o te une según tu elección.",
+        "routingTitle": "Llevándote al destino correcto",
+        "routingDescription": "Finalizando la navegación hacia tu espacio o pantalla elegida.",
+        "confirmationHint": "Tú mantienes el control: la AI pide confirmación antes de crear o actualizar."
+      }
+    },
     "spacePlaceholder": "Seleccionar espacio",
     "spaceSearchPlaceholder": "Buscar espacios...",
     "searchToSeeSpaces": "Empieza a escribir para ver espacios coincidentes.",
@@ -855,7 +892,8 @@
       "browserNotifications": "Notificaciones del navegador (anteriormente \"Notificaciones emergentes de escritorio\")",
       "yes": "Sí",
       "no": "No",
-      "emailNotificationsWithEmail": "Notificaciones por correo electrónico ({email})"
+      "emailNotificationsWithEmail": "Notificaciones por correo electrónico ({email})",
+      "mentionConsent": "Consentimiento para notificaciones de menciones"
     },
     "subscriptions": {
       "title": "Recibe una notificación cuando...",
@@ -868,7 +906,11 @@
         "title": "Una propuesta es aprobada o rechazada.",
         "description": "En cualquiera de los espacios de los que eres miembro."
       },
-      "labelWithComingSoon": "{title} ({comingSoon})"
+      "labelWithComingSoon": "{title} ({comingSoon})",
+      "mentionOnChatMessage": {
+        "title": "Se te menciona en un mensaje de chat",
+        "description": "En cualquier hilo o chat donde las menciones estén habilitadas para ti."
+      }
     },
     "actions": {
       "retry": "Reintentar",
@@ -1183,7 +1225,10 @@
         "selectMember": "Selecciona un miembro",
         "selectSpace": "Selecciona un espacio"
       }
-    }
+    },
+    "aiAgents": "Agentes de IA",
+    "aiAgentsEmptyState": "Aún no hay agentes de IA movilizados. Haz preguntas estratégicas para activarlos.",
+    "aiAgentsMobilizedCount": "Movilizado {count, plural, one {# vez} other {# veces}}"
   },
   "TreasuryTab": {
     "balance": "Balance",
@@ -1658,6 +1703,8 @@
     "rootSpaceDescription": "Marcar este espacio como Espacio Raíz lo hará independiente. Ya no estará vinculado a la organización actual y todos sus espacios vinculados se trasladarán con ella.",
     "uploadEcosystemLogoLight": "Subir logo del ecosistema (claro)",
     "uploadEcosystemLogoDark": "Subir logo del ecosistema (oscuro)",
+    "ecosystemLogoPlaceholder": "Subir logo del ecosistema de {spaceName}",
+    "ecosystemLogoPlaceholderFallback": "este espacio",
     "ecosystemLogoLightDescription": "Sube un logo en modo claro para tu ecosistema (PNG, JPG, GIF o WEBP).",
     "ecosystemLogoDarkDescription": "Sube un logo en modo oscuro para tu ecosistema (PNG, JPG, GIF o WEBP).",
     "search": "Buscar...",
@@ -1928,7 +1975,13 @@
     "toolTokens": "{count} token(s) obtenido(s) para el espacio \"{slug}\".",
     "toolError": "Error: {message}",
     "streamError": "Ocurrió un error al generar la respuesta.",
-    "attachment": "Adjunto"
+    "attachment": "Adjunto",
+    "pendingAction": "Acción pendiente",
+    "confirmWith": "Confirmar con:",
+    "confirm": "Confirmar",
+    "cancel": "Cancelar",
+    "showMore": "Leer más",
+    "showLess": "Mostrar menos"
   },
   "HumanChatPanel": {
     "title": "Chat",
@@ -1984,6 +2037,7 @@
     "mentionNotAvailable": "Menciones (próximamente)",
     "mentionNoMembers": "Aún no hay miembros cargados — inténtalo en un momento",
     "mentionListLabel": "Mencionar a alguien",
+    "mentionListHintIncludesParentSpaceMembers": "Elige a quién mencionar. Esta lista puede incluir miembros del espacio principal.",
     "mentionInboxTitle": "Menciones",
     "mentionInboxBellCallRingHint": "Haz clic en la campana para silenciar o activar el tono de llamada. Abre la pestaña Menciones para ver las @menciones.",
     "callJoinCallAlertsMutedShort": "Silenciado",
@@ -2142,6 +2196,8 @@
     "callRemoteParticipant": "Participante",
     "callScreenShare": "Pantalla compartida",
     "callScreenShareActive": "Compartir pantalla activo",
+    "callYouAreSharingScreen": "Estás compartiendo tu pantalla",
+    "callYouAreSharingScreenHint": "Los demás pueden ver tu pantalla. Aquí no verás tu propia compartición.",
     "callFullView": "Vista ampliada",
     "callFullViewDescription": "Vista más grande de la llamada. La llamada del espacio sigue activa al cerrar esta ventana.",
     "callFullViewClose": "Cerrar",
@@ -2159,7 +2215,68 @@
     "callLeftBannerDismiss": "Cerrar",
     "callPaneResizeSharePeople": "Redimensionar pantalla y personas",
     "callPaneResizeShareStrip": "Redimensionar pantalla y tira de vídeo",
-    "callPaneResizeSpeakerShare": "Redimensionar orador y pantalla"
+    "callPaneResizeSpeakerShare": "Redimensionar orador y pantalla",
+    "callDockTitleWithMembers": "Llamada - {count, plural, one {# miembro} other {# miembros}}",
+    "callDockOpenCallSpace": "Abrir espacio de llamada",
+    "callDockSpaceLabel": "Espacio",
+    "callDockMinimize": "Minimizar llamada",
+    "callDockExpand": "Expandir llamada",
+    "callDockFullscreen": "Pantalla completa",
+    "callDockExitFullscreen": "Salir de pantalla completa",
+    "callCaptureLabel": "Captura de llamada",
+    "callCaptureModeNone": "Desactivado",
+    "callCaptureModeTranscriptOnly": "Solo transcripción",
+    "callCaptureModeRecordingWithTranscript": "Grabación + transcripción",
+    "callCaptureStatusIdle": "Inactivo",
+    "callCaptureStatusCapturing": "Capturando",
+    "callCaptureStatusStarting": "Iniciando…",
+    "callCaptureStatusPaused": "En pausa",
+    "callCaptureStatusSaving": "Guardando",
+    "callCaptureStop": "Detener grabación",
+    "callCapturePause": "Pausar grabación",
+    "callCaptureResume": "Reanudar grabación",
+    "callCaptureConfirmStopRecordingTitle": "¿Detener la grabación en la nube?",
+    "callCaptureConfirmStopRecording": "La grabación terminará para todos en esta llamada.",
+    "callCaptureConfirmStopRecordingAction": "Detener grabación",
+    "callCaptureConfirmStopTranscriptTitle": "¿Detener la transcripción?",
+    "callCaptureConfirmStopTranscript": "La transcripción sigue activa. ¿Detenerla y guardarla ahora?",
+    "callCaptureConfirmStopTranscriptAction": "Detener transcripción",
+    "callCaptureConfirmCancel": "Cancelar",
+    "callCaptureStatusError": "Error de captura",
+    "messageReadMore": "Leer más",
+    "messageShowLess": "Mostrar menos",
+    "callCaptureOffHint": "La captura está desactivada. No se guardarán grabación ni transcripción de esta llamada.",
+    "threadSummaryLabel": "Resumen del hilo",
+    "threadSummaryTitle": "Resumen vivo",
+    "threadSummaryLoading": "Actualizando resumen del hilo…",
+    "threadSummaryUpdated": "Actualizado {when}",
+    "threadSummaryExpand": "Expandir resumen",
+    "threadSummaryCollapse": "Contraer resumen",
+    "callCaptureLeaveWarning": "La captura está desactivada. Pulsa Salir de nuevo para confirmar que sales sin grabación.",
+    "callCaptureConsentLocal": "Estás capturando esta llamada ({mode}). Se notifica a los demás.",
+    "callCaptureConsentRemote": "{actor} está capturando esta llamada ({mode}).",
+    "callCaptureConsentJoin": "Esta llamada se está capturando ({mode}) por {actor}. Unirse implica tu consentimiento.",
+    "callCaptureConsentLegalNote": "La grabación y la transcripción pueden guardarse en la memoria del espacio.",
+    "callCaptureConsentPausedSuffix": " La captura está en pausa.",
+    "callCaptureVoiceStartedRecordingTranscript": "Esta llamada se está grabando y transcribiendo.",
+    "callCaptureVoiceStoppedRecordingTranscript": "La grabación y la transcripción se han detenido.",
+    "callCaptureVoiceStartedTranscript": "Esta llamada se está transcribiendo.",
+    "callCaptureVoiceStoppedTranscript": "La transcripción se ha detenido.",
+    "composerLockedPlaceholder": "Solo los miembros seleccionados del equipo pueden participar en este hilo.",
+    "signalTeamInteractionRestricted": "Solo los miembros seleccionados del equipo pueden enviar mensajes y menciones en este hilo.",
+    "signalTeamBannerReadOnly": "Este hilo está restringido al equipo. Puedes leer las actualizaciones, pero solo los miembros seleccionados del equipo pueden interactuar.",
+    "signalTeamRequestAccess": "Solicitar inclusión",
+    "signalTeamRequestPending": "Solicitud pendiente",
+    "signalTeamManageTitle": "Equipo de Signal",
+    "signalTeamManageOpen": "Gestionar",
+    "signalTeamManageClose": "Listo",
+    "signalTeamMemberListHint": "Selecciona los miembros que pueden enviar mensajes, mencionar y unirse a llamadas del hilo.",
+    "signalTeamAddMember": "Añadir",
+    "signalTeamRemoveMember": "Quitar",
+    "signalTeamPendingRequests": "Solicitudes pendientes",
+    "signalTeamApproveRequester": "Añadir al equipo",
+    "mentionOpenFallbackRoom": "No pudimos resolver esa sala desde tu contexto local. Abre el espacio correspondiente e inténtalo de nuevo.",
+    "mentionOpenFallbackMissingMessage": "Ese mensaje de mención aún no está disponible en la cronología cargada. Vuelve a intentarlo en un momento."
   },
   "CoherenceTab": {
     "signals": "Señales",
@@ -2187,6 +2304,7 @@
     "openConversation": "Abrir conversación",
     "saySomething": "Diga algo...",
     "proposeAgreement": "Proponer acuerdo",
+    "comingSoon": "Próximamente",
     "errorOhSnap": "¡Vaya! Ocurrió un error",
     "reset": "Restablecer",
     "creatingNewSignal": "Creando nueva señal",
@@ -2215,25 +2333,33 @@
     "spaceMemoryLoadMoreError": "No se pudieron cargar más elementos. Inténtalo de nuevo.",
     "spaceMemoryRetry": "Reintentar",
     "spaceMemoryRefresh": "Actualizar",
-    "spaceMemoryTimelineLabel": "Historial de memoria del espacio",
+    "openDocument": "Abrir documento",
     "spaceMemoryContext": "De «{title}» · {state}",
+    "spaceMemoryContextMemory": "Memoria · «{title}»",
     "spaceMemoryContextMatrix": "Del chat de Matrix",
     "spaceMemoryMatrixPreviewNeedsChat": "La vista previa requiere Human Chat (Matrix)",
     "spaceMemoryMatrixOpenHint": "Abre Human Chat para conectar Matrix y actualiza Space Memory para abrir este archivo.",
     "spaceMemoryMatrixVideoPlayHint": "Toca para ver la vista previa",
+    "spaceMemoryPdfPreviewUnavailable": "Vista previa de PDF no disponible",
     "spaceMemoryOpenAsset": "Abrir {name}",
     "untitledDocument": "Documento sin título",
     "spaceMemoryGeneral": "General",
     "spaceMemoryProposals": "Propuestas",
     "spaceMemoryConversations": "Conversaciones",
+    "spaceMemoryCalls": "Llamadas",
     "spaceMemoryAiChat": "Chat con IA",
+    "newMemoryUploadDocumentsTitle": "Subir documentos",
+    "newMemoryUploadingFiles": "Subiendo recuerdos del espacio...",
+    "newMemoryAttachmentsRequired": "Sube al menos un documento para este recuerdo.",
     "newMemory": "Nueva memoria",
     "spaceMemoryEmptyTab": "No se encontraron elementos en esta vista.",
     "spaceMemoryAiChatEmpty": "Las memorias del chat con IA aún no están disponibles.",
+    "spaceMemoryCallsEmpty": "Aún no hay grabaciones ni transcripciones de llamadas. Aparecerán aquí cuando termine una llamada grupal grabada.",
     "documentStates": {
       "discussion": "Discusión",
       "proposal": "Propuesta",
-      "agreement": "Acuerdo"
+      "agreement": "Acuerdo",
+      "memory": "Memoria"
     },
     "types": {
       "Opportunity": "Oportunidad",
@@ -2346,7 +2472,113 @@
     "spaceMemoryCallRecordingNoUrl": "Recording will be available when a media URL is ingested for this session.",
     "spaceMemoryCallTranscriptExcerpt": "Transcript",
     "spaceMemoryContextCallRecording": "Grabación de llamada (memoria organizacional)",
-    "spaceMemoryContextCallTranscript": "Transcripción de llamada (memoria organizacional)"
+    "spaceMemoryContextCallTranscript": "Transcripción de llamada (memoria organizacional)",
+    "aiAgentsCatalog": {
+      "purpose": {
+        "role": "Estratega Senior",
+        "focus": "aclarar misión, alineación estratégica, resultados norte y dirección de largo plazo",
+        "roleDefinition": [
+          "Define la intención estratégica y conecta decisiones diarias con resultados de misión a largo plazo.",
+          "Identifica puntos ciegos estratégicos, compensaciones y efectos de segundo orden antes de compromisos.",
+          "Traduce la visión en prioridades medibles, criterios de decisión e indicadores de éxito."
+        ]
+      },
+      "governance": {
+        "role": "Arquitecto/a de Gobernanza",
+        "focus": "derechos de decisión, modelos de responsabilidad, calidad de propuestas y mecanismos de coordinación colectiva",
+        "roleDefinition": [
+          "Diseña flujos de gobernanza que mantengan propuestas claras, responsables y ejecutables.",
+          "Mejora la calidad de votación al hacer visibles supuestos, impacto en stakeholders y preparación para decidir.",
+          "Recomienda guardrails de política ligeros que protegen autonomía y reducen fricción de coordinación."
+        ]
+      },
+      "operations": {
+        "role": "Líder de Operaciones",
+        "focus": "planes de ejecución, cadencia de entrega, gestión de dependencias y detalles prácticos de implementación",
+        "roleDefinition": [
+          "Convierte estrategia en planes ejecutables con responsables, hitos y cronogramas realistas.",
+          "Detecta cuellos de botella por dependencias temprano y propone opciones concretas de secuenciación.",
+          "Mejora la confiabilidad de entrega con ritmos operativos claros y bucles de retroalimentación."
+        ]
+      },
+      "community": {
+        "role": "Constructor/a de Comunidad",
+        "focus": "engagement de miembros, calidad de participación, onboarding y salud de contribuidores",
+        "roleDefinition": [
+          "Fortalece la calidad de participación mejorando onboarding y claridad para contribuidores.",
+          "Detecta caídas de engagement y propone intervenciones de retención y activación.",
+          "Equilibra apertura con normas sanas, confianza y experiencia sostenible para contribuidores."
+        ]
+      },
+      "finance": {
+        "role": "Analista de Tesorería y Token",
+        "focus": "implicaciones de token/tesorería, efectos de distribución, sostenibilidad y compensaciones de asignación de capital",
+        "roleDefinition": [
+          "Evalúa decisiones de tesorería y token por sostenibilidad, riesgo de concentración e impacto en runway.",
+          "Conecta decisiones presupuestarias con prioridades estratégicas y resultados organizacionales esperados.",
+          "Recomienda opciones de asignación conscientes de riesgo con framing explícito de ventajas/desventajas."
+        ]
+      },
+      "product": {
+        "role": "Estratega de Producto",
+        "focus": "impacto en usuarios, priorización de producto, diseño de experimentos y resultados medibles de adopción",
+        "roleDefinition": [
+          "Prioriza funcionalidades por valor para usuarios, encaje estratégico y apalancamiento de implementación.",
+          "Diseña experimentos que validan supuestos con resultados de aprendizaje medibles.",
+          "Alinea decisiones de roadmap con métricas de adopción, retención y cambio de comportamiento."
+        ]
+      },
+      "risk": {
+        "role": "Asesor/a de Riesgo y Cumplimiento",
+        "focus": "modos de fallo, escenarios de riesgo, planes de mitigación y consideraciones de política/cumplimiento",
+        "roleDefinition": [
+          "Hace visibles modos de fallo operativos, de gobernanza y de seguridad antes de ejecutar.",
+          "Recomienda mitigaciones prácticas con propiedad clara y condiciones de activación.",
+          "Mantiene propuestas en cumplimiento y resilientes sin sobre-burocratizar la ejecución."
+        ]
+      },
+      "ecosystem": {
+        "role": "Estratega de Ecosistema y Alianzas",
+        "focus": "colaboración entre espacios, alianzas, dependencias del ecosistema y apalancamiento de coordinación externa",
+        "roleDefinition": [
+          "Mapea dependencias del ecosistema e identifica oportunidades de alianzas de alto apalancamiento.",
+          "Diseña planes de coordinación entre espacios con propiedad clara y resultados mutuos.",
+          "Mejora el enrutamiento de señales externas para que insights accionables lleguen rápido a los espacios correctos."
+        ]
+      },
+      "learning": {
+        "role": "Arquitecto/a de Aprendizaje y Conocimiento",
+        "focus": "captura de conocimiento, bucles de aprendizaje, calidad de evidencia y sistemas de mejora continua",
+        "roleDefinition": [
+          "Convierte discusiones y experimentos en conocimiento organizacional reutilizable.",
+          "Diseña bucles de retroalimentación que mejoran la calidad de decisión con el tiempo.",
+          "Eleva estándares de evidencia al clarificar supuestos, métricas y lecciones aprendidas."
+        ]
+      },
+      "reputation": {
+        "role": "Responsable de Reputación y Confianza",
+        "focus": "señales de credibilidad, confianza de stakeholders, coherencia narrativa y gestión de riesgo comunicacional",
+        "roleDefinition": [
+          "Protege la confianza alineando narrativa pública con comportamiento operativo real.",
+          "Hace visibles riesgos reputacionales temprano y propone pasos de mitigación proactivos.",
+          "Mejora la calidad de comunicación con stakeholders durante cambio, conflicto e incertidumbre."
+        ]
+      }
+    },
+    "createBoard": "Crear tablero",
+    "createBoardDescription": "Guarda un filtro de tablero por categoría de etiqueta o etiqueta individual.",
+    "boardName": "Nombre del tablero",
+    "boardNamePlaceholder": "p. ej. Tablero de impacto",
+    "boardFilterBy": "Filtrar por",
+    "boardFilterCategory": "Categoría de etiqueta",
+    "boardFilterTag": "Etiqueta individual",
+    "boardSelectCategory": "Categoría",
+    "boardSelectTag": "Etiqueta",
+    "boardCreateAction": "Crear tablero",
+    "boardCancelAction": "Cancelar",
+    "boardAll": "Todas las señales",
+    "boardDelete": "Eliminar tablero {boardName}",
+    "spaceMemoryTimelineLabel": "Historial de memoria del espacio"
   },
   "GlobalCallDock": {
     "callTitle": "Llamada - {count, plural, one {# miembro} other {# miembros}}",
@@ -2358,7 +2590,9 @@
     "exitFullscreenLabel": "Salir de pantalla completa",
     "unknownMember": "Desconocido",
     "resizeTopRightLabel": "Redimensionar la llamada desde la esquina superior derecha",
-    "resizeBottomLeftLabel": "Redimensionar la llamada desde la esquina inferior izquierda"
+    "resizeBottomLeftLabel": "Redimensionar la llamada desde la esquina inferior izquierda",
+    "openFloatingWindowLabel": "Abrir ventana flotante de llamada",
+    "closeFloatingWindowLabel": "Cerrar ventana flotante de llamada"
   },
   "SignalCard": {
     "noConversationRoom": "Aún no hay sala de conversación",

--- a/packages/i18n/src/messages/fr.json
+++ b/packages/i18n/src/messages/fr.json
@@ -100,7 +100,43 @@
   },
   "OnboardingAdventure": {
     "title": "Votre aventure commence ici.",
-    "subtitle": "Choisissez votre prochaine étape.",
+    "continueAdventure": "Votre aventure continue ici",
+    "subtitle": "Vous avez une vision puissante du monde, nous vous donnons les outils pour la concrétiser.",
+    "aiHero": {
+      "title": "Build Anything, Together",
+      "description": "Expliquez à Hypha AI ce que vous voulez construire, et elle vous guidera étape par étape.",
+      "placeholder": "Créer un espace, rejoindre un espace existant, explorer le réseau ou financer une trésorerie - décrivez votre objectif et l’AI vous guide.",
+      "rotating": {
+        "createSpace": "Demandez à Hypha AI de créer un espace pour votre mission...",
+        "governance": "Demandez à Hypha AI de proposer une gouvernance pour votre communauté...",
+        "joinSpace": "Demandez à Hypha AI de vous aider à rejoindre le bon espace...",
+        "treasury": "Demandez à Hypha AI de préparer un espace prêt pour la trésorerie...",
+        "explore": "Demandez à Hypha AI d’identifier des opportunités dans le réseau..."
+      },
+      "cta": "Commencer avec l’AI",
+      "starting": "Démarrage...",
+      "openingAi": "Ouverture du panneau AI...",
+      "sending": "Envoi de votre prompt à l’AI...",
+      "handoffFailed": "Impossible de démarrer la conversation AI. Veuillez réessayer.",
+      "handoffTimeout": "Le transfert AI prend plus de temps que prévu. Veuillez réessayer.",
+      "sendFailed": "Le prompt n’a pas pu être envoyé à l’AI. Veuillez réessayer.",
+      "helper": "L’AI proposera chaque action et demandera une confirmation avant toute création ou modification.",
+      "unavailable": "L’onboarding AI est temporairement indisponible sur ce déploiement.",
+      "ariaLabel": "Invite d’onboarding AI",
+      "flow": {
+        "badge": "Simple. Powerful. By design.",
+        "reviewingTitle": "Analyse de votre demande",
+        "reviewingDescription": "L’AI prépare le meilleur parcours pour votre objectif.",
+        "reviewingDescriptionPersonalized": "{firstName}, l’AI prépare le meilleur parcours pour votre objectif.",
+        "confirmingTitle": "Préparation d’une confirmation claire",
+        "confirmingDescription": "Vous verrez un choix ciblé avant toute action d’écriture.",
+        "executingTitle": "Exécution de l’action choisie",
+        "executingDescription": "L’AI crée, oriente ou rejoint selon votre choix.",
+        "routingTitle": "Navigation vers la bonne destination",
+        "routingDescription": "Finalisation de la navigation vers votre espace ou l’écran ciblé.",
+        "confirmationHint": "Vous gardez le contrôle : l’AI demande une confirmation avant toute création ou mise à jour."
+      }
+    },
     "spacePlaceholder": "Sélectionner un espace",
     "spaceSearchPlaceholder": "Rechercher des espaces...",
     "searchToSeeSpaces": "Commencez à taper pour voir les espaces correspondants.",
@@ -165,7 +201,8 @@
       "browserNotifications": "Notifications du navigateur (anciennement « Notifications pop-up bureau »)",
       "yes": "Oui",
       "no": "Non",
-      "emailNotificationsWithEmail": "Notifications par e-mail ({email})"
+      "emailNotificationsWithEmail": "Notifications par e-mail ({email})",
+      "mentionConsent": "Consentement aux notifications de mention"
     },
     "subscriptions": {
       "title": "Être notifié quand...",
@@ -178,7 +215,11 @@
         "title": "Une proposition est approuvée ou rejetée",
         "description": "Dans n’importe lequel des espaces dont vous êtes membre."
       },
-      "labelWithComingSoon": "{title} ({comingSoon})"
+      "labelWithComingSoon": "{title} ({comingSoon})",
+      "mentionOnChatMessage": {
+        "title": "Vous êtes mentionné dans un message du chat",
+        "description": "Dans tout fil ou chat où les mentions sont activées pour vous."
+      }
     },
     "actions": {
       "retry": "Réessayer",
@@ -493,7 +534,10 @@
         "selectMember": "Veuillez sélectionner un membre",
         "selectSpace": "Veuillez sélectionner un espace"
       }
-    }
+    },
+    "aiAgents": "Agents IA",
+    "aiAgentsEmptyState": "Aucun agent IA mobilisé pour le moment. Posez des questions stratégiques pour les activer.",
+    "aiAgentsMobilizedCount": "Mobilisé {count, plural, one {# fois} other {# fois}}"
   },
   "TreasuryTab": {
     "balance": "Solde",
@@ -968,6 +1012,8 @@
     "rootSpaceDescription": "Marquer cet espace comme Espace racine le rendra indépendant. Il ne sera plus lié à l’organisation actuelle, et tous ses espaces liés seront déplacés avec lui.",
     "uploadEcosystemLogoLight": "Téléverser le logo de l’écosystème (clair)",
     "uploadEcosystemLogoDark": "Téléverser le logo de l’écosystème (sombre)",
+    "ecosystemLogoPlaceholder": "Téléverser le logo de l’écosystème de {spaceName}",
+    "ecosystemLogoPlaceholderFallback": "cet espace",
     "ecosystemLogoLightDescription": "Téléversez un logo clair pour votre écosystème (PNG, JPG, GIF ou WEBP).",
     "ecosystemLogoDarkDescription": "Téléversez un logo sombre pour votre écosystème (PNG, JPG, GIF ou WEBP).",
     "search": "Rechercher...",
@@ -988,6 +1034,7 @@
       "votingMethod": "Méthode de vote",
       "entryMethod": "Méthode d'entrée",
       "membershipExit": "Sortie de membre",
+      "spaceMemory": "Space Memory",
       "spaceToSpace": "Espace-à-espace",
       "issueNewToken": "Émettre un nouveau token",
       "treasuryMinting": "Frappe de trésorerie",
@@ -1928,7 +1975,13 @@
     "toolTokens": "{count} jeton(s) récupéré(s) pour l'espace \"{slug}\".",
     "toolError": "Erreur : {message}",
     "streamError": "Une erreur est survenue lors de la génération de la réponse.",
-    "attachment": "Pièce jointe"
+    "attachment": "Pièce jointe",
+    "pendingAction": "Action en attente",
+    "confirmWith": "Confirmer avec :",
+    "confirm": "Confirmer",
+    "cancel": "Annuler",
+    "showMore": "Lire la suite",
+    "showLess": "Afficher moins"
   },
   "HumanChatPanel": {
     "title": "Chat",
@@ -1984,6 +2037,7 @@
     "mentionNotAvailable": "Mentions (bientôt)",
     "mentionNoMembers": "Membres pas encore chargés — réessayez dans un instant",
     "mentionListLabel": "Mentionner quelqu’un",
+    "mentionListHintIncludesParentSpaceMembers": "Choisissez un membre à mentionner. Cette liste peut aussi inclure des membres de l’espace parent.",
     "mentionInboxTitle": "Mentions",
     "mentionInboxBellCallRingHint": "Cliquez sur la cloche pour couper ou réactiver le son d’appel. Ouvrez l’onglet Mentions pour voir les @mentions.",
     "callJoinCallAlertsMutedShort": "Muet",
@@ -2142,6 +2196,8 @@
     "callRemoteParticipant": "Participant",
     "callScreenShare": "Partage d’écran",
     "callScreenShareActive": "Partage d’écran actif",
+    "callYouAreSharingScreen": "Vous partagez votre écran",
+    "callYouAreSharingScreenHint": "Les autres voient votre écran. Vous ne voyez pas votre propre partage ici.",
     "callFullView": "Plein affichage",
     "callFullViewDescription": "Affichage plus large de l’appel. L’appel dans l’espace reste actif lorsque vous fermez cette fenêtre.",
     "callFullViewClose": "Fermer",
@@ -2159,7 +2215,66 @@
     "callLeftBannerDismiss": "Fermer",
     "callPaneResizeSharePeople": "Redimensionner partage d’écran et personnes",
     "callPaneResizeShareStrip": "Redimensionner partage d’écran et film",
-    "callPaneResizeSpeakerShare": "Redimensionner l’orateur et le partage d’écran"
+    "callPaneResizeSpeakerShare": "Redimensionner l’orateur et le partage d’écran",
+    "callDockTitleWithMembers": "Appel - {count, plural, one {# membre} other {# membres}}",
+    "callDockOpenCallSpace": "Ouvrir l’espace d’appel",
+    "callDockSpaceLabel": "Espace",
+    "callDockMinimize": "Réduire l’appel",
+    "callDockExpand": "Agrandir l’appel",
+    "callDockFullscreen": "Plein écran",
+    "callDockExitFullscreen": "Quitter le plein écran",
+    "callCaptureLabel": "Capture de l’appel",
+    "callCaptureModeNone": "Désactivé",
+    "callCaptureModeTranscriptOnly": "Transcription uniquement",
+    "callCaptureModeRecordingWithTranscript": "Enregistrement + transcription",
+    "callCaptureStatusIdle": "Inactif",
+    "callCaptureStatusCapturing": "Capture en cours",
+    "callCaptureStatusStarting": "Démarrage…",
+    "callCaptureStatusPaused": "En pause",
+    "callCaptureStatusSaving": "Enregistrement",
+    "callCaptureStatusError": "Erreur de capture",
+    "callCaptureStop": "Arrêter l’enregistrement",
+    "callCapturePause": "Mettre l’enregistrement en pause",
+    "callCaptureResume": "Reprendre l’enregistrement",
+    "callCaptureConfirmStopRecordingTitle": "Arrêter l’enregistrement cloud ?",
+    "callCaptureConfirmStopRecording": "L’enregistrement prendra fin pour tous les participants de cet appel.",
+    "callCaptureConfirmStopRecordingAction": "Arrêter l’enregistrement",
+    "callCaptureConfirmStopTranscriptTitle": "Arrêter la transcription ?",
+    "callCaptureConfirmStopTranscript": "La transcription est encore active. L’arrêter et l’enregistrer maintenant ?",
+    "callCaptureConfirmStopTranscriptAction": "Arrêter la transcription",
+    "callCaptureConfirmCancel": "Annuler",
+    "callCaptureOffHint": "La capture est désactivée. Aucun enregistrement ni transcription ne sera enregistré pour cet appel.",
+    "threadSummaryLabel": "Résumé du fil",
+    "threadSummaryTitle": "Résumé vivant",
+    "threadSummaryLoading": "Mise à jour du résumé du fil…",
+    "threadSummaryUpdated": "Mis à jour {when}",
+    "threadSummaryExpand": "Développer le résumé",
+    "threadSummaryCollapse": "Réduire le résumé",
+    "callCaptureLeaveWarning": "La capture est désactivée. Appuyez à nouveau sur Quitter pour confirmer.",
+    "callCaptureConsentLocal": "Vous capturez cet appel ({mode}). Les autres sont informés.",
+    "callCaptureConsentRemote": "{actor} capture cet appel ({mode}).",
+    "callCaptureConsentJoin": "Cet appel est capturé ({mode}) par {actor}. Rejoindre vaut consentement.",
+    "callCaptureConsentLegalNote": "L'enregistrement et la transcription peuvent être stockés dans la mémoire de l'espace.",
+    "callCaptureConsentPausedSuffix": " La capture est en pause.",
+    "callCaptureVoiceStartedRecordingTranscript": "Cet appel est maintenant enregistré et transcrit.",
+    "callCaptureVoiceStoppedRecordingTranscript": "L'enregistrement et la transcription sont terminés.",
+    "callCaptureVoiceStartedTranscript": "Cet appel est maintenant transcrit.",
+    "callCaptureVoiceStoppedTranscript": "La transcription est terminée.",
+    "composerLockedPlaceholder": "Seuls les membres sélectionnés de l’équipe peuvent interagir dans ce fil.",
+    "signalTeamInteractionRestricted": "Seuls les membres sélectionnés de l’équipe peuvent envoyer des messages et des mentions dans ce fil.",
+    "signalTeamBannerReadOnly": "Ce fil est limité à l’équipe. Vous pouvez lire les mises à jour, mais seuls les membres sélectionnés peuvent interagir.",
+    "signalTeamRequestAccess": "Demander à être inclus",
+    "signalTeamRequestPending": "Demande en attente",
+    "signalTeamManageTitle": "Équipe Signal",
+    "signalTeamManageOpen": "Gérer",
+    "signalTeamManageClose": "Terminé",
+    "signalTeamMemberListHint": "Sélectionnez les membres qui peuvent envoyer des messages, mentionner et rejoindre les appels du fil.",
+    "signalTeamAddMember": "Ajouter",
+    "signalTeamRemoveMember": "Retirer",
+    "signalTeamPendingRequests": "Demandes en attente",
+    "signalTeamApproveRequester": "Ajouter à l’équipe",
+    "mentionOpenFallbackRoom": "Impossible de résoudre ce salon depuis votre contexte local. Ouvrez l'espace concerné puis réessayez.",
+    "mentionOpenFallbackMissingMessage": "Ce message de mention n'est pas encore disponible dans la chronologie chargée. Réessayez dans un instant."
   },
   "CoherenceTab": {
     "signals": "Signaux",
@@ -2187,6 +2302,7 @@
     "openConversation": "Ouvrir la conversation",
     "saySomething": "Dites quelque chose...",
     "proposeAgreement": "Proposer un accord",
+    "comingSoon": "Bientôt disponible",
     "errorOhSnap": "Oups ! Une erreur est survenue",
     "reset": "Réinitialiser",
     "creatingNewSignal": "Création d'un nouveau signal",
@@ -2215,8 +2331,9 @@
     "spaceMemoryLoadMoreError": "Impossible de charger d'autres éléments. Veuillez réessayer.",
     "spaceMemoryRetry": "Réessayer",
     "spaceMemoryRefresh": "Actualiser",
-    "spaceMemoryTimelineLabel": "Historique de la mémoire de l'espace",
+    "openDocument": "Ouvrir le document",
     "spaceMemoryContext": "Depuis «{title}» · {state}",
+    "spaceMemoryContextMemory": "Mémoire · «{title}»",
     "spaceMemoryContextMatrix": "Depuis le chat Matrix",
     "spaceMemoryContextCallTranscript": "Transcription d'appel (mémoire organisationnelle)",
     "spaceMemoryContextCallRecording": "Enregistrement d'appel (mémoire organisationnelle)",
@@ -2226,19 +2343,26 @@
     "spaceMemoryMatrixPreviewNeedsChat": "L’aperçu nécessite Human Chat (Matrix)",
     "spaceMemoryMatrixOpenHint": "Ouvrez Human Chat pour connecter Matrix, puis actualisez la mémoire d’espace pour ouvrir ce fichier.",
     "spaceMemoryMatrixVideoPlayHint": "Appuyez pour lire l’aperçu",
+    "spaceMemoryPdfPreviewUnavailable": "Aperçu PDF indisponible",
     "spaceMemoryOpenAsset": "Ouvrir {name}",
     "untitledDocument": "Document sans titre",
     "spaceMemoryGeneral": "Général",
     "spaceMemoryProposals": "Propositions",
     "spaceMemoryConversations": "Conversations",
+    "spaceMemoryCalls": "Appels",
     "spaceMemoryAiChat": "Chat IA",
+    "newMemoryUploadDocumentsTitle": "Téléverser des documents",
+    "newMemoryUploadingFiles": "Téléversement des souvenirs de l'espace...",
+    "newMemoryAttachmentsRequired": "Veuillez téléverser au moins un document pour ce souvenir.",
     "newMemory": "Nouvelle mémoire",
     "spaceMemoryEmptyTab": "Aucun élément trouvé dans cette vue.",
     "spaceMemoryAiChatEmpty": "Les mémoires du chat IA ne sont pas encore disponibles.",
+    "spaceMemoryCallsEmpty": "Aucun enregistrement ni transcription d'appel pour l'instant. Ils apparaissent ici après la fin d'un appel de groupe enregistré.",
     "documentStates": {
       "discussion": "Discussion",
       "proposal": "Proposition",
-      "agreement": "Accord"
+      "agreement": "Accord",
+      "memory": "Mémoire"
     },
     "types": {
       "Opportunity": "Opportunité",
@@ -2344,7 +2468,113 @@
       "needsResources": "Besoins & ressources",
       "valueModel": "Valeur & modèle",
       "evidenceImpact": "Preuves & impact"
-    }
+    },
+    "aiAgentsCatalog": {
+      "purpose": {
+        "role": "Stratège Senior",
+        "focus": "clarifier la mission, l'alignement stratégique, les résultats nord-star et la direction à long terme",
+        "roleDefinition": [
+          "Définit l'intention stratégique et relie les décisions quotidiennes aux résultats de mission à long terme.",
+          "Identifie les angles morts stratégiques, les arbitrages et les effets de second ordre avant les engagements.",
+          "Traduit la vision en priorités mesurables, critères de décision et indicateurs de succès."
+        ]
+      },
+      "governance": {
+        "role": "Architecte de Gouvernance",
+        "focus": "droits de décision, modèles de responsabilité, qualité des propositions et mécanismes de coordination collective",
+        "roleDefinition": [
+          "Conçoit des flux de gouvernance qui gardent les propositions claires, responsables et exécutables.",
+          "Améliore la qualité des votes en rendant visibles hypothèses, impact parties prenantes et maturité décisionnelle.",
+          "Recommande des garde-fous de politique légers qui protègent l'autonomie tout en réduisant la friction de coordination."
+        ]
+      },
+      "operations": {
+        "role": "Responsable Opérations",
+        "focus": "plans d'exécution, cadence de livraison, gestion des dépendances et détails pratiques d'implémentation",
+        "roleDefinition": [
+          "Transforme la stratégie en plans exécutables avec responsables, jalons et calendriers réalistes.",
+          "Signale tôt les goulots d'étranglement de dépendances et propose des options de séquencement concrètes.",
+          "Améliore la fiabilité de livraison grâce à des rythmes opératoires clairs et des boucles de feedback."
+        ]
+      },
+      "community": {
+        "role": "Bâtisseur de Communauté",
+        "focus": "engagement des membres, qualité de participation, onboarding et santé des contributeurs",
+        "roleDefinition": [
+          "Renforce la qualité de participation en améliorant l'onboarding et la clarté pour les contributeurs.",
+          "Détecte les baisses d'engagement et propose des interventions de rétention et d'activation.",
+          "Équilibre ouverture, normes saines, confiance et expérience contributeur durable."
+        ]
+      },
+      "finance": {
+        "role": "Analyste Trésorerie et Token",
+        "focus": "implications token/trésorerie, effets de distribution, durabilité et arbitrages d'allocation du capital",
+        "roleDefinition": [
+          "Évalue les décisions trésorerie/token sur la durabilité, le risque de concentration et l'impact sur le runway.",
+          "Relie les choix budgétaires aux priorités stratégiques et aux résultats organisationnels attendus.",
+          "Recommande des options d'allocation conscientes du risque avec cadrage explicite upside/downside."
+        ]
+      },
+      "product": {
+        "role": "Stratège Produit",
+        "focus": "impact utilisateur, priorisation produit, design d'expérimentation et résultats d'adoption mesurables",
+        "roleDefinition": [
+          "Priorise les fonctionnalités selon la valeur utilisateur, l'alignement stratégique et l'effet de levier d'implémentation.",
+          "Conçoit des expériences qui valident les hypothèses avec des apprentissages mesurables.",
+          "Aligne les choix de roadmap avec des métriques d'adoption, de rétention et de changement de comportement."
+        ]
+      },
+      "risk": {
+        "role": "Conseiller Risque et Conformité",
+        "focus": "modes de défaillance, scénarios de risque, plans de mitigation et considérations politique/conformité",
+        "roleDefinition": [
+          "Fait émerger les modes de défaillance opérationnels, de gouvernance et de sécurité avant exécution.",
+          "Recommande des mitigations pratiques avec ownership clair et conditions de déclenchement.",
+          "Maintient les propositions conformes et résilientes sans sur-bureaucratiser l'exécution."
+        ]
+      },
+      "ecosystem": {
+        "role": "Stratège Écosystème et Partenariats",
+        "focus": "collaboration inter-espaces, partenariats, dépendances écosystème et levier de coordination externe",
+        "roleDefinition": [
+          "Cartographie les dépendances de l'écosystème et identifie les opportunités de partenariat à fort levier.",
+          "Conçoit des plans de coordination inter-espaces avec ownership clair et résultats mutuels.",
+          "Améliore le routage des signaux externes pour que les insights actionnables atteignent vite les bons espaces."
+        ]
+      },
+      "learning": {
+        "role": "Architecte Apprentissage et Connaissance",
+        "focus": "capture de connaissance, boucles d'apprentissage, qualité des preuves et systèmes d'amélioration continue",
+        "roleDefinition": [
+          "Transforme discussions et expériences en connaissance organisationnelle réutilisable.",
+          "Conçoit des boucles de feedback qui améliorent la qualité des décisions dans le temps.",
+          "Élève les standards de preuve en clarifiant hypothèses, métriques et leçons apprises."
+        ]
+      },
+      "reputation": {
+        "role": "Référent Réputation et Confiance",
+        "focus": "signaux de crédibilité, confiance des parties prenantes, cohérence narrative et gestion du risque de communication",
+        "roleDefinition": [
+          "Protège la confiance en alignant le narratif public avec le comportement opérationnel réel.",
+          "Fait remonter tôt les risques réputationnels et propose des étapes de mitigation proactives.",
+          "Améliore la qualité de communication avec les parties prenantes en période de changement, conflit et incertitude."
+        ]
+      }
+    },
+    "createBoard": "Créer un tableau",
+    "createBoardDescription": "Enregistrez un filtre de tableau par catégorie de tag ou tag individuel.",
+    "boardName": "Nom du tableau",
+    "boardNamePlaceholder": "ex. Tableau d'impact",
+    "boardFilterBy": "Filtrer par",
+    "boardFilterCategory": "Catégorie de tag",
+    "boardFilterTag": "Tag individuel",
+    "boardSelectCategory": "Catégorie",
+    "boardSelectTag": "Tag",
+    "boardCreateAction": "Créer un tableau",
+    "boardCancelAction": "Annuler",
+    "boardAll": "Tous les signaux",
+    "boardDelete": "Supprimer le tableau {boardName}",
+    "spaceMemoryTimelineLabel": "Historique de la mémoire de l'espace"
   },
   "GlobalCallDock": {
     "callTitle": "Appel - {count, plural, one {# membre} other {# membres}}",
@@ -2356,7 +2586,9 @@
     "exitFullscreenLabel": "Quitter le plein écran",
     "unknownMember": "Inconnu",
     "resizeTopRightLabel": "Redimensionner l'appel depuis le coin supérieur droit",
-    "resizeBottomLeftLabel": "Redimensionner l'appel depuis le coin inférieur gauche"
+    "resizeBottomLeftLabel": "Redimensionner l'appel depuis le coin inférieur gauche",
+    "openFloatingWindowLabel": "Ouvrir la fenêtre d'appel flottante",
+    "closeFloatingWindowLabel": "Fermer la fenêtre d'appel flottante"
   },
   "SignalCard": {
     "noConversationRoom": "Pas encore de salle de conversation",

--- a/packages/i18n/src/messages/pt.json
+++ b/packages/i18n/src/messages/pt.json
@@ -604,6 +604,7 @@
       "votingMethod": "Método de votação",
       "entryMethod": "Método de entrada",
       "membershipExit": "Saída de adesão",
+      "spaceMemory": "Space Memory",
       "spaceToSpace": "Espaço para Espaço",
       "issueNewToken": "Emitir novo token",
       "treasuryMinting": "Cunhagem de Tesouro",
@@ -790,7 +791,43 @@
   },
   "OnboardingAdventure": {
     "title": "Sua aventura começa aqui.",
-    "subtitle": "Escolha seu próximo passo.",
+    "continueAdventure": "Sua aventura continua aqui",
+    "subtitle": "Você tem uma visão poderosa para o mundo; nós damos a você as ferramentas para colocá-la em ação.",
+    "aiHero": {
+      "title": "Construa qualquer coisa, juntos",
+      "description": "Diga ao Hypha AI o que você quer construir e ele vai guiar a configuração passo a passo.",
+      "placeholder": "Criar um espaço, entrar em um espaço existente, explorar a rede ou financiar uma tesouraria - descreva seu objetivo e a AI guia você.",
+      "rotating": {
+        "createSpace": "Peça ao Hypha AI para criar um espaço para sua missão...",
+        "governance": "Peça ao Hypha AI para desenhar a governança da sua comunidade...",
+        "joinSpace": "Peça ao Hypha AI para ajudar você a entrar no espaço certo...",
+        "treasury": "Peça ao Hypha AI para preparar um espaço pronto para tesouraria...",
+        "explore": "Peça ao Hypha AI para encontrar oportunidades na rede..."
+      },
+      "cta": "Começar com AI",
+      "starting": "Iniciando...",
+      "openingAi": "Abrindo o painel de AI...",
+      "sending": "Enviando seu prompt para a AI...",
+      "handoffFailed": "Não foi possível iniciar a conversa com a AI. Tente novamente.",
+      "handoffTimeout": "A transferência para a AI está demorando mais do que o esperado. Tente novamente.",
+      "sendFailed": "Não foi possível enviar o prompt para a AI. Tente novamente.",
+      "helper": "A AI vai propor cada ação e pedir confirmação antes de criar ou atualizar qualquer coisa.",
+      "unavailable": "O onboarding com AI está temporariamente indisponível nesta implantação.",
+      "ariaLabel": "Prompt de onboarding com AI",
+      "flow": {
+        "badge": "Simples. Poderoso. Feito por design.",
+        "reviewingTitle": "Analisando sua solicitação",
+        "reviewingDescription": "A AI está mapeando o melhor caminho para o seu objetivo.",
+        "reviewingDescriptionPersonalized": "{firstName}, a AI está mapeando o melhor caminho para o seu objetivo.",
+        "confirmingTitle": "Preparando uma confirmação clara",
+        "confirmingDescription": "Você verá uma escolha objetiva antes de qualquer ação de escrita.",
+        "executingTitle": "Executando a ação selecionada",
+        "executingDescription": "A AI agora cria, direciona ou conecta você com base na sua escolha.",
+        "routingTitle": "Levando você ao destino certo",
+        "routingDescription": "Finalizando a navegação para seu espaço ou tela selecionada.",
+        "confirmationHint": "Você mantém o controle: a AI pede confirmação antes de criar ou atualizar."
+      }
+    },
     "spacePlaceholder": "Selecionar espaço",
     "spaceSearchPlaceholder": "Buscar espaços...",
     "searchToSeeSpaces": "Comece a digitar para ver espaços correspondentes.",
@@ -855,7 +892,8 @@
       "browserNotifications": "Notificações do navegador (anteriormente \"Notificações pop-up na área de trabalho\")",
       "yes": "Sim",
       "no": "Não",
-      "emailNotificationsWithEmail": "Notificações por e-mail ({email})"
+      "emailNotificationsWithEmail": "Notificações por e-mail ({email})",
+      "mentionConsent": "Consentimento para notificações de menções"
     },
     "subscriptions": {
       "title": "Seja notificado quando...",
@@ -868,7 +906,11 @@
         "title": "Uma proposta é aprovada ou rejeitada",
         "description": "Em qualquer um dos espaços dos quais você é membro."
       },
-      "labelWithComingSoon": "{title} ({comingSoon})"
+      "labelWithComingSoon": "{title} ({comingSoon})",
+      "mentionOnChatMessage": {
+        "title": "Você foi mencionado em uma mensagem de chat",
+        "description": "Em qualquer thread ou chat em que as menções estejam habilitadas para você."
+      }
     },
     "actions": {
       "retry": "Tentar novamente",
@@ -1183,7 +1225,10 @@
         "selectMember": "Selecione um membro",
         "selectSpace": "Selecione um espaço"
       }
-    }
+    },
+    "aiAgents": "Agentes de IA",
+    "aiAgentsEmptyState": "Ainda não há agentes de IA mobilizados. Faça perguntas estratégicas para os ativar.",
+    "aiAgentsMobilizedCount": "Mobilizado {count, plural, one {# vez} other {# vezes}}"
   },
   "TreasuryTab": {
     "balance": "Equilíbrio",
@@ -1658,6 +1703,8 @@
     "rootSpaceDescription": "Marcar este espaço como Root Space o tornará independente. Não estará mais vinculado à organização atual e todos os seus espaços vinculados se moverão com ele.",
     "uploadEcosystemLogoLight": "Enviar logo do ecossistema (claro)",
     "uploadEcosystemLogoDark": "Enviar logo do ecossistema (escuro)",
+    "ecosystemLogoPlaceholder": "Enviar logo do ecossistema de {spaceName}",
+    "ecosystemLogoPlaceholderFallback": "este espaço",
     "ecosystemLogoLightDescription": "Envie um logo em modo claro para o seu ecossistema (PNG, JPG, GIF ou WEBP).",
     "ecosystemLogoDarkDescription": "Envie um logo em modo escuro para o seu ecossistema (PNG, JPG, GIF ou WEBP).",
     "search": "Procurar...",
@@ -1928,7 +1975,13 @@
     "toolTokens": "{count} token(s) obtido(s) para o espaço \"{slug}\".",
     "toolError": "Erro: {message}",
     "streamError": "Ocorreu um erro ao gerar a resposta.",
-    "attachment": "Anexo"
+    "attachment": "Anexo",
+    "pendingAction": "Ação pendente",
+    "confirmWith": "Confirmar com:",
+    "confirm": "Confirmar",
+    "cancel": "Cancelar",
+    "showMore": "Ler mais",
+    "showLess": "Mostrar menos"
   },
   "HumanChatPanel": {
     "title": "Chat",
@@ -1984,6 +2037,7 @@
     "mentionNotAvailable": "Menções (em breve)",
     "mentionNoMembers": "Membros ainda não carregados — tente novamente em instantes",
     "mentionListLabel": "Mencionar alguém",
+    "mentionListHintIncludesParentSpaceMembers": "Escolha o membro que deseja mencionar. Esta lista pode incluir membros do espaço principal.",
     "mentionInboxTitle": "Menções",
     "mentionInboxBellCallRingHint": "Clique no sino para silenciar ou ativar o toque de chamada. Abre o separador Menções para ver as @menções.",
     "callJoinCallAlertsMutedShort": "Silenciado",
@@ -2142,6 +2196,8 @@
     "callRemoteParticipant": "Participante",
     "callScreenShare": "Partilha de ecrã",
     "callScreenShareActive": "Partilha de ecrã ativa",
+    "callYouAreSharingScreen": "Está a partilhar o seu ecrã",
+    "callYouAreSharingScreenHint": "Os outros veem o seu ecrã. A sua própria partilha não aparece aqui.",
     "callFullView": "Vista alargada",
     "callFullViewDescription": "Vista mais ampla da chamada. A chamada no espaço continua ativa ao fechar esta janela.",
     "callFullViewClose": "Fechar",
@@ -2159,7 +2215,68 @@
     "callLeftBannerDismiss": "Fechar",
     "callPaneResizeSharePeople": "Redimensionar partilha e pessoas",
     "callPaneResizeShareStrip": "Redimensionar partilha e filme",
-    "callPaneResizeSpeakerShare": "Redimensionar orador e partilha de ecrã"
+    "callPaneResizeSpeakerShare": "Redimensionar orador e partilha de ecrã",
+    "callDockTitleWithMembers": "Chamada - {count, plural, one {# membro} other {# membros}}",
+    "callDockOpenCallSpace": "Abrir espaço da chamada",
+    "callDockSpaceLabel": "Espaço",
+    "callDockMinimize": "Minimizar chamada",
+    "callDockExpand": "Expandir chamada",
+    "callDockFullscreen": "Ecrã inteiro",
+    "callDockExitFullscreen": "Sair do ecrã inteiro",
+    "callCaptureLabel": "Captura da chamada",
+    "callCaptureModeNone": "Desativado",
+    "callCaptureModeTranscriptOnly": "Apenas transcrição",
+    "callCaptureModeRecordingWithTranscript": "Gravação + transcrição",
+    "callCaptureStatusIdle": "Inativo",
+    "callCaptureStatusCapturing": "A capturar",
+    "callCaptureStatusStarting": "A iniciar…",
+    "callCaptureStatusPaused": "Em pausa",
+    "callCaptureStatusSaving": "A guardar",
+    "callCaptureStop": "Parar gravação",
+    "callCapturePause": "Pausar gravação",
+    "callCaptureResume": "Retomar gravação",
+    "callCaptureConfirmStopRecordingTitle": "Parar gravação na nuvem?",
+    "callCaptureConfirmStopRecording": "A gravação terminará para todos nesta chamada.",
+    "callCaptureConfirmStopRecordingAction": "Parar gravação",
+    "callCaptureConfirmStopTranscriptTitle": "Parar transcrição?",
+    "callCaptureConfirmStopTranscript": "A transcrição ainda está ativa. Parar e guardar agora?",
+    "callCaptureConfirmStopTranscriptAction": "Parar transcrição",
+    "callCaptureConfirmCancel": "Cancelar",
+    "callCaptureStatusError": "Erro de captura",
+    "messageReadMore": "Ler mais",
+    "messageShowLess": "Mostrar menos",
+    "callCaptureOffHint": "A captura está desativada. Nenhuma gravação ou transcrição será guardada para esta chamada.",
+    "threadSummaryLabel": "Resumo do tópico",
+    "threadSummaryTitle": "Resumo vivo",
+    "threadSummaryLoading": "A atualizar resumo do tópico…",
+    "threadSummaryUpdated": "Atualizado {when}",
+    "threadSummaryExpand": "Expandir resumo",
+    "threadSummaryCollapse": "Recolher resumo",
+    "callCaptureLeaveWarning": "A captura está desativada. Prima Sair novamente para confirmar que sai sem gravação.",
+    "callCaptureConsentLocal": "Está a capturar esta chamada ({mode}). Os outros são notificados.",
+    "callCaptureConsentRemote": "{actor} está a capturar esta chamada ({mode}).",
+    "callCaptureConsentJoin": "Esta chamada está a ser capturada ({mode}) por {actor}. Entrar implica o seu consentimento.",
+    "callCaptureConsentLegalNote": "A gravação e a transcrição podem ser guardadas na memória do espaço.",
+    "callCaptureConsentPausedSuffix": " A captura está em pausa.",
+    "callCaptureVoiceStartedRecordingTranscript": "Esta chamada está a ser gravada e transcrita.",
+    "callCaptureVoiceStoppedRecordingTranscript": "A gravação e a transcrição foram interrompidas.",
+    "callCaptureVoiceStartedTranscript": "Esta chamada está a ser transcrita.",
+    "callCaptureVoiceStoppedTranscript": "A transcrição foi interrompida.",
+    "composerLockedPlaceholder": "Apenas os membros selecionados da equipe podem interagir nesta thread.",
+    "signalTeamInteractionRestricted": "Apenas os membros selecionados da equipe podem enviar mensagens e menções nesta thread.",
+    "signalTeamBannerReadOnly": "Esta thread é restrita à equipe. Você pode ler as atualizações, mas apenas os membros selecionados da equipe podem interagir.",
+    "signalTeamRequestAccess": "Solicitar inclusão",
+    "signalTeamRequestPending": "Solicitação pendente",
+    "signalTeamManageTitle": "Equipe do Signal",
+    "signalTeamManageOpen": "Gerenciar",
+    "signalTeamManageClose": "Concluir",
+    "signalTeamMemberListHint": "Selecione os membros que podem enviar mensagens, mencionar e participar de chamadas da thread.",
+    "signalTeamAddMember": "Adicionar",
+    "signalTeamRemoveMember": "Remover",
+    "signalTeamPendingRequests": "Solicitações pendentes",
+    "signalTeamApproveRequester": "Adicionar à equipe",
+    "mentionOpenFallbackRoom": "Não foi possível resolver essa sala no seu contexto local. Abra o espaço relacionado e tente novamente.",
+    "mentionOpenFallbackMissingMessage": "Essa mensagem de menção ainda não está disponível na linha do tempo carregada. Tente novamente em instantes."
   },
   "CoherenceTab": {
     "signals": "Sinais",
@@ -2187,6 +2304,7 @@
     "openConversation": "Abrir conversa",
     "saySomething": "Diga algo...",
     "proposeAgreement": "Propor acordo",
+    "comingSoon": "Em breve",
     "errorOhSnap": "Ops! Ocorreu um erro",
     "reset": "Redefinir",
     "creatingNewSignal": "Criando novo sinal",
@@ -2215,25 +2333,33 @@
     "spaceMemoryLoadMoreError": "Não foi possível carregar mais itens. Tente novamente.",
     "spaceMemoryRetry": "Tentar novamente",
     "spaceMemoryRefresh": "Atualizar",
-    "spaceMemoryTimelineLabel": "Histórico da memória do espaço",
+    "openDocument": "Abrir documento",
     "spaceMemoryContext": "De «{title}» · {state}",
+    "spaceMemoryContextMemory": "Memória · «{title}»",
     "spaceMemoryContextMatrix": "Do chat Matrix",
     "spaceMemoryMatrixPreviewNeedsChat": "A pré-visualização precisa do Human Chat (Matrix)",
     "spaceMemoryMatrixOpenHint": "Abra o Human Chat para ligar o Matrix e atualize a memória do espaço para abrir este ficheiro.",
     "spaceMemoryMatrixVideoPlayHint": "Toque para ver a pré-visualização",
+    "spaceMemoryPdfPreviewUnavailable": "Pré-visualização de PDF indisponível",
     "spaceMemoryOpenAsset": "Abrir {name}",
     "untitledDocument": "Documento sem título",
     "spaceMemoryGeneral": "Geral",
     "spaceMemoryProposals": "Propostas",
     "spaceMemoryConversations": "Conversas",
+    "spaceMemoryCalls": "Chamadas",
     "spaceMemoryAiChat": "Chat com IA",
+    "newMemoryUploadDocumentsTitle": "Carregar documentos",
+    "newMemoryUploadingFiles": "A carregar memórias do espaço...",
+    "newMemoryAttachmentsRequired": "Carregue pelo menos um documento para esta memória.",
     "newMemory": "Nova memória",
     "spaceMemoryEmptyTab": "Nenhum item encontrado nesta visualização.",
     "spaceMemoryAiChatEmpty": "As memórias do chat com IA ainda não estão disponíveis.",
+    "spaceMemoryCallsEmpty": "Ainda não há gravações nem transcrições de chamadas. Aparecem aqui depois de uma chamada de grupo gravada terminar.",
     "documentStates": {
       "discussion": "Discussão",
       "proposal": "Proposta",
-      "agreement": "Acordo"
+      "agreement": "Acordo",
+      "memory": "Memória"
     },
     "types": {
       "Opportunity": "Oportunidade",
@@ -2344,7 +2470,113 @@
     "spaceMemoryCallRecordingNoUrl": "Recording will be available when a media URL is ingested for this session.",
     "spaceMemoryCallTranscriptExcerpt": "Transcript",
     "spaceMemoryContextCallRecording": "Call recording (organizational memory)",
-    "spaceMemoryContextCallTranscript": "Call transcript (organizational memory)"
+    "spaceMemoryContextCallTranscript": "Call transcript (organizational memory)",
+    "aiAgentsCatalog": {
+      "purpose": {
+        "role": "Estratega Sénior",
+        "focus": "clarificar missão, alinhamento estratégico, resultados north-star e direção de longo prazo",
+        "roleDefinition": [
+          "Define intenção estratégica e liga decisões diárias a resultados de missão de longo prazo.",
+          "Identifica pontos cegos estratégicos, trade-offs e efeitos de segunda ordem antes de compromissos.",
+          "Traduz visão em prioridades mensuráveis, critérios de decisão e indicadores de sucesso."
+        ]
+      },
+      "governance": {
+        "role": "Arquiteto/a de Governança",
+        "focus": "direitos de decisão, modelos de responsabilidade, qualidade de propostas e mecanismos de coordenação coletiva",
+        "roleDefinition": [
+          "Desenha fluxos de governança que mantêm propostas claras, responsáveis e executáveis.",
+          "Melhora a qualidade de votação ao tornar visíveis pressupostos, impacto em stakeholders e prontidão para decisão.",
+          "Recomenda guardrails de política leves que protegem autonomia e reduzem fricção de coordenação."
+        ]
+      },
+      "operations": {
+        "role": "Líder de Operações",
+        "focus": "planos de execução, cadência de entrega, gestão de dependências e detalhes práticos de implementação",
+        "roleDefinition": [
+          "Transforma estratégia em planos executáveis com responsáveis, marcos e cronogramas realistas.",
+          "Sinaliza cedo gargalos de dependências e propõe opções concretas de sequenciação.",
+          "Melhora a fiabilidade de entrega com ritmos operacionais claros e loops de feedback."
+        ]
+      },
+      "community": {
+        "role": "Construtor/a de Comunidade",
+        "focus": "engajamento de membros, qualidade de participação, onboarding e saúde de contribuidores",
+        "roleDefinition": [
+          "Fortalece a qualidade de participação ao melhorar onboarding e clareza para contribuidores.",
+          "Deteta quedas de engajamento e propõe intervenções de retenção e ativação.",
+          "Equilibra abertura com normas saudáveis, confiança e experiência sustentável para contribuidores."
+        ]
+      },
+      "finance": {
+        "role": "Analista de Tesouraria e Token",
+        "focus": "implicações de token/tesouraria, efeitos de distribuição, sustentabilidade e trade-offs de alocação de capital",
+        "roleDefinition": [
+          "Avalia decisões de tesouraria e token por sustentabilidade, risco de concentração e impacto no runway.",
+          "Liga escolhas orçamentais a prioridades estratégicas e resultados organizacionais esperados.",
+          "Recomenda opções de alocação com consciência de risco e framing explícito de upside/downside."
+        ]
+      },
+      "product": {
+        "role": "Estratega de Produto",
+        "focus": "impacto no utilizador, priorização de produto, desenho de experimentação e resultados mensuráveis de adoção",
+        "roleDefinition": [
+          "Prioriza funcionalidades por valor para utilizador, alinhamento estratégico e alavancagem de implementação.",
+          "Desenha experiências que validam pressupostos com resultados de aprendizagem mensuráveis.",
+          "Alinha escolhas de roadmap com métricas de adoção, retenção e mudança de comportamento."
+        ]
+      },
+      "risk": {
+        "role": "Consultor/a de Risco e Compliance",
+        "focus": "modos de falha, cenários de risco, planos de mitigação e considerações de política/compliance",
+        "roleDefinition": [
+          "Torna visíveis modos de falha operacionais, de governança e de segurança antes da execução.",
+          "Recomenda mitigação prática com ownership claro e condições de disparo.",
+          "Mantém propostas em compliance e resilientes sem burocratizar em excesso a execução."
+        ]
+      },
+      "ecosystem": {
+        "role": "Estratega de Ecossistema e Parcerias",
+        "focus": "colaboração entre espaços, parcerias, dependências do ecossistema e alavancagem de coordenação externa",
+        "roleDefinition": [
+          "Mapeia dependências do ecossistema e identifica oportunidades de parceria de alta alavancagem.",
+          "Desenha planos de coordenação entre espaços com ownership claro e resultados mútuos.",
+          "Melhora o roteamento de sinais externos para que insights acionáveis cheguem rapidamente aos espaços certos."
+        ]
+      },
+      "learning": {
+        "role": "Arquiteto/a de Aprendizagem e Conhecimento",
+        "focus": "captura de conhecimento, loops de aprendizagem, qualidade de evidência e sistemas de melhoria contínua",
+        "roleDefinition": [
+          "Transforma discussões e experiências em conhecimento organizacional reutilizável.",
+          "Desenha loops de feedback que melhoram a qualidade de decisão ao longo do tempo.",
+          "Eleva padrões de evidência ao clarificar pressupostos, métricas e lições aprendidas."
+        ]
+      },
+      "reputation": {
+        "role": "Responsável por Reputação e Confiança",
+        "focus": "sinais de credibilidade, confiança de stakeholders, coerência narrativa e gestão de risco de comunicação",
+        "roleDefinition": [
+          "Protege a confiança alinhando narrativa pública com comportamento operacional real.",
+          "Torna visíveis riscos reputacionais cedo e propõe passos de mitigação proativos.",
+          "Melhora a qualidade de comunicação com stakeholders durante mudança, conflito e incerteza."
+        ]
+      }
+    },
+    "createBoard": "Criar quadro",
+    "createBoardDescription": "Salve um filtro de quadro por categoria de tag ou tag individual.",
+    "boardName": "Nome do quadro",
+    "boardNamePlaceholder": "ex. Quadro de impacto",
+    "boardFilterBy": "Filtrar por",
+    "boardFilterCategory": "Categoria de tag",
+    "boardFilterTag": "Tag individual",
+    "boardSelectCategory": "Categoria",
+    "boardSelectTag": "Tag",
+    "boardCreateAction": "Criar quadro",
+    "boardCancelAction": "Cancelar",
+    "boardAll": "Todos os sinais",
+    "boardDelete": "Excluir quadro {boardName}",
+    "spaceMemoryTimelineLabel": "Histórico da memória do espaço"
   },
   "GlobalCallDock": {
     "callTitle": "Chamada - {count, plural, one {# membro} other {# membros}}",
@@ -2356,7 +2588,9 @@
     "exitFullscreenLabel": "Sair do ecrã inteiro",
     "unknownMember": "Desconhecido",
     "resizeTopRightLabel": "Redimensionar chamada pelo canto superior direito",
-    "resizeBottomLeftLabel": "Redimensionar chamada pelo canto inferior esquerdo"
+    "resizeBottomLeftLabel": "Redimensionar chamada pelo canto inferior esquerdo",
+    "openFloatingWindowLabel": "Abrir janela flutuante da chamada",
+    "closeFloatingWindowLabel": "Fechar janela flutuante da chamada"
   },
   "SignalCard": {
     "noConversationRoom": "Ainda não há sala de conversa",

--- a/packages/storage-postgres/migrations/0052_thread_summaries.sql
+++ b/packages/storage-postgres/migrations/0052_thread_summaries.sql
@@ -1,0 +1,33 @@
+CREATE TABLE IF NOT EXISTS "thread_summaries" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"space_id" integer NOT NULL,
+	"matrix_room_id" text NOT NULL,
+	"thread_kind" varchar(32) NOT NULL,
+	"coherence_slug" varchar(255),
+	"thread_title" varchar(512),
+	"summary" text DEFAULT '' NOT NULL,
+	"bullets" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"message_count" integer DEFAULT 0 NOT NULL,
+	"participant_count" integer DEFAULT 0 NOT NULL,
+	"last_summarized_event_id" text,
+	"last_message_event_id" text,
+	"last_message_origin_server_ts" bigint,
+	"last_summarized_origin_server_ts" bigint,
+	"last_refreshed_at" timestamp with time zone,
+	"source" varchar(128) DEFAULT 'llm' NOT NULL,
+	"metadata" jsonb,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "thread_summaries" ADD CONSTRAINT "thread_summaries_space_id_spaces_id_fk" FOREIGN KEY ("space_id") REFERENCES "public"."spaces"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "thread_summaries_space_room_unique" ON "thread_summaries" USING btree ("space_id","matrix_room_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "thread_summaries_space_idx" ON "thread_summaries" USING btree ("space_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "thread_summaries_updated_idx" ON "thread_summaries" USING btree ("updated_at");

--- a/packages/storage-postgres/migrations/meta/_journal.json
+++ b/packages/storage-postgres/migrations/meta/_journal.json
@@ -344,6 +344,34 @@
       "when": 1777800000000,
       "tag": "0048_ecosystem_logo_theme_variants",
       "breakpoints": true
+    },
+    {
+      "idx": 49,
+      "version": "7",
+      "when": 1777900000000,
+      "tag": "0049_space_call_artifacts",
+      "breakpoints": true
+    },
+    {
+      "idx": 50,
+      "version": "7",
+      "when": 1778000000000,
+      "tag": "0050_signal_orchestrator",
+      "breakpoints": true
+    },
+    {
+      "idx": 51,
+      "version": "7",
+      "when": 1778100000000,
+      "tag": "0051_document_state_memory",
+      "breakpoints": true
+    },
+    {
+      "idx": 52,
+      "version": "7",
+      "when": 1778200000000,
+      "tag": "0052_thread_summaries",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/storage-postgres/src/schema/index.ts
+++ b/packages/storage-postgres/src/schema/index.ts
@@ -13,6 +13,17 @@ import { transfers } from './transfers';
 import { coherences } from './coherence';
 import { matrixUserLinks } from './matrix-user-link';
 import { tokenUpdates, tokenUpdateRelations } from './token-updates';
+import {
+  spaceCallRecordings,
+  spaceCallTranscripts,
+  spaceDiscussionSummaries,
+} from './call-artifacts';
+import { threadSummaries } from './thread-summaries';
+import {
+  signalOrchestratorCooldowns,
+  signalOrchestratorDispatches,
+  signalOrchestratorQueue,
+} from './signal-orchestrator';
 
 export { SPACE_FLAGS } from './flags';
 export { CATEGORIES } from './categories';
@@ -29,6 +40,9 @@ export * from './transfers';
 export * from './coherence';
 export * from './matrix-user-link';
 export * from './token-updates';
+export * from './call-artifacts';
+export * from './thread-summaries';
+export * from './signal-orchestrator';
 
 export const schema = {
   documents,
@@ -48,4 +62,11 @@ export const schema = {
   matrixUserLinks,
   tokenUpdates,
   tokenUpdateRelations,
+  spaceCallRecordings,
+  spaceCallTranscripts,
+  spaceDiscussionSummaries,
+  threadSummaries,
+  signalOrchestratorQueue,
+  signalOrchestratorCooldowns,
+  signalOrchestratorDispatches,
 };

--- a/packages/storage-postgres/src/schema/thread-summaries.ts
+++ b/packages/storage-postgres/src/schema/thread-summaries.ts
@@ -1,0 +1,59 @@
+import {
+  bigint,
+  index,
+  integer,
+  jsonb,
+  pgTable,
+  serial,
+  text,
+  timestamp,
+  uniqueIndex,
+  varchar,
+} from 'drizzle-orm/pg-core';
+import { InferInsertModel, InferSelectModel } from 'drizzle-orm';
+import { commonDateFields } from './shared';
+import { spaces } from './space';
+
+export const threadSummaries = pgTable(
+  'thread_summaries',
+  {
+    id: serial('id').primaryKey(),
+    spaceId: integer('space_id')
+      .notNull()
+      .references(() => spaces.id, { onDelete: 'cascade' }),
+    matrixRoomId: text('matrix_room_id').notNull(),
+    threadKind: varchar('thread_kind', { length: 32 }).notNull(),
+    coherenceSlug: varchar('coherence_slug', { length: 255 }),
+    threadTitle: varchar('thread_title', { length: 512 }),
+    summary: text('summary').notNull().default(''),
+    bullets: jsonb('bullets').$type<string[]>().notNull().default([]),
+    messageCount: integer('message_count').notNull().default(0),
+    participantCount: integer('participant_count').notNull().default(0),
+    lastSummarizedEventId: text('last_summarized_event_id'),
+    lastMessageEventId: text('last_message_event_id'),
+    lastMessageOriginServerTs: bigint('last_message_origin_server_ts', {
+      mode: 'number',
+    }),
+    lastSummarizedOriginServerTs: bigint('last_summarized_origin_server_ts', {
+      mode: 'number',
+    }),
+    lastRefreshedAt: timestamp('last_refreshed_at', {
+      withTimezone: true,
+      mode: 'string',
+    }),
+    source: varchar('source', { length: 128 }).notNull().default('llm'),
+    metadata: jsonb('metadata').$type<Record<string, unknown>>(),
+    ...commonDateFields,
+  },
+  (table) => [
+    uniqueIndex('thread_summaries_space_room_unique').on(
+      table.spaceId,
+      table.matrixRoomId,
+    ),
+    index('thread_summaries_space_idx').on(table.spaceId),
+    index('thread_summaries_updated_idx').on(table.updatedAt),
+  ],
+);
+
+export type ThreadSummary = InferSelectModel<typeof threadSummaries>;
+export type NewThreadSummary = InferInsertModel<typeof threadSummaries>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -975,18 +975,30 @@ importers:
       '@hypha-platform/ui-utils':
         specifier: workspace:*
         version: link:../ui-utils
+      '@openrouter/ai-sdk-provider':
+        specifier: ^2.3.3
+        version: 2.3.3(ai@6.0.138(zod@3.25.76))(zod@3.25.76)
       '@privy-io/node':
         specifier: ^0.12.0
         version: 0.12.0(viem@2.33.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       '@wagmi/cli':
         specifier: ^2.2.0
         version: 2.2.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
+      ai:
+        specifier: ^6.0.105
+        version: 6.0.138(zod@3.25.76)
       matrix-js-sdk:
         specifier: ^40.0.0
         version: 40.2.0
       pdf-parse:
         specifier: ^1.1.1
         version: 1.1.4
+      server-only:
+        specifier: ^0.0.1
+        version: 0.0.1
+      zod:
+        specifier: ^3.24.2
+        version: 3.25.76
     devDependencies:
       '@hypha-platform/config-eslint':
         specifier: workspace:*
@@ -31774,7 +31786,7 @@ snapshots:
 
   '@wagmi/cli@2.2.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)':
     dependencies:
-      abitype: 1.0.8(typescript@5.8.3)(zod@3.24.3)
+      abitype: 1.0.8(typescript@5.8.3)(zod@3.25.76)
       bundle-require: 4.2.1(esbuild@0.19.12)
       cac: 6.7.14
       change-case: 5.4.4
@@ -31790,8 +31802,8 @@ snapshots:
       picocolors: 1.1.1
       picomatch: 3.0.1
       prettier: 3.5.3
-      viem: 2.31.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.24.3)
-      zod: 3.24.3
+      viem: 2.31.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      zod: 3.25.76
     optionalDependencies:
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -40500,8 +40512,8 @@ snapshots:
       react-compiler-runtime: 0.0.0-experimental-22c6e49-20241219(react@19.1.2)
       react-dom: 19.1.2(react@19.1.2)
       scroll-into-view-if-needed: 3.1.0
-      zod: 3.24.3
-      zod-validation-error: 3.4.0(zod@3.24.3)
+      zod: 3.25.76
+      zod-validation-error: 3.4.0(zod@3.25.76)
       zustand: 5.0.3(@types/react@19.1.2)(immer@10.1.1)(react@19.1.2)(use-sync-external-store@1.5.0(react@19.1.2))
     transitivePeerDependencies:
       - '@types/react'
@@ -40549,8 +40561,8 @@ snapshots:
       unist-util-visit: 5.0.0
       unist-util-visit-children: 3.0.0
       yaml: 2.7.1
-      zod: 3.24.3
-      zod-validation-error: 3.4.0(zod@3.24.3)
+      zod: 3.25.76
+      zod-validation-error: 3.4.0(zod@3.25.76)
     transitivePeerDependencies:
       - acorn
       - supports-color
@@ -45532,6 +45544,23 @@ snapshots:
       - utf-8-validate
       - zod
 
+  viem@2.31.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76):
+    dependencies:
+      '@noble/curves': 1.9.2
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.0.8(typescript@5.8.3)(zod@3.25.76)
+      isows: 1.0.7(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      ox: 0.8.1(typescript@5.8.3)(zod@3.25.76)
+      ws: 8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+    optionalDependencies:
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+
   viem@2.33.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.22.4):
     dependencies:
       '@noble/curves': 1.9.2
@@ -46291,9 +46320,9 @@ snapshots:
     dependencies:
       zod: 3.25.76
 
-  zod-validation-error@3.4.0(zod@3.24.3):
+  zod-validation-error@3.4.0(zod@3.25.76):
     dependencies:
-      zod: 3.24.3
+      zod: 3.25.76
 
   zod@3.22.4: {}
 


### PR DESCRIPTION
## Summary
- Cherry-pick `3f2f3cdac84934923fe9742ea10161b145243591` (Zoom-style call capture voice announcements).
- Cherry-pick `dcdd6ed33376743b86968db15c68ace73e0b8ec2` (living thread summaries with org memory integration).
- Resolve cherry-pick conflicts against latest `main` while preserving the cherry-picked feature changes.

## Test plan
- [ ] Let CI run on this PR and confirm checks pass.
- [ ] Verify human chat call capture announcements in-app.
- [ ] Verify thread summary endpoints and UI behavior in-app.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Thread summaries automatically generated for space and coherence discussions with LLM-powered insights and key points
  * Call recording and transcript capture with optional voice announcements during capture events
  * Enhanced Space Memory to include call artifacts, transcripts, and discussion summaries alongside existing content
  * Signal team member access controls for coherence threads with request/approval workflows
  * Expanded org-memory signal evaluation and relay system with guardrails and dispatch tracking

* **Documentation**
  * Production runbook for Space Memory operations including health checks, automation, and go-live verification

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hypha-dao/hypha-web/pull/2272?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->