### PR TITLE
docs(calls): call stability hardening spec and phased plan

### DIFF
--- a/docs/requirements/call-stability-hardening-plan.md
+++ b/docs/requirements/call-stability-hardening-plan.md
@@ -1,0 +1,233 @@
+# Implementation plan — Call stability hardening
+
+## Document control
+
+| Field | Value |
+| ----- | ----- |
+| **Status** | Ready to execute (phased) |
+| **Spec** | [call-stability-hardening-spec.md](./call-stability-hardening-spec.md) |
+| **Parent plans** | [voice-video-call-implementation-plan.md](./voice-video-call-implementation-plan.md) (Phases 1–6 baseline) |
+| **Hotfix** | PR [#2284](https://github.com/hypha-dao/hypha-web/pull/2284) — merge first |
+
+---
+
+## 1) Guiding principles
+
+1. **Restore before extend** — Ship PR #2284 (banner + share handoff) before new features.
+2. **Mesh honesty** — Document and UI-warn participant limits; do not market community-scale until SFU ships.
+3. **Vertical slices** — Each phase leaves calling demoable with updated manual QA script (spec §9.2).
+4. **One surface for video** — Sidebar OR dock stage, never duplicate takeover dialogs.
+5. **Specs drive PRs** — Each implementation PR references `CSH-*` requirement IDs from the spec.
+
+---
+
+## 2) Phase overview
+
+| Phase | Name | Goal | Depends on |
+| ----- | ---- | ---- | ---------- |
+| **P0** | Hotfix merge | Banner + share handoff regression fix | PR #2284 CI green |
+| **P1** | Chrome & discoverability | Dock/sidebar contract guardrails, join modal, deep-link retry, scale warning | P0 |
+| **P2** | Screen share hardening | Mobile policy, handoff QA, gallery reset tests | P0 |
+| **P3** | Mesh reliability | Multi-tab UX, keepalive fix, stall copy, optional 20s pairwise retry | P0 |
+| **P4** | Recording stability | Compositor feed refresh, upload persistence, error surfaces | P0 |
+| **P5** | SFU / community calls | LiveKit integration, active speaker, server egress | ADR 0001, infra |
+| **P6** | Observability | Debug flag, runbook, load-test notes | P1–P4 |
+
+---
+
+## 3) Phase 0 — Hotfix merge (PR #2284)
+
+**Status:** Implemented on branch `fix/call-banner-regression`; awaiting merge.
+
+| Step | Action | Spec IDs | Done when |
+| ---- | ------ | -------- | --------- |
+| 0.1 | Merge PR #2284 to `main` | CSH-CHROME-1–7, CSH-SHARE-1–3 | Production banner visible with dock open |
+| 0.2 | Verify CI: `check-types`, `format:check`, `matrix-sdk`, `i18n-verify` | CSH-QA-* | All green on merge commit |
+| 0.3 | Run manual QA script rows 1–2 (spec §9.2) | CSH-QA-* | Signed off in PR test plan |
+
+**Deliverables already on branch:**
+
+- `showSidebarCallChrome` / `showSidebarCallVideo` split in `human-right-panel.tsx`
+- Dock resume snapshot fields in `global-call-dock-context.tsx`
+- `call-stage-share-layout.ts` + unit tests
+- Feed batching after takeover in `use-space-group-call.ts`
+
+---
+
+## 4) Phase 1 — Chrome, discoverability, scale warnings
+
+| Step | Action | Spec IDs | Done when |
+| ---- | ------ | -------- | --------- |
+| 1.1 | Add code comment + unit test guarding `showSidebarCallChrome` against `showFloatingDock` | CSH-CHROME-6 | Test fails if regression reintroduced |
+| 1.2 | Implement join invitation modal (spec §1.2.2) | CSH-DISCOVER-1 | Modal opens once per join opportunity; i18n all locales |
+| 1.3 | Signal deep-link auth retry with backoff | CSH-DISCOVER-2, CSH-DISCOVER-3 | Deep link resolves after auth without error flash |
+| 1.4 | Participant count warning banner (default threshold: 12 devices) | CSH-SCALE-2 | Banner shows in sidebar + dock when over threshold |
+
+**Files (expected touch):**
+
+- `packages/epics/src/common/human-right-panel.tsx`
+- `packages/epics/src/common/human-chat-panel/` (new modal component)
+- `packages/i18n/src/messages/*.json`
+
+**Acceptance:**
+
+- [ ] Join modal: dismiss + “Not now” does not block join strip
+- [ ] Scale warning: non-blocking; does not prevent join
+- [ ] Chrome guard test in CI
+
+---
+
+## 5) Phase 2 — Screen share hardening
+
+| Step | Action | Spec IDs | Done when |
+| ---- | ------ | -------- | --------- |
+| 2.1 | Product decision: mobile share policy (A/B/C from spec §4.3) | CSH-SHARE-5, CSH-SHARE-6 | Decision recorded in spec §4.3 table (selected option) |
+| 2.2 | Implement selected mobile policy | CSH-SHARE-5, CSH-SHARE-6 | Manual QA row 7 passes |
+| 2.3 | Expand `call-stage-share-layout.test.ts` for ghost/ended feeds | CSH-SHARE-1 | Coverage for all layout states in spec table |
+| 2.4 | E2e smoke: share button visibility desktop vs mobile (UI only) | CSH-QA-3 | Playwright asserts control presence/absence |
+
+**Files:**
+
+- `packages/epics/src/common/human-chat-panel/human-chat-panel-in-call-controls.tsx`
+- `packages/epics/src/common/global-call-dock-overlay.tsx`
+- `packages/epics/src/common/human-chat-panel/call-stage-share-layout.ts`
+
+**Acceptance:**
+
+- [ ] Presenter handoff A→B stable on desktop (QA row 2)
+- [ ] Mobile: no stuck “presenting” state when viewport shrinks (if policy B)
+
+---
+
+## 6) Phase 3 — Mesh reliability
+
+| Step | Action | Spec IDs | Done when |
+| ---- | ------ | -------- | --------- |
+| 3.1 | Multi-tab prompt when follower detects active call | CSH-MESH-5, CSH-MESH-6 | User can claim leadership from Human panel |
+| 3.2 | Fix wake lock: only when hidden + in call | CSH-MESH-7, CSH-MESH-8 | No wake lock on visible idle tab |
+| 3.3 | Stall banner copy split: waiting vs connection problem | CSH-MESH-3, CSH-MESH-4 | i18n keys; UX review |
+| 3.4 | Optional: 20s `placeOutgoingCalls` retry behind env flag | CSH-MESH-1 | Staging metrics show reduced stall rate (if enabled) |
+| 3.5 | Manual QA: token refresh mid-call | CSH-MESH-9 | Document result in runbook |
+
+**Files:**
+
+- `packages/core/src/matrix/client/hooks/use-space-group-call.ts`
+- `packages/core/src/matrix/client/matrix-tab-leader.ts`
+- `packages/epics/src/common/use-call-document-keepalive.ts`
+- `packages/epics/src/common/human-right-panel.tsx`
+
+**Acceptance:**
+
+- [ ] QA rows 4, 5, 8 pass
+- [ ] No duplicate Matrix `/sync` on two tabs without user consent
+
+---
+
+## 7) Phase 4 — Recording stability
+
+| Step | Action | Spec IDs | Done when |
+| ---- | ------ | -------- | --------- |
+| 4.1 | Compositor re-binds on feed change events during capture | CSH-RECORD-1 | Recording includes new camera after mid-call enable |
+| 4.2 | 10s compositor start timeout with user-visible error | CSH-RECORD-2 | Error state shown; capture mode reset safely |
+| 4.3 | Pending upload persistence in `sessionStorage` | CSH-RECORD-3 | Retry survives in-app navigation |
+| 4.4 | QA row 6: full capture → upload → memory tile | CSH-RECORD-4, CSH-QA-* | End-to-end on staging |
+
+**Files:**
+
+- `packages/core/src/matrix/client/hooks/call-recording.ts`
+- `packages/core/src/matrix/client/hooks/use-space-group-call.ts`
+
+**Acceptance:**
+
+- [ ] 90 min / 640 MB limits still enforced
+- [ ] No second `getUserMedia` mic during Matrix call (existing guard preserved)
+
+---
+
+## 8) Phase 5 — SFU / community calls (epic)
+
+**Prerequisite:** Infrastructure provisioning (LiveKit or vendor), ADR 0001 amend if vendor changes.
+
+| Step | Action | Spec IDs | Done when |
+| ---- | ------ | -------- | --------- |
+| 5.1 | ADR amend or successor for chosen SFU vendor | CSH-SFU-1 | ADR merged |
+| 5.2 | Feature flag `NEXT_PUBLIC_ENABLE_LIVEKIT_CALLS` | CSH-SFU-1 | Off by default |
+| 5.3 | `createClient` LiveKit options + join path | CSH-SFU-2 | Staging: 2-user call via SFU |
+| 5.4 | Active speaker UI (dominant + filmstrip) | CSH-SFU-3 | Tier L load test: 25 receive-only viewers |
+| 5.5 | Server egress recording | CSH-SFU-5, CSH-RECORD-6 | Recording ingested via existing artifact API |
+| 5.6 | Load test: 50 participants (product target) | CSH-SFU-6 | p95 join <5s documented |
+
+**Out of mesh hardening PR scope** — track as separate GitHub epic with sub-issues per step.
+
+---
+
+## 9) Phase 6 — Observability and runbook
+
+| Step | Action | Spec IDs | Done when |
+| ---- | ------ | -------- | --------- |
+| 6.1 | Add `hypha.callDebug` localStorage gate for media snapshots | CSH-QA-2 | Support can enable without rebuild |
+| 6.2 | Extend [voice-video-call-phase-0-runbook.md](./voice-video-call-phase-0-runbook.md) with stall/recover and multi-tab sections | CSH-QA-* | Runbook PR merged |
+| 6.3 | Document mesh load targets (tiers S/M/L) in runbook | CSH-SCALE-* | QA uses tiers for test planning |
+
+---
+
+## 10) Acceptance criteria — epic complete (mesh v1)
+
+These supplement [voice-video-call-implementation-plan.md §3](./voice-video-call-implementation-plan.md).
+
+### Functional
+
+- [ ] **CSH-CHROME-1–5** enforced; PR #2284 merged
+- [ ] Share handoff stable (CSH-SHARE-1–3)
+- [ ] Join modal shipped (CSH-DISCOVER-1) OR explicitly deferred with product sign-off
+- [ ] Scale warning visible above 12 devices (CSH-SCALE-2)
+- [ ] Recording compositor refresh (CSH-RECORD-1)
+
+### Quality
+
+- [ ] Manual QA script (spec §9.2) all rows pass on staging
+- [ ] Tier **S** (≤8 devices): p95 join <8s on broadband (dev telemetry)
+- [ ] Tier **M** (8–15): no critical crashes in 30-min call test
+- [ ] Product copy does not claim community-scale until Phase 5 ships
+
+### Not required for mesh v1 complete
+
+- LiveKit / SFU (Phase 5)
+- Hard join cap at 20 devices (unless product requests CSH-SCALE-3 enforcement)
+
+---
+
+## 11) Suggested PR breakdown
+
+| PR | Branch prefix | Phase | Scope |
+| -- | ------------- | ----- | ----- |
+| 1 | `fix/call-banner-regression` | P0 | **Existing PR #2284** |
+| 2 | `feat/call-chrome-guardrails` | P1 | Chrome test + scale warning |
+| 3 | `feat/call-join-invitation-modal` | P1 | Modal §1.2.2 |
+| 4 | `fix/signal-deeplink-auth-retry` | P1 | Deep-link retry |
+| 5 | `feat/call-mobile-share-policy` | P2 | Mobile share decision + impl |
+| 6 | `feat/call-mesh-reliability` | P3 | Multi-tab, keepalive, stall copy |
+| 7 | `feat/call-recording-stability` | P4 | Compositor + upload persistence |
+| 8 | `docs/call-stability-runbook` | P6 | Runbook updates |
+| Epic | `feat/livekit-group-calls` | P5 | SFU integration |
+
+---
+
+## 12) Risk register
+
+| Risk | Impact | Mitigation |
+| ---- | ------ | ---------- |
+| Mesh overload at 15+ devices | Poor UX, support load | CSH-SCALE-2 warning; honest product bounds |
+| PR #2284 merge delay | Banner regression persists in prod | Prioritize CI fix + merge |
+| Mobile presenter stuck | User cannot stop share | CSH-SHARE-6 auto-stop or explicit stop affordance |
+| Client recording CPU at tier M | Tab freeze during capture | CSH-RECORD-5; cap compositor participant tiles in recording layout |
+| SFU infra delay | Cannot serve community calls | Phase 5 epic; do not block P0–P4 |
+
+---
+
+## 13) References
+
+- [call-stability-hardening-spec.md](./call-stability-hardening-spec.md)
+- [voice-video-call-implementation-spec.md](./voice-video-call-implementation-spec.md)
+- [ADR 0001](../adr/0001-voice-video-recording-pipeline.md)
+- PR #2284, #2273, #2275, #2276

--- a/docs/requirements/call-stability-hardening-spec.md
+++ b/docs/requirements/call-stability-hardening-spec.md
@@ -1,0 +1,303 @@
+# Implementation specification — Call stability hardening (Human panel)
+
+## Document control
+
+| Field | Value |
+| ----- | ----- |
+| **Status** | Ready to implement (spec only) |
+| **Parent** | [voice-video-call-implementation-spec.md](./voice-video-call-implementation-spec.md), [voice-video-call-matrix-tech-spec.md](./voice-video-call-matrix-tech-spec.md) |
+| **Plan** | [call-stability-hardening-plan.md](./call-stability-hardening-plan.md) |
+| **ADR** | [0001 — recording pipeline](../adr/0001-voice-video-recording-pipeline.md) |
+| **Hotfix context** | PR [#2284](https://github.com/hypha-dao/hypha-web/pull/2284) (`fix/call-banner-regression`) — banner + share handoff regressions from PRs #2273 / #2276 |
+| **Architecture (v1)** | Matrix `GroupCall` with **mesh WebRTC** (`useLivekitForGroupCalls: false`) |
+
+---
+
+## 1) Problem statement
+
+Production regressions and reliability gaps were identified in May 2026 around the Human panel call experience:
+
+1. **Call banner hidden** when the floating call dock is open (regression re-introduced in PR #2276).
+2. **Screen share layout collapse** during presenter handoff (warming remote feeds not accounted for).
+3. **Mesh WebRTC limits** — no product guardrails for participant count; UI gallery paginates at 20 tiles but WebRTC does not scale to “community call” sizes.
+4. **Recording pipeline** — client-side canvas compositor is fragile at scale; ADR 0001 defers primary path to SFU egress.
+5. **Reliability edges** — multi-tab sync leadership, signal deep-link auth timing, mobile screen share policy, tab keepalive side effects.
+
+This document defines **normative requirements** to make calls, screen sharing, and recordings **stable and predictable** within the current mesh architecture, and defines the **upgrade path** for large-audience calls.
+
+---
+
+## 2) Scale model (normative product bounds)
+
+### 2.1 Current media topology
+
+| Property | Value |
+| -------- | ----- |
+| Signaling | Matrix `GroupCall` on Space `roomId` |
+| Media | Native matrix-js-sdk WebRTC (**pairwise** `m.call.*` between peers) |
+| SFU | **Not enabled** (`useLivekitForGroupCalls: false`) |
+| Reference | `packages/core/src/matrix/client/hooks/use-space-group-call.ts` (pairwise placement comments) |
+
+### 2.2 Participant tiers (product + engineering)
+
+These tiers **SHALL** be documented in product copy and used for QA load targets. They are **not** hard join caps unless explicitly implemented in a later phase.
+
+| Tier | Device count in `GroupCall.participants` | Expected reliability | Product positioning |
+| ---- | ---------------------------------------- | -------------------- | ------------------- |
+| **S — Small** | 2–8 | High for audio + video + share + recording | Default “team call” |
+| **M — Medium** | 8–15 | Degraded: CPU/bandwidth pressure, more stall/recover cycles | “Extended team call” with caution |
+| **L — Large (unsupported mesh)** | 15–30+ | Poor: dropped feeds, high latency, tab crashes likely | **Do not market** until SFU epic ships |
+| **XL — Community** | 30–500+ | Requires SFU (LiveKit or vendor) | Out of scope for mesh v1 |
+
+**Device count vs user count:** Count **devices** (each `RoomMember` × device map entry), not unique users. One person on laptop + phone = 2 devices.
+
+### 2.3 UI display limits (distinct from WebRTC limits)
+
+| Constant | Value | File |
+| -------- | ----- | ---- |
+| Gallery mode threshold | 4+ tiles | `call-gallery-grid.ts` → `CALL_GALLERY_MIN_PARTICIPANTS` |
+| Tiles per gallery page | 20 | `call-gallery-grid.ts` → `CALL_GALLERY_MAX_TILES_PER_PAGE` |
+| Recording compositor | 854×480 @ 24fps | `call-recording-constants.ts` |
+| Recording max duration | 90 min | `call-recording-constants.ts` |
+| Recording max file size | 640 MB | `call-recording-constants.ts` |
+
+**CSH-SCALE-1:** The UI **MAY** paginate gallery beyond 20 tiles; it **SHALL NOT** imply that all remote feeds are decoded simultaneously beyond mesh practical limits (§2.2 tier M).
+
+**CSH-SCALE-2:** When device count exceeds tier **M** (configurable threshold, default **12**), the UI **SHALL** show a non-blocking warning banner: “This call has many participants. Quality may be reduced.” (i18n key TBD in `HumanChatPanel`.)
+
+**CSH-SCALE-3:** When device count exceeds tier **L** (default **20**), the UI **SHOULD** recommend SFU upgrade path in internal/admin docs only until SFU is available; **SHALL NOT** block join in v1 unless product explicitly requests a cap.
+
+---
+
+## 3) Sidebar vs floating dock contract (CSH-CHROME)
+
+### 3.1 Split visibility flags
+
+**Problem:** Gating all sidebar call UI with `!showFloatingDock` hid the in-chat call banner while the dock was active.
+
+**Normative model:**
+
+| Surface | When visible | Contents |
+| ------- | ------------ | -------- |
+| **Sidebar call chrome** (`showSidebarCallChrome`) | `callUiEnabled && callAppliesToCurrentChatRoom` | Join strip, call banner (participant count, leave, errors), capture consent |
+| **Sidebar call video** (`showSidebarCallVideo`) | above **AND** `!showFloatingDock` | In-panel `HumanChatPanelCallStage`, screenshare takeover dialog (sidebar instance) |
+| **Floating dock** | Global call dock active for same session | Controls, optional error/stall banner, stage, dock-owned takeover dialog |
+
+**CSH-CHROME-1:** `showSidebarCallChrome` **SHALL NOT** depend on `showFloatingDock`.
+
+**CSH-CHROME-2:** `showSidebarCallVideo` **SHALL** depend on `!showFloatingDock` (video stage lives in one place).
+
+**CSH-CHROME-3:** `HumanChatPanelCallBanner` in sidebar **SHALL** remain visible when dock is open (controls mode `leave_only` in sidebar; full controls in dock).
+
+**CSH-CHROME-4:** `HumanChatPanelScreenshareTakeoverDialog` **SHALL** render in **at most one** place: sidebar when `!showFloatingDock`, else dock.
+
+**CSH-CHROME-5:** Dock healthy-call banner (`showDockBanner`) **SHALL** remain **controls-only** — full participant banner is sidebar responsibility. Dock banner **SHALL** show for: `errorCode`, `screenshareErrorCode`, `remoteMediaStall`.
+
+**Reference implementation:** PR #2284 — `human-right-panel.tsx`, `global-call-dock-context.tsx`.
+
+**CSH-CHROME-6 (guardrail):** Add unit test or code comment at `showSidebarCallChrome` definition documenting CSH-CHROME-1; CI **SHALL** fail if `showFloatingDock` is re-added to that expression.
+
+### 3.2 Dock resume snapshot
+
+**CSH-CHROME-7:** When navigating away from the Space while in call, the global dock resume snapshot **SHALL** persist: `signalTitle`, `signalSlug`, `roomTitle`, `roomId`, `spaceSlug`, `threadRootEventId` (existing fields + PR #2284 additions).
+
+---
+
+## 4) Screen share and presenter handoff (CSH-SHARE)
+
+### 4.1 Share layout state machine
+
+Extract share layout resolution into a **pure module** (implemented in PR #2284 as `call-stage-share-layout.ts`):
+
+| State | Condition | UI behavior |
+| ----- | --------- | ----------- |
+| **Local presenting** | `isScreensharing && no remote live share feeds` | Presenter layout; trust SDK flag before local track is `live` |
+| **Remote live share** | Remote feed with `readyState === 'live'` and unmuted video | Dominant share tile + participant band |
+| **Remote warming** | Remote feed with track `new` or not yet `live` | Keep share layout; show pending/warming indicator (spinner) |
+| **Ended ghost** | Track `ended` | Drop from layout; do not reserve empty share region |
+
+**CSH-SHARE-1:** `resolveCallStageShareLayout()` **SHALL** implement the table above.
+
+**CSH-SHARE-2:** `shareFeedLayoutKey()` **SHALL** change when active share stream identity changes; gallery page index **SHALL** reset on key change.
+
+**CSH-SHARE-3:** After screenshare takeover approval, `useSpaceGroupCall` **SHALL** schedule additional feed batch refreshes (minimum: +350ms and +900ms after approval) to absorb WebRTC handoff latency.
+
+### 4.2 Takeover dialog
+
+**CSH-SHARE-4:** Presenter takeover flow (`screenshare-takeover.ts`) **SHALL** remain functional on desktop; mobile policy per §5.
+
+### 4.3 Mobile screen share policy
+
+**CSH-SHARE-5:** Product **SHALL** choose one policy (document decision in PR):
+
+| Option | Behavior |
+| ------ | -------- |
+| **A — View only (recommended v1)** | Mobile users can **view** remote share; **cannot** start share or request takeover |
+| **B — Auto-stop on resize** | If user was presenting and viewport `< 768px`, automatically stop local share |
+| **C — Full parity** | Show share controls on mobile (may fail on OS/browser) |
+
+**CSH-SHARE-6:** If option A or B: when local share is active and viewport crosses mobile breakpoint, **SHALL** stop share or show dismissible warning within 5s.
+
+---
+
+## 5) Mesh call reliability (CSH-MESH)
+
+### 5.1 Pairwise call placement
+
+Matrix group calls use **pairwise VoIP**. Known race: first `placeOutgoingCalls()` after join may skip peers.
+
+**CSH-MESH-1:** Retries **SHALL** remain after enter: 600ms initial + [1500, 4000, 8000, 12000]ms (existing). **SHOULD** add optional 20s retry behind feature flag if stall metrics justify it.
+
+**CSH-MESH-2:** Local media bootstrap retries **SHALL** remain: [800, 2000, 5000, 10000]ms.
+
+### 5.2 Stall detection and recovery
+
+| Timer | Value | Purpose |
+| ----- | ----- | ------- |
+| `CONNECT_STALL_ABORT_MS` | 90s | Abort hung `gc.enter()` |
+| `REMOTE_MEDIA_STALL_MS` | 45s | Banner: others in map but no remote feeds |
+| `REMOTE_MEDIA_AUTO_RECOVER_MS` | 70s | Auto recover attempt |
+
+**CSH-MESH-3:** Stall banner copy **SHALL** distinguish:
+
+- **Waiting for media** — participants present, feeds warming (first 45s)
+- **Connection problem** — exceeded stall threshold; offer **Retry** / **Leave**
+
+**CSH-MESH-4:** `remoteMediaStall` banner **SHALL** be dismissible; dismissal **SHALL NOT** block auto-recover at 70s.
+
+### 5.3 Multi-tab sync leadership
+
+**CSH-MESH-5:** When `isSyncLeader === false` and user opens Human panel with active call session in another tab, UI **SHALL** show prompt: “Call active in another tab” with **Switch to this tab** (`claimSyncLeadership()`).
+
+**CSH-MESH-6:** Follower tab **SHALL NOT** show stale participant counts as authoritative; **SHOULD** show “Sync paused — switch tab for live call.”
+
+### 5.4 Tab background and keepalive
+
+**CSH-MESH-7:** `useCallDocumentKeepalive` **SHALL** request screen wake lock only when: call active **AND** (`document.hidden` **OR** document PiP open).
+
+**CSH-MESH-8:** Wake lock **SHALL** release when tab becomes visible and PiP is closed.
+
+### 5.5 Token refresh during call
+
+**CSH-MESH-9:** `MatrixProvider` **SHALL** continue deferring client recycle while `isGroupCallSessionActive()` (existing). Add integration test or manual QA step: token refresh mid-call does not drop `GroupCall`.
+
+---
+
+## 6) Human panel discoverability (CSH-DISCOVER)
+
+### 6.1 Join invitation modal (spec §1.2.2 — not yet implemented)
+
+**CSH-DISCOVER-1:** Implement [voice-video-call-implementation-spec.md §1.2.2](./voice-video-call-implementation-spec.md) join invitation modal:
+
+- Opens once per join opportunity (`showRoomCallInProgress` false → true for `roomId`)
+- Primary: Join with audio; Secondary: Join with video; Tertiary: Not now
+- Throttled dismissal key in session storage
+- i18n all locales
+
+### 6.2 Signal deep-link auth retry
+
+**CSH-DISCOVER-2:** When signal thread deep-link lookup fails and auth token is not yet available, **SHALL** retry resolution with backoff (max 3 attempts, 500ms / 1.5s / 4s) before surfacing error toast.
+
+**CSH-DISCOVER-3:** Error copy **SHALL** distinguish auth-not-ready vs signal-not-found.
+
+---
+
+## 7) Recording and transcription stability (CSH-RECORD)
+
+### 7.1 Client capture (current non-default path)
+
+**CSH-RECORD-1:** `createCallRecording()` lazy `resolveGroupCall()` **SHALL** re-bind feeds on `UserMediaFeedsChanged` and `ScreenshareFeedsChanged` while recording is active.
+
+**CSH-RECORD-2:** If compositor cannot produce ≥1 track within 10s of capture start, **SHALL** set `recordingStatus: 'error'` with actionable copy; **SHALL NOT** silently record audio-only without user notice when video was expected.
+
+**CSH-RECORD-3:** Upload retry (`canRetryRecordingUpload`) **SHALL** persist pending upload metadata in `sessionStorage` until success or explicit discard (survive soft navigation within session).
+
+**CSH-RECORD-4:** Limits from `call-recording-limits.ts` **SHALL** remain enforced; warn at 80%, critical at 90% of duration and size.
+
+### 7.2 SFU egress (primary path — ADR 0001)
+
+**CSH-RECORD-5:** Large calls (tier L+) **SHALL NOT** rely on client canvas compositor. Server egress **SHALL** be the recording source when SFU epic ships.
+
+**CSH-RECORD-6:** `callSessionId` from `useSpaceGroupCall` **SHALL** correlate SFU egress artifacts with `space_call_recordings` / ingest API.
+
+---
+
+## 8) Large-audience SFU epic (CSH-SFU) — specification stub
+
+Out of scope for mesh hardening PRs; **SHALL** be tracked as separate epic.
+
+| Requirement | Description |
+| ----------- | ----------- |
+| **CSH-SFU-1** | Enable `useLivekitForGroupCalls: true` + `livekitServiceURL` in `matrix-provider.tsx` behind feature flag |
+| **CSH-SFU-2** | Matrix handles membership/signaling; LiveKit handles media |
+| **CSH-SFU-3** | Active speaker + simulcast: decode dominant speaker + filmstrip, not full mesh |
+| **CSH-SFU-4** | Optional receive-only “viewer” role for audience |
+| **CSH-SFU-5** | Server-side recording egress replaces client compositor for tier L+ |
+| **CSH-SFU-6** | Target: **50+ participants** (product-defined) with <5s p95 join time on broadband |
+
+Reference: [voice-video-call-matrix-tech-spec.md Option C](./voice-video-call-matrix-tech-spec.md).
+
+---
+
+## 9) Observability and QA (CSH-QA)
+
+### 9.1 Dev telemetry
+
+**CSH-QA-1:** Retain dev-only `[hypha.group_call]` logs (`space-group-call-telemetry.ts`) for join latency, leave reason, error codes.
+
+**CSH-QA-2:** **SHOULD** add optional `localStorage` debug flag `hypha.callDebug=1` to enable `MEDIA_SNAPSHOT_INTERVAL_MS` feed vs participant snapshots in production support sessions (no PII in logs).
+
+### 9.2 Manual QA script (required before each phase merge)
+
+| # | Scenario | Pass criteria |
+| - | -------- | ------------- |
+| 1 | Banner + dock | In call with dock open: sidebar banner shows participant count + leave |
+| 2 | Share handoff | A presents → B takeover → layout stable through warming → B presents |
+| 3 | Join idle | Browser B sees join strip; joins same session as A |
+| 4 | Stall recover | Simulate slow peer: stall banner → retry or auto-recover by 70s |
+| 5 | Multi-tab | Call in tab 1; open tab 2 → prompt to claim leadership |
+| 6 | Recording | Start capture → stop → upload succeeds or retry offered |
+| 7 | Mobile | Viewport <768px: share policy per §4.3; no stuck presenter state |
+| 8 | Deep link | Signal URL before auth ready: retries, then resolves |
+
+### 9.3 Automated tests
+
+| Area | Test type | File / note |
+| ---- | --------- | ----------- |
+| Share layout pure functions | Unit (vitest) | `call-stage-share-layout.test.ts` |
+| Chrome visibility flags | Unit or component | Mock `showFloatingDock` / `showSidebarCallChrome` |
+| WebRTC media | Manual only | Playwright cannot assert real media (document in plan) |
+
+---
+
+## 10) Traceability matrix
+
+| ID | Phase | Primary files |
+| -- | ----- | ------------- |
+| CSH-CHROME-* | P0–P1 | `human-right-panel.tsx`, `global-call-dock-overlay.tsx`, `global-call-dock-context.tsx` |
+| CSH-SHARE-* | P0–P2 | `call-stage-share-layout.ts`, `human-chat-panel-call-stage.tsx`, `use-space-group-call.ts`, `screenshare-takeover.ts` |
+| CSH-MESH-* | P2–P3 | `use-space-group-call.ts`, `matrix-tab-leader.ts`, `use-call-document-keepalive.ts`, `matrix-provider.tsx` |
+| CSH-DISCOVER-* | P1 | `human-right-panel.tsx`, join modal (new), `use-call-join-chime.ts` |
+| CSH-RECORD-* | P3–P4 | `call-recording.ts`, `use-space-group-call.ts` |
+| CSH-SCALE-* | P1, P5 | `call-gallery-grid.ts`, new warning banner component |
+| CSH-SFU-* | P5 | `matrix-provider.tsx`, new LiveKit integration package |
+| CSH-QA-* | All | Test files, runbook additions |
+
+---
+
+## 11) Out of scope
+
+- Coherence-mode (`mode === 'coherence'`) call UI unless extended explicitly
+- Thread-isolated calls (parallel calls per Signal in same Space)
+- E2E encrypted group calls (`useE2eForGroupCall: true`) on SDK v40
+- Legal/consent workflow beyond existing capture consent banner (product follow-up)
+
+---
+
+## 12) References
+
+- PR #2284 — hotfix branch `fix/call-banner-regression`
+- PRs #2273, #2275, #2276 — tightening regressions (May 2026)
+- `packages/core/src/matrix/client/hooks/use-space-group-call.ts`
+- `packages/epics/src/common/human-chat-panel/call-gallery-grid.ts`
+- `packages/core/src/assets/call-recording-constants.ts`

--- a/docs/requirements/voice-video-call-implementation-plan.md
+++ b/docs/requirements/voice-video-call-implementation-plan.md
@@ -5,7 +5,8 @@
 | Field                       | Value                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
 | --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Status**                  | Ready to execute (phased)                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| **Specs**                   | [voice-video-call-matrix-tech-spec.md](./voice-video-call-matrix-tech-spec.md), [voice-video-call-implementation-spec.md](./voice-video-call-implementation-spec.md)                                                                                                                                                                                                                                                                                                       |
+| **Specs**                   | [voice-video-call-matrix-tech-spec.md](./voice-video-call-matrix-tech-spec.md), [voice-video-call-implementation-spec.md](./voice-video-call-implementation-spec.md), [call-stability-hardening-spec.md](./call-stability-hardening-spec.md)                                                                                                                                                                                                                                                                                              |
+| **Stability hardening**     | [call-stability-hardening-plan.md](./call-stability-hardening-plan.md) — post-v1 reliability, scale bounds, SFU path (May 2026)                                                                                                                                                                                                                                                                                                                                            |
 | **Phase 0 (env)**           | [voice-video-call-phase-0-runbook.md](./voice-video-call-phase-0-runbook.md) — HS/TURN checklist, CSP notes, `pnpm run check:matrix-sdk`                                                                                                                                                                                                                                                                                                                                   |
 | **Media storage alignment** | Implementations of **recording** and **artifact URLs** SHALL follow [**ADR 0001** — recording pipeline and space media storage](../adr/0001-voice-video-recording-pipeline.md) (normative: object storage, signed URLs, `spaces` FK, and metadata rows). The older [Cursor design thread](https://cursor.com/agents/bc-31e34c30-45d0-4f7a-b00b-9a6f46346b06?branch=cursor%2F-bc-31e34c30-45d0-4f7a-b00b-9a6f46346b06-b1a4) remains **informational** only. |
 
@@ -103,6 +104,17 @@
 **Status (implemented in codebase):** **6.1** — [ADR 0001](../adr/0001-voice-video-recording-pipeline.md) (external SFU / egress as primary; client capture noted as non-default). **6.2–6.3** — `space_call_transcripts` and `space_call_recordings` tables (migration `0047`), `ingestSpaceCallArtifacts` (server) + `POST /api/v1/spaces/{slug}/call-artifacts` (secret `HYPHA_CALL_ARTIFACT_INGEST_SECRET`). **6.4** — Coherence **Space memory** merges `call_artifacts` from org-memory (page 1) with the same access gate as other memory; transcript tiles show excerpt; recording uses `media_uri` when https. **Consent** — i18n note in Coherence; full legal flow is product follow-up. **6.1 correlation** — `useSpaceGroupCall` exposes `callSessionId` (UUID per join) for workers.
 
 **Phases 1–3** deliver **in-app calling**; **Phase 6** may run **in parallel** after 6.1 once ADR is fixed.
+
+### Phase 7 — Stability hardening (post-v1 reliability)
+
+**Status:** **Specified** — see [call-stability-hardening-plan.md](./call-stability-hardening-plan.md) and [call-stability-hardening-spec.md](./call-stability-hardening-spec.md).
+
+| Step | Action | Done when |
+| ---- | ------ | --------- |
+| 7.0  | Merge PR #2284 (banner + share handoff hotfix) | Production banner visible with floating dock |
+| 7.1  | Chrome guardrails, join modal, scale warnings (P1) | CSH-CHROME / CSH-DISCOVER / CSH-SCALE acceptance |
+| 7.2  | Mesh reliability + recording stability (P2–P4) | Manual QA script (spec §9.2) passes on staging |
+| 7.3  | SFU epic for community calls (P5) | LiveKit or vendor; 50+ participant load test |
 
 ---
 
@@ -209,6 +221,7 @@ Implementers SHALL define a **dedicated** persistence layer (example shape — a
 | Architecture                   | [voice-video-call-matrix-tech-spec.md](./voice-video-call-matrix-tech-spec.md)       |
 | UI + SDK mapping               | [voice-video-call-implementation-spec.md](./voice-video-call-implementation-spec.md) |
 | Phasing + quality bar + memory | This document                                                                        |
+| Stability hardening (P7)       | [call-stability-hardening-spec.md](./call-stability-hardening-spec.md), [call-stability-hardening-plan.md](./call-stability-hardening-plan.md) |
 | Phase 0 runbook                | [voice-video-call-phase-0-runbook.md](./voice-video-call-phase-0-runbook.md)         |
 
 ---


### PR DESCRIPTION
## Summary

- Adds **call-stability-hardening-spec.md** — normative `CSH-*` requirements for Human panel call reliability (sidebar/dock contract, screen share handoff, mesh scale bounds, multi-tab sync, recording stability, SFU upgrade path).
- Adds **call-stability-hardening-plan.md** — phased implementation plan (P0–P6) with spec ID traceability and QA checkpoints.
- Links Phase 7 from **voice-video-call-implementation-plan.md** to the new hardening docs.

This is **spec-only** — no runtime code changes. Intended as the source of truth for follow-up implementation PRs after hotfix [#2284](https://github.com/hypha-dao/hypha-web/pull/2284) merges.

## Test plan

- [ ] Review spec §2 scale tiers and `CSH-*` requirement IDs for completeness
- [ ] Confirm plan phases P0–P6 align with spec sections and PR #2284 scope
- [ ] Verify cross-links resolve (`call-stability-hardening-spec.md`, `call-stability-hardening-plan.md`, `voice-video-call-implementation-plan.md`)


Made with [Cursor](https://cursor.com)