### PR TITLE
fix(spaces): uniform space card sizing on network page

### DIFF
--- a/packages/epics/src/spaces/components/explore-spaces.tsx
+++ b/packages/epics/src/spaces/components/explore-spaces.tsx
@@ -360,7 +360,7 @@ export function ExploreSpaces({
         <SpaceCardList
           lang={lang}
           spaces={sortedSpaces}
-          pageSize={15}
+          pageSize={12}
           cardGridClassName="sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4"
         />
       </div>

--- a/packages/epics/src/spaces/components/inner-space-card-list.tsx
+++ b/packages/epics/src/spaces/components/inner-space-card-list.tsx
@@ -43,7 +43,7 @@ export function InnerSpaceCardList({
   return (
     <>
       {pagination?.totalPages > 0 ? (
-        <div className="flex flex-col justify-around items-center gap-4 mb-4">
+        <div className="flex flex-col justify-around items-center gap-4 mb-4 w-full">
           <div className="w-full space-y-2">
             {showLoadMore ? (
               Array.from({ length: pages }).map((_, index) => {

--- a/packages/epics/src/spaces/components/space-card-list.tsx
+++ b/packages/epics/src/spaces/components/space-card-list.tsx
@@ -40,7 +40,7 @@ export function SpaceCardList({
   return (
     <>
       {pagination?.totalPages > 0 ? (
-        <div className="flex flex-col justify-around items-center gap-4">
+        <div className="flex flex-col justify-around items-center gap-4 w-full">
           <div className="w-full">
             <SpaceCardContainer
               key={`spaces-${spaces.length}`}

--- a/packages/epics/src/spaces/components/space-card-list.tsx
+++ b/packages/epics/src/spaces/components/space-card-list.tsx
@@ -41,31 +41,14 @@ export function SpaceCardList({
     <>
       {pagination?.totalPages > 0 ? (
         <div className="flex flex-col justify-around items-center gap-4">
-          <div className="w-full space-y-2">
-            {showLoadMore ? (
-              Array.from({ length: pages }).map((_, index) => {
-                const startIndex = index * pageSize;
-                const endIndex = startIndex + pageSize;
-                const pageSpaces = spaces.slice(startIndex, endIndex);
-                return (
-                  <SpaceCardContainer
-                    key={index}
-                    spaces={pageSpaces}
-                    lang={lang}
-                    showExitButton={showExitButton}
-                    gridClassName={cardGridClassName}
-                  />
-                );
-              })
-            ) : (
-              <SpaceCardContainer
-                key={`spaces-${spaces.length}`}
-                spaces={spaces}
-                lang={lang}
-                showExitButton={showExitButton}
-                gridClassName={cardGridClassName}
-              />
-            )}
+          <div className="w-full">
+            <SpaceCardContainer
+              key={`spaces-${spaces.length}`}
+              spaces={showLoadMore ? spaces.slice(0, pages * pageSize) : spaces}
+              lang={lang}
+              showExitButton={showExitButton}
+              gridClassName={cardGridClassName}
+            />
           </div>
           {showLoadMore && (
             <SectionLoadMore

--- a/packages/epics/src/spaces/components/space-card.container.tsx
+++ b/packages/epics/src/spaces/components/space-card.container.tsx
@@ -24,11 +24,14 @@ export const SpaceCardContainer = ({
   return (
     <div
       data-testid="member-spaces-container"
-      className={cn('grid grid-cols-1 gap-2 sm:grid-cols-3', gridClassName)}
+      className={cn(
+        'grid grid-cols-1 gap-2 sm:grid-cols-3 auto-rows-fr items-stretch',
+        gridClassName,
+      )}
     >
       {spaces.map((space) =>
         space.slug ? (
-          <div key={space.id}>
+          <div key={space.id} className="flex flex-col h-full">
             <SpaceCardWithDiscoverability
               space={space}
               getHref={getHref}

--- a/packages/epics/src/spaces/components/space-card.tsx
+++ b/packages/epics/src/spaces/components/space-card.tsx
@@ -62,7 +62,10 @@ export const SpaceCard: React.FC<SpaceCardProps> = ({
   const format = useFormatter();
   return (
     <Card
-      className={cn('group relative w-full h-full flex flex-col', className)}
+      className={cn(
+        'group relative w-full h-full flex flex-col @container/spacecard',
+        className,
+      )}
     >
       {showExitButton && web3SpaceId && (
         <div
@@ -132,7 +135,7 @@ export const SpaceCard: React.FC<SpaceCardProps> = ({
           </div>
           <div className="flex gap-2 text-xs items-center">
             <div className="flex flex-col gap-y-2 gap-x-4 flex-wrap">
-              <div className="flex flex-row gap-y-2 gap-x-4 flex-wrap">
+              <div className="flex flex-col gap-y-2 gap-x-4 @min-[22rem]:flex-row">
                 <div className="flex flex-row">
                   <Skeleton loading={isLoading} height="16px" width="80px">
                     <div className="font-bold text-1">{members}</div>


### PR DESCRIPTION
## Summary

On the main network page, space cards rendered at inconsistent heights and the layout showed apparent "missing" cards. This PR makes every card the same size with consistent, aligned rows at any screen width.

### Root cause analysis

1. **Cards collapsed to content height.** The grid stretches each grid *cell* to the tallest card in the row (`align-items: stretch`), but the cell was a plain block `<div>`. The inner `<Link className="flex flex-col flex-1">` therefore never filled that stretched height, so its `flex-1` had no effect and the `Card`'s `h-full` only matched the Link's content height. Cards with shorter descriptions (1 line vs the `line-clamp-2` 2 lines) ended up visibly shorter than their row neighbors.
2. **One grid per load-more page.** `SpaceCardList` rendered a *separate* `<SpaceCardContainer>` grid for every page (`pageSize=15`). With 4 columns, each page left a partial trailing row (e.g. 4/4/4/3) and an empty trailing cell, which read as "missing" cards mid-list, and split the list into independently-aligned grids.

### Fix

- Make the grid-cell wrapper a full-height flex column (`flex flex-col h-full`) and add `auto-rows-fr items-stretch` to the grid so every row is equal height and each card fills its cell. Footers (members/agreements/date/mode) now align across the row.
- Render all loaded spaces in a **single** grid (`spaces.slice(0, pages * pageSize)`) instead of one grid per page, so rows stay continuous and only the final row can be partial.

Responsive columns are unchanged and remain equal-width at every breakpoint: 1 col (mobile) → 2 (`sm`) → 3 (`lg`) → 4 (`2xl`).

## Test plan

- [ ] Open `/[lang]/network` and confirm all cards in a row are identical height with aligned footers.
- [ ] Resize the window across mobile / `sm` / `lg` / `2xl` breakpoints and confirm equal-size cards and consistent cards-per-row.
- [ ] Click "Load more" and confirm cards form one continuous grid with no gaps/empty cells between pages.
- [ ] Verify `my-spaces`, category, and network-selected lists (which reuse `SpaceCardList`) still render correctly.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated explore spaces pagination to display 12 spaces per page (previously 15)
  * Enhanced grid layout with improved spacing and alignment
  * Optimized space card header layout for better mobile responsiveness
  * Improved card component styling flexibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->