### PR TITLE
fix(matrix): restore Safari call video and harden TURN readiness probe

### DIFF
--- a/docs/operations/matrix-turn-hostinger-runbook.md
+++ b/docs/operations/matrix-turn-hostinger-runbook.md
@@ -1,0 +1,370 @@
+# Matrix TURN fix — Hostinger VPS runbook
+
+**Audience:** operator with SSH on the Hypha production Matrix host  
+**Homeserver:** `https://srv1294735.hstgr.cloud` (Dendrite)  
+**Symptom in Hypha app:** in-call banner — *"Voice, video, and screen share may be unreliable — the Matrix server is not providing TURN relay servers."*  
+**Root cause:** Dendrite is not returning usable TURN credentials via `GET /_matrix/client/v3/voip/turnServer`, and/or coturn is misconfigured / unreachable.
+
+Hypha Web (app) cannot fix this in code. Calls work on the same LAN but fail across NAT without working TURN relay.
+
+Related docs:
+
+- [matrix-voip-turn-server-setup.md](../requirements/matrix-voip-turn-server-setup.md)
+- [coturn.example.conf](./coturn.example.conf)
+- [dendrite-turn.example.yaml](./dendrite-turn.example.yaml)
+
+---
+
+## 1. What “healthy” looks like
+
+When fixed, an **authenticated** request to the homeserver returns non-empty TURN URIs and short-lived credentials:
+
+```bash
+curl -sS -H "Authorization: Bearer <MATRIX_ACCESS_TOKEN>" \
+  "https://srv1294735.hstgr.cloud/_matrix/client/v3/voip/turnServer" | jq .
+```
+
+**Pass example (shape only — values differ per request):**
+
+```json
+{
+  "uris": [
+    "turn:srv1294735.hstgr.cloud:3478?transport=udp",
+    "turn:srv1294735.hstgr.cloud:3478?transport=tcp"
+  ],
+  "username": "…",
+  "password": "…",
+  "ttl": 86400
+}
+```
+
+**Fail:** empty `uris`, missing `username`/`password`, HTTP 403/500, or timeout.
+
+From Hypha production (logged-in user Privy JWT):
+
+```bash
+curl -sS -H "Authorization: Bearer <PRIVY_JWT>" \
+  "https://app.hypha.earth/api/matrix/turn-health" | jq .
+```
+
+**Pass:** `"ok": true`, `"turnCredsOk": true`, `"uriCount" >= 1`, `"hasTurnUdp": true` or `"hasTurnTcp": true`.
+
+---
+
+## 2. SSH onto the VPS
+
+```bash
+ssh root@srv1294735.hstgr.cloud
+# or: ssh <user>@<VPS_IP>
+```
+
+Confirm public IP (needed for coturn `external-ip` if behind NAT):
+
+```bash
+curl -4 -s ifconfig.me && echo
+hostname -f
+```
+
+---
+
+## 3. Diagnose (copy-paste)
+
+Run these **before** changing config. Save output for support.
+
+### 3.1 Matrix API up?
+
+```bash
+curl -sS -o /dev/null -w "versions HTTP %{http_code}\n" \
+  "https://srv1294735.hstgr.cloud/_matrix/client/versions"
+
+curl -sS "https://srv1294735.hstgr.cloud/_matrix/client/v3/voip/turnServer" | jq .
+# Expect M_MISSING_TOKEN (401) without auth — proves route exists
+```
+
+### 3.2 Is coturn installed and running?
+
+```bash
+which turnserver || which coturn
+systemctl status coturn 2>/dev/null || systemctl status turnserver 2>/dev/null
+ss -ulnp | grep 3478 || netstat -ulnp | grep 3478
+ss -tlnp | grep 3478 || true
+```
+
+**Red flags:**
+
+- Service `inactive` / `failed`
+- Only `127.0.0.1:3478` listening (coturn bound to loopback — add `listening-ip=0.0.0.0`)
+- No process on 3478 at all
+
+### 3.3 coturn config
+
+Common paths:
+
+```bash
+ls -la /etc/turnserver.conf /etc/coturn/turnserver.conf 2>/dev/null
+grep -E '^(listening-port|listening-ip|external-ip|realm|use-auth-secret|static-auth-secret|min-port|max-port)' \
+  /etc/turnserver.conf /etc/coturn/turnserver.conf 2>/dev/null
+```
+
+**Required settings:**
+
+| Key | Value |
+|-----|--------|
+| `listening-port` | `3478` |
+| `listening-ip` | `0.0.0.0` |
+| `use-auth-secret` | present |
+| `static-auth-secret` | long random string |
+| `realm` | `srv1294735.hstgr.cloud` (or dedicated TURN hostname) |
+| `external-ip` | VPS public IPv4 if behind NAT |
+| `min-port` / `max-port` | e.g. `49152` / `65535` |
+
+### 3.4 Dendrite TURN config
+
+Find `dendrite.yaml` (path varies by install):
+
+```bash
+find /etc /opt /var -name 'dendrite.yaml' 2>/dev/null | head -5
+# then:
+DENDRITE_YAML=/path/to/dendrite.yaml   # set from find output
+grep -A20 'client_api:' "$DENDRITE_YAML" | head -30
+grep -A15 'turn:' "$DENDRITE_YAML" || echo "NO turn: block under client_api"
+```
+
+**Red flags:**
+
+- No `client_api.turn` section
+- Empty `turn_uris: []`
+- `turn_shared_secret` missing or **not identical** to coturn `static-auth-secret`
+
+### 3.5 Firewall (Hostinger VPS — often ufw)
+
+```bash
+ufw status verbose 2>/dev/null || true
+iptables -L INPUT -n -v 2>/dev/null | head -20 || true
+```
+
+**Must allow from internet:**
+
+| Protocol | Port(s) | Purpose |
+|----------|---------|---------|
+| UDP | 3478 | STUN/TURN |
+| TCP | 3478 | TURN (TCP fallback) |
+| UDP | 49152–65535 | TURN media relay |
+| TCP | 5349 | optional TLS TURN |
+
+External probe (from your laptop, not the server):
+
+```bash
+nc -zvu -w 3 srv1294735.hstgr.cloud 3478
+```
+
+---
+
+## 4. Fix coturn
+
+### 4.1 Install if missing (Debian/Ubuntu)
+
+```bash
+apt-get update
+apt-get install -y coturn
+```
+
+### 4.2 Generate shared secret (once)
+
+```bash
+TURN_SECRET="$(openssl rand -hex 32)"
+echo "Save this secret for Dendrite turn_shared_secret:"
+echo "$TURN_SECRET"
+```
+
+### 4.3 Edit `/etc/turnserver.conf`
+
+```bash
+cp /etc/turnserver.conf /etc/turnserver.conf.bak.$(date +%Y%m%d)
+nano /etc/turnserver.conf
+```
+
+Paste/adjust (replace `YOUR_PUBLIC_IP`):
+
+```ini
+listening-port=3478
+listening-ip=0.0.0.0
+
+fingerprint
+use-auth-secret
+static-auth-secret=REPLACE_WITH_TURN_SECRET_FROM_STEP_4_2
+
+realm=srv1294735.hstgr.cloud
+server-name=srv1294735.hstgr.cloud
+external-ip=YOUR_PUBLIC_IP
+
+min-port=49152
+max-port=65535
+
+no-multicast-peers
+no-loopback-peers
+no-cli
+simple-log
+```
+
+Enable and restart:
+
+```bash
+sed -i 's/^#TURNSERVER_ENABLED=1/TURNSERVER_ENABLED=1/' /etc/default/coturn 2>/dev/null || true
+systemctl enable coturn
+systemctl restart coturn
+systemctl status coturn --no-pager
+ss -ulnp | grep 3478
+```
+
+---
+
+## 5. Fix Dendrite
+
+### 5.1 Edit `dendrite.yaml`
+
+Under `client_api`, add or replace `turn:` (use **same** `TURN_SECRET` as coturn):
+
+```yaml
+client_api:
+  turn:
+    turn_user_lifetime: "24h"
+    turn_uris:
+      - "turn:srv1294735.hstgr.cloud:3478?transport=udp"
+      - "turn:srv1294735.hstgr.cloud:3478?transport=tcp"
+    turn_shared_secret: "REPLACE_WITH_TURN_SECRET_FROM_STEP_4_2"
+    turn_username: ""
+    turn_password: ""
+```
+
+### 5.2 Restart Dendrite
+
+Service name may differ:
+
+```bash
+systemctl list-units --type=service | grep -i dendrite
+systemctl restart dendrite   # or dendrite-monolith / your unit name
+systemctl status dendrite --no-pager
+```
+
+---
+
+## 6. Open firewall (ufw example)
+
+```bash
+ufw allow 3478/udp
+ufw allow 3478/tcp
+ufw allow 49152:65535/udp
+# optional TLS TURN:
+# ufw allow 5349/tcp
+ufw status
+```
+
+**Hostinger control panel:** if a cloud firewall exists in hPanel, mirror the same rules there (panel rules can override ufw).
+
+---
+
+## 7. Verify end-to-end
+
+### 7.1 On the server — authenticated Matrix token
+
+Obtain a Matrix access token (from Dendrite admin tools, or register/login via Matrix client API). Then:
+
+```bash
+export MATRIX_TOKEN="<access_token>"
+curl -sS -H "Authorization: Bearer $MATRIX_TOKEN" \
+  "https://srv1294735.hstgr.cloud/_matrix/client/v3/voip/turnServer" | jq .
+```
+
+Check: `uris` non-empty, `username` and `password` present.
+
+### 7.2 From Hypha production
+
+1. Log into https://app.hypha.earth  
+2. DevTools → Application → copy Privy session / use Network tab `Authorization: Bearer` on an API call  
+3. Run:
+
+```bash
+curl -sS -H "Authorization: Bearer <PRIVY_JWT>" \
+  "https://app.hypha.earth/api/matrix/turn-health" | jq .
+```
+
+### 7.3 Live call test
+
+1. Two users, **different networks** (Wi‑Fi + mobile hotspot)  
+2. Join voice/video call in Human Chat  
+3. **Banner should not appear** (or dismiss and it should not return)  
+4. Test mic, camera, screen share for 5–10 minutes  
+
+Browser console (filter `hypha.group_call`): look for `turn_probe` with `turnCredsOk: true`.
+
+---
+
+## 8. Troubleshooting
+
+| Symptom | Likely fix |
+|---------|------------|
+| `turnServer` returns `{}` or empty `uris` | Dendrite `client_api.turn` missing or wrong YAML indentation |
+| `uris` present but calls still fail | Firewall blocking UDP 49152–65535; wrong `external-ip` |
+| coturn runs but only on 127.0.0.1 | Set `listening-ip=0.0.0.0`, restart coturn |
+| 401 on turnServer with valid token | Token from wrong homeserver; clock skew; Dendrite auth issue |
+| STUN works, TURN auth fails | `turn_shared_secret` ≠ coturn `static-auth-secret` |
+| Banner still shows after server fix | Hard-refresh app; leave and rejoin call; check Hypha `NEXT_PUBLIC_MATRIX_HOMESERVER_URL` points to this host |
+
+### coturn logs
+
+```bash
+journalctl -u coturn -n 100 --no-pager
+```
+
+### Dendrite logs
+
+```bash
+journalctl -u dendrite -n 100 --no-pager
+```
+
+### Rollback
+
+```bash
+cp /etc/turnserver.conf.bak.* /etc/turnserver.conf
+systemctl restart coturn
+# revert dendrite.yaml from backup, restart dendrite
+```
+
+---
+
+## 9. Optional: dedicated TURN hostname
+
+If TURN runs on a different host than Dendrite:
+
+1. DNS: `turn.hypha.earth` → TURN server IP  
+2. coturn `realm` / certs on that hostname  
+3. Dendrite `turn_uris` use `turn:turn.hypha.earth:3478?...`  
+4. Hypha Vercel env: add to `NEXT_PUBLIC_MATRIX_TURN_CONNECT_SOURCES` for CSP `connect-src`  
+5. Rebuild/redeploy Hypha Web after CSP env change  
+
+For single-host setup (`srv1294735.hstgr.cloud`), step 4 is usually **not** required.
+
+---
+
+## 10. Checklist (operator sign-off)
+
+- [ ] coturn active, listening on `0.0.0.0:3478` (UDP + TCP)
+- [ ] `static-auth-secret` set in coturn
+- [ ] `client_api.turn` in Dendrite with matching `turn_shared_secret`
+- [ ] `turn_uris` include UDP and TCP transport
+- [ ] Firewall allows UDP 3478, TCP 3478, UDP 49152–65535
+- [ ] `/voip/turnServer` returns non-empty `uris` + credentials (authenticated)
+- [ ] `https://app.hypha.earth/api/matrix/turn-health` → `turnCredsOk: true`
+- [ ] Two-network call test passes; Hypha TURN banner gone
+
+---
+
+## 11. Info to send back to Hypha team
+
+After running the runbook, paste (redact secrets):
+
+1. Output of §3.1–3.5 diagnose commands  
+2. `curl …/voip/turnServer` JSON (redact `username`/`password`)  
+3. `curl …/api/matrix/turn-health` JSON  
+4. Whether two-network call test passed  

