### PR TITLE
fix: prevent sandbox demo panel from appearing in production builds

### DIFF
--- a/apps/web/.env.template
+++ b/apps/web/.env.template
@@ -43,7 +43,7 @@ BRIDGE_API_KEY=
 # Set to https://api.bridge.xyz for production.
 BRIDGE_API_BASE_URL=
 # Temporary local demo: shows "Simulate KYB approval" below Bank Deposits (sandbox API only).
-NEXT_PUBLIC_BRIDGE_SANDBOX_DEMO=true
+NEXT_PUBLIC_BRIDGE_SANDBOX_DEMO=false
 
 # Alchemy webhooks
 WH_SPACE_CREATED_SIGN_KEY=whsec_000000000000000000000000

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,7 +9,7 @@
     "start": "next start",
     "lint": "next lint",
     "check-types": "tsc --noEmit",
-    "postinstall": "if [ ! -f .env ]; then cp .env.template .env; fi"
+    "postinstall": "if [ ! -f .env ] && [ -z \"$CI\" ]; then cp .env.template .env; fi"
   },
   "dependencies": {
     "@ai-sdk/react": "^3.0.107",


### PR DESCRIPTION
Template had `NEXT_PUBLIC_BRIDGE_SANDBOX_DEMO=true`; postinstall was copying the template to .env in CI runners (where no .env exists), causing the var to be baked into production bundles when absent from Vercel's production env config.

- Set NEXT_PUBLIC_BRIDGE_SANDBOX_DEMO=false in apps/web/.env.template
- Guard both postinstall scripts with a CI env check so the template copy only runs in local dev, never in CI/production

Closes #2280

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled KYB approval simulation demo by default in the application configuration.
  * Improved build setup process to properly handle CI environment deployments by skipping automatic environment file initialization when running in CI.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hypha-dao/hypha-web/pull/2282?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->