### PR TITLE
fix(calls): restore call banner and fix mobile dock controls

### DIFF
--- a/apps/web/src/app/[lang]/dho/[id]/@aside/[tab]/edit-signal/[signalSlug]/page.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@aside/[tab]/edit-signal/[signalSlug]/page.tsx
@@ -1,4 +1,5 @@
-import { CreateSignalForm, ProposalOverlayShell } from '@hypha-platform/epics';
+import { ConnectedCreateSignalForm } from '@web/components/connected-create-signal-form';
+import { ProposalOverlayShell } from '@hypha-platform/epics';
 import { getDhoPathCoherence } from '../../../../@tab/coherence/constants';
 import { Locale } from '@hypha-platform/i18n';
 import {
@@ -43,10 +44,11 @@ export default async function EditSignalPage({ params }: PageProps) {
 
   return (
     <ProposalOverlayShell>
-      <CreateSignalForm
+      <ConnectedCreateSignalForm
         mode="edit"
         signalSlug={signal.slug}
         signalRoomId={signal.roomId}
+        spaceSlug={id}
         initialValues={{
           title: signal.title,
           description: signal.description,

--- a/apps/web/src/app/[lang]/dho/[id]/@aside/[tab]/new-signal/page.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@aside/[tab]/new-signal/page.tsx
@@ -1,4 +1,5 @@
-import { CreateSignalForm, ProposalOverlayShell } from '@hypha-platform/epics';
+import { ConnectedCreateSignalForm } from '@web/components/connected-create-signal-form';
+import { ProposalOverlayShell } from '@hypha-platform/epics';
 import { getDhoPathCoherence } from '../../../@tab/coherence/constants';
 import { Locale } from '@hypha-platform/i18n';
 import { COHERENCE_TAGS, findSpaceBySlug } from '@hypha-platform/core/server';
@@ -34,11 +35,12 @@ export default async function NewSignalPage({
   const successfulUrl = getDhoPathCoherence(lang, id);
   return (
     <ProposalOverlayShell>
-      <CreateSignalForm
+      <ConnectedCreateSignalForm
         successfulUrl={successfulUrl}
         closeUrl={successfulUrl}
         backUrl={successfulUrl}
         spaceId={spaceFromDb.id}
+        spaceSlug={id}
         initialValues={
           inheritedBoardTags.length > 0
             ? { tags: inheritedBoardTags }

--- a/apps/web/src/app/[lang]/dho/[id]/_components/space-visualization.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/space-visualization.tsx
@@ -143,6 +143,27 @@ function clampSvgLength(value: number): number {
   return Number.isFinite(value) ? Math.max(0, value) : 0;
 }
 
+function finiteOr(value: number | undefined, fallback: number): number {
+  return Number.isFinite(value) ? (value as number) : fallback;
+}
+
+function sanitizeZoomView(
+  view: [number, number, number],
+  fallbackDiameter = VISUALIZATION_CONFIG.BASE_RADIUS * 2,
+): [number, number, number] {
+  const diameter = finiteOr(view[2], fallbackDiameter);
+  return [finiteOr(view[0], 0), finiteOr(view[1], 0), Math.max(diameter, 1)];
+}
+
+function sanitizeHierarchyLayout(root: SpaceHierarchyNode): void {
+  root.each((node) => {
+    const d = node as SpaceHierarchyNode;
+    d.x = finiteOr(d.x, 0);
+    d.y = finiteOr(d.y, 0);
+    d.r = Math.max(finiteOr(d.r, VISUALIZATION_CONFIG.BASE_RADIUS), 1);
+  });
+}
+
 export function SpaceVisualization({
   data,
   currentSpaceId,
@@ -461,12 +482,19 @@ export function SpaceVisualization({
       }
 
       const step = (2 * Math.PI) / n;
+      const safeOrbitRadius = Number.isFinite(orbitRadius)
+        ? Math.max(minOrbitRadius, orbitRadius)
+        : minOrbitRadius;
       children.forEach((childNode, i) => {
         const angle = i * step;
-        childNode.x = d.x! + Math.cos(angle) * orbitRadius;
-        childNode.y = d.y! + Math.sin(angle) * orbitRadius;
+        const parentX = finiteOr(d.x, 0);
+        const parentY = finiteOr(d.y, 0);
+        childNode.x = parentX + Math.cos(angle) * safeOrbitRadius;
+        childNode.y = parentY + Math.sin(angle) * safeOrbitRadius;
       });
     });
+
+    sanitizeHierarchyLayout(root);
 
     const findNodeById = (
       node: SpaceHierarchyNode,
@@ -504,7 +532,11 @@ export function SpaceVisualization({
 
     focusRef.current = focus;
     savedFocusIdRef.current = focus.data.id;
-    let view: [number, number, number] = [focus.x!, focus.y!, focus.r! * 2];
+    let view = sanitizeZoomView([
+      finiteOr(focus.x, 0),
+      finiteOr(focus.y, 0),
+      finiteOr(focus.r, VISUALIZATION_CONFIG.BASE_RADIUS) * 2,
+    ]);
 
     const svg = d3
       .select(svgRef.current)
@@ -785,12 +817,17 @@ export function SpaceVisualization({
         .transition()
         .duration(VISUALIZATION_CONFIG.ZOOM_DURATION)
         .tween('zoom', () => {
-          const i = d3.interpolateZoom(view, [
-            focus.x!,
-            focus.y!,
-            focus.r! * 2,
+          const targetView = sanitizeZoomView([
+            finiteOr(focus.x, 0),
+            finiteOr(focus.y, 0),
+            finiteOr(focus.r, VISUALIZATION_CONFIG.BASE_RADIUS) * 2,
           ]);
-          return (t) => zoomTo(i(t));
+          const startView = sanitizeZoomView(view);
+          const interpolator = d3.interpolateZoom(startView, targetView);
+          return (t) => {
+            const next = sanitizeZoomView(interpolator(t), targetView[2]);
+            zoomTo(next);
+          };
         });
 
       transition
@@ -823,16 +860,21 @@ export function SpaceVisualization({
     }
 
     function zoomTo(v: [number, number, number]) {
-      const k = width / Math.max(v[2], 1);
-      view = v;
+      const safeView = sanitizeZoomView(v, view[2]);
+      const k = width / safeView[2];
+      view = safeView;
+
+      const nodeTransform = (d: SpaceHierarchyNode) => {
+        const tx = (finiteOr(d.x, 0) - safeView[0]) * k;
+        const ty = (finiteOr(d.y, 0) - safeView[1]) * k;
+        return `translate(${tx}, ${ty})`;
+      };
 
       orbits
-        .attr(
-          'transform',
-          (d: SpaceHierarchyNode) =>
-            `translate(${(d.x! - v[0]) * k}, ${(d.y! - v[1]) * k})`,
+        .attr('transform', nodeTransform)
+        .attr('r', (d: SpaceHierarchyNode) =>
+          clampSvgLength(finiteOr(d.r, 0) * k),
         )
-        .attr('r', (d: SpaceHierarchyNode) => clampSvgLength(d.r! * k))
         .style('fill', 'none')
         .attr('stroke', (d: SpaceHierarchyNode) => {
           const accent = d.depth === 0 ? resolvedRootAccent : getNodeAccent(d);
@@ -845,13 +887,11 @@ export function SpaceVisualization({
         .attr('stroke-dasharray', ORBIT_DASH_PATTERN);
 
       logos
-        .attr(
-          'transform',
-          (d: SpaceHierarchyNode) =>
-            `translate(${(d.x! - v[0]) * k}, ${(d.y! - v[1]) * k})`,
-        )
+        .attr('transform', nodeTransform)
         .each(function (d: SpaceHierarchyNode) {
-          const r = clampSvgLength(d.r! * k * VISUALIZATION_CONFIG.LOGO_RATIO);
+          const r = clampSvgLength(
+            finiteOr(d.r, 0) * k * VISUALIZATION_CONFIG.LOGO_RATIO,
+          );
           const clipId = `clip-${d.data.id}`;
           const diameter = clampSvgLength(r * 2);
 
@@ -900,6 +940,7 @@ export function SpaceVisualization({
     });
     return () => {
       isCancelled = true;
+      svg.interrupt();
       cancelIntroSequence();
     };
   }, [data, currentSpaceId, resolvedTheme, enableHoverActions, rootAccentHex]);

--- a/apps/web/src/components/connected-create-signal-form.tsx
+++ b/apps/web/src/components/connected-create-signal-form.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import { CreateSignalForm, CreateSignalFormProps } from '@hypha-platform/epics';
+import { useMembers } from '@web/hooks/use-members';
+
+export function ConnectedCreateSignalForm(props: CreateSignalFormProps) {
+  return <CreateSignalForm {...props} useMembers={useMembers} />;
+}

--- a/packages/core/src/matrix/signal-team-events.ts
+++ b/packages/core/src/matrix/signal-team-events.ts
@@ -1,6 +1,60 @@
+import { EventType, MsgType } from 'matrix-js-sdk';
+
 export const SIGNAL_TEAM_EVENT_BODY_MARKER = '[hypha:signal-team]';
 export const SIGNAL_TEAM_REQUEST_EVENT_BODY_MARKER =
   '[hypha:signal-team-request]';
+
+export type PublishSignalTeamNoticeInput = {
+  client: {
+    sendEvent: (
+      roomId: string,
+      eventType: string,
+      content: Record<string, unknown>,
+    ) => Promise<unknown>;
+  };
+  roomId: string;
+  coherenceSlug: string;
+  /** Selected team member MXIDs (owner/actor are merged in automatically). */
+  memberMatrixUserIds: string[];
+  ownerMatrixUserId?: string | null;
+  actorMatrixUserId?: string | null;
+  addedMemberMatrixUserIds?: string[];
+  removedMemberMatrixUserIds?: string[];
+};
+
+/** Publish a signal-team notice event (same wire format as chat panel team management). */
+export async function publishSignalTeamNotice({
+  client,
+  roomId,
+  coherenceSlug,
+  memberMatrixUserIds,
+  ownerMatrixUserId,
+  actorMatrixUserId,
+  addedMemberMatrixUserIds,
+  removedMemberMatrixUserIds,
+}: PublishSignalTeamNoticeInput): Promise<void> {
+  const ownerId = ownerMatrixUserId?.trim() || null;
+  const actorId = actorMatrixUserId?.trim() || null;
+  const deduped = normalizeMatrixUserIds([
+    ...memberMatrixUserIds,
+    ...(ownerId ? [ownerId] : []),
+    ...(actorId ? [actorId] : []),
+  ]);
+  await client.sendEvent(roomId, EventType.RoomMessage, {
+    msgtype: MsgType.Notice,
+    body: SIGNAL_TEAM_EVENT_BODY_MARKER,
+    coherenceSlug: coherenceSlug.trim() || null,
+    memberMatrixUserIds: deduped,
+    ownerMatrixUserId: ownerId,
+    addedMemberMatrixUserIds: normalizeMatrixUserIds(
+      addedMemberMatrixUserIds ?? memberMatrixUserIds,
+    ),
+    removedMemberMatrixUserIds: normalizeMatrixUserIds(
+      removedMemberMatrixUserIds,
+    ),
+    updatedAt: new Date().toISOString(),
+  });
+}
 
 export type SignalTeamNoticeKind =
   | 'updated'

--- a/packages/epics/src/coherence/components/coherence-block.tsx
+++ b/packages/epics/src/coherence/components/coherence-block.tsx
@@ -200,8 +200,6 @@ export function CoherenceBlock({
             signals={filteredSignals}
             leadImage={space?.leadImage ?? undefined}
             isLoading={isSpaceLoading || isSignalsLoading}
-            firstPageSize={4}
-            pageSize={4}
             hideArchived={hideArchived}
             setHideArchived={setHideArchived}
             refresh={refresh}

--- a/packages/epics/src/coherence/components/create-signal-form.tsx
+++ b/packages/epics/src/coherence/components/create-signal-form.tsx
@@ -17,6 +17,7 @@ import {
   RequirementMark,
   RichTextEditor,
   Separator,
+  AddAttachment,
 } from '@hypha-platform/ui';
 import { Text } from '@radix-ui/themes';
 import { RefreshCw } from 'lucide-react';
@@ -30,12 +31,15 @@ import {
   COHERENCE_TYPE_OPTIONS,
   CoherenceTag,
   CoherenceType,
+  publishSignalTeamNotice,
   schemaCreateCoherenceForm,
   useCoherenceMutationsWeb2Rsc,
   useJwt,
   useMatrix,
   useMe,
 } from '@hypha-platform/core/client';
+import { UseMembers } from '../../spaces';
+import { SignalTeamMemberPicker } from './signal-team-member-picker';
 import React from 'react';
 import { useScrollToErrors } from '../../hooks';
 import { useRouter } from 'next/navigation';
@@ -53,8 +57,10 @@ import {
 
 type FormValues = z.infer<typeof schemaCreateCoherenceForm>;
 
-interface CreateSignalFormProps {
+export interface CreateSignalFormProps {
   spaceId: number;
+  spaceSlug?: string;
+  useMembers?: UseMembers;
   successfulUrl: string;
   closeUrl?: string;
   backUrl?: string;
@@ -62,6 +68,10 @@ interface CreateSignalFormProps {
   signalSlug?: string;
   signalRoomId?: string | null;
   initialValues?: Partial<FormValues>;
+}
+
+function matrixAttachmentKind(file: File): 'file' | 'image' {
+  return file.type.startsWith('image/') ? 'image' : 'file';
 }
 
 const SIGNAL_TEAM_EVENT_KIND = 'io.hypha.signal.team.v1';
@@ -148,6 +158,8 @@ function normalizeSignalDescriptionForChat(
 
 export const CreateSignalForm = ({
   spaceId,
+  spaceSlug,
+  useMembers,
   successfulUrl,
   closeUrl,
   backUrl,
@@ -315,6 +327,15 @@ export const CreateSignalForm = ({
     resolver: zodResolver(schemaCreateCoherenceForm),
     defaultValues: formDefaults,
   });
+  const [teamMemberMatrixIds, setTeamMemberMatrixIds] = React.useState<
+    string[]
+  >([]);
+  const [attachments, setAttachments] = React.useState<File[]>([]);
+  const showCreateExtras =
+    mode === 'create' && Boolean(spaceSlug?.trim() && useMembers);
+  const attachmentLabel = tAgreementFlow(
+    'createAgreementBaseFields.addAttachmentLabel',
+  );
 
   React.useEffect(() => {
     if (mode !== 'edit') return;
@@ -505,6 +526,8 @@ export const CreateSignalForm = ({
 
   const handleResetForm = React.useCallback(() => {
     form.reset(formDefaults);
+    setTeamMemberMatrixIds([]);
+    setAttachments([]);
   }, [form, formDefaults]);
 
   const setSignalProvisioningNotice = React.useCallback(
@@ -617,6 +640,8 @@ export const CreateSignalForm = ({
         const coherence = await createCoherence({ ...data });
         setSignalProvisioningNotice(null);
         const coherenceSlug = coherence.slug;
+        const teamIdsToSeed = normalizeMatrixUserIds(teamMemberMatrixIds);
+        const attachmentFiles = [...attachments];
         if (!isMatrixAvailable) {
           setSignalProvisioningNotice(t('provisioning.chatUnavailable'));
           console.warn('Matrix client is unavailable — skipping room creation');
@@ -627,9 +652,11 @@ export const CreateSignalForm = ({
             try {
               const roomCreationResult = await createRoom(coherence.title);
               roomId = roomCreationResult.roomId;
+              const canonicalRoomId = await joinRoom(roomId);
+              await loadRoomHistory(canonicalRoomId);
               try {
                 await upsertSignalDescriptionMessage({
-                  roomId,
+                  roomId: canonicalRoomId,
                   description: coherence.description,
                 });
               } catch (messageSeedError) {
@@ -637,6 +664,47 @@ export const CreateSignalForm = ({
                   'Signal room created but failed to seed description message:',
                   messageSeedError,
                 );
+              }
+
+              if (
+                teamIdsToSeed.length > 0 &&
+                matrixClient &&
+                currentUserMatrixId
+              ) {
+                try {
+                  await publishSignalTeamNotice({
+                    client: matrixClient,
+                    roomId: canonicalRoomId,
+                    coherenceSlug,
+                    memberMatrixUserIds: teamIdsToSeed,
+                    ownerMatrixUserId: currentUserMatrixId,
+                    actorMatrixUserId: currentUserMatrixId,
+                    addedMemberMatrixUserIds: teamIdsToSeed,
+                  });
+                } catch (teamSeedError) {
+                  console.warn(
+                    'Signal room created but failed to seed signal team:',
+                    teamSeedError,
+                  );
+                }
+              }
+
+              if (attachmentFiles.length > 0) {
+                try {
+                  await sendMessage({
+                    roomId: canonicalRoomId,
+                    message: '',
+                    attachments: attachmentFiles.map((file) => ({
+                      file,
+                      kind: matrixAttachmentKind(file),
+                    })),
+                  });
+                } catch (attachmentUploadError) {
+                  console.warn(
+                    'Signal room created but failed to upload attachments:',
+                    attachmentUploadError,
+                  );
+                }
               }
             } catch (matrixError) {
               const matrixErrorMessage =
@@ -683,10 +751,17 @@ export const CreateSignalForm = ({
       }
     },
     [
+      attachments,
       authToken,
       createCoherence,
       createRoom,
+      currentUserMatrixId,
       isEditAuthorized,
+      joinRoom,
+      loadRoomHistory,
+      matrixClient,
+      sendMessage,
+      teamMemberMatrixIds,
       updateCoherenceBySlug,
       updateCoherenceSignalBySlug,
       isMatrixAvailable,
@@ -981,6 +1056,41 @@ export const CreateSignalForm = ({
                 )}
               />
             </section>
+
+            {showCreateExtras ? (
+              <section className="rounded-xl border border-border/70 bg-muted/15 p-4 shadow-sm ring-1 ring-border/40 dark:bg-muted/10 lg:p-6">
+                <div className="flex flex-col gap-3">
+                  <FormLabel className="text-foreground">
+                    {t('signalTeamManageTitle')}
+                  </FormLabel>
+                  <SignalTeamMemberPicker
+                    spaceSlug={spaceSlug!.trim()}
+                    useMembers={useMembers!}
+                    ownerMatrixUserId={currentUserMatrixId}
+                    selectedMemberIds={teamMemberMatrixIds}
+                    onSelectedMemberIdsChange={setTeamMemberMatrixIds}
+                    disabled={isMutating}
+                  />
+                </div>
+              </section>
+            ) : null}
+
+            {showCreateExtras ? (
+              <section className="rounded-xl border border-border/70 bg-muted/15 p-4 shadow-sm ring-1 ring-border/40 dark:bg-muted/10 lg:p-6">
+                <FormItem>
+                  <FormLabel className="mb-2 block gap-1 text-foreground">
+                    {t('createSignalAttachmentsTitle')}
+                  </FormLabel>
+                  <FormControl>
+                    <AddAttachment
+                      label={attachmentLabel}
+                      value={attachments.length > 0 ? attachments : undefined}
+                      onChange={setAttachments}
+                    />
+                  </FormControl>
+                </FormItem>
+              </section>
+            ) : null}
 
             <div className="flex w-full justify-end gap-2">
               {form.formState.errors.root?.message ? (

--- a/packages/epics/src/coherence/components/create-signal-form.tsx
+++ b/packages/epics/src/coherence/components/create-signal-form.tsx
@@ -538,7 +538,16 @@ export const CreateSignalForm = ({
         window.dispatchEvent(new Event(SIGNAL_PROVISIONING_NOTICE_EVENT));
         return;
       }
-      const lines = details ? [message, details] : [message];
+      const previous = JSON.parse(
+        sessionStorage.getItem(SIGNAL_PROVISIONING_NOTICE_STORAGE_KEY) ?? '[]',
+      );
+      const existing = Array.isArray(previous)
+        ? previous.filter(
+            (line): line is string =>
+              typeof line === 'string' && line.trim().length > 0,
+          )
+        : [];
+      const lines = [...existing, message, ...(details ? [details] : [])];
       sessionStorage.setItem(
         SIGNAL_PROVISIONING_NOTICE_STORAGE_KEY,
         JSON.stringify(lines),

--- a/packages/epics/src/coherence/components/create-signal-form.tsx
+++ b/packages/epics/src/coherence/components/create-signal-form.tsx
@@ -666,26 +666,36 @@ export const CreateSignalForm = ({
                 );
               }
 
-              if (
-                teamIdsToSeed.length > 0 &&
-                matrixClient &&
-                currentUserMatrixId
-              ) {
-                try {
-                  await publishSignalTeamNotice({
-                    client: matrixClient,
-                    roomId: canonicalRoomId,
-                    coherenceSlug,
-                    memberMatrixUserIds: teamIdsToSeed,
-                    ownerMatrixUserId: currentUserMatrixId,
-                    actorMatrixUserId: currentUserMatrixId,
-                    addedMemberMatrixUserIds: teamIdsToSeed,
-                  });
-                } catch (teamSeedError) {
-                  console.warn(
-                    'Signal room created but failed to seed signal team:',
-                    teamSeedError,
+              if (teamIdsToSeed.length > 0) {
+                if (!matrixClient || !currentUserMatrixId) {
+                  setSignalProvisioningNotice(
+                    t('provisioning.teamSeedSkipped'),
                   );
+                } else {
+                  try {
+                    await publishSignalTeamNotice({
+                      client: matrixClient,
+                      roomId: canonicalRoomId,
+                      coherenceSlug,
+                      memberMatrixUserIds: teamIdsToSeed,
+                      ownerMatrixUserId: currentUserMatrixId,
+                      actorMatrixUserId: currentUserMatrixId,
+                      addedMemberMatrixUserIds: teamIdsToSeed,
+                    });
+                  } catch (teamSeedError) {
+                    const teamSeedErrorMessage =
+                      teamSeedError instanceof Error
+                        ? teamSeedError.message
+                        : String(teamSeedError);
+                    setSignalProvisioningNotice(
+                      t('provisioning.teamSeedFailed'),
+                      teamSeedErrorMessage,
+                    );
+                    console.warn(
+                      'Signal room created but failed to seed signal team:',
+                      teamSeedError,
+                    );
+                  }
                 }
               }
 
@@ -700,6 +710,14 @@ export const CreateSignalForm = ({
                     })),
                   });
                 } catch (attachmentUploadError) {
+                  const attachmentUploadErrorMessage =
+                    attachmentUploadError instanceof Error
+                      ? attachmentUploadError.message
+                      : String(attachmentUploadError);
+                  setSignalProvisioningNotice(
+                    t('provisioning.attachmentsUploadFailed'),
+                    attachmentUploadErrorMessage,
+                  );
                   console.warn(
                     'Signal room created but failed to upload attachments:',
                     attachmentUploadError,

--- a/packages/epics/src/coherence/components/signal-section.tsx
+++ b/packages/epics/src/coherence/components/signal-section.tsx
@@ -3,6 +3,7 @@
 import { FC, ReactNode } from 'react';
 import { Text } from '@radix-ui/themes';
 import { useSignalsSection } from '../hooks';
+import { useSignalGridColumns } from '../hooks/use-signal-grid-columns';
 import {
   Button,
   Checkbox,
@@ -161,8 +162,6 @@ type SignalSectionProps = {
   leadImage?: string;
   toolbarLeft?: ReactNode;
   isLoading: boolean;
-  firstPageSize?: number;
-  pageSize?: number;
   hideArchived: boolean;
   setHideArchived: (checked: boolean) => void;
   order?: string;
@@ -177,8 +176,6 @@ export const SignalSection: FC<SignalSectionProps> = ({
   leadImage,
   toolbarLeft,
   isLoading,
-  firstPageSize = 10,
-  pageSize = 10,
   hideArchived,
   setHideArchived,
   refresh,
@@ -545,17 +542,19 @@ export const SignalSection: FC<SignalSectionProps> = ({
     [activeBoardId],
   );
 
+  const gridMeasureRef = React.useRef<HTMLDivElement | null>(null);
+  const { rowBatchSize } = useSignalGridColumns(gridMeasureRef);
+
   const {
-    pages,
     loadMore,
-    pagination,
+    hasMore,
+    visibleSignals,
     onUpdateSearch,
     searchTerm,
     filteredSignals,
   } = useSignalsSection({
     signals: boardFilteredSignals,
-    firstPageSize,
-    pageSize,
+    rowBatchSize,
   });
   const searchFilteredSignals = React.useMemo(() => {
     const query = searchTerm?.trim()?.toLowerCase();
@@ -576,14 +575,9 @@ export const SignalSection: FC<SignalSectionProps> = ({
     }
     return byId;
   }, [activeBoards, filterSignalsByBoard, searchFilteredSignals]);
-  const visibleSignals = React.useMemo(() => {
-    const visibleCount =
-      pages <= 1 ? firstPageSize : firstPageSize + (pages - 1) * pageSize;
-    return filteredSignals.slice(0, visibleCount);
-  }, [filteredSignals, firstPageSize, pageSize, pages]);
 
   return (
-    <div className="flex w-full flex-col gap-4">
+    <div ref={gridMeasureRef} className="flex w-full flex-col gap-4">
       {toolbarLeft || activeBoards.length > 0 ? (
         <div className="flex flex-wrap items-center gap-2">
           {toolbarLeft}
@@ -884,7 +878,7 @@ export const SignalSection: FC<SignalSectionProps> = ({
         <ErrorAlert lines={provisioningNoticeLines} bgColor="bg-yellow-600" />
       ) : null}
 
-      {pagination?.totalPages === 0 ? (
+      {filteredSignals.length === 0 ? (
         <Empty>
           <p>{t('listIsEmpty')}</p>
         </Empty>
@@ -898,15 +892,14 @@ export const SignalSection: FC<SignalSectionProps> = ({
           onSignalClick={onSignalClick}
         />
       )}
-      {pagination?.totalPages === 0 ||
-      filteredSignals.length <= firstPageSize ? null : (
+      {filteredSignals.length <= rowBatchSize ? null : (
         <SectionLoadMore
           onClick={loadMore}
-          disabled={pagination?.totalPages === pages}
+          disabled={!hasMore}
           isLoading={isLoading}
         >
           <Text className="line-clamp-3 max-w-md text-center text-sm leading-snug">
-            {pagination?.totalPages === pages ? t('noMore') : t('loadMore')}
+            {!hasMore ? t('noMore') : t('loadMore')}
           </Text>
         </SectionLoadMore>
       )}

--- a/packages/epics/src/coherence/components/signal-team-member-picker.tsx
+++ b/packages/epics/src/coherence/components/signal-team-member-picker.tsx
@@ -213,9 +213,12 @@ export function SignalTeamMemberPicker({
                 isOwner={isOwner}
                 onToggle={() => {
                   if (isOwner && selected) return;
+                  const memberIdsOnly = effectiveSelectedIds.filter(
+                    (id) => id !== ownerMatrixUserId,
+                  );
                   const next = selected
-                    ? selectedMemberIds.filter((id) => id !== member.userId)
-                    : [...selectedMemberIds, member.userId];
+                    ? memberIdsOnly.filter((id) => id !== member.userId)
+                    : [...memberIdsOnly, member.userId];
                   onSelectedMemberIdsChange(normalizeMatrixUserIds(next));
                 }}
               />

--- a/packages/epics/src/coherence/components/signal-team-member-picker.tsx
+++ b/packages/epics/src/coherence/components/signal-team-member-picker.tsx
@@ -1,0 +1,228 @@
+'use client';
+
+import React from 'react';
+import { Check, Plus } from 'lucide-react';
+import {
+  Person,
+  useMatrixUserIdsByPrivySubs,
+} from '@hypha-platform/core/client';
+import { useTranslations } from 'next-intl';
+import { PersonAvatar } from '../../people/components/person-avatar';
+import { UseMembers } from '../../spaces';
+import { useResolvedMentionCandidateLabel } from '../../common/human-chat-panel/use-resolved-mention-candidate-label';
+
+function personRosterLabel(p: Person, unknownLabel: string): string {
+  const full = [p.name, p.surname].filter(Boolean).join(' ').trim();
+  if (full) return full;
+  if (p.nickname?.trim()) return p.nickname.trim();
+  return unknownLabel;
+}
+
+function normalizeMatrixUserIds(ids: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const value of ids) {
+    const trimmed = value.trim();
+    if (!trimmed || seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    out.push(trimmed);
+  }
+  return out;
+}
+
+function SignalTeamPickerRow({
+  matrixUserId,
+  displayLabel,
+  privySub,
+  avatarUrl,
+  selected,
+  disabled,
+  isOwner,
+  onToggle,
+}: {
+  matrixUserId: string;
+  displayLabel: string;
+  privySub?: string;
+  avatarUrl?: string | null;
+  selected: boolean;
+  disabled?: boolean;
+  isOwner?: boolean;
+  onToggle: () => void;
+}) {
+  const t = useTranslations('CoherenceTab');
+  const { resolvedLabel } = useResolvedMentionCandidateLabel({
+    userId: matrixUserId,
+    displayLabel,
+    privySub,
+  });
+  const label = resolvedLabel?.trim() || displayLabel;
+
+  return (
+    <button
+      type="button"
+      className={`flex items-center justify-between rounded-md px-2 py-1.5 text-left text-sm ${
+        selected
+          ? 'border border-accent-8/55 bg-accent-3/28 ring-1 ring-accent-8/35'
+          : 'border border-transparent hover:bg-muted/70'
+      }`}
+      disabled={disabled || (isOwner && selected)}
+      onClick={onToggle}
+    >
+      <span className="flex min-w-0 items-center gap-2">
+        <PersonAvatar size="sm" avatarSrc={avatarUrl || ''} userName={label} />
+        <span className="truncate">{label}</span>
+      </span>
+      <span className="inline-flex shrink-0 items-center gap-1 pl-2 text-xs text-muted-foreground">
+        {isOwner ? (
+          t('createSignalTeamOwner')
+        ) : selected ? (
+          <>
+            <Check className="h-3.5 w-3.5 text-accent-11" />
+            {t('signalTeamRemoveMember')}
+          </>
+        ) : (
+          <>
+            <Plus className="h-3.5 w-3.5" />
+            {t('signalTeamAddMember')}
+          </>
+        )}
+      </span>
+    </button>
+  );
+}
+
+export type SignalTeamMemberPickerProps = {
+  spaceSlug: string;
+  useMembers: UseMembers;
+  ownerMatrixUserId: string | null;
+  selectedMemberIds: string[];
+  onSelectedMemberIdsChange: (ids: string[]) => void;
+  disabled?: boolean;
+};
+
+export function SignalTeamMemberPicker({
+  spaceSlug,
+  useMembers,
+  ownerMatrixUserId,
+  selectedMemberIds,
+  onSelectedMemberIdsChange,
+  disabled,
+}: SignalTeamMemberPickerProps) {
+  const t = useTranslations('CoherenceTab');
+  const { persons, isLoading: isLoadingMembers } = useMembers({
+    spaceSlug,
+    paginationDisabled: true,
+  });
+  const spaceMembers = persons.data;
+  const privySubs = React.useMemo(
+    () =>
+      spaceMembers
+        .map((member) => member.sub?.trim())
+        .filter((sub): sub is string => Boolean(sub)),
+    [spaceMembers],
+  );
+  const { subToMatrixUserId, isLoading: isLoadingMatrixIds } =
+    useMatrixUserIdsByPrivySubs({ privySubs });
+
+  const ownerPerson = React.useMemo(() => {
+    if (!ownerMatrixUserId) return null;
+    return (
+      spaceMembers.find(
+        (member) =>
+          member.sub?.trim() &&
+          subToMatrixUserId[member.sub.trim()] === ownerMatrixUserId,
+      ) ?? null
+    );
+  }, [ownerMatrixUserId, spaceMembers, subToMatrixUserId]);
+
+  const selectableMembers = React.useMemo(() => {
+    const rows: Array<{
+      userId: string;
+      displayLabel: string;
+      privySub?: string;
+      avatarUrl?: string | null;
+    }> = [];
+
+    if (ownerMatrixUserId) {
+      rows.push({
+        userId: ownerMatrixUserId,
+        displayLabel: ownerPerson
+          ? personRosterLabel(ownerPerson, t('unknownMember'))
+          : t('createSignalTeamOwner'),
+        privySub: ownerPerson?.sub?.trim(),
+        avatarUrl: ownerPerson?.avatarUrl,
+      });
+    }
+
+    for (const member of spaceMembers) {
+      const sub = member.sub?.trim();
+      if (!sub) continue;
+      const matrixUserId = subToMatrixUserId[sub];
+      if (!matrixUserId) continue;
+      if (ownerMatrixUserId && matrixUserId === ownerMatrixUserId) continue;
+      rows.push({
+        userId: matrixUserId,
+        displayLabel: personRosterLabel(member, t('unknownMember')),
+        privySub: sub,
+        avatarUrl: member.avatarUrl,
+      });
+    }
+
+    return rows.sort((a, b) =>
+      a.displayLabel.localeCompare(b.displayLabel, undefined, {
+        sensitivity: 'base',
+      }),
+    );
+  }, [ownerMatrixUserId, ownerPerson, spaceMembers, subToMatrixUserId, t]);
+
+  const effectiveSelectedIds = React.useMemo(() => {
+    const base = normalizeMatrixUserIds(selectedMemberIds);
+    if (ownerMatrixUserId && !base.includes(ownerMatrixUserId)) {
+      return normalizeMatrixUserIds([ownerMatrixUserId, ...base]);
+    }
+    return base;
+  }, [ownerMatrixUserId, selectedMemberIds]);
+
+  const isLoading = isLoadingMembers || isLoadingMatrixIds;
+
+  return (
+    <div className="space-y-2">
+      <p className="text-xs text-muted-foreground">
+        {t('signalTeamMemberListHint')}
+      </p>
+      {isLoading ? (
+        <p className="text-sm text-muted-foreground">{t('loading')}</p>
+      ) : selectableMembers.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          {t('createSignalTeamNoMembers')}
+        </p>
+      ) : (
+        <div className="grid gap-1">
+          {selectableMembers.map((member) => {
+            const isOwner = member.userId === ownerMatrixUserId;
+            const selected = effectiveSelectedIds.includes(member.userId);
+            return (
+              <SignalTeamPickerRow
+                key={member.userId}
+                matrixUserId={member.userId}
+                displayLabel={member.displayLabel}
+                privySub={member.privySub}
+                avatarUrl={member.avatarUrl}
+                selected={selected}
+                disabled={disabled}
+                isOwner={isOwner}
+                onToggle={() => {
+                  if (isOwner && selected) return;
+                  const next = selected
+                    ? selectedMemberIds.filter((id) => id !== member.userId)
+                    : [...selectedMemberIds, member.userId];
+                  onSelectedMemberIdsChange(normalizeMatrixUserIds(next));
+                }}
+              />
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/epics/src/coherence/hooks/use-signal-grid-columns.ts
+++ b/packages/epics/src/coherence/hooks/use-signal-grid-columns.ts
@@ -1,0 +1,45 @@
+'use client';
+
+import React from 'react';
+import {
+  SIGNAL_GRID_ROW_BATCH_COUNT,
+  computeSignalGridRowBatchSize,
+} from '../signal-grid-layout';
+
+const DEFAULT_ROW_BATCH_SIZE = SIGNAL_GRID_ROW_BATCH_COUNT;
+
+export function useSignalGridColumns(
+  containerRef: React.RefObject<HTMLElement | null>,
+) {
+  const [rowBatchSize, setRowBatchSize] = React.useState(
+    DEFAULT_ROW_BATCH_SIZE,
+  );
+
+  React.useEffect(() => {
+    const element = containerRef.current;
+    if (!element) return;
+
+    const update = () => {
+      const containerWidth = element.getBoundingClientRect().width;
+      const viewportWidth = window.innerWidth;
+      setRowBatchSize(
+        computeSignalGridRowBatchSize(containerWidth, viewportWidth),
+      );
+    };
+
+    update();
+    const resizeObserver = new ResizeObserver(update);
+    resizeObserver.observe(element);
+    window.addEventListener('resize', update, { passive: true });
+
+    return () => {
+      resizeObserver.disconnect();
+      window.removeEventListener('resize', update);
+    };
+  }, [containerRef]);
+
+  return {
+    rowBatchSize,
+    columns: rowBatchSize / SIGNAL_GRID_ROW_BATCH_COUNT,
+  };
+}

--- a/packages/epics/src/coherence/hooks/use-signals-section.ts
+++ b/packages/epics/src/coherence/hooks/use-signals-section.ts
@@ -3,21 +3,22 @@
 import { Coherence } from '@hypha-platform/core/client';
 import React from 'react';
 import { useDebouncedCallback } from 'use-debounce';
+import { alignSignalVisibleCount } from '../signal-grid-layout';
 
 export const useSignalsSection = ({
   signals,
-  firstPageSize = 3,
-  pageSize = 3,
+  rowBatchSize,
 }: {
   signals: Coherence[];
-  firstPageSize?: number;
-  pageSize?: number;
+  rowBatchSize: number;
 }) => {
   const [activeFilter, setActiveFilter] = React.useState('most-recent');
-  const [pages, setPages] = React.useState(1);
+  const [visibleCount, setVisibleCount] = React.useState(rowBatchSize);
   const [searchTerm, setSearchTerm] = React.useState<string | undefined>(
     undefined,
   );
+  const rowBatchSizeRef = React.useRef(rowBatchSize);
+  rowBatchSizeRef.current = rowBatchSize;
 
   const onUpdateSearch = useDebouncedCallback((term: string) => {
     setSearchTerm(term);
@@ -38,40 +39,38 @@ export const useSignalsSection = ({
     return result;
   }, [signals, searchTerm]);
 
-  const pagination = React.useMemo(() => {
-    const total = filteredSignals.length;
-    const totalPages =
-      total === 0
-        ? 0
-        : total <= firstPageSize
-        ? 1
-        : 1 + Math.ceil((total - firstPageSize) / pageSize);
-    const hasNextPage = pages < totalPages;
-
-    return {
-      page: pages,
-      pageSize,
-      total,
-      totalPages,
-      hasNextPage,
-    };
-  }, [filteredSignals, pages, firstPageSize, pageSize]);
+  React.useEffect(() => {
+    const batch = rowBatchSizeRef.current > 0 ? rowBatchSizeRef.current : 3;
+    setVisibleCount(batch);
+  }, [searchTerm, activeFilter, signals]);
 
   React.useEffect(() => {
-    setPages(1);
-  }, [activeFilter, searchTerm]);
+    if (rowBatchSize <= 0) return;
+    setVisibleCount((prev) => alignSignalVisibleCount(prev, rowBatchSize));
+  }, [rowBatchSize]);
+
+  const visibleSignals = React.useMemo(
+    () => filteredSignals.slice(0, visibleCount),
+    [filteredSignals, visibleCount],
+  );
+
+  const hasMore = visibleCount < filteredSignals.length;
 
   const loadMore = React.useCallback(() => {
-    if (!pagination?.hasNextPage) return;
-    setPages((prev) => prev + 1);
-  }, [pagination?.hasNextPage]);
+    if (!hasMore || rowBatchSize <= 0) return;
+    setVisibleCount((prev) =>
+      Math.min(prev + rowBatchSize, filteredSignals.length),
+    );
+  }, [filteredSignals.length, hasMore, rowBatchSize]);
 
   return {
     isLoading: false,
     loadMore,
-    pagination,
-    pages,
-    setPages,
+    hasMore,
+    visibleSignals,
+    visibleCount,
+    rowBatchSize,
+    setVisibleCount,
     activeFilter,
     setActiveFilter,
     onUpdateSearch,

--- a/packages/epics/src/coherence/signal-grid-layout.ts
+++ b/packages/epics/src/coherence/signal-grid-layout.ts
@@ -1,4 +1,5 @@
-import { MOBILE_BREAKPOINT_PX } from '@hypha-platform/ui';
+/** Tailwind `md` breakpoint — keep in sync with `packages/ui/src/breakpoints.ts`. */
+const MD_BREAKPOINT_PX = 768;
 
 /** Rows revealed per "Load more" — keeps the grid from ending mid-row. */
 export const SIGNAL_GRID_ROW_BATCH_COUNT = 3;
@@ -23,7 +24,7 @@ export function computeSignalGridColumns(
   containerWidthPx: number,
   viewportWidthPx: number,
 ): number {
-  if (viewportWidthPx < MOBILE_BREAKPOINT_PX) return 1;
+  if (viewportWidthPx < MD_BREAKPOINT_PX) return 1;
   const width = Math.max(0, containerWidthPx);
   const minColumnPx = Math.min(width, remPx(SIGNAL_GRID_MIN_COLUMN_REM));
   const gapPx = remPx(SIGNAL_GRID_GAP_REM);

--- a/packages/epics/src/coherence/signal-grid-layout.ts
+++ b/packages/epics/src/coherence/signal-grid-layout.ts
@@ -1,0 +1,54 @@
+import { MOBILE_BREAKPOINT_PX } from '@hypha-platform/ui';
+
+/** Rows revealed per "Load more" — keeps the grid from ending mid-row. */
+export const SIGNAL_GRID_ROW_BATCH_COUNT = 3;
+
+/** Matches {@link SignalGrid} `minmax(min(100%, 14.25rem), 1fr)`. */
+export const SIGNAL_GRID_MIN_COLUMN_REM = 14.25;
+
+/** Matches {@link SignalGrid} `gap-2`. */
+export const SIGNAL_GRID_GAP_REM = 0.5;
+
+export function remPx(rem: number): number {
+  if (typeof document === 'undefined') return rem * 16;
+  const root = parseFloat(getComputedStyle(document.documentElement).fontSize);
+  return rem * (Number.isFinite(root) && root > 0 ? root : 16);
+}
+
+/**
+ * Column count for the signal auto-fill grid (md+), or 1 below the md breakpoint.
+ * Mirrors CSS `repeat(auto-fill, minmax(min(100%, 14.25rem), 1fr))`.
+ */
+export function computeSignalGridColumns(
+  containerWidthPx: number,
+  viewportWidthPx: number,
+): number {
+  if (viewportWidthPx < MOBILE_BREAKPOINT_PX) return 1;
+  const width = Math.max(0, containerWidthPx);
+  const minColumnPx = Math.min(width, remPx(SIGNAL_GRID_MIN_COLUMN_REM));
+  const gapPx = remPx(SIGNAL_GRID_GAP_REM);
+  return Math.max(1, Math.floor((width + gapPx) / (minColumnPx + gapPx)));
+}
+
+export function computeSignalGridRowBatchSize(
+  containerWidthPx: number,
+  viewportWidthPx: number,
+): number {
+  return (
+    computeSignalGridColumns(containerWidthPx, viewportWidthPx) *
+    SIGNAL_GRID_ROW_BATCH_COUNT
+  );
+}
+
+/** Snap a visible count down to full rows when column count changes. */
+export function alignSignalVisibleCount(
+  count: number,
+  rowBatchSize: number,
+): number {
+  if (rowBatchSize <= 0) return count;
+  const columns = rowBatchSize / SIGNAL_GRID_ROW_BATCH_COUNT;
+  if (columns <= 0 || !Number.isFinite(columns)) return count;
+  if (count <= rowBatchSize) return rowBatchSize;
+  const aligned = Math.floor(count / columns) * columns;
+  return Math.max(rowBatchSize, aligned);
+}

--- a/packages/epics/src/common/global-call-dock-context.tsx
+++ b/packages/epics/src/common/global-call-dock-context.tsx
@@ -462,9 +462,13 @@ function useGlobalCallDockValue() {
     [activeRoomId, boundAuthToken, call],
   );
 
-  const showFloatingDock = inSession || call.recordingStatus === 'uploading';
+  const callChatRoomAligned =
+    boundRoomId != null && activeRoomId != null && boundRoomId === activeRoomId;
+  const showFloatingDock =
+    (inSession && !callChatRoomAligned) || call.recordingStatus === 'uploading';
   const holdsMatrixSyncForCall =
-    showFloatingDock ||
+    inSession ||
+    call.recordingStatus === 'uploading' ||
     pendingJoin != null ||
     restoreInProgressRef.current ||
     call.isCallRecovering;

--- a/packages/epics/src/common/global-call-dock-context.tsx
+++ b/packages/epics/src/common/global-call-dock-context.tsx
@@ -472,10 +472,7 @@ function useGlobalCallDockValue() {
     [activeRoomId, boundAuthToken, call],
   );
 
-  const callChatRoomAligned =
-    boundRoomId != null && activeRoomId != null && boundRoomId === activeRoomId;
-  const showFloatingDock =
-    (inSession && !callChatRoomAligned) || call.recordingStatus === 'uploading';
+  const showFloatingDock = inSession || call.recordingStatus === 'uploading';
   const holdsMatrixSyncForCall =
     inSession ||
     call.recordingStatus === 'uploading' ||

--- a/packages/epics/src/common/global-call-dock-context.tsx
+++ b/packages/epics/src/common/global-call-dock-context.tsx
@@ -208,10 +208,20 @@ function useGlobalCallDockValue() {
 
   React.useEffect(() => {
     if (inSession && activeRoomId) {
+      const prevSessionRoomId = callSessionRoomIdRef.current;
       callSessionRoomIdRef.current = activeRoomId;
-      callSessionSpaceSlugRef.current = activeSpaceSlug;
       callSessionAuthTokenRef.current = activeAuthToken;
-      setPinnedCallSpaceSlug(activeSpaceSlug);
+
+      if (prevSessionRoomId !== activeRoomId) {
+        const slugToPin = activeSpaceSlug?.trim() || null;
+        if (slugToPin) {
+          callSessionSpaceSlugRef.current = slugToPin;
+          setPinnedCallSpaceSlug(slugToPin);
+        }
+      } else if (!callSessionSpaceSlugRef.current && activeSpaceSlug?.trim()) {
+        callSessionSpaceSlugRef.current = activeSpaceSlug.trim();
+        setPinnedCallSpaceSlug(activeSpaceSlug.trim());
+      }
       return;
     }
     if (

--- a/packages/epics/src/common/global-call-dock-overlay.tsx
+++ b/packages/epics/src/common/global-call-dock-overlay.tsx
@@ -17,7 +17,7 @@ import {
   useMe,
   type SpaceGroupCallCaptureMode,
 } from '@hypha-platform/core/client';
-import { useIsMobile } from '@hypha-platform/ui';
+import { useIsMobile, MOBILE_BREAKPOINT_PX } from '@hypha-platform/ui';
 import { cn } from '@hypha-platform/ui-utils';
 import { usePathname, useRouter } from 'next/navigation';
 import {
@@ -61,7 +61,6 @@ type ResizeHandle =
 const DOCK_GEOMETRY_KEY = 'hypha-global-call-dock-geometry-v2';
 const DOCK_MARGIN_PX = 16;
 const SNAP_EDGE_PX = 24;
-const DOCK_NARROW_VIEWPORT_PX = 768;
 // Minimum dock size (thumbnail mode baseline); resize can never go below this.
 const DOCK_MIN_WIDTH = 480;
 const DOCK_MIN_HEIGHT = 320;
@@ -310,7 +309,7 @@ function readDockMinSize(): Pick<DockGeometry, 'width' | 'height'> {
   if (typeof window === 'undefined') {
     return { width: DOCK_MIN_WIDTH, height: DOCK_MIN_HEIGHT };
   }
-  const narrow = window.innerWidth < DOCK_NARROW_VIEWPORT_PX;
+  const narrow = window.innerWidth < MOBILE_BREAKPOINT_PX;
   const viewportMinWidth = Math.max(0, window.innerWidth - 2 * DOCK_MARGIN_PX);
   const viewportMinHeight = Math.max(
     0,

--- a/packages/epics/src/common/global-call-dock-overlay.tsx
+++ b/packages/epics/src/common/global-call-dock-overlay.tsx
@@ -1024,7 +1024,10 @@ export function GlobalCallDockOverlay() {
               {t('spaceButton')}
             </button>
           )}
-          {isScreensharing && roomGroupCallDeviceCount > 1 && !dockCompact ? (
+          {dockStageLayout === 'fullView' &&
+          isScreensharing &&
+          roomGroupCallDeviceCount > 1 &&
+          !dockCompact ? (
             <HumanChatPanelCallFullViewLayoutMenu
               value={layoutMode}
               onValueChange={onShareLayoutModeChange}

--- a/packages/epics/src/common/global-call-dock-overlay.tsx
+++ b/packages/epics/src/common/global-call-dock-overlay.tsx
@@ -1002,7 +1002,7 @@ export function GlobalCallDockOverlay() {
           >
             {t('callTitle', { count: roomGroupCallDeviceCount })}
           </p>
-          {callSpaceHref && (
+          {!isMobile && callSpaceHref && (
             <button
               type="button"
               data-no-dock-drag
@@ -1024,7 +1024,8 @@ export function GlobalCallDockOverlay() {
               {t('spaceButton')}
             </button>
           )}
-          {dockStageLayout === 'fullView' &&
+          {!isMobile &&
+          dockStageLayout === 'fullView' &&
           isScreensharing &&
           roomGroupCallDeviceCount > 1 &&
           !dockCompact ? (
@@ -1034,89 +1035,91 @@ export function GlobalCallDockOverlay() {
               className="shrink-0"
             />
           ) : null}
-          <div
-            className={cn(
-              'flex items-center',
-              dockCompact ? 'gap-0.5' : 'gap-1',
-            )}
-          >
-            {isDocumentPipSupported && (
-              <button
-                type="button"
-                data-no-dock-drag
-                onClick={() => {
-                  void onToggleDocumentPip();
-                }}
-                className={cn(
-                  'inline-flex items-center justify-center rounded-md border border-border/60 bg-background hover:bg-muted',
-                  dockCompact ? 'h-6 w-6' : 'h-7 w-7',
-                  isDocumentPipOpen && 'border-primary/50 bg-primary/10',
-                )}
-                aria-label={
-                  isDocumentPipOpen
-                    ? t('closeFloatingWindowLabel')
-                    : t('openFloatingWindowLabel')
-                }
-                title={
-                  isDocumentPipOpen
-                    ? t('closeFloatingWindowLabel')
-                    : t('openFloatingWindowLabel')
-                }
-              >
-                <PictureInPicture2
-                  className={dockCompact ? 'h-3 w-3' : 'h-3.5 w-3.5'}
-                />
-              </button>
-            )}
-            {!dockCompact && dockMode !== 'thumbnail' && (
-              <button
-                type="button"
-                data-no-dock-drag
-                onClick={() => applyDockMode('thumbnail')}
-                className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-border/60 bg-background hover:bg-muted"
-                aria-label={t('minimizeLabel')}
-                title={t('minimizeLabel')}
-              >
-                <Shrink className="h-3.5 w-3.5" />
-              </button>
-            )}
-            {!dockCompact && !modeIsFullscreen && dockMode !== 'expanded' && (
-              <button
-                type="button"
-                data-no-dock-drag
-                onClick={() => applyDockMode('expanded')}
-                className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-border/60 bg-background hover:bg-muted"
-                aria-label={t('expandLabel')}
-                title={t('expandLabel')}
-              >
-                <Expand className="h-3.5 w-3.5" />
-              </button>
-            )}
-            {!dockCompact && (
-              <button
-                type="button"
-                data-no-dock-drag
-                onClick={onToggleFullscreen}
-                className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-border/60 bg-background hover:bg-muted"
-                aria-label={
-                  modeIsFullscreen
-                    ? t('exitFullscreenLabel')
-                    : t('fullscreenLabel')
-                }
-                title={
-                  modeIsFullscreen
-                    ? t('exitFullscreenLabel')
-                    : t('fullscreenLabel')
-                }
-              >
-                {modeIsFullscreen ? (
-                  <Minimize2 className="h-3.5 w-3.5" />
-                ) : (
-                  <Maximize2 className="h-3.5 w-3.5" />
-                )}
-              </button>
-            )}
-          </div>
+          {!isMobile ? (
+            <div
+              className={cn(
+                'flex items-center',
+                dockCompact ? 'gap-0.5' : 'gap-1',
+              )}
+            >
+              {isDocumentPipSupported && (
+                <button
+                  type="button"
+                  data-no-dock-drag
+                  onClick={() => {
+                    void onToggleDocumentPip();
+                  }}
+                  className={cn(
+                    'inline-flex items-center justify-center rounded-md border border-border/60 bg-background hover:bg-muted',
+                    dockCompact ? 'h-6 w-6' : 'h-7 w-7',
+                    isDocumentPipOpen && 'border-primary/50 bg-primary/10',
+                  )}
+                  aria-label={
+                    isDocumentPipOpen
+                      ? t('closeFloatingWindowLabel')
+                      : t('openFloatingWindowLabel')
+                  }
+                  title={
+                    isDocumentPipOpen
+                      ? t('closeFloatingWindowLabel')
+                      : t('openFloatingWindowLabel')
+                  }
+                >
+                  <PictureInPicture2
+                    className={dockCompact ? 'h-3 w-3' : 'h-3.5 w-3.5'}
+                  />
+                </button>
+              )}
+              {!dockCompact && dockMode !== 'thumbnail' && (
+                <button
+                  type="button"
+                  data-no-dock-drag
+                  onClick={() => applyDockMode('thumbnail')}
+                  className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-border/60 bg-background hover:bg-muted"
+                  aria-label={t('minimizeLabel')}
+                  title={t('minimizeLabel')}
+                >
+                  <Shrink className="h-3.5 w-3.5" />
+                </button>
+              )}
+              {!dockCompact && !modeIsFullscreen && dockMode !== 'expanded' && (
+                <button
+                  type="button"
+                  data-no-dock-drag
+                  onClick={() => applyDockMode('expanded')}
+                  className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-border/60 bg-background hover:bg-muted"
+                  aria-label={t('expandLabel')}
+                  title={t('expandLabel')}
+                >
+                  <Expand className="h-3.5 w-3.5" />
+                </button>
+              )}
+              {!dockCompact && (
+                <button
+                  type="button"
+                  data-no-dock-drag
+                  onClick={onToggleFullscreen}
+                  className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-border/60 bg-background hover:bg-muted"
+                  aria-label={
+                    modeIsFullscreen
+                      ? t('exitFullscreenLabel')
+                      : t('fullscreenLabel')
+                  }
+                  title={
+                    modeIsFullscreen
+                      ? t('exitFullscreenLabel')
+                      : t('fullscreenLabel')
+                  }
+                >
+                  {modeIsFullscreen ? (
+                    <Minimize2 className="h-3.5 w-3.5" />
+                  ) : (
+                    <Maximize2 className="h-3.5 w-3.5" />
+                  )}
+                </button>
+              )}
+            </div>
+          ) : null}
         </div>
 
         <div

--- a/packages/epics/src/common/global-call-dock-overlay.tsx
+++ b/packages/epics/src/common/global-call-dock-overlay.tsx
@@ -23,8 +23,10 @@ import { usePathname, useRouter } from 'next/navigation';
 import {
   DEFAULT_CALL_FULL_VIEW_LAYOUT,
   HumanChatPanelCallBanner,
+  HumanChatPanelCaptureConsentBanner,
   HumanChatPanelCallStage,
   HumanChatPanelCallFullViewLayoutMenu,
+  HumanChatPanelInCallControls,
   HumanChatPanelScreenshareTakeoverDialog,
   readCallFullViewLayoutFromStorage,
   persistCallFullViewLayout,
@@ -911,6 +913,9 @@ export function GlobalCallDockOverlay() {
   const onStopCapture = () => {
     stopCapture();
   };
+  const showDockBanner =
+    errorCode != null || screenshareErrorCode != null || remoteMediaStall;
+
   const dockContent = (
     <div
       ref={dockRef}
@@ -1153,46 +1158,102 @@ export function GlobalCallDockOverlay() {
               <p className="text-[11px] text-destructive">{recordingError}</p>
             ) : null
           ) : (
-            <HumanChatPanelCallBanner
-              callState={callState}
-              callKind={callKind}
-              errorCode={errorCode}
-              isScreensharing={isScreensharing}
-              screenshareErrorCode={screenshareErrorCode}
-              tabBackgroundWhileInCall={tabBackgroundWhileInCall}
-              isMicrophoneMuted={isMicrophoneMuted}
-              isLocalVideoMuted={isLocalVideoMuted}
-              participantCount={roomGroupCallDeviceCount}
-              othersInRoomCallCount={othersInRoomCallCount}
-              remoteMediaStall={remoteMediaStall}
-              onDismissRemoteMediaStall={dismissRemoteMediaStallBanner}
-              onLeave={() => {
-                void leave();
-              }}
-              onToggleMic={onToggleMic}
-              onToggleCamera={onToggleCamera}
-              onToggleScreenshare={onToggleScreenshare}
-              voiceProcessingPreset={voiceProcessingPreset}
-              onVoiceProcessingPresetChange={onVoiceProcessingPresetChange}
-              captureMode={captureMode}
-              capturePreference={capturePreference}
-              capturePreferenceSelected={capturePreferenceSelected}
-              onCapturePreferenceChange={onCapturePreferenceChange}
-              onStartCapture={onStartCaptureWithMode}
-              onPauseCapture={onPauseCapture}
-              onResumeCapture={onResumeCapture}
-              onStopCapture={onStopCapture}
-              recordingStatus={recordingStatus}
-              recordingError={recordingError}
-              recordingWarning={recordingWarning}
-              canRetryRecordingUpload={canRetryRecordingUpload}
-              onRetryRecordingUpload={() => void retryRecordingUpload()}
-              captureConsent={captureConsent}
-              roomId={activeRoomId}
-              onDismissScreenshareError={dismissScreenshareError}
-              onRetryCall={retryFromError}
-              onDismissCallError={dismissCallError}
-            />
+            <>
+              {captureConsent &&
+              callState === 'connected' &&
+              !showDockBanner ? (
+                <HumanChatPanelCaptureConsentBanner
+                  consent={captureConsent}
+                  roomId={activeRoomId}
+                  variant="inCall"
+                  className={cn(
+                    'rounded-none border-x-0 border-t-0',
+                    dockCompact
+                      ? '-mx-1 -mt-1 mb-1 px-2 py-1 [&_p]:text-[10px] [&_p]:leading-tight'
+                      : '-mx-2 -mt-2 mb-2',
+                  )}
+                />
+              ) : null}
+              {showDockBanner ? (
+                <HumanChatPanelCallBanner
+                  callState={callState}
+                  callKind={callKind}
+                  errorCode={errorCode}
+                  isScreensharing={isScreensharing}
+                  screenshareErrorCode={screenshareErrorCode}
+                  tabBackgroundWhileInCall={tabBackgroundWhileInCall}
+                  isMicrophoneMuted={isMicrophoneMuted}
+                  isLocalVideoMuted={isLocalVideoMuted}
+                  participantCount={roomGroupCallDeviceCount}
+                  othersInRoomCallCount={othersInRoomCallCount}
+                  remoteMediaStall={remoteMediaStall}
+                  onDismissRemoteMediaStall={dismissRemoteMediaStallBanner}
+                  onLeave={() => {
+                    void leave();
+                  }}
+                  onToggleMic={onToggleMic}
+                  onToggleCamera={onToggleCamera}
+                  onToggleScreenshare={onToggleScreenshare}
+                  voiceProcessingPreset={voiceProcessingPreset}
+                  onVoiceProcessingPresetChange={onVoiceProcessingPresetChange}
+                  captureMode={captureMode}
+                  capturePreference={capturePreference}
+                  capturePreferenceSelected={capturePreferenceSelected}
+                  onCapturePreferenceChange={onCapturePreferenceChange}
+                  onStartCapture={onStartCaptureWithMode}
+                  onPauseCapture={onPauseCapture}
+                  onResumeCapture={onResumeCapture}
+                  onStopCapture={onStopCapture}
+                  recordingStatus={recordingStatus}
+                  recordingError={recordingError}
+                  recordingWarning={recordingWarning}
+                  canRetryRecordingUpload={canRetryRecordingUpload}
+                  onRetryRecordingUpload={() => void retryRecordingUpload()}
+                  captureConsent={captureConsent}
+                  roomId={activeRoomId}
+                  onDismissScreenshareError={dismissScreenshareError}
+                  onRetryCall={retryFromError}
+                  onDismissCallError={dismissCallError}
+                />
+              ) : (
+                <HumanChatPanelInCallControls
+                  callState={callState}
+                  isMicrophoneMuted={isMicrophoneMuted}
+                  isLocalVideoMuted={isLocalVideoMuted}
+                  isScreensharing={isScreensharing}
+                  onToggleMic={onToggleMic}
+                  onToggleCamera={onToggleCamera}
+                  onToggleScreenshare={onToggleScreenshare}
+                  voiceProcessingPreset={voiceProcessingPreset}
+                  onVoiceProcessingPresetChange={onVoiceProcessingPresetChange}
+                  captureMode={captureMode}
+                  capturePreference={capturePreference}
+                  capturePreferenceSelected={capturePreferenceSelected}
+                  onCapturePreferenceChange={onCapturePreferenceChange}
+                  onStartCapture={onStartCaptureWithMode}
+                  onPauseCapture={onPauseCapture}
+                  onResumeCapture={onResumeCapture}
+                  onStopCapture={onStopCapture}
+                  recordingStatus={recordingStatus}
+                  recordingError={recordingError}
+                  recordingWarning={recordingWarning}
+                  canRetryRecordingUpload={canRetryRecordingUpload}
+                  onRetryRecordingUpload={() => void retryRecordingUpload()}
+                  onLeave={() => {
+                    void leave();
+                  }}
+                  density={dockCompact ? 'compact' : 'default'}
+                  variant={modeIsFullscreen ? 'fullView' : 'inBanner'}
+                  inBannerLayout={
+                    dockCompact
+                      ? 'inline'
+                      : modeIsFullscreen
+                      ? 'inline'
+                      : 'centered'
+                  }
+                />
+              )}
+            </>
           )}
         </div>
       </div>

--- a/packages/epics/src/common/global-call-dock-overlay.tsx
+++ b/packages/epics/src/common/global-call-dock-overlay.tsx
@@ -94,18 +94,18 @@ function readCallSpaceSlug(
 ): string | null {
   const fromPinned = pinnedSpaceSlug?.trim();
   if (fromPinned) return fromPinned;
-  const fromState = activeSpaceSlug?.trim();
-  if (fromState) return fromState;
-  if (!activeRoomId?.trim() || typeof window === 'undefined') return null;
-  try {
-    return (
-      window.sessionStorage
-        .getItem(`${SESSION_ROOM_TO_SPACE_PREFIX}${activeRoomId.trim()}`)
-        ?.trim() || null
-    );
-  } catch {
-    return null;
+  if (!activeRoomId?.trim() || typeof window === 'undefined') {
+    return activeSpaceSlug?.trim() || null;
   }
+  try {
+    const fromSession = window.sessionStorage
+      .getItem(`${SESSION_ROOM_TO_SPACE_PREFIX}${activeRoomId.trim()}`)
+      ?.trim();
+    if (fromSession) return fromSession;
+  } catch {
+    // ignore session read failure
+  }
+  return activeSpaceSlug?.trim() || null;
 }
 
 /**
@@ -813,16 +813,18 @@ export function GlobalCallDockOverlay() {
     window.focus();
 
     const normalizedPath = (pathname.split('?')[0] ?? '').replace(/\/$/, '');
-    const signalTarget = await resolveSignalThreadByMatrixRoom(
-      activeRoomId.trim(),
-    );
-    const spaceSlug = signalTarget?.spaceSlug ?? callSpaceSlug;
-    const destinationHref = `/${locale}/dho/${spaceSlug}/coherence`.replace(
+    const destinationHref = `/${locale}/dho/${callSpaceSlug}/coherence`.replace(
       /\/$/,
       '',
     );
 
-    if (signalTarget) {
+    const signalTarget = await resolveSignalThreadByMatrixRoom(
+      activeRoomId.trim(),
+    );
+    if (
+      signalTarget &&
+      signalTarget.spaceSlug.trim() === callSpaceSlug.trim()
+    ) {
       openCoherenceChat(
         signalTarget.roomId,
         signalTarget.signalTitle,

--- a/packages/epics/src/common/global-call-dock-overlay.tsx
+++ b/packages/epics/src/common/global-call-dock-overlay.tsx
@@ -915,6 +915,21 @@ export function GlobalCallDockOverlay() {
   };
   const showDockBanner =
     errorCode != null || screenshareErrorCode != null || remoteMediaStall;
+  /** Mobile dock is always edge-to-edge; panel layout avoids full-view splitters eating taps. */
+  const dockStageLayout = isMobile
+    ? 'panel'
+    : modeIsFullscreen
+    ? 'fullView'
+    : 'panel';
+  const dockControlsVariant =
+    isMobile || !modeIsFullscreen ? 'inBanner' : 'fullView';
+  const dockControlsLayout = isMobile
+    ? 'centered'
+    : dockCompact
+    ? 'inline'
+    : modeIsFullscreen
+    ? 'inline'
+    : 'centered';
 
   const dockContent = (
     <div
@@ -924,7 +939,8 @@ export function GlobalCallDockOverlay() {
         inDocumentPip
           ? 'relative flex h-full w-full min-h-0 min-w-0 select-none flex-col overflow-hidden rounded-lg border border-border/60 bg-background/95 shadow-lg'
           : cn(
-              'fixed z-[130] flex select-none flex-col overflow-hidden rounded-xl border border-border/60 bg-background/95 shadow-2xl backdrop-blur-sm',
+              'fixed z-[130] flex select-none flex-col overflow-hidden rounded-xl border border-border/60 bg-background/95 shadow-2xl',
+              isMobile ? '' : 'backdrop-blur-sm',
               isMobile || modeIsFullscreen
                 ? 'min-h-0 min-w-0'
                 : 'min-h-[320px] min-w-[480px]',
@@ -970,7 +986,7 @@ export function GlobalCallDockOverlay() {
       <div className="relative z-[5] flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden rounded-[inherit]">
         <div
           className={cn(
-            'flex shrink-0 items-center gap-1 border-b border-border/50 bg-muted/45',
+            'pointer-events-auto flex shrink-0 items-center gap-1 border-b border-border/50 bg-muted/45',
             dockCompact ? 'px-1.5 py-1' : 'px-2.5 py-2',
             modeIsFullscreen || inDocumentPip
               ? 'cursor-default'
@@ -1103,8 +1119,10 @@ export function GlobalCallDockOverlay() {
         <div
           ref={splitContainerRef}
           className={cn(
-            'min-h-0 min-w-0',
-            inDocumentPip ? 'max-h-[72px] shrink-0' : 'flex-1',
+            'pointer-events-none min-h-0 min-w-0 overflow-hidden',
+            inDocumentPip
+              ? 'max-h-[72px] shrink-0'
+              : 'flex min-h-0 flex-1 flex-col',
           )}
         >
           {captureUploadFinalizing ? (
@@ -1131,14 +1149,14 @@ export function GlobalCallDockOverlay() {
               remoteMediaStall={remoteMediaStall}
               currentUserProfileAvatarUrl={me?.avatarUrl ?? null}
               resolveMemberLabel={resolveMemberLabel}
-              layout={modeIsFullscreen ? 'fullView' : 'panel'}
+              layout={dockStageLayout}
               panelVideoFit={
-                !modeIsFullscreen && dockMode === 'thumbnail'
+                dockStageLayout === 'panel' && dockMode === 'thumbnail'
                   ? 'contain'
                   : 'cover'
               }
-              panelFlush={!modeIsFullscreen}
-              fullViewOpen={modeIsFullscreen}
+              panelFlush={dockStageLayout === 'panel'}
+              fullViewOpen={dockStageLayout === 'fullView'}
               fullViewLayoutMode={layoutMode}
               fullViewPaneSplit={paneSplit}
               onFullViewPaneSplitChange={onPaneSplitChange}
@@ -1149,7 +1167,7 @@ export function GlobalCallDockOverlay() {
 
         <div
           className={cn(
-            'relative z-10 shrink-0 overflow-visible border-t border-border/50 bg-muted/35',
+            'pointer-events-auto relative isolate z-30 shrink-0 touch-manipulation overflow-visible border-t border-border/50 bg-muted/35',
             dockCompact ? 'px-1 py-1' : 'px-2 py-2',
           )}
         >
@@ -1243,24 +1261,14 @@ export function GlobalCallDockOverlay() {
                     void leave();
                   }}
                   density={dockCompact ? 'compact' : 'default'}
-                  variant={modeIsFullscreen ? 'fullView' : 'inBanner'}
-                  inBannerLayout={
-                    dockCompact
-                      ? 'inline'
-                      : modeIsFullscreen
-                      ? 'inline'
-                      : 'centered'
-                  }
+                  variant={dockControlsVariant}
+                  inBannerLayout={dockControlsLayout}
                 />
               )}
             </>
           )}
         </div>
       </div>
-
-      {modeIsFullscreen && (
-        <div className="pointer-events-none absolute inset-0 rounded-2xl ring-1 ring-black/5" />
-      )}
 
       <HumanChatPanelScreenshareTakeoverDialog
         incoming={screenshareTakeoverIncoming}
@@ -1280,9 +1288,10 @@ export function GlobalCallDockOverlay() {
     </div>
   );
 
-  if (pipWindow) {
-    return createPortal(dockContent, pipWindow.document.body);
+  if (typeof document === 'undefined') {
+    return dockContent;
   }
 
-  return dockContent;
+  const portalTarget = pipWindow?.document.body ?? document.body;
+  return createPortal(dockContent, portalTarget);
 }

--- a/packages/epics/src/common/global-call-dock-overlay.tsx
+++ b/packages/epics/src/common/global-call-dock-overlay.tsx
@@ -17,15 +17,14 @@ import {
   useMe,
   type SpaceGroupCallCaptureMode,
 } from '@hypha-platform/core/client';
+import { useIsMobile } from '@hypha-platform/ui';
 import { cn } from '@hypha-platform/ui-utils';
 import { usePathname, useRouter } from 'next/navigation';
 import {
   DEFAULT_CALL_FULL_VIEW_LAYOUT,
   HumanChatPanelCallBanner,
-  HumanChatPanelCaptureConsentBanner,
   HumanChatPanelCallStage,
   HumanChatPanelCallFullViewLayoutMenu,
-  HumanChatPanelInCallControls,
   HumanChatPanelScreenshareTakeoverDialog,
   readCallFullViewLayoutFromStorage,
   persistCallFullViewLayout,
@@ -62,9 +61,12 @@ type ResizeHandle =
 const DOCK_GEOMETRY_KEY = 'hypha-global-call-dock-geometry-v2';
 const DOCK_MARGIN_PX = 16;
 const SNAP_EDGE_PX = 24;
+const DOCK_NARROW_VIEWPORT_PX = 768;
 // Minimum dock size (thumbnail mode baseline); resize can never go below this.
 const DOCK_MIN_WIDTH = 480;
 const DOCK_MIN_HEIGHT = 320;
+const DOCK_MIN_WIDTH_NARROW = 280;
+const DOCK_MIN_HEIGHT_NARROW = 220;
 /** Keep the dock in a usable video-call aspect range and avoid extreme sizes. */
 const DOCK_MAX_WIDTH = 880;
 const DOCK_MAX_HEIGHT = 640;
@@ -304,19 +306,40 @@ function getDockOffsetBounds(width: number, height: number) {
   return { minX, maxX, minY, maxY };
 }
 
+function readDockMinSize(): Pick<DockGeometry, 'width' | 'height'> {
+  if (typeof window === 'undefined') {
+    return { width: DOCK_MIN_WIDTH, height: DOCK_MIN_HEIGHT };
+  }
+  const narrow = window.innerWidth < DOCK_NARROW_VIEWPORT_PX;
+  const viewportMinWidth = Math.max(0, window.innerWidth - 2 * DOCK_MARGIN_PX);
+  const viewportMinHeight = Math.max(
+    0,
+    window.innerHeight - 2 * DOCK_MARGIN_PX,
+  );
+  return {
+    width: narrow
+      ? Math.min(DOCK_MIN_WIDTH_NARROW, viewportMinWidth)
+      : DOCK_MIN_WIDTH,
+    height: narrow
+      ? Math.min(DOCK_MIN_HEIGHT_NARROW, viewportMinHeight)
+      : DOCK_MIN_HEIGHT,
+  };
+}
+
 function clampDockGeometry(next: DockGeometry): DockGeometry {
+  const dockMinSize = readDockMinSize();
   const viewportMaxWidth =
     typeof window === 'undefined'
       ? DOCK_MAX_WIDTH
-      : Math.max(DOCK_MIN_WIDTH, window.innerWidth - 2 * DOCK_MARGIN_PX);
+      : Math.max(dockMinSize.width, window.innerWidth - 2 * DOCK_MARGIN_PX);
   const viewportMaxHeight =
     typeof window === 'undefined'
       ? DOCK_MAX_HEIGHT
-      : Math.max(DOCK_MIN_HEIGHT, window.innerHeight - 2 * DOCK_MARGIN_PX);
+      : Math.max(dockMinSize.height, window.innerHeight - 2 * DOCK_MARGIN_PX);
   const maxWidth = Math.min(DOCK_MAX_WIDTH, viewportMaxWidth);
   const maxHeight = Math.min(DOCK_MAX_HEIGHT, viewportMaxHeight);
-  const minWidth = Math.min(DOCK_MIN_WIDTH, maxWidth);
-  const minHeight = Math.min(DOCK_MIN_HEIGHT, maxHeight);
+  const minWidth = Math.min(dockMinSize.width, maxWidth);
+  const minHeight = Math.min(dockMinSize.height, maxHeight);
   const safeWidth = Number.isFinite(next.width) ? next.width : minWidth;
   const safeHeight = Number.isFinite(next.height) ? next.height : minHeight;
   const safeX = Number.isFinite(next.x) ? next.x : 0;
@@ -403,6 +426,7 @@ function persistDockGeometry(next: DockGeometry): void {
 export function GlobalCallDockOverlay() {
   const t = useTranslations('GlobalCallDock');
   const tCapture = useTranslations('HumanChatPanel');
+  const isMobile = useIsMobile() ?? false;
   const router = useRouter();
   const pathname = usePathname() ?? '';
   const { openHumanChatPanel, openCoherenceChat } = useHumanChatPanel();
@@ -608,6 +632,15 @@ export function GlobalCallDockOverlay() {
     window.addEventListener('resize', onResize);
     return () => window.removeEventListener('resize', onResize);
   }, [dockMode]);
+
+  React.useEffect(() => {
+    if (!isMobile || !showFloatingDock || isDocumentPipOpen) return;
+    if (dockMode === 'fullscreen') return;
+    if (dockMode === 'thumbnail' || dockMode === 'expanded') {
+      lastNonFullscreenModeRef.current = dockMode;
+    }
+    setDockMode('fullscreen');
+  }, [dockMode, isDocumentPipOpen, isMobile, setDockMode, showFloatingDock]);
 
   React.useEffect(() => {
     if (dockMode === 'fullscreen') return;
@@ -829,10 +862,10 @@ export function GlobalCallDockOverlay() {
     ? { width: '100%', height: '100%' }
     : modeIsFullscreen
     ? {
-        left: 16,
-        right: 16,
-        top: 72,
-        bottom: 16,
+        left: isMobile ? 8 : 16,
+        right: isMobile ? 8 : 16,
+        top: isMobile ? 8 : 72,
+        bottom: isMobile ? 8 : 16,
       }
     : {
         width: geometry.width,
@@ -877,9 +910,6 @@ export function GlobalCallDockOverlay() {
   const onStopCapture = () => {
     stopCapture();
   };
-  const showDockBanner =
-    errorCode != null || screenshareErrorCode != null || remoteMediaStall;
-
   const dockContent = (
     <div
       ref={dockRef}
@@ -887,12 +917,17 @@ export function GlobalCallDockOverlay() {
       className={cn(
         inDocumentPip
           ? 'relative flex h-full w-full min-h-0 min-w-0 select-none flex-col overflow-hidden rounded-lg border border-border/60 bg-background/95 shadow-lg'
-          : 'fixed z-[130] flex min-h-[320px] min-w-[480px] select-none flex-col overflow-visible rounded-xl border border-border/60 bg-background/95 shadow-2xl backdrop-blur-sm',
+          : cn(
+              'fixed z-[130] flex select-none flex-col overflow-hidden rounded-xl border border-border/60 bg-background/95 shadow-2xl backdrop-blur-sm',
+              isMobile || modeIsFullscreen
+                ? 'min-h-0 min-w-0'
+                : 'min-h-[320px] min-w-[480px]',
+            ),
         modeIsFullscreen ? 'rounded-2xl' : '',
       )}
       style={{ ...spaceAccentStyles, ...containerStyle }}
     >
-      {!modeIsFullscreen && !inDocumentPip && (
+      {!modeIsFullscreen && !inDocumentPip && !isMobile && (
         <>
           <DockResizeHandle
             handle="top-left"
@@ -926,7 +961,7 @@ export function GlobalCallDockOverlay() {
           />
         </>
       )}
-      <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden rounded-[inherit]">
+      <div className="relative z-[5] flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden rounded-[inherit]">
         <div
           className={cn(
             'flex shrink-0 items-center gap-1 border-b border-border/50 bg-muted/45',
@@ -1117,102 +1152,46 @@ export function GlobalCallDockOverlay() {
               <p className="text-[11px] text-destructive">{recordingError}</p>
             ) : null
           ) : (
-            <>
-              {captureConsent &&
-              callState === 'connected' &&
-              !showDockBanner ? (
-                <HumanChatPanelCaptureConsentBanner
-                  consent={captureConsent}
-                  roomId={activeRoomId}
-                  variant="inCall"
-                  className={cn(
-                    'rounded-none border-x-0 border-t-0',
-                    dockCompact
-                      ? '-mx-1 -mt-1 mb-1 px-2 py-1 [&_p]:text-[10px] [&_p]:leading-tight'
-                      : '-mx-2 -mt-2 mb-2',
-                  )}
-                />
-              ) : null}
-              {showDockBanner ? (
-                <HumanChatPanelCallBanner
-                  callState={callState}
-                  callKind={callKind}
-                  errorCode={errorCode}
-                  isScreensharing={isScreensharing}
-                  screenshareErrorCode={screenshareErrorCode}
-                  tabBackgroundWhileInCall={tabBackgroundWhileInCall}
-                  isMicrophoneMuted={isMicrophoneMuted}
-                  isLocalVideoMuted={isLocalVideoMuted}
-                  participantCount={roomGroupCallDeviceCount}
-                  othersInRoomCallCount={othersInRoomCallCount}
-                  remoteMediaStall={remoteMediaStall}
-                  onDismissRemoteMediaStall={dismissRemoteMediaStallBanner}
-                  onLeave={() => {
-                    void leave();
-                  }}
-                  onToggleMic={onToggleMic}
-                  onToggleCamera={onToggleCamera}
-                  onToggleScreenshare={onToggleScreenshare}
-                  voiceProcessingPreset={voiceProcessingPreset}
-                  onVoiceProcessingPresetChange={onVoiceProcessingPresetChange}
-                  captureMode={captureMode}
-                  capturePreference={capturePreference}
-                  capturePreferenceSelected={capturePreferenceSelected}
-                  onCapturePreferenceChange={onCapturePreferenceChange}
-                  onStartCapture={onStartCaptureWithMode}
-                  onPauseCapture={onPauseCapture}
-                  onResumeCapture={onResumeCapture}
-                  onStopCapture={onStopCapture}
-                  recordingStatus={recordingStatus}
-                  recordingError={recordingError}
-                  recordingWarning={recordingWarning}
-                  canRetryRecordingUpload={canRetryRecordingUpload}
-                  onRetryRecordingUpload={() => void retryRecordingUpload()}
-                  captureConsent={captureConsent}
-                  roomId={activeRoomId}
-                  onDismissScreenshareError={dismissScreenshareError}
-                  onRetryCall={retryFromError}
-                  onDismissCallError={dismissCallError}
-                />
-              ) : (
-                <HumanChatPanelInCallControls
-                  callState={callState}
-                  isMicrophoneMuted={isMicrophoneMuted}
-                  isLocalVideoMuted={isLocalVideoMuted}
-                  isScreensharing={isScreensharing}
-                  onToggleMic={onToggleMic}
-                  onToggleCamera={onToggleCamera}
-                  onToggleScreenshare={onToggleScreenshare}
-                  voiceProcessingPreset={voiceProcessingPreset}
-                  onVoiceProcessingPresetChange={onVoiceProcessingPresetChange}
-                  captureMode={captureMode}
-                  capturePreference={capturePreference}
-                  capturePreferenceSelected={capturePreferenceSelected}
-                  onCapturePreferenceChange={onCapturePreferenceChange}
-                  onStartCapture={onStartCaptureWithMode}
-                  onPauseCapture={onPauseCapture}
-                  onResumeCapture={onResumeCapture}
-                  onStopCapture={onStopCapture}
-                  recordingStatus={recordingStatus}
-                  recordingError={recordingError}
-                  recordingWarning={recordingWarning}
-                  canRetryRecordingUpload={canRetryRecordingUpload}
-                  onRetryRecordingUpload={() => void retryRecordingUpload()}
-                  onLeave={() => {
-                    void leave();
-                  }}
-                  density={dockCompact ? 'compact' : 'default'}
-                  variant={modeIsFullscreen ? 'fullView' : 'inBanner'}
-                  inBannerLayout={
-                    dockCompact
-                      ? 'inline'
-                      : modeIsFullscreen
-                      ? 'inline'
-                      : 'centered'
-                  }
-                />
-              )}
-            </>
+            <HumanChatPanelCallBanner
+              callState={callState}
+              callKind={callKind}
+              errorCode={errorCode}
+              isScreensharing={isScreensharing}
+              screenshareErrorCode={screenshareErrorCode}
+              tabBackgroundWhileInCall={tabBackgroundWhileInCall}
+              isMicrophoneMuted={isMicrophoneMuted}
+              isLocalVideoMuted={isLocalVideoMuted}
+              participantCount={roomGroupCallDeviceCount}
+              othersInRoomCallCount={othersInRoomCallCount}
+              remoteMediaStall={remoteMediaStall}
+              onDismissRemoteMediaStall={dismissRemoteMediaStallBanner}
+              onLeave={() => {
+                void leave();
+              }}
+              onToggleMic={onToggleMic}
+              onToggleCamera={onToggleCamera}
+              onToggleScreenshare={onToggleScreenshare}
+              voiceProcessingPreset={voiceProcessingPreset}
+              onVoiceProcessingPresetChange={onVoiceProcessingPresetChange}
+              captureMode={captureMode}
+              capturePreference={capturePreference}
+              capturePreferenceSelected={capturePreferenceSelected}
+              onCapturePreferenceChange={onCapturePreferenceChange}
+              onStartCapture={onStartCaptureWithMode}
+              onPauseCapture={onPauseCapture}
+              onResumeCapture={onResumeCapture}
+              onStopCapture={onStopCapture}
+              recordingStatus={recordingStatus}
+              recordingError={recordingError}
+              recordingWarning={recordingWarning}
+              canRetryRecordingUpload={canRetryRecordingUpload}
+              onRetryRecordingUpload={() => void retryRecordingUpload()}
+              captureConsent={captureConsent}
+              roomId={activeRoomId}
+              onDismissScreenshareError={dismissScreenshareError}
+              onRetryCall={retryFromError}
+              onDismissCallError={dismissCallError}
+            />
           )}
         </div>
       </div>

--- a/packages/epics/src/common/human-chat-panel/human-chat-panel-connection-banner.tsx
+++ b/packages/epics/src/common/human-chat-panel/human-chat-panel-connection-banner.tsx
@@ -14,8 +14,12 @@ type HumanChatPanelConnectionBannerProps = {
   onUseThisTab: () => void;
 };
 
+const accentBorder =
+  'border-[color:color-mix(in_srgb,var(--color-accent-9,var(--space-accent,#4a65d8))_30%,transparent)]';
+const accentSurface =
+  'bg-[color:color-mix(in_srgb,var(--color-accent-9,var(--space-accent,#4a65d8))_12%,var(--background))]';
 const bannerButtonClassName =
-  'h-7 min-h-7 shrink-0 gap-1.5 self-center border-border bg-background/90 px-2.5 py-0 text-xs font-semibold leading-none whitespace-nowrap text-foreground hover:bg-muted disabled:opacity-50';
+  'h-7 min-h-7 shrink-0 gap-1.5 self-center border-[color:color-mix(in_srgb,var(--color-accent-9,var(--space-accent,#4a65d8))_45%,var(--border))] bg-background/90 px-2.5 py-0 text-xs font-semibold leading-none whitespace-nowrap text-foreground hover:bg-accent-3 disabled:opacity-50';
 
 export function HumanChatPanelConnectionBanner({
   connectionStatus,
@@ -37,7 +41,9 @@ export function HumanChatPanelConnectionBanner({
       role="status"
       aria-live="polite"
       className={cn(
-        'mt-0 w-full border-y border-border/70 bg-muted/40 px-3 py-2 text-sm',
+        'mt-0 w-full border-y px-3 py-2 text-sm',
+        accentBorder,
+        accentSurface,
       )}
     >
       <div className="flex flex-wrap items-center justify-between gap-2">

--- a/packages/epics/src/common/human-chat-panel/human-chat-panel-connection-banner.tsx
+++ b/packages/epics/src/common/human-chat-panel/human-chat-panel-connection-banner.tsx
@@ -14,15 +14,8 @@ type HumanChatPanelConnectionBannerProps = {
   onUseThisTab: () => void;
 };
 
-const accentBorder =
-  'border-[color:color-mix(in_srgb,var(--color-accent-9,var(--space-accent,#4a65d8))_30%,transparent)]';
-const accentSurface =
-  'bg-[color:color-mix(in_srgb,var(--color-accent-9,var(--space-accent,#4a65d8))_12%,var(--background))]';
-const accentTitle = 'text-[color:var(--color-accent-12,var(--foreground))]';
-const accentBody =
-  'text-[color:color-mix(in_srgb,var(--color-accent-11,var(--foreground))_85%,transparent)]';
-const accentButton =
-  'h-7 min-h-7 shrink-0 gap-1.5 self-center border-[color:var(--space-accent)] bg-background px-2.5 py-0 text-xs font-semibold leading-none whitespace-nowrap text-[color:var(--space-accent)] hover:bg-accent-3 disabled:border-[color:var(--space-accent)]/45 disabled:text-[color:var(--space-accent)]/55 disabled:opacity-100';
+const bannerButtonClassName =
+  'h-7 min-h-7 shrink-0 gap-1.5 self-center border-border bg-background/90 px-2.5 py-0 text-xs font-semibold leading-none whitespace-nowrap text-foreground hover:bg-muted disabled:opacity-50';
 
 export function HumanChatPanelConnectionBanner({
   connectionStatus,
@@ -44,19 +37,17 @@ export function HumanChatPanelConnectionBanner({
       role="status"
       aria-live="polite"
       className={cn(
-        'mt-0 w-full border-y px-3 py-2 text-sm',
-        accentBorder,
-        accentSurface,
+        'mt-0 w-full border-y border-border/70 bg-muted/40 px-3 py-2 text-sm',
       )}
     >
       <div className="flex flex-wrap items-center justify-between gap-2">
         <div>
-          <p className={cn('font-medium', accentTitle)}>
+          <p className="font-medium text-foreground">
             {isFollower
               ? t('connectionFollowerTitle')
               : t('connectionLostTitle')}
           </p>
-          <p className={cn('mt-0.5', accentBody)}>
+          <p className="mt-0.5 text-muted-foreground">
             {isFollower
               ? t('connectionFollowerDescription')
               : isReconnecting
@@ -68,8 +59,8 @@ export function HumanChatPanelConnectionBanner({
           <Button
             type="button"
             variant="outline"
-            colorVariant="accent"
-            className={accentButton}
+            colorVariant="neutral"
+            className={bannerButtonClassName}
             onClick={onUseThisTab}
           >
             {t('connectionFollowerUseTab')}
@@ -78,8 +69,8 @@ export function HumanChatPanelConnectionBanner({
           <Button
             type="button"
             variant="outline"
-            colorVariant="accent"
-            className={accentButton}
+            colorVariant="neutral"
+            className={bannerButtonClassName}
             disabled={isReconnecting}
             onClick={onRetry}
           >

--- a/packages/epics/src/common/human-chat-panel/human-chat-panel-in-call-controls.tsx
+++ b/packages/epics/src/common/human-chat-panel/human-chat-panel-in-call-controls.tsx
@@ -126,6 +126,7 @@ export function HumanChatPanelInCallControls({
   const isFull = variant === 'fullView';
   const isCenteredInBanner =
     !isFull && !isCompact && inBannerLayout === 'centered';
+  const useMobileCenteredToolbar = isMobile && isCenteredInBanner;
   /**
    * Full view modal: §3.4.4.4 — white glyphs on dark / green / red (not
    * `text-foreground` on near-black / green where Lucide would read as black).
@@ -609,15 +610,21 @@ export function HumanChatPanelInCallControls({
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
-      <div role="group" aria-label={t('callToolbarLabel')}>
+      <div
+        role="group"
+        aria-label={t('callToolbarLabel')}
+        className={cn(useMobileCenteredToolbar && 'w-full')}
+      >
         <div
           className={cn(
-            useSideAudioSettings
+            useMobileCenteredToolbar
+              ? 'flex w-full items-center justify-center gap-2.5'
+              : useSideAudioSettings
               ? 'grid w-full grid-cols-[1fr_auto_1fr] items-center'
               : 'flex w-auto items-center',
           )}
         >
-          <div />
+          {!useMobileCenteredToolbar && useSideAudioSettings ? <div /> : null}
           <div
             className={cn(
               'flex items-center',
@@ -626,7 +633,9 @@ export function HumanChatPanelInCallControls({
                 : isCompact
                 ? 'gap-1'
                 : 'gap-1.5 sm:gap-2',
-              useSideAudioSettings ? 'justify-center' : 'justify-start',
+              useMobileCenteredToolbar || useSideAudioSettings
+                ? 'justify-center'
+                : 'justify-start',
             )}
           >
             {!leaveOnly ? (

--- a/packages/epics/src/common/human-chat-panel/human-chat-panel-in-call-controls.tsx
+++ b/packages/epics/src/common/human-chat-panel/human-chat-panel-in-call-controls.tsx
@@ -29,6 +29,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
   Button,
+  useIsMobile,
 } from '@hypha-platform/ui';
 import { cn } from '@hypha-platform/ui-utils';
 import {
@@ -111,6 +112,8 @@ export function HumanChatPanelInCallControls({
   controlsMode = 'full',
 }: HumanChatPanelInCallControlsProps) {
   const t = useTranslations('HumanChatPanel');
+  const isMobile = useIsMobile() ?? false;
+  const showAdvancedCallControls = !isMobile;
   const { controlsDisabled } = getCallControlsPhase(callState);
   const isCompact = density === 'compact';
   const [isAudioMenuOpen, setIsAudioMenuOpen] = useState(false);
@@ -186,6 +189,7 @@ export function HumanChatPanelInCallControls({
     ? 'h-4 w-4 text-white'
     : 'h-4 w-4 text-foreground';
   const useSideAudioSettings =
+    showAdvancedCallControls &&
     !isCompact &&
     (isFull || inBannerLayout === 'balanced' || inBannerLayout === 'centered');
   const captureActive = captureMode !== 'none' && recordingStatus !== 'error';
@@ -687,36 +691,38 @@ export function HumanChatPanelInCallControls({
                     <Video className={icon} />
                   )}
                 </button>
-                <button
-                  type="button"
-                  onClick={onToggleScreenshare}
-                  disabled={controlsDisabled}
-                  className={cn(
-                    isFull
-                      ? isScreensharing
+                {showAdvancedCallControls ? (
+                  <button
+                    type="button"
+                    onClick={onToggleScreenshare}
+                    disabled={controlsDisabled}
+                    className={cn(
+                      isFull
+                        ? isScreensharing
+                          ? shareActiveBtn
+                          : baseBtn
+                        : isScreensharing
                         ? shareActiveBtn
-                        : baseBtn
-                      : isScreensharing
-                      ? shareActiveBtn
-                      : neutralBtn,
-                    (isFull || isScreensharing) &&
-                      'inline-flex items-center justify-center',
-                    'disabled:cursor-not-allowed',
-                    !isFull && controlsDisabled && 'opacity-50',
-                  )}
-                  title={t('callControlsScreenshare')}
-                  aria-label={
-                    isScreensharing
-                      ? t('callControlsScreenshareActiveAria')
-                      : t('callControlsScreenshareInactiveAria')
-                  }
-                >
-                  {isScreensharing ? (
-                    <MonitorOff className={icon} />
-                  ) : (
-                    <Monitor className={icon} />
-                  )}
-                </button>
+                        : neutralBtn,
+                      (isFull || isScreensharing) &&
+                        'inline-flex items-center justify-center',
+                      'disabled:cursor-not-allowed',
+                      !isFull && controlsDisabled && 'opacity-50',
+                    )}
+                    title={t('callControlsScreenshare')}
+                    aria-label={
+                      isScreensharing
+                        ? t('callControlsScreenshareActiveAria')
+                        : t('callControlsScreenshareInactiveAria')
+                    }
+                  >
+                    {isScreensharing ? (
+                      <MonitorOff className={icon} />
+                    ) : (
+                      <Monitor className={icon} />
+                    )}
+                  </button>
+                ) : null}
               </>
             ) : null}
             <button
@@ -733,23 +739,27 @@ export function HumanChatPanelInCallControls({
             >
               <CallHangUpIcon className={leaveIcon} />
             </button>
-            {!leaveOnly && !useSideAudioSettings ? renderCaptureMenu : null}
-            {!leaveOnly && !useSideAudioSettings
+            {!leaveOnly && showAdvancedCallControls && !useSideAudioSettings
+              ? renderCaptureMenu
+              : null}
+            {!leaveOnly && showAdvancedCallControls && !useSideAudioSettings
               ? renderAudioSettingsMenu
               : null}
           </div>
-          {useSideAudioSettings && !leaveOnly ? (
+          {useSideAudioSettings && !leaveOnly && showAdvancedCallControls ? (
             <div className="justify-self-end flex items-center gap-2">
               {renderCaptureMenu}
               {renderAudioSettingsMenu}
             </div>
           ) : null}
         </div>
-        {!isCompact && recordingStatus === 'uploading' ? (
+        {!isCompact &&
+        showAdvancedCallControls &&
+        recordingStatus === 'uploading' ? (
           <p className={cn('mt-1 text-[11px] text-muted-foreground')}>
             {t('callCaptureStatusSaving')}
           </p>
-        ) : recordingWarningMessage ? (
+        ) : showAdvancedCallControls && recordingWarningMessage ? (
           <p
             className={cn(
               'mt-1 text-[11px]',
@@ -760,7 +770,9 @@ export function HumanChatPanelInCallControls({
           >
             {recordingWarningMessage}
           </p>
-        ) : recordingStatus === 'error' && recordingError?.trim() ? (
+        ) : showAdvancedCallControls &&
+          recordingStatus === 'error' &&
+          recordingError?.trim() ? (
           <div className="mt-1 flex flex-wrap items-center gap-2">
             <p className={cn('text-[11px] text-destructive')}>
               {recordingError}

--- a/packages/epics/src/common/human-right-panel.tsx
+++ b/packages/epics/src/common/human-right-panel.tsx
@@ -1114,6 +1114,7 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
   const {
     bindRoomContext,
     activeRoomId: callSessionRoomId,
+    pinnedCallSpaceSlug,
     callState: spaceCallState,
     errorCode: spaceCallError,
     callKind: spaceCallKind,
@@ -2873,16 +2874,30 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
       !roomId?.trim()
     )
       return;
+    if (
+      callSessionRoomId?.trim() === roomId.trim() &&
+      pinnedCallSpaceSlug?.trim() &&
+      pinnedCallSpaceSlug.trim() !== spaceSlug.trim()
+    ) {
+      return;
+    }
     rememberRoomToSpaceSlugSession(roomId, spaceSlug.trim());
-  }, [mode, spaceSlug, roomId]);
+  }, [callSessionRoomId, mode, pinnedCallSpaceSlug, roomId, spaceSlug]);
 
   useEffect(() => {
     const pathSlug = getDhoSpaceSlugFromPathname(pathname)?.trim();
     const rid = roomId?.trim() ?? null;
     if (pathSlug && rid && mode === 'space' && typeof window !== 'undefined') {
+      if (
+        callSessionRoomId?.trim() === rid &&
+        pinnedCallSpaceSlug?.trim() &&
+        pinnedCallSpaceSlug.trim() !== pathSlug
+      ) {
+        return;
+      }
       rememberRoomToSpaceSlugSession(rid, pathSlug);
     }
-  }, [pathname, roomId, mode]);
+  }, [callSessionRoomId, mode, pathname, pinnedCallSpaceSlug, roomId]);
 
   useEffect(() => {
     const rid = roomId?.trim() ?? null;

--- a/packages/epics/src/common/human-right-panel.tsx
+++ b/packages/epics/src/common/human-right-panel.tsx
@@ -1212,9 +1212,8 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
     return sessionRoomId === chatRoomId;
   }, [callSessionRoomId, roomId]);
 
-  /** Sidebar call chrome only for the chat room that owns the active session. */
-  const showSidebarCallUi =
-    callUiEnabled && callAppliesToCurrentChatRoom && !showFloatingDock;
+  /** Sidebar call chrome for the chat room that owns the active session. */
+  const showSidebarCallUi = callUiEnabled && callAppliesToCurrentChatRoom;
 
   const spaceCallToolbarJoinHint = callUiEnabled && spaceCallShowJoinStrip;
   const showAuthedUi = !isAuthLoading && isAuthenticated;

--- a/packages/epics/src/common/human-right-panel.tsx
+++ b/packages/epics/src/common/human-right-panel.tsx
@@ -3794,7 +3794,7 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
                 role="tabpanel"
                 id="chat-tabpanel-chat"
               >
-                {showSidebarCallUi && (
+                {showSidebarCallUi && !showFloatingDock && (
                   <div
                     className={
                       inSpaceCall

--- a/packages/i18n/src/messages/de.json
+++ b/packages/i18n/src/messages/de.json
@@ -2441,7 +2441,10 @@
     "provisioning": {
       "chatUnavailable": "Signal erstellt, aber der Chat ist derzeit nicht verfügbar.",
       "roomProvisionFailed": "Signal erstellt, aber die Bereitstellung des Chatraums ist fehlgeschlagen.",
-      "roomLinkFailedRetry": "Signal erstellt, aber der Chatraum konnte nicht verknüpft werden. Bitte versuchen Sie es erneut."
+      "roomLinkFailedRetry": "Signal erstellt, aber der Chatraum konnte nicht verknüpft werden. Bitte versuchen Sie es erneut.",
+      "teamSeedSkipped": "Signal erstellt, aber ausgewählte Teammitglieder konnten dem Chat noch nicht hinzugefügt werden.",
+      "teamSeedFailed": "Signal erstellt, aber ausgewählte Teammitglieder konnten dem Chat nicht hinzugefügt werden.",
+      "attachmentsUploadFailed": "Signal erstellt, aber Anhänge konnten nicht in den Chat hochgeladen werden."
     },
     "tagLabels": {
       "Purpose": "Zweck",

--- a/packages/i18n/src/messages/de.json
+++ b/packages/i18n/src/messages/de.json
@@ -2434,6 +2434,10 @@
     "savingSignal": "Signal wird gespeichert",
     "saveChanges": "Änderungen speichern",
     "keepWindowOpenWhileCreating": "Lassen Sie dieses Fenster geöffnet, bis wir fertig sind.",
+    "createSignalAttachmentsTitle": "Anhänge",
+    "createSignalTeamOwner": "Inhaber",
+    "createSignalTeamNoMembers": "Noch keine Space-Mitglieder mit Chat-Konten verfügbar.",
+    "loading": "Wird geladen...",
     "provisioning": {
       "chatUnavailable": "Signal erstellt, aber der Chat ist derzeit nicht verfügbar.",
       "roomProvisionFailed": "Signal erstellt, aber die Bereitstellung des Chatraums ist fehlgeschlagen.",

--- a/packages/i18n/src/messages/en.json
+++ b/packages/i18n/src/messages/en.json
@@ -2540,6 +2540,10 @@
     "editSignalMissingSlug": "Signal identifier is missing. Please close and reopen the edit form.",
     "editSignalSaveFailed": "Could not save signal changes. Please try again.",
     "keepWindowOpenWhileCreating": "Keep this window open until we're finished.",
+    "createSignalAttachmentsTitle": "Attachments",
+    "createSignalTeamOwner": "Owner",
+    "createSignalTeamNoMembers": "No space members with chat accounts are available yet.",
+    "loading": "Loading...",
     "provisioning": {
       "chatUnavailable": "Signal created but chat is currently unavailable.",
       "roomProvisionFailed": "Signal created but chat room provisioning failed.",

--- a/packages/i18n/src/messages/en.json
+++ b/packages/i18n/src/messages/en.json
@@ -2547,7 +2547,10 @@
     "provisioning": {
       "chatUnavailable": "Signal created but chat is currently unavailable.",
       "roomProvisionFailed": "Signal created but chat room provisioning failed.",
-      "roomLinkFailedRetry": "Signal created but chat room could not be linked. Please retry."
+      "roomLinkFailedRetry": "Signal created but chat room could not be linked. Please retry.",
+      "teamSeedSkipped": "Signal created but selected team members could not be added to chat yet.",
+      "teamSeedFailed": "Signal created but selected team members could not be added to chat.",
+      "attachmentsUploadFailed": "Signal created but attachments could not be uploaded to chat."
     },
     "tagLabels": {
       "Purpose": "Purpose",

--- a/packages/i18n/src/messages/es.json
+++ b/packages/i18n/src/messages/es.json
@@ -2424,6 +2424,10 @@
     "savingSignal": "Guardando señal",
     "saveChanges": "Guardar cambios",
     "keepWindowOpenWhileCreating": "Mantén esta ventana abierta hasta que terminemos.",
+    "createSignalAttachmentsTitle": "Adjuntos",
+    "createSignalTeamOwner": "Propietario",
+    "createSignalTeamNoMembers": "Aún no hay miembros del espacio con cuentas de chat disponibles.",
+    "loading": "Cargando...",
     "provisioning": {
       "chatUnavailable": "Señal creada, pero el chat no está disponible en este momento.",
       "roomProvisionFailed": "Señal creada, pero falló el aprovisionamiento de la sala de chat.",

--- a/packages/i18n/src/messages/es.json
+++ b/packages/i18n/src/messages/es.json
@@ -2431,7 +2431,10 @@
     "provisioning": {
       "chatUnavailable": "Señal creada, pero el chat no está disponible en este momento.",
       "roomProvisionFailed": "Señal creada, pero falló el aprovisionamiento de la sala de chat.",
-      "roomLinkFailedRetry": "Señal creada, pero no se pudo vincular la sala de chat. Inténtalo de nuevo."
+      "roomLinkFailedRetry": "Señal creada, pero no se pudo vincular la sala de chat. Inténtalo de nuevo.",
+      "teamSeedSkipped": "Señal creada, pero los miembros del equipo seleccionados aún no se pudieron añadir al chat.",
+      "teamSeedFailed": "Señal creada, pero no se pudieron añadir al chat los miembros del equipo seleccionados.",
+      "attachmentsUploadFailed": "Señal creada, pero no se pudieron subir los archivos adjuntos al chat."
     },
     "tagLabels": {
       "Purpose": "Propósito",

--- a/packages/i18n/src/messages/fr.json
+++ b/packages/i18n/src/messages/fr.json
@@ -2427,7 +2427,10 @@
     "provisioning": {
       "chatUnavailable": "Signal créé, mais le chat est actuellement indisponible.",
       "roomProvisionFailed": "Signal créé, mais l’approvisionnement de la salle de chat a échoué.",
-      "roomLinkFailedRetry": "Signal créé, mais la salle de chat n’a pas pu être liée. Veuillez réessayer."
+      "roomLinkFailedRetry": "Signal créé, mais la salle de chat n’a pas pu être liée. Veuillez réessayer.",
+      "teamSeedSkipped": "Signal créé, mais les membres d’équipe sélectionnés n’ont pas encore pu être ajoutés au chat.",
+      "teamSeedFailed": "Signal créé, mais les membres d’équipe sélectionnés n’ont pas pu être ajoutés au chat.",
+      "attachmentsUploadFailed": "Signal créé, mais les pièces jointes n’ont pas pu être téléversées dans le chat."
     },
     "tagLabels": {
       "Purpose": "Raison d'être",

--- a/packages/i18n/src/messages/fr.json
+++ b/packages/i18n/src/messages/fr.json
@@ -2420,6 +2420,10 @@
     "editSignalMissingSlug": "L'identifiant du signal est manquant. Fermez puis rouvrez le formulaire d'édition.",
     "editSignalSaveFailed": "Impossible d'enregistrer les modifications du signal. Veuillez réessayer.",
     "keepWindowOpenWhileCreating": "Gardez cette fenêtre ouverte jusqu’à la fin.",
+    "createSignalAttachmentsTitle": "Pièces jointes",
+    "createSignalTeamOwner": "Propriétaire",
+    "createSignalTeamNoMembers": "Aucun membre de l'espace avec un compte de chat n'est disponible pour le moment.",
+    "loading": "Chargement...",
     "provisioning": {
       "chatUnavailable": "Signal créé, mais le chat est actuellement indisponible.",
       "roomProvisionFailed": "Signal créé, mais l’approvisionnement de la salle de chat a échoué.",

--- a/packages/i18n/src/messages/pt.json
+++ b/packages/i18n/src/messages/pt.json
@@ -2422,6 +2422,10 @@
     "editSignalMissingSlug": "O identificador do sinal está em falta. Feche e volte a abrir o formulário de edição.",
     "editSignalSaveFailed": "Não foi possível guardar as alterações do sinal. Tente novamente.",
     "keepWindowOpenWhileCreating": "Mantenha esta janela aberta até terminarmos.",
+    "createSignalAttachmentsTitle": "Anexos",
+    "createSignalTeamOwner": "Proprietário",
+    "createSignalTeamNoMembers": "Ainda não há membros do espaço com contas de chat disponíveis.",
+    "loading": "Carregando...",
     "provisioning": {
       "chatUnavailable": "Sinal criado, mas o chat está indisponível no momento.",
       "roomProvisionFailed": "Sinal criado, mas a criação da sala de chat falhou.",

--- a/packages/i18n/src/messages/pt.json
+++ b/packages/i18n/src/messages/pt.json
@@ -2429,7 +2429,10 @@
     "provisioning": {
       "chatUnavailable": "Sinal criado, mas o chat está indisponível no momento.",
       "roomProvisionFailed": "Sinal criado, mas a criação da sala de chat falhou.",
-      "roomLinkFailedRetry": "Sinal criado, mas não foi possível vincular a sala de chat. Tente novamente."
+      "roomLinkFailedRetry": "Sinal criado, mas não foi possível vincular a sala de chat. Tente novamente.",
+      "teamSeedSkipped": "Sinal criado, mas os membros da equipe selecionados ainda não puderam ser adicionados ao chat.",
+      "teamSeedFailed": "Sinal criado, mas os membros da equipe selecionados não puderam ser adicionados ao chat.",
+      "attachmentsUploadFailed": "Sinal criado, mas os anexos não puderam ser enviados ao chat."
     },
     "tagLabels": {
       "Purpose": "Propósito",

--- a/packages/ui/src/breakpoints.ts
+++ b/packages/ui/src/breakpoints.ts
@@ -1,0 +1,2 @@
+/** Tailwind `md` breakpoint — shared by mobile layout hooks and responsive UI. */
+export const MOBILE_BREAKPOINT_PX = 768;

--- a/packages/ui/src/hooks/use-mobile.tsx
+++ b/packages/ui/src/hooks/use-mobile.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 
-const MOBILE_BREAKPOINT = 768;
+import { MOBILE_BREAKPOINT_PX } from '../breakpoints';
 
 export function useIsMobile(): boolean | undefined {
   const [isMobile, setIsMobile] = React.useState<boolean | undefined>(
@@ -10,12 +10,12 @@ export function useIsMobile(): boolean | undefined {
   );
 
   React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
+    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT_PX - 1}px)`);
     const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT_PX);
     };
     mql.addEventListener('change', onChange);
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT_PX);
     return () => mql.removeEventListener('change', onChange);
   }, []);
 

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -48,6 +48,7 @@ export * from './textarea';
 export * from './tooltip';
 export * from './sidebar';
 export * from './sheet';
+export * from './breakpoints';
 export * from './hooks/use-mobile';
 export * from './hooks/use-compact-header-mode';
 


### PR DESCRIPTION
## Summary

- Restores the in-call banner in the chat sidebar when viewing the call room, by only showing the floating dock after navigating away from the pinned call room (Matrix sync still stays active for the full session).
- Fixes unresponsive call controls on mobile/narrow viewports: dock content now stacks above resize handles, resize grips are hidden on mobile, and the dock auto-expands to fullscreen with viewport-safe sizing.
- Always renders `HumanChatPanelCallBanner` in the floating dock (with participant count and full controls) instead of the stripped-down controls-only strip.

## Test plan

- [ ] Join a video call on mobile (<768px) and verify mute, camera, screen share, and leave buttons respond to taps
- [ ] Join a call in the chat panel and confirm the call banner appears in the sidebar with participant count
- [ ] Navigate to another space while in a call and confirm the floating dock appears with the full call banner
- [ ] On desktop, confirm resize handles still work and controls remain clickable
- [ ] End call from mobile dock and confirm call disconnects cleanly


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Smarter call dock/session handling, refined sidebar call visibility, and safer dock portal behavior with PIP-aware rendering
  * Mobile dock sizing, placement tweaks, and forced fullscreen on small viewports
  * Sanitized zoom/layout to prevent rendering glitches in space visualization

* **New Features**
  * Signal creation: selectable team members, attachments, and a connected create-signal form
  * Responsive signal grid with adaptive “load more” batching
  * Advanced in-call controls hidden on mobile for simplified UI

* **Localization**
  * Added EN/DE/ES/FR/PT strings for the signal creation flow

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hypha-dao/hypha-web/pull/2275?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->