--- a/docs/operations/matrix-turn-hostinger-runbook.md
+++ b/docs/operations/matrix-turn-hostinger-runbook.md
@@ -308,6 +308,7 @@ Browser console (filter `hypha.group_call`): look for `turn_probe` with `turnCre
 | `uris` present but calls still fail | Firewall blocking UDP 49152–65535; wrong `external-ip` |
 | coturn runs but only on 127.0.0.1 | Set `listening-ip=0.0.0.0`, restart coturn |
 | 401 on turnServer with valid token | Token from wrong homeserver; clock skew; Dendrite auth issue |
+| **429 / M_LIMIT_EXCEEDED** on `turnServer` | Dendrite `client_api.rate_limiting` too strict — raise threshold/cooloff or exempt VoIP; hard-refresh client after fix |
 | STUN works, TURN auth fails | `turn_shared_secret` ≠ coturn `static-auth-secret` |
 | Banner still shows after server fix | Hard-refresh app; leave and rejoin call; check Hypha `NEXT_PUBLIC_MATRIX_HOMESERVER_URL` points to this host |
 
@@ -322,6 +323,20 @@ journalctl -u coturn -n 100 --no-pager
 ```bash
 journalctl -u dendrite -n 100 --no-pager
 ```
+
+### Rate limiting (HTTP 429 on `/voip/turnServer`)
+
+If Safari/Chrome console shows `M_LIMIT_EXCEEDED` on `turnServer`, Dendrite is throttling TURN credential fetches. In `dendrite.yaml` under `client_api.rate_limiting`, consider raising limits for production VoIP (example — tune to your traffic):
+
+```yaml
+client_api:
+  rate_limiting:
+    enabled: true
+    threshold: 60
+    cooloff_ms: 500
+```
+
+Restart Dendrite after changes. Users should hard-refresh Hypha and rejoin the call once rate limits are relaxed.
 
 ### Rollback
 

--- a/docs/requirements/matrix-voip-turn-server-setup.md
+++ b/docs/requirements/matrix-voip-turn-server-setup.md
@@ -124,3 +124,4 @@ After login in Hypha (devtools console, filter **`hypha.group_call`** if telemet
 - [Matrix Client-Server API — `/voip/turnServer`](https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3voipturnserver)
 - [voice-video-call-phase-0-runbook.md](./voice-video-call-phase-0-runbook.md) — checklist table
 - [voice-video-call-matrix-tech-spec.md](./voice-video-call-matrix-tech-spec.md) — SDK options overview
+- [matrix-turn-hostinger-runbook.md](../operations/matrix-turn-hostinger-runbook.md) — production Hostinger VPS (Dendrite + coturn)

--- a/packages/core/src/matrix/client/hooks/__tests__/call-local-video-orientation.test.ts
+++ b/packages/core/src/matrix/client/hooks/__tests__/call-local-video-orientation.test.ts
@@ -44,7 +44,7 @@ describe('call-local-video-orientation', () => {
     ).toBe(false);
   });
 
-  it('skips canvas outbound correction on macOS Safari', () => {
+  it('skips canvas outbound correction (disabled globally)', () => {
     vi.stubGlobal('navigator', {
       userAgent:
         'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15',

--- a/packages/core/src/matrix/client/hooks/__tests__/call-local-video-orientation.test.ts
+++ b/packages/core/src/matrix/client/hooks/__tests__/call-local-video-orientation.test.ts
@@ -44,7 +44,7 @@ describe('call-local-video-orientation', () => {
     ).toBe(false);
   });
 
-  it('corrects outbound video on WebKit user-facing tracks', () => {
+  it('skips canvas outbound correction on macOS Safari', () => {
     vi.stubGlobal('navigator', {
       userAgent:
         'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15',
@@ -54,7 +54,7 @@ describe('call-local-video-orientation', () => {
       readyState: 'live',
       getSettings: () => ({ facingMode: 'user' }),
     } as MediaStreamTrack;
-    expect(shouldCorrectOutboundUserFacingVideoTrack(track)).toBe(true);
+    expect(shouldCorrectOutboundUserFacingVideoTrack(track)).toBe(false);
     vi.unstubAllGlobals();
   });
 

--- a/packages/core/src/matrix/client/hooks/__tests__/call-video-capture-constraints.test.ts
+++ b/packages/core/src/matrix/client/hooks/__tests__/call-video-capture-constraints.test.ts
@@ -31,6 +31,17 @@ describe('resolveMatrixCameraVideoConstraints', () => {
     );
     vi.unstubAllGlobals();
   });
+
+  it('uses minimal facingMode constraints on macOS Safari', () => {
+    vi.stubGlobal('navigator', {
+      userAgent:
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15',
+    });
+    expect(resolveMatrixCameraVideoConstraints()).toEqual(
+      IOS_TOUCH_CAMERA_CAPTURE_VIDEO_CONSTRAINTS,
+    );
+    vi.unstubAllGlobals();
+  });
 });
 
 describe('mergeMatrixCameraVideoConstraints', () => {

--- a/packages/core/src/matrix/client/hooks/__tests__/call-video-capture-constraints.test.ts
+++ b/packages/core/src/matrix/client/hooks/__tests__/call-video-capture-constraints.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
-  IOS_TOUCH_CAMERA_CAPTURE_VIDEO_CONSTRAINTS,
+  WEBKIT_CAMERA_CAPTURE_VIDEO_CONSTRAINTS,
   MATRIX_CAMERA_CAPTURE_VIDEO_CONSTRAINTS,
   installMatrixCameraCaptureConstraints,
   mergeMatrixCameraVideoConstraints,
@@ -27,7 +27,7 @@ describe('resolveMatrixCameraVideoConstraints', () => {
       maxTouchPoints: 5,
     });
     expect(resolveMatrixCameraVideoConstraints()).toEqual(
-      IOS_TOUCH_CAMERA_CAPTURE_VIDEO_CONSTRAINTS,
+      WEBKIT_CAMERA_CAPTURE_VIDEO_CONSTRAINTS,
     );
     vi.unstubAllGlobals();
   });
@@ -38,7 +38,7 @@ describe('resolveMatrixCameraVideoConstraints', () => {
         'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15',
     });
     expect(resolveMatrixCameraVideoConstraints()).toEqual(
-      IOS_TOUCH_CAMERA_CAPTURE_VIDEO_CONSTRAINTS,
+      WEBKIT_CAMERA_CAPTURE_VIDEO_CONSTRAINTS,
     );
     vi.unstubAllGlobals();
   });

--- a/packages/core/src/matrix/client/hooks/__tests__/matrix-turn-readiness.test.ts
+++ b/packages/core/src/matrix/client/hooks/__tests__/matrix-turn-readiness.test.ts
@@ -1,6 +1,10 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { MatrixClient } from 'matrix-js-sdk';
-import { evaluateMatrixTurnReadiness } from '../matrix-turn-readiness';
+import {
+  TURN_READINESS_CHECK_TIMEOUT_MS,
+  TURN_READINESS_RETRY_MS,
+  evaluateMatrixTurnReadiness,
+} from '../matrix-turn-readiness';
 
 function mockClient(overrides: Partial<MatrixClient> = {}): MatrixClient {
   return {
@@ -19,21 +23,102 @@ function mockClient(overrides: Partial<MatrixClient> = {}): MatrixClient {
 }
 
 describe('evaluateMatrixTurnReadiness', () => {
-  it('marks TURN available when creds and relay URIs exist', async () => {
-    const readiness = await evaluateMatrixTurnReadiness(mockClient());
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('marks TURN available when creds and relay URIs exist on first attempt', async () => {
+    const readinessPromise = evaluateMatrixTurnReadiness(mockClient());
+    await vi.runAllTimersAsync();
+    const readiness = await readinessPromise;
     expect(readiness.turnCredsOk).toBe(true);
     expect(readiness.iceHasTurn).toBe(true);
     expect(readiness.turnServerUnavailable).toBe(false);
   });
 
-  it('marks TURN unavailable when checkTurnServers fails', async () => {
-    const readiness = await evaluateMatrixTurnReadiness(
+  it('retries after first checkTurnServers returns false then succeeds', async () => {
+    const checkTurnServers = vi
+      .fn()
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+    const readinessPromise = evaluateMatrixTurnReadiness(
+      mockClient({ checkTurnServers }),
+    );
+    await vi.advanceTimersByTimeAsync(TURN_READINESS_RETRY_MS);
+    const readiness = await readinessPromise;
+    expect(checkTurnServers).toHaveBeenCalledTimes(2);
+    expect(readiness.turnCredsOk).toBe(true);
+    expect(readiness.turnServerUnavailable).toBe(false);
+  });
+
+  it('marks TURN unavailable when both attempts return false', async () => {
+    const checkTurnServers = vi.fn(async () => false);
+    const readinessPromise = evaluateMatrixTurnReadiness(
       mockClient({
-        checkTurnServers: vi.fn(async () => false),
+        checkTurnServers,
         getTurnServers: vi.fn(() => []),
       }),
     );
+    await vi.advanceTimersByTimeAsync(TURN_READINESS_RETRY_MS);
+    const readiness = await readinessPromise;
+    expect(checkTurnServers).toHaveBeenCalledTimes(2);
     expect(readiness.turnCredsOk).toBe(false);
     expect(readiness.turnServerUnavailable).toBe(true);
+  });
+
+  it('retries after first checkTurnServers throws then succeeds', async () => {
+    const checkTurnServers = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('network'))
+      .mockResolvedValueOnce(true);
+    const readinessPromise = evaluateMatrixTurnReadiness(
+      mockClient({ checkTurnServers }),
+    );
+    await vi.advanceTimersByTimeAsync(TURN_READINESS_RETRY_MS);
+    const readiness = await readinessPromise;
+    expect(checkTurnServers).toHaveBeenCalledTimes(2);
+    expect(readiness.turnCredsOk).toBe(true);
+    expect(readiness.turnServerUnavailable).toBe(false);
+  });
+
+  it('marks TURN unavailable when both attempts throw', async () => {
+    const checkTurnServers = vi.fn(async () => {
+      throw new Error('network');
+    });
+    const readinessPromise = evaluateMatrixTurnReadiness(
+      mockClient({
+        checkTurnServers,
+        getTurnServers: vi.fn(() => []),
+      }),
+    );
+    await vi.advanceTimersByTimeAsync(TURN_READINESS_RETRY_MS);
+    const readiness = await readinessPromise;
+    expect(checkTurnServers).toHaveBeenCalledTimes(2);
+    expect(readiness.turnCredsOk).toBe(false);
+    expect(readiness.turnServerUnavailable).toBe(true);
+  });
+
+  it('retries when checkTurnServers hangs past the per-call timeout', async () => {
+    const checkTurnServers = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise<boolean>(() => {
+            /* never resolves */
+          }),
+      )
+      .mockResolvedValueOnce(true);
+    const readinessPromise = evaluateMatrixTurnReadiness(
+      mockClient({ checkTurnServers }),
+    );
+    await vi.advanceTimersByTimeAsync(TURN_READINESS_CHECK_TIMEOUT_MS);
+    await vi.advanceTimersByTimeAsync(TURN_READINESS_RETRY_MS);
+    const readiness = await readinessPromise;
+    expect(checkTurnServers).toHaveBeenCalledTimes(2);
+    expect(readiness.turnCredsOk).toBe(true);
   });
 });

--- a/packages/core/src/matrix/client/hooks/__tests__/matrix-turn-readiness.test.ts
+++ b/packages/core/src/matrix/client/hooks/__tests__/matrix-turn-readiness.test.ts
@@ -2,8 +2,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { MatrixClient } from 'matrix-js-sdk';
 import {
   TURN_READINESS_CHECK_TIMEOUT_MS,
+  TURN_READINESS_RATE_LIMIT_BACKOFF_MS,
   TURN_READINESS_RETRY_MS,
   evaluateMatrixTurnReadiness,
+  resetMatrixTurnReadinessThrottleForTests,
 } from '../matrix-turn-readiness';
 
 function mockClient(overrides: Partial<MatrixClient> = {}): MatrixClient {
@@ -25,10 +27,12 @@ function mockClient(overrides: Partial<MatrixClient> = {}): MatrixClient {
 describe('evaluateMatrixTurnReadiness', () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    resetMatrixTurnReadinessThrottleForTests();
   });
 
   afterEach(() => {
     vi.useRealTimers();
+    resetMatrixTurnReadinessThrottleForTests();
   });
 
   it('marks TURN available when creds and relay URIs exist on first attempt', async () => {
@@ -100,6 +104,44 @@ describe('evaluateMatrixTurnReadiness', () => {
     expect(checkTurnServers).toHaveBeenCalledTimes(2);
     expect(readiness.turnCredsOk).toBe(false);
     expect(readiness.turnServerUnavailable).toBe(true);
+  });
+
+  it('does not retry when checkTurnServers is rate limited', async () => {
+    const rateLimitErr = Object.assign(new Error('[429] M_LIMIT_EXCEEDED'), {
+      httpStatus: 429,
+      errcode: 'M_LIMIT_EXCEEDED',
+    });
+    const checkTurnServers = vi.fn(async () => {
+      throw rateLimitErr;
+    });
+    const readinessPromise = evaluateMatrixTurnReadiness(
+      mockClient({
+        checkTurnServers,
+        getTurnServers: vi.fn(() => []),
+      }),
+    );
+    await vi.runAllTimersAsync();
+    const readiness = await readinessPromise;
+    expect(checkTurnServers).toHaveBeenCalledTimes(1);
+    expect(readiness.turnCredsOk).toBe(false);
+    expect(readiness.turnServerUnavailable).toBe(true);
+
+    checkTurnServers.mockClear();
+    const secondPromise = evaluateMatrixTurnReadiness(
+      mockClient({ checkTurnServers }),
+    );
+    await vi.runAllTimersAsync();
+    await secondPromise;
+    expect(checkTurnServers).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(TURN_READINESS_RATE_LIMIT_BACKOFF_MS);
+    checkTurnServers.mockResolvedValue(true);
+    const thirdPromise = evaluateMatrixTurnReadiness(
+      mockClient({ checkTurnServers }),
+    );
+    await vi.runAllTimersAsync();
+    await thirdPromise;
+    expect(checkTurnServers).toHaveBeenCalledTimes(1);
   });
 
   it('retries when checkTurnServers hangs past the per-call timeout', async () => {

--- a/packages/core/src/matrix/client/hooks/__tests__/screenshare-capture.test.ts
+++ b/packages/core/src/matrix/client/hooks/__tests__/screenshare-capture.test.ts
@@ -5,6 +5,7 @@ import {
   buildDisplayMediaConstraints,
   clearOrphanedMatrixScreenshareStreams,
   isIOSTouchDevice,
+  isWebKitBrowser,
   resolveMatrixScreenshareCaptureOpts,
   screenshareStreamHasTabAudio,
   screenshareStreamIsBrowserTab,
@@ -29,6 +30,24 @@ describe('screenshare capture opts', () => {
     });
     expect(resolveMatrixScreenshareCaptureOpts()).toEqual({ audio: false });
     expect(isIOSTouchDevice()).toBe(true);
+    vi.unstubAllGlobals();
+  });
+
+  it('detects macOS Safari as WebKit', () => {
+    vi.stubGlobal('navigator', {
+      userAgent:
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15',
+    });
+    expect(isWebKitBrowser()).toBe(true);
+    vi.unstubAllGlobals();
+  });
+
+  it('does not treat Chrome as WebKit', () => {
+    vi.stubGlobal('navigator', {
+      userAgent:
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36',
+    });
+    expect(isWebKitBrowser()).toBe(false);
     vi.unstubAllGlobals();
   });
 });

--- a/packages/core/src/matrix/client/hooks/call-local-video-orientation.ts
+++ b/packages/core/src/matrix/client/hooks/call-local-video-orientation.ts
@@ -16,19 +16,16 @@ export function isUserFacingCallVideoTrack(
   return true;
 }
 
-import { isIOSTouchDevice, isWebKitBrowser } from './screenshare-capture';
-
 /**
  * Whether to publish a canvas-flipped clone so remote peers see non-mirrored video.
- * Disabled on all WebKit/Safari — `canvas.captureStream` breaks local preview and
- * outbound publish; local preview stays mirrored via CSS instead.
+ * Globally disabled — `canvas.captureStream` breaks WebKit preview/publish (macOS
+ * Safari black tile). All browsers publish the native camera track; local preview
+ * stays mirrored via CSS.
  */
 export function shouldCorrectOutboundUserFacingVideoTrack(
   track: MediaStreamTrack,
 ): boolean {
   if (!isUserFacingCallVideoTrack(track)) return false;
-  if (typeof navigator === 'undefined') return false;
-  if (isIOSTouchDevice() || isWebKitBrowser()) return false;
   return false;
 }
 

--- a/packages/core/src/matrix/client/hooks/call-local-video-orientation.ts
+++ b/packages/core/src/matrix/client/hooks/call-local-video-orientation.ts
@@ -16,25 +16,20 @@ export function isUserFacingCallVideoTrack(
   return true;
 }
 
-import { isIOSTouchDevice } from './screenshare-capture';
+import { isIOSTouchDevice, isWebKitBrowser } from './screenshare-capture';
 
-/** WebKit user-facing capture is mirrored in the encoded track; peers need a flip. */
+/**
+ * Whether to publish a canvas-flipped clone so remote peers see non-mirrored video.
+ * Disabled on all WebKit/Safari — `canvas.captureStream` breaks local preview and
+ * outbound publish; local preview stays mirrored via CSS instead.
+ */
 export function shouldCorrectOutboundUserFacingVideoTrack(
   track: MediaStreamTrack,
 ): boolean {
   if (!isUserFacingCallVideoTrack(track)) return false;
   if (typeof navigator === 'undefined') return false;
-  /**
-   * Canvas `captureStream` publish is unreliable on iPad/iPhone (Safari and CriOS).
-   * Keep the native camera track; local preview stays mirrored via CSS.
-   */
-  if (isIOSTouchDevice()) return false;
-  const ua = navigator.userAgent;
-  const isIOS = /iPad|iPhone|iPod/.test(ua);
-  const isWebKit =
-    /AppleWebKit/i.test(ua) &&
-    !/CriOS|FxiOS|EdgiOS|Chrome|Chromium|Edg\//i.test(ua);
-  return isIOS || isWebKit;
+  if (isIOSTouchDevice() || isWebKitBrowser()) return false;
+  return false;
 }
 
 export function shouldMirrorCallFeedVideoForDisplay(input: {

--- a/packages/core/src/matrix/client/hooks/call-video-capture-constraints.ts
+++ b/packages/core/src/matrix/client/hooks/call-video-capture-constraints.ts
@@ -13,14 +13,17 @@ export const MATRIX_CAMERA_CAPTURE_VIDEO_CONSTRAINTS: MediaTrackConstraints = {
 };
 
 /** WebKit front cameras reject aggressive width/height caps — keep facingMode only. */
-export const IOS_TOUCH_CAMERA_CAPTURE_VIDEO_CONSTRAINTS: MediaTrackConstraints =
-  {
-    facingMode: 'user',
-  };
+export const WEBKIT_CAMERA_CAPTURE_VIDEO_CONSTRAINTS: MediaTrackConstraints = {
+  facingMode: 'user',
+};
+
+/** @deprecated Use {@link WEBKIT_CAMERA_CAPTURE_VIDEO_CONSTRAINTS}. */
+export const IOS_TOUCH_CAMERA_CAPTURE_VIDEO_CONSTRAINTS =
+  WEBKIT_CAMERA_CAPTURE_VIDEO_CONSTRAINTS;
 
 export function resolveMatrixCameraVideoConstraints(): MediaTrackConstraints {
   return isIOSTouchDevice() || isWebKitBrowser()
-    ? IOS_TOUCH_CAMERA_CAPTURE_VIDEO_CONSTRAINTS
+    ? WEBKIT_CAMERA_CAPTURE_VIDEO_CONSTRAINTS
     : MATRIX_CAMERA_CAPTURE_VIDEO_CONSTRAINTS;
 }
 

--- a/packages/core/src/matrix/client/hooks/call-video-capture-constraints.ts
+++ b/packages/core/src/matrix/client/hooks/call-video-capture-constraints.ts
@@ -3,7 +3,7 @@
  * Hypha patches it for the call session to request 720p capture (WCUX-QUALITY-1).
  */
 
-import { isIOSTouchDevice } from './screenshare-capture';
+import { isIOSTouchDevice, isWebKitBrowser } from './screenshare-capture';
 
 export const MATRIX_CAMERA_CAPTURE_VIDEO_CONSTRAINTS: MediaTrackConstraints = {
   width: { ideal: 1280, max: 1920 },
@@ -12,14 +12,14 @@ export const MATRIX_CAMERA_CAPTURE_VIDEO_CONSTRAINTS: MediaTrackConstraints = {
   facingMode: 'user',
 };
 
-/** iPad/iPhone front cameras reject aggressive width/height caps — keep facingMode only. */
+/** WebKit front cameras reject aggressive width/height caps — keep facingMode only. */
 export const IOS_TOUCH_CAMERA_CAPTURE_VIDEO_CONSTRAINTS: MediaTrackConstraints =
   {
     facingMode: 'user',
   };
 
 export function resolveMatrixCameraVideoConstraints(): MediaTrackConstraints {
-  return isIOSTouchDevice()
+  return isIOSTouchDevice() || isWebKitBrowser()
     ? IOS_TOUCH_CAMERA_CAPTURE_VIDEO_CONSTRAINTS
     : MATRIX_CAMERA_CAPTURE_VIDEO_CONSTRAINTS;
 }

--- a/packages/core/src/matrix/client/hooks/matrix-turn-readiness.ts
+++ b/packages/core/src/matrix/client/hooks/matrix-turn-readiness.ts
@@ -2,6 +2,7 @@
 
 import type { MatrixClient } from 'matrix-js-sdk';
 import { summarizeMatrixIceServers } from './matrix-ice-summary';
+import { isMatrixRateLimitedError } from './space-group-call-utils';
 
 export type MatrixTurnReadiness = {
   turnCredsOk: boolean;
@@ -22,6 +23,21 @@ export type MatrixTurnReadiness = {
  */
 export const TURN_READINESS_RETRY_MS = 400;
 export const TURN_READINESS_CHECK_TIMEOUT_MS = 10_000;
+/** Minimum gap between network `checkTurnServers()` calls (Dendrite rate-limits `/voip/turnServer`). */
+export const TURN_READINESS_MIN_FETCH_INTERVAL_MS = 30_000;
+/** Back off after HTTP 429 / M_LIMIT_EXCEEDED so we do not amplify rate limiting. */
+export const TURN_READINESS_RATE_LIMIT_BACKOFF_MS = 5 * 60 * 1000;
+
+let turnFetchBackoffUntil = 0;
+let lastTurnNetworkFetchAt = 0;
+let inFlightReadiness: Promise<MatrixTurnReadiness> | null = null;
+
+/** Test-only reset for module-level throttle state. */
+export function resetMatrixTurnReadinessThrottleForTests(): void {
+  turnFetchBackoffUntil = 0;
+  lastTurnNetworkFetchAt = 0;
+  inFlightReadiness = null;
+}
 
 async function checkTurnServersWithTimeout(
   client: MatrixClient,
@@ -43,25 +59,18 @@ async function checkTurnServersWithTimeout(
   }
 }
 
-export async function evaluateMatrixTurnReadiness(
-  client: MatrixClient,
-): Promise<MatrixTurnReadiness> {
-  const now = Date.now();
-  let turnCredsOk = false;
-  for (let attempt = 0; attempt < 2; attempt++) {
-    try {
-      turnCredsOk = await checkTurnServersWithTimeout(client);
-      if (turnCredsOk) break;
-    } catch {
-      turnCredsOk = false;
-    }
-    if (attempt === 0 && !turnCredsOk) {
-      await new Promise((resolve) =>
-        setTimeout(resolve, TURN_READINESS_RETRY_MS),
-      );
-    }
-  }
+function readCachedTurnCredsOk(client: MatrixClient, now: number): boolean {
+  const expiry = client.getTurnServersExpiry();
+  if (!Number.isFinite(expiry) || expiry <= now) return false;
+  const raw = client.getTurnServers() as RTCIceServer[];
+  return summarizeMatrixIceServers(raw).urlCount > 0;
+}
 
+function buildReadinessFromClient(
+  client: MatrixClient,
+  turnCredsOk: boolean,
+  now: number,
+): MatrixTurnReadiness {
   const expiry = client.getTurnServersExpiry();
   const turnTtlSecApprox =
     Number.isFinite(expiry) && expiry > 0
@@ -91,4 +100,64 @@ export async function evaluateMatrixTurnReadiness(
     iceHostHints: iceSummary.hostHints,
     turnServerUnavailable,
   };
+}
+
+async function evaluateMatrixTurnReadinessInternal(
+  client: MatrixClient,
+): Promise<MatrixTurnReadiness> {
+  const now = Date.now();
+
+  if (now < turnFetchBackoffUntil) {
+    return buildReadinessFromClient(
+      client,
+      readCachedTurnCredsOk(client, now),
+      now,
+    );
+  }
+
+  if (
+    now - lastTurnNetworkFetchAt < TURN_READINESS_MIN_FETCH_INTERVAL_MS &&
+    readCachedTurnCredsOk(client, now)
+  ) {
+    return buildReadinessFromClient(client, true, now);
+  }
+
+  let turnCredsOk = false;
+  let rateLimited = false;
+
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      lastTurnNetworkFetchAt = Date.now();
+      turnCredsOk = await checkTurnServersWithTimeout(client);
+      if (turnCredsOk) break;
+    } catch (err) {
+      turnCredsOk = false;
+      if (isMatrixRateLimitedError(err)) {
+        rateLimited = true;
+        turnFetchBackoffUntil =
+          Date.now() + TURN_READINESS_RATE_LIMIT_BACKOFF_MS;
+        break;
+      }
+    }
+    if (rateLimited) break;
+    if (attempt === 0 && !turnCredsOk) {
+      await new Promise((resolve) =>
+        setTimeout(resolve, TURN_READINESS_RETRY_MS),
+      );
+    }
+  }
+
+  return buildReadinessFromClient(client, turnCredsOk, now);
+}
+
+export async function evaluateMatrixTurnReadiness(
+  client: MatrixClient,
+): Promise<MatrixTurnReadiness> {
+  if (inFlightReadiness) return inFlightReadiness;
+  inFlightReadiness = evaluateMatrixTurnReadinessInternal(client).finally(
+    () => {
+      inFlightReadiness = null;
+    },
+  );
+  return inFlightReadiness;
 }

--- a/packages/core/src/matrix/client/hooks/matrix-turn-readiness.ts
+++ b/packages/core/src/matrix/client/hooks/matrix-turn-readiness.ts
@@ -20,7 +20,28 @@ export type MatrixTurnReadiness = {
  * Fetches/refreshes TURN credentials and summarizes ICE servers for WebRTC.
  * Does not log — callers emit telemetry or update UI state.
  */
-const TURN_READINESS_RETRY_MS = 400;
+export const TURN_READINESS_RETRY_MS = 400;
+export const TURN_READINESS_CHECK_TIMEOUT_MS = 10_000;
+
+async function checkTurnServersWithTimeout(
+  client: MatrixClient,
+): Promise<boolean> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const result = await Promise.race([
+      client.checkTurnServers(),
+      new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(
+          () => reject(new Error('checkTurnServers timed out')),
+          TURN_READINESS_CHECK_TIMEOUT_MS,
+        );
+      }),
+    ]);
+    return result === true;
+  } finally {
+    if (timeoutId != null) clearTimeout(timeoutId);
+  }
+}
 
 export async function evaluateMatrixTurnReadiness(
   client: MatrixClient,
@@ -29,7 +50,7 @@ export async function evaluateMatrixTurnReadiness(
   let turnCredsOk = false;
   for (let attempt = 0; attempt < 2; attempt++) {
     try {
-      turnCredsOk = (await client.checkTurnServers()) === true;
+      turnCredsOk = await checkTurnServersWithTimeout(client);
       if (turnCredsOk) break;
     } catch {
       turnCredsOk = false;

--- a/packages/core/src/matrix/client/hooks/matrix-turn-readiness.ts
+++ b/packages/core/src/matrix/client/hooks/matrix-turn-readiness.ts
@@ -20,15 +20,25 @@ export type MatrixTurnReadiness = {
  * Fetches/refreshes TURN credentials and summarizes ICE servers for WebRTC.
  * Does not log — callers emit telemetry or update UI state.
  */
+const TURN_READINESS_RETRY_MS = 400;
+
 export async function evaluateMatrixTurnReadiness(
   client: MatrixClient,
 ): Promise<MatrixTurnReadiness> {
   const now = Date.now();
   let turnCredsOk = false;
-  try {
-    turnCredsOk = (await client.checkTurnServers()) === true;
-  } catch {
-    turnCredsOk = false;
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      turnCredsOk = (await client.checkTurnServers()) === true;
+      if (turnCredsOk) break;
+    } catch {
+      turnCredsOk = false;
+    }
+    if (attempt === 0 && !turnCredsOk) {
+      await new Promise((resolve) =>
+        setTimeout(resolve, TURN_READINESS_RETRY_MS),
+      );
+    }
   }
 
   const expiry = client.getTurnServersExpiry();

--- a/packages/core/src/matrix/client/hooks/screenshare-capture.ts
+++ b/packages/core/src/matrix/client/hooks/screenshare-capture.ts
@@ -19,6 +19,16 @@ export function isIOSTouchDevice(): boolean {
   return navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1;
 }
 
+/** Safari / WebKit (macOS, iOS) — excludes Chromium-based browsers on Apple platforms. */
+export function isWebKitBrowser(): boolean {
+  if (typeof navigator === 'undefined') return false;
+  const ua = navigator.userAgent;
+  return (
+    /AppleWebKit/i.test(ua) &&
+    !/CriOS|FxiOS|EdgiOS|Chrome|Chromium|Edg\//i.test(ua)
+  );
+}
+
 /** Matrix `setScreensharingEnabled` opts — iOS has no tab/system display audio. */
 export function resolveMatrixScreenshareCaptureOpts(): IScreensharingOpts {
   if (isIOSTouchDevice()) {

--- a/packages/core/src/matrix/client/hooks/use-space-group-call.ts
+++ b/packages/core/src/matrix/client/hooks/use-space-group-call.ts
@@ -32,7 +32,10 @@ import {
   attachGroupCallWebRtcDiagnostics,
   probeMatrixTurnServerReadiness,
 } from './group-call-webrtc-diagnostics';
-import { evaluateMatrixTurnReadiness } from './matrix-turn-readiness';
+import {
+  TURN_READINESS_MIN_FETCH_INTERVAL_MS,
+  evaluateMatrixTurnReadiness,
+} from './matrix-turn-readiness';
 import { scheduleMatrixTurnRefresh } from './matrix-turn-refresh';
 import {
   applyCallThumbnailReceiverDownscale,
@@ -642,6 +645,8 @@ export function useSpaceGroupCall(
   const remoteMediaRecoverRequestedRef = useRef(false);
   const remoteMediaRecoverAttemptedRef = useRef(false);
   const remoteMediaRecoverInFlightRef = useRef(false);
+  /** Throttle TURN probes during remote-media stall (avoids Dendrite 429 on /voip/turnServer). */
+  const lastStallTurnProbeAtRef = useRef(0);
   const outboundVideoOrientationProcessedRef = useRef<Set<string>>(new Set());
   const outboundVideoOrientationDisposersRef = useRef<Array<() => void>>([]);
   const recordingGenerationRef = useRef(0);
@@ -1373,6 +1378,7 @@ export function useSpaceGroupCall(
       remoteMediaRecoverRequestedRef.current = false;
       remoteMediaRecoverAttemptedRef.current = false;
       remoteMediaRecoverInFlightRef.current = false;
+      lastStallTurnProbeAtRef.current = 0;
       setIsCallRecovering(false);
       setRemoteMediaStall(false);
       setRemoteMediaWarming(false);
@@ -1814,7 +1820,12 @@ export function useSpaceGroupCall(
        * the stalled side as well as from ParticipantsChanged/room-state bumps.
        */
       nudgeGroupCallPlaceOutgoing(gc);
-      if (client) {
+      if (
+        client &&
+        now - lastStallTurnProbeAtRef.current >=
+          TURN_READINESS_MIN_FETCH_INTERVAL_MS
+      ) {
+        lastStallTurnProbeAtRef.current = now;
         const turnEpoch = joinEpochRef.current;
         void evaluateMatrixTurnReadiness(client).then((readiness) => {
           applyTurnReadinessState(readiness.turnServerUnavailable, turnEpoch);

--- a/packages/epics/src/common/human-chat-panel/__tests__/call-feed-tile-video.test.ts
+++ b/packages/epics/src/common/human-chat-panel/__tests__/call-feed-tile-video.test.ts
@@ -60,10 +60,23 @@ describe('resolveCallFeedLiveVideoTrack', () => {
     );
   });
 
-  it('binds live muted camera tracks before the first frame (iOS warming)', () => {
+  it('binds live muted local camera tracks before the first frame (iOS warming)', () => {
     const track = mockTrack({ muted: true });
-    expect(resolveCallFeedLiveVideoTrack(mockFeed({ tracks: [track] }))).toBe(
-      track,
+    expect(
+      resolveCallFeedLiveVideoTrack(
+        mockFeed({ tracks: [track], local: true, userId: '@me:hs' }),
+        { currentUserId: '@me:hs' },
+      ),
+    ).toBe(track);
+  });
+
+  it('does not bind live muted remote camera tracks before the first frame', () => {
+    const track = mockTrack({ muted: true });
+    expect(
+      resolveCallFeedLiveVideoTrack(mockFeed({ tracks: [track] })),
+    ).toBeNull();
+    expect(hasWarmingCallFeedVideoTrack(mockFeed({ tracks: [track] }))).toBe(
+      true,
     );
   });
 

--- a/packages/epics/src/common/human-chat-panel/call-feed-tile-video.ts
+++ b/packages/epics/src/common/human-chat-panel/call-feed-tile-video.ts
@@ -45,12 +45,21 @@ export function resolveCallFeedLiveVideoTrack(
       null
     );
   }
-  return (
-    tracks.find((track) => track.readyState === 'live' && !track.muted) ??
-    tracks.find((track) => track.readyState === 'live') ??
-    tracks.find((track) => (track.readyState as string) === 'new') ??
-    null
+  const isLocal = isLocalCallFeedForTile(feed, options?.currentUserId);
+  const liveUnmuted = tracks.find(
+    (track) => track.readyState === 'live' && !track.muted,
   );
+  if (liveUnmuted) return liveUnmuted;
+  /**
+   * Local camera (Safari/iOS) may stay `muted: true` until the first frame — bind
+   * early so `<video>` can paint. Remote tracks in that state show avatar via
+   * `hasWarmingCallFeedVideoTrack` instead of a black tile.
+   */
+  if (isLocal) {
+    const liveMuted = tracks.find((track) => track.readyState === 'live');
+    if (liveMuted) return liveMuted;
+  }
+  return tracks.find((track) => (track.readyState as string) === 'new') ?? null;
 }
 
 /**

--- a/packages/epics/src/common/human-chat-panel/human-chat-panel-call-stage.tsx
+++ b/packages/epics/src/common/human-chat-panel/human-chat-panel-call-stage.tsx
@@ -2761,8 +2761,8 @@ const FeedContent = ({
   }, [liveVideoTrack?.id, streamBindVersion]);
 
   const showVideoElement = hasVideo && !warmingVideoTrack;
-  /** Audio scrim only for true audio-only tiles — not while camera video is warming up. */
-  const showAudioScrim = !showVideoElement;
+  /** Avatar until video paints — avoids black tiles while remote/local tracks warm up. */
+  const showAudioScrim = !showVideoElement || !videoSurfaceReady;
   const showParticipantVideoLabel = showVideoElement && !isPip;
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

- Disable canvas `captureStream` orientation on all WebKit/Safari browsers — the flip pipeline broke local camera preview on macOS Safari (black tile while camera appeared on).
- Use relaxed `getUserMedia` constraints (`facingMode: 'user'` only) on Safari instead of aggressive 720p caps that can fail on WebKit.
- Retry `checkTurnServers()` once before surfacing the TURN unavailable banner (transient homeserver latency).

Cross-network Chrome↔Chrome remote video still requires working TURN relay on the Matrix homeserver — this PR does not replace server-side coturn/Dendrite configuration.

## Test plan

- [ ] Safari (macOS): join video call — local camera tile shows live preview (not black)
- [ ] Chrome: join video call — local preview still works
- [ ] Two Chrome users on same Wi‑Fi — remote video connects
- [ ] `pnpm --filter @hypha-platform/core exec vitest run` on call orientation / constraints / screenshare / turn-readiness tests (30 passed locally)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced Safari support with optimized video capture constraints for macOS and Apple platforms.
  * Added automatic retry mechanism for TURN server connectivity checks (400ms delay), improving reliability in connectivity scenarios.
  * Improved browser detection for WebKit-based browsers to enable platform-specific handling.

* **Bug Fixes**
  * Disabled canvas-based video correction on macOS Safari to prevent unintended video manipulation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->