### PR TITLE
fix(calls): stop auto leave/re-enter on remote media stall

### DIFF
--- a/docs/operations/matrix-turn-hostinger-runbook.md
+++ b/docs/operations/matrix-turn-hostinger-runbook.md
@@ -311,6 +311,38 @@ Browser console (filter `hypha.group_call`): look for `turn_probe` with `turnCre
 | **429 / M_LIMIT_EXCEEDED** on `turnServer` | Dendrite `client_api.rate_limiting` too strict — raise threshold/cooloff or exempt VoIP; hard-refresh client after fix |
 | STUN works, TURN auth fails | `turn_shared_secret` ≠ coturn `static-auth-secret` |
 | Banner still shows after server fix | Hard-refresh app; leave and rejoin call; check Hypha `NEXT_PUBLIC_MATRIX_HOMESERVER_URL` points to this host |
+| **`CREATE_PERMISSION` → `error 403: Forbidden IP`** in coturn logs (ALLOCATE succeeds) | coturn is blocking peer relay permissions — see §8.1 |
+
+### 8.1 `CREATE_PERMISSION` / `403 Forbidden IP` (calls connect but no media)
+
+**Symptom in `journalctl -u coturn` during a live call:**
+
+```
+incoming packet ALLOCATE processed, success
+incoming packet CREATE_PERMISSION processed, error 403: Forbidden IP
+peer usage: ... rp=0, rb=0, sp=0, sb=0
+```
+
+TURN credentials and relay allocation work; **media cannot flow** because coturn refuses to relay between peers.
+
+**On the VPS:**
+
+```bash
+grep -E '^(denied-peer-ip|allowed-peer-ip|external-ip|relay-ip|no-loopback-peers)' \
+  /etc/turnserver.conf /etc/coturn/turnserver.conf 2>/dev/null
+```
+
+**Fix:** edit `/etc/turnserver.conf` — ensure `external-ip` is the VPS public IPv4, remove overly broad `denied-peer-ip` lines, and allow peer permissions:
+
+```ini
+external-ip=YOUR_PUBLIC_IP
+relay-ip=YOUR_PUBLIC_IP
+allowed-peer-ip=0.0.0.0-255.255.255.255
+```
+
+Do **not** add `denied-peer-ip=YOUR_PUBLIC_IP`. Restart: `systemctl restart coturn`.
+
+**Verify:** during a call, logs should show `CREATE_PERMISSION processed, success` and non-zero `peer usage`.
 
 ### coturn logs
 

--- a/docs/operations/matrix-turn-hostinger-runbook.md
+++ b/docs/operations/matrix-turn-hostinger-runbook.md
@@ -317,7 +317,7 @@ Browser console (filter `hypha.group_call`): look for `turn_probe` with `turnCre
 
 **Symptom in `journalctl -u coturn` during a live call:**
 
-```
+```text
 incoming packet ALLOCATE processed, success
 incoming packet CREATE_PERMISSION processed, error 403: Forbidden IP
 peer usage: ... rp=0, rb=0, sp=0, sb=0

--- a/packages/core/src/matrix/client/hooks/__tests__/call-camera-access.test.ts
+++ b/packages/core/src/matrix/client/hooks/__tests__/call-camera-access.test.ts
@@ -1,6 +1,35 @@
 import { describe, expect, it, vi } from 'vitest';
 import { resolveMatrixCameraVideoConstraints } from '../call-video-capture-constraints';
-import { requestLocalCameraAccess } from '../call-camera-access';
+import {
+  isLocalCameraPermissionDenied,
+  requestLocalCameraAccess,
+} from '../call-camera-access';
+
+describe('isLocalCameraPermissionDenied', () => {
+  it('returns true when the Permissions API reports denied', async () => {
+    Object.defineProperty(navigator, 'permissions', {
+      configurable: true,
+      value: {
+        query: vi.fn().mockResolvedValue({ state: 'denied' }),
+      },
+    });
+    await expect(isLocalCameraPermissionDenied()).resolves.toBe(true);
+  });
+
+  it('returns false when permission is granted or prompt', async () => {
+    Object.defineProperty(navigator, 'permissions', {
+      configurable: true,
+      value: {
+        query: vi
+          .fn()
+          .mockResolvedValueOnce({ state: 'granted' })
+          .mockResolvedValueOnce({ state: 'prompt' }),
+      },
+    });
+    await expect(isLocalCameraPermissionDenied()).resolves.toBe(false);
+    await expect(isLocalCameraPermissionDenied()).resolves.toBe(false);
+  });
+});
 
 describe('requestLocalCameraAccess', () => {
   it('returns unavailable when getUserMedia is missing', async () => {

--- a/packages/core/src/matrix/client/hooks/__tests__/call-pairwise-republish-schedule.test.ts
+++ b/packages/core/src/matrix/client/hooks/__tests__/call-pairwise-republish-schedule.test.ts
@@ -1,0 +1,33 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  clearPairwiseRepublishSchedule,
+  resetPairwiseRepublishScheduleForTests,
+  scheduleRepublishLocalMediaToPairwiseCalls,
+} from '../call-pairwise-republish-schedule';
+import * as restart from '../call-pairwise-restart';
+
+describe('scheduleRepublishLocalMediaToPairwiseCalls', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    resetPairwiseRepublishScheduleForTests();
+    vi.spyOn(restart, 'republishLocalMediaToPairwiseCalls').mockResolvedValue(
+      1,
+    );
+  });
+
+  it('debounces rapid schedule calls into one republish', async () => {
+    const gc = { id: 'gc' };
+    scheduleRepublishLocalMediaToPairwiseCalls(gc, { delayMs: 1000 });
+    scheduleRepublishLocalMediaToPairwiseCalls(gc, { delayMs: 1000 });
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(restart.republishLocalMediaToPairwiseCalls).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears pending republish on cleanup', async () => {
+    const gc = { id: 'gc' };
+    scheduleRepublishLocalMediaToPairwiseCalls(gc, { delayMs: 1000 });
+    clearPairwiseRepublishSchedule();
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(restart.republishLocalMediaToPairwiseCalls).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/matrix/client/hooks/__tests__/call-pairwise-restart.test.ts
+++ b/packages/core/src/matrix/client/hooks/__tests__/call-pairwise-restart.test.ts
@@ -236,6 +236,39 @@ describe('republishLocalMediaToPairwiseCalls', () => {
     expect(update).toHaveBeenCalledWith(stream, true, true);
   });
 
+  it('uses GroupCall mute intent when CallFeed mute state lags during recovery', async () => {
+    const audioTrack = {
+      kind: 'audio',
+      id: 'a1',
+      readyState: 'live',
+      muted: false,
+      enabled: true,
+    } as MediaStreamTrack;
+    const stream = {
+      id: 'local-stream',
+      getTracks: () => [audioTrack],
+    } as MediaStream;
+    const update = vi.fn().mockResolvedValue(undefined);
+    const gc = {
+      isMicrophoneMuted: () => false,
+      isLocalVideoMuted: () => true,
+      localCallFeed: {
+        stream,
+        isVideoMuted: () => true,
+        isAudioMuted: () => true,
+      },
+      forEachCall: (callback: (call: unknown) => void) => {
+        callback({
+          callHasEnded: () => false,
+          updateLocalUsermediaStream: update,
+        });
+      },
+    };
+
+    await expect(republishLocalMediaToPairwiseCalls(gc)).resolves.toBe(1);
+    expect(update).toHaveBeenCalledWith(stream, true, false);
+  });
+
   it('forces video publish when the pairwise call feed still reports video muted', async () => {
     const audioTrack = {
       kind: 'audio',

--- a/packages/core/src/matrix/client/hooks/__tests__/call-pairwise-restart.test.ts
+++ b/packages/core/src/matrix/client/hooks/__tests__/call-pairwise-restart.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  countActivePairwiseCalls,
   hangupAllActivePairwiseCalls,
   hangupPairwiseCallsForRemoteUsers,
   hasActivePairwiseCalls,
@@ -8,6 +9,7 @@ import {
   resetPairwiseVideoResyncScheduleForTests,
   restartAllPairwiseCallsForVideo,
   schedulePairwiseVideoResync,
+  waitForActivePairwiseCalls,
 } from '../call-pairwise-restart';
 
 describe('hangupPairwiseCallsForRemoteUsers', () => {
@@ -65,6 +67,29 @@ describe('pairwise video resync', () => {
       },
     };
     expect(hasActivePairwiseCalls(gc)).toBe(true);
+    expect(countActivePairwiseCalls(gc)).toBe(1);
+  });
+
+  it('waits until new pairwise calls appear after hangup', async () => {
+    vi.useFakeTimers();
+    let active = false;
+    const gc = {
+      forEachCall: (callback: (call: unknown) => void) => {
+        if (active) {
+          callback({ callHasEnded: () => false });
+        }
+      },
+    };
+    const pending = waitForActivePairwiseCalls(gc, {
+      timeoutMs: 2_000,
+      pollMs: 200,
+    });
+    await vi.advanceTimersByTimeAsync(199);
+    expect(countActivePairwiseCalls(gc)).toBe(0);
+    active = true;
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(pending).resolves.toBe(true);
+    vi.useRealTimers();
   });
 
   it('hangs up all active pairwise calls', () => {
@@ -385,7 +410,7 @@ describe('republishLocalMediaToPairwiseCalls', () => {
     };
 
     await republishLocalMediaToPairwiseCalls(gc);
-    track.muted = false;
+    Object.defineProperty(track, 'muted', { value: false, writable: true });
     await expect(republishLocalMediaToPairwiseCalls(gc)).resolves.toBe(1);
     expect(update).toHaveBeenCalledTimes(2);
   });

--- a/packages/core/src/matrix/client/hooks/__tests__/call-pairwise-restart.test.ts
+++ b/packages/core/src/matrix/client/hooks/__tests__/call-pairwise-restart.test.ts
@@ -56,6 +56,8 @@ describe('republishLocalMediaToPairwiseCalls', () => {
       kind: 'video',
       id: 'v1',
       readyState: 'live',
+      muted: false,
+      enabled: true,
     } as MediaStreamTrack;
     const stream = {
       id: 'local-stream',
@@ -76,29 +78,101 @@ describe('republishLocalMediaToPairwiseCalls', () => {
     expect(update).toHaveBeenCalledWith(stream);
   });
 
-  it('skips duplicate republish for the same stream fingerprint', async () => {
+  it('skips duplicate republish for the same call and stream fingerprint', async () => {
     const track = {
       kind: 'video',
       id: 'v1',
       readyState: 'live',
+      muted: false,
+      enabled: true,
     } as MediaStreamTrack;
     const stream = {
       id: 'local-stream',
       getTracks: () => [track],
     } as MediaStream;
     const update = vi.fn().mockResolvedValue(undefined);
+    const call = {
+      callHasEnded: () => false,
+      updateLocalUsermediaStream: update,
+    };
     const gc = {
       localCallFeed: { stream },
       forEachCall: (callback: (call: unknown) => void) => {
-        callback({
-          callHasEnded: () => false,
-          updateLocalUsermediaStream: update,
-        });
+        callback(call);
       },
     };
 
     await republishLocalMediaToPairwiseCalls(gc);
     await expect(republishLocalMediaToPairwiseCalls(gc)).resolves.toBe(0);
     expect(update).toHaveBeenCalledTimes(1);
+  });
+
+  it('republishes when a new pairwise call appears with the same stream', async () => {
+    const track = {
+      kind: 'video',
+      id: 'v1',
+      readyState: 'live',
+      muted: false,
+      enabled: true,
+    } as MediaStreamTrack;
+    const stream = {
+      id: 'local-stream',
+      getTracks: () => [track],
+    } as MediaStream;
+    const updateA = vi.fn().mockResolvedValue(undefined);
+    const updateB = vi.fn().mockResolvedValue(undefined);
+    const callA = {
+      callHasEnded: () => false,
+      updateLocalUsermediaStream: updateA,
+    };
+    const callB = {
+      callHasEnded: () => false,
+      updateLocalUsermediaStream: updateB,
+    };
+    const gc = {
+      localCallFeed: { stream },
+      forEachCall: (callback: (call: unknown) => void) => {
+        callback(callA);
+      },
+    };
+
+    await republishLocalMediaToPairwiseCalls(gc);
+    gc.forEachCall = (callback: (call: unknown) => void) => {
+      callback(callA);
+      callback(callB);
+    };
+    await expect(republishLocalMediaToPairwiseCalls(gc)).resolves.toBe(1);
+    expect(updateA).toHaveBeenCalledTimes(1);
+    expect(updateB).toHaveBeenCalledTimes(1);
+  });
+
+  it('republishes when a warmed camera track unmutes', async () => {
+    const track = {
+      kind: 'video',
+      id: 'v1',
+      readyState: 'live',
+      muted: true,
+      enabled: true,
+    } as MediaStreamTrack;
+    const stream = {
+      id: 'local-stream',
+      getTracks: () => [track],
+    } as MediaStream;
+    const update = vi.fn().mockResolvedValue(undefined);
+    const call = {
+      callHasEnded: () => false,
+      updateLocalUsermediaStream: update,
+    };
+    const gc = {
+      localCallFeed: { stream },
+      forEachCall: (callback: (call: unknown) => void) => {
+        callback(call);
+      },
+    };
+
+    await republishLocalMediaToPairwiseCalls(gc);
+    track.muted = false;
+    await expect(republishLocalMediaToPairwiseCalls(gc)).resolves.toBe(1);
+    expect(update).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/core/src/matrix/client/hooks/__tests__/call-pairwise-restart.test.ts
+++ b/packages/core/src/matrix/client/hooks/__tests__/call-pairwise-restart.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
-import { hangupPairwiseCallsForRemoteUsers } from '../call-pairwise-restart';
+import {
+  hangupPairwiseCallsForRemoteUsers,
+  republishLocalMediaToPairwiseCalls,
+} from '../call-pairwise-restart';
 
 describe('hangupPairwiseCallsForRemoteUsers', () => {
   it('hangs up calls whose opponent matches a target user id', () => {
@@ -39,5 +42,28 @@ describe('hangupPairwiseCallsForRemoteUsers', () => {
 
     expect(hangupPairwiseCallsForRemoteUsers(gc, ['@a:hs'])).toBe(0);
     expect(hangup).not.toHaveBeenCalled();
+  });
+});
+
+describe('republishLocalMediaToPairwiseCalls', () => {
+  it('pushes the local feed stream into each active MatrixCall', async () => {
+    const track = { kind: 'video' } as MediaStreamTrack;
+    const stream = {
+      id: 'local-stream',
+      getTracks: () => [track],
+    } as MediaStream;
+    const update = vi.fn().mockResolvedValue(undefined);
+    const gc = {
+      localCallFeed: { stream },
+      forEachCall: (callback: (call: unknown) => void) => {
+        callback({
+          callHasEnded: () => false,
+          updateLocalUsermediaStream: update,
+        });
+      },
+    };
+
+    await expect(republishLocalMediaToPairwiseCalls(gc)).resolves.toBe(1);
+    expect(update).toHaveBeenCalledWith(stream);
   });
 });

--- a/packages/core/src/matrix/client/hooks/__tests__/call-pairwise-restart.test.ts
+++ b/packages/core/src/matrix/client/hooks/__tests__/call-pairwise-restart.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest';
+import { hangupPairwiseCallsForRemoteUsers } from '../call-pairwise-restart';
+
+describe('hangupPairwiseCallsForRemoteUsers', () => {
+  it('hangs up calls whose opponent matches a target user id', () => {
+    const hangupA = vi.fn();
+    const hangupB = vi.fn();
+    const gc = {
+      forEachCall: (callback: (call: unknown) => void) => {
+        callback({
+          getOpponentMember: () => ({ userId: '@a:hs' }),
+          callHasEnded: () => false,
+          hangup: hangupA,
+        });
+        callback({
+          getOpponentMember: () => ({ userId: '@b:hs' }),
+          callHasEnded: () => false,
+          hangup: hangupB,
+        });
+      },
+    };
+
+    expect(hangupPairwiseCallsForRemoteUsers(gc, ['@a:hs'])).toBe(1);
+    expect(hangupA).toHaveBeenCalledTimes(1);
+    expect(hangupB).not.toHaveBeenCalled();
+  });
+
+  it('skips calls that already ended', () => {
+    const hangup = vi.fn();
+    const gc = {
+      forEachCall: (callback: (call: unknown) => void) => {
+        callback({
+          getOpponentMember: () => ({ userId: '@a:hs' }),
+          callHasEnded: () => true,
+          hangup,
+        });
+      },
+    };
+
+    expect(hangupPairwiseCallsForRemoteUsers(gc, ['@a:hs'])).toBe(0);
+    expect(hangup).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/matrix/client/hooks/__tests__/call-pairwise-restart.test.ts
+++ b/packages/core/src/matrix/client/hooks/__tests__/call-pairwise-restart.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   hangupPairwiseCallsForRemoteUsers,
   republishLocalMediaToPairwiseCalls,
+  resetPairwiseRepublishFingerprintForTests,
 } from '../call-pairwise-restart';
 
 describe('hangupPairwiseCallsForRemoteUsers', () => {
@@ -46,8 +47,16 @@ describe('hangupPairwiseCallsForRemoteUsers', () => {
 });
 
 describe('republishLocalMediaToPairwiseCalls', () => {
+  beforeEach(() => {
+    resetPairwiseRepublishFingerprintForTests();
+  });
+
   it('pushes the local feed stream into each active MatrixCall', async () => {
-    const track = { kind: 'video' } as MediaStreamTrack;
+    const track = {
+      kind: 'video',
+      id: 'v1',
+      readyState: 'live',
+    } as MediaStreamTrack;
     const stream = {
       id: 'local-stream',
       getTracks: () => [track],
@@ -65,5 +74,31 @@ describe('republishLocalMediaToPairwiseCalls', () => {
 
     await expect(republishLocalMediaToPairwiseCalls(gc)).resolves.toBe(1);
     expect(update).toHaveBeenCalledWith(stream);
+  });
+
+  it('skips duplicate republish for the same stream fingerprint', async () => {
+    const track = {
+      kind: 'video',
+      id: 'v1',
+      readyState: 'live',
+    } as MediaStreamTrack;
+    const stream = {
+      id: 'local-stream',
+      getTracks: () => [track],
+    } as MediaStream;
+    const update = vi.fn().mockResolvedValue(undefined);
+    const gc = {
+      localCallFeed: { stream },
+      forEachCall: (callback: (call: unknown) => void) => {
+        callback({
+          callHasEnded: () => false,
+          updateLocalUsermediaStream: update,
+        });
+      },
+    };
+
+    await republishLocalMediaToPairwiseCalls(gc);
+    await expect(republishLocalMediaToPairwiseCalls(gc)).resolves.toBe(0);
+    expect(update).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/core/src/matrix/client/hooks/__tests__/call-pairwise-restart.test.ts
+++ b/packages/core/src/matrix/client/hooks/__tests__/call-pairwise-restart.test.ts
@@ -9,6 +9,7 @@ import {
   resetPairwiseVideoResyncScheduleForTests,
   restartAllPairwiseCallsForVideo,
   schedulePairwiseVideoResync,
+  syncPairwisePublishIntent,
   waitForActivePairwiseCalls,
 } from '../call-pairwise-restart';
 
@@ -236,7 +237,7 @@ describe('republishLocalMediaToPairwiseCalls', () => {
     expect(update).toHaveBeenCalledWith(stream, true, true);
   });
 
-  it('uses GroupCall mute intent when CallFeed mute state lags during recovery', async () => {
+  it('uses synced publish intent when GroupCall mute state flips during recovery', async () => {
     const audioTrack = {
       kind: 'audio',
       id: 'a1',
@@ -250,7 +251,7 @@ describe('republishLocalMediaToPairwiseCalls', () => {
     } as MediaStream;
     const update = vi.fn().mockResolvedValue(undefined);
     const gc = {
-      isMicrophoneMuted: () => false,
+      isMicrophoneMuted: () => true,
       isLocalVideoMuted: () => true,
       localCallFeed: {
         stream,
@@ -264,6 +265,7 @@ describe('republishLocalMediaToPairwiseCalls', () => {
         });
       },
     };
+    syncPairwisePublishIntent(gc, { wantAudio: true, wantVideo: false });
 
     await expect(republishLocalMediaToPairwiseCalls(gc)).resolves.toBe(1);
     expect(update).toHaveBeenCalledWith(stream, true, false);

--- a/packages/core/src/matrix/client/hooks/__tests__/call-pairwise-restart.test.ts
+++ b/packages/core/src/matrix/client/hooks/__tests__/call-pairwise-restart.test.ts
@@ -116,6 +116,7 @@ describe('pairwise video resync', () => {
       enabled: true,
     } as MediaStreamTrack;
     const gc = {
+      groupCallId: 'gc-test-1',
       localCallFeed: {
         stream: { id: 's1', getTracks: () => [track] } as MediaStream,
         isVideoMuted: () => false,
@@ -138,6 +139,28 @@ describe('pairwise video resync', () => {
     expect(hangup).toHaveBeenCalledTimes(1);
     expect(nudge).toHaveBeenCalledTimes(1);
     expect(update).toHaveBeenCalledWith(gc.localCallFeed.stream, true, true);
+  });
+
+  it('caps full video resync to two attempts per group call', async () => {
+    vi.useFakeTimers();
+    const hangup = vi.fn();
+    const nudge = vi.fn();
+    const gc = {
+      groupCallId: 'gc-cap-test',
+      localCallFeed: { stream: null },
+      forEachCall: (callback: (call: unknown) => void) => {
+        callback({ callHasEnded: () => false, hangup });
+      },
+    };
+
+    schedulePairwiseVideoResync(gc, nudge, 50);
+    await vi.advanceTimersByTimeAsync(50);
+    schedulePairwiseVideoResync(gc, nudge, 50);
+    await vi.advanceTimersByTimeAsync(50);
+    schedulePairwiseVideoResync(gc, nudge, 50);
+    await vi.advanceTimersByTimeAsync(50);
+
+    expect(hangup).toHaveBeenCalledTimes(2);
   });
 
   it('restartAllPairwiseCallsForVideo hangs up, nudges, and republishes', async () => {

--- a/packages/core/src/matrix/client/hooks/__tests__/call-pairwise-restart.test.ts
+++ b/packages/core/src/matrix/client/hooks/__tests__/call-pairwise-restart.test.ts
@@ -51,7 +51,7 @@ describe('republishLocalMediaToPairwiseCalls', () => {
     resetPairwiseRepublishFingerprintForTests();
   });
 
-  it('pushes the local feed stream into each active MatrixCall', async () => {
+  it('pushes the local feed stream into each active MatrixCall with force A/V flags', async () => {
     const track = {
       kind: 'video',
       id: 'v1',
@@ -65,17 +65,107 @@ describe('republishLocalMediaToPairwiseCalls', () => {
     } as MediaStream;
     const update = vi.fn().mockResolvedValue(undefined);
     const gc = {
-      localCallFeed: { stream },
+      localCallFeed: {
+        stream,
+        isVideoMuted: () => false,
+        isAudioMuted: () => false,
+      },
       forEachCall: (callback: (call: unknown) => void) => {
         callback({
           callHasEnded: () => false,
+          isLocalVideoMuted: () => false,
+          hasUserMediaVideoSender: true,
           updateLocalUsermediaStream: update,
         });
       },
     };
 
     await expect(republishLocalMediaToPairwiseCalls(gc)).resolves.toBe(1);
-    expect(update).toHaveBeenCalledWith(stream);
+    expect(update).toHaveBeenCalledWith(stream, true, true);
+  });
+
+  it('forces video publish when the pairwise call feed still reports video muted', async () => {
+    const audioTrack = {
+      kind: 'audio',
+      id: 'a1',
+      readyState: 'live',
+      muted: false,
+      enabled: true,
+    } as MediaStreamTrack;
+    const videoTrack = {
+      kind: 'video',
+      id: 'v1',
+      readyState: 'live',
+      muted: false,
+      enabled: true,
+    } as MediaStreamTrack;
+    const stream = {
+      id: 'local-stream',
+      getTracks: () => [audioTrack, videoTrack],
+    } as MediaStream;
+    const update = vi.fn().mockResolvedValue(undefined);
+    const setLocalVideoMuted = vi.fn().mockResolvedValue(true);
+    const setAudioVideoMuted = vi.fn();
+    const gc = {
+      localCallFeed: {
+        stream,
+        isVideoMuted: () => false,
+        isAudioMuted: () => false,
+      },
+      forEachCall: (callback: (call: unknown) => void) => {
+        callback({
+          callHasEnded: () => false,
+          isLocalVideoMuted: () => true,
+          hasUserMediaVideoSender: true,
+          localUsermediaFeed: { setAudioVideoMuted },
+          setLocalVideoMuted,
+          updateLocalUsermediaStream: update,
+        });
+      },
+    };
+
+    await republishLocalMediaToPairwiseCalls(gc);
+
+    expect(setLocalVideoMuted).toHaveBeenCalledWith(false);
+    expect(setAudioVideoMuted).toHaveBeenCalledWith(false, false);
+    expect(update).toHaveBeenCalledWith(stream, true, true);
+  });
+
+  it('upgrades audio-first pairwise calls that lack a video sender', async () => {
+    const videoTrack = {
+      kind: 'video',
+      id: 'v1',
+      readyState: 'live',
+      muted: false,
+      enabled: true,
+    } as MediaStreamTrack;
+    const stream = {
+      id: 'local-stream',
+      getTracks: () => [videoTrack],
+    } as MediaStream;
+    const setLocalVideoMuted = vi.fn().mockResolvedValue(true);
+    const update = vi.fn().mockResolvedValue(undefined);
+    const gc = {
+      localCallFeed: {
+        stream,
+        isVideoMuted: () => false,
+        isAudioMuted: () => false,
+      },
+      forEachCall: (callback: (call: unknown) => void) => {
+        callback({
+          callHasEnded: () => false,
+          isLocalVideoMuted: () => true,
+          hasUserMediaVideoSender: false,
+          setLocalVideoMuted,
+          updateLocalUsermediaStream: update,
+        });
+      },
+    };
+
+    await republishLocalMediaToPairwiseCalls(gc);
+
+    expect(setLocalVideoMuted).toHaveBeenCalledWith(false);
+    expect(update).toHaveBeenCalledWith(stream, true, true);
   });
 
   it('skips duplicate republish for the same call and stream fingerprint', async () => {
@@ -93,10 +183,16 @@ describe('republishLocalMediaToPairwiseCalls', () => {
     const update = vi.fn().mockResolvedValue(undefined);
     const call = {
       callHasEnded: () => false,
+      isLocalVideoMuted: () => false,
+      hasUserMediaVideoSender: true,
       updateLocalUsermediaStream: update,
     };
     const gc = {
-      localCallFeed: { stream },
+      localCallFeed: {
+        stream,
+        isVideoMuted: () => false,
+        isAudioMuted: () => false,
+      },
       forEachCall: (callback: (call: unknown) => void) => {
         callback(call);
       },
@@ -123,14 +219,22 @@ describe('republishLocalMediaToPairwiseCalls', () => {
     const updateB = vi.fn().mockResolvedValue(undefined);
     const callA = {
       callHasEnded: () => false,
+      isLocalVideoMuted: () => false,
+      hasUserMediaVideoSender: true,
       updateLocalUsermediaStream: updateA,
     };
     const callB = {
       callHasEnded: () => false,
+      isLocalVideoMuted: () => false,
+      hasUserMediaVideoSender: true,
       updateLocalUsermediaStream: updateB,
     };
     const gc = {
-      localCallFeed: { stream },
+      localCallFeed: {
+        stream,
+        isVideoMuted: () => false,
+        isAudioMuted: () => false,
+      },
       forEachCall: (callback: (call: unknown) => void) => {
         callback(callA);
       },
@@ -161,10 +265,16 @@ describe('republishLocalMediaToPairwiseCalls', () => {
     const update = vi.fn().mockResolvedValue(undefined);
     const call = {
       callHasEnded: () => false,
+      isLocalVideoMuted: () => false,
+      hasUserMediaVideoSender: true,
       updateLocalUsermediaStream: update,
     };
     const gc = {
-      localCallFeed: { stream },
+      localCallFeed: {
+        stream,
+        isVideoMuted: () => false,
+        isAudioMuted: () => false,
+      },
       forEachCall: (callback: (call: unknown) => void) => {
         callback(call);
       },

--- a/packages/core/src/matrix/client/hooks/__tests__/call-pairwise-restart.test.ts
+++ b/packages/core/src/matrix/client/hooks/__tests__/call-pairwise-restart.test.ts
@@ -1,8 +1,13 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  hangupAllActivePairwiseCalls,
   hangupPairwiseCallsForRemoteUsers,
+  hasActivePairwiseCalls,
   republishLocalMediaToPairwiseCalls,
   resetPairwiseRepublishFingerprintForTests,
+  resetPairwiseVideoResyncScheduleForTests,
+  restartAllPairwiseCallsForVideo,
+  schedulePairwiseVideoResync,
 } from '../call-pairwise-restart';
 
 describe('hangupPairwiseCallsForRemoteUsers', () => {
@@ -43,6 +48,105 @@ describe('hangupPairwiseCallsForRemoteUsers', () => {
 
     expect(hangupPairwiseCallsForRemoteUsers(gc, ['@a:hs'])).toBe(0);
     expect(hangup).not.toHaveBeenCalled();
+  });
+});
+
+describe('pairwise video resync', () => {
+  afterEach(() => {
+    resetPairwiseVideoResyncScheduleForTests();
+    vi.useRealTimers();
+  });
+
+  it('detects active pairwise calls', () => {
+    const gc = {
+      forEachCall: (callback: (call: unknown) => void) => {
+        callback({ callHasEnded: () => true });
+        callback({ callHasEnded: () => false });
+      },
+    };
+    expect(hasActivePairwiseCalls(gc)).toBe(true);
+  });
+
+  it('hangs up all active pairwise calls', () => {
+    const hangup = vi.fn();
+    const gc = {
+      forEachCall: (callback: (call: unknown) => void) => {
+        callback({ callHasEnded: () => false, hangup });
+      },
+    };
+    expect(hangupAllActivePairwiseCalls(gc)).toBe(1);
+    expect(hangup).toHaveBeenCalledTimes(1);
+  });
+
+  it('schedules a debounced full video resync', async () => {
+    vi.useFakeTimers();
+    const hangup = vi.fn();
+    const update = vi.fn().mockResolvedValue(undefined);
+    const nudge = vi.fn();
+    const track = {
+      kind: 'video',
+      id: 'v1',
+      readyState: 'live',
+      muted: false,
+      enabled: true,
+    } as MediaStreamTrack;
+    const gc = {
+      localCallFeed: {
+        stream: { id: 's1', getTracks: () => [track] } as MediaStream,
+        isVideoMuted: () => false,
+        isAudioMuted: () => false,
+      },
+      forEachCall: (callback: (call: unknown) => void) => {
+        callback({
+          callHasEnded: () => false,
+          hangup,
+          isLocalVideoMuted: () => false,
+          hasUserMediaVideoSender: true,
+          updateLocalUsermediaStream: update,
+        });
+      },
+    };
+
+    schedulePairwiseVideoResync(gc, nudge, 100);
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(hangup).toHaveBeenCalledTimes(1);
+    expect(nudge).toHaveBeenCalledTimes(1);
+    expect(update).toHaveBeenCalledWith(gc.localCallFeed.stream, true, true);
+  });
+
+  it('restartAllPairwiseCallsForVideo hangs up, nudges, and republishes', async () => {
+    const hangup = vi.fn();
+    const update = vi.fn().mockResolvedValue(undefined);
+    const nudge = vi.fn();
+    const track = {
+      kind: 'video',
+      id: 'v1',
+      readyState: 'live',
+      muted: false,
+      enabled: true,
+    } as MediaStreamTrack;
+    const gc = {
+      localCallFeed: {
+        stream: { id: 's1', getTracks: () => [track] } as MediaStream,
+        isVideoMuted: () => false,
+        isAudioMuted: () => false,
+      },
+      forEachCall: (callback: (call: unknown) => void) => {
+        callback({
+          callHasEnded: () => false,
+          hangup,
+          isLocalVideoMuted: () => false,
+          hasUserMediaVideoSender: true,
+          updateLocalUsermediaStream: update,
+        });
+      },
+    };
+
+    await expect(restartAllPairwiseCallsForVideo(gc, nudge)).resolves.toBe(1);
+    expect(hangup).toHaveBeenCalledTimes(1);
+    expect(nudge).toHaveBeenCalledTimes(1);
+    expect(update).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/core/src/matrix/client/hooks/__tests__/call-pairwise-retry-env.test.ts
+++ b/packages/core/src/matrix/client/hooks/__tests__/call-pairwise-retry-env.test.ts
@@ -17,20 +17,21 @@ describe('call-pairwise-retry-env (CSH-MESH-1)', () => {
     }
   });
 
-  it('returns base retry schedule by default', () => {
+  it('includes 20s retry by default', () => {
     delete process.env.NEXT_PUBLIC_CALL_PAIRWISE_RETRY_20S;
-    expect(isCallPairwiseRetry20sEnabled()).toBe(false);
+    expect(isCallPairwiseRetry20sEnabled()).toBe(true);
     expect(resolvePlaceOutgoingRetryDelaysMs()).toEqual(
       PLACE_OUTGOING_RETRY_BASE_MS,
     );
   });
 
-  it('appends 20s retry when env flag is enabled', () => {
-    process.env.NEXT_PUBLIC_CALL_PAIRWISE_RETRY_20S = 'true';
-    expect(isCallPairwiseRetry20sEnabled()).toBe(true);
-    expect(resolvePlaceOutgoingRetryDelaysMs()).toEqual([
-      ...PLACE_OUTGOING_RETRY_BASE_MS,
-      PLACE_OUTGOING_RETRY_EXTENDED_MS,
-    ]);
+  it('omits 20s retry when env flag is false', () => {
+    process.env.NEXT_PUBLIC_CALL_PAIRWISE_RETRY_20S = 'false';
+    expect(isCallPairwiseRetry20sEnabled()).toBe(false);
+    expect(resolvePlaceOutgoingRetryDelaysMs()).toEqual(
+      PLACE_OUTGOING_RETRY_BASE_MS.filter(
+        (ms) => ms !== PLACE_OUTGOING_RETRY_EXTENDED_MS,
+      ),
+    );
   });
 });

--- a/packages/core/src/matrix/client/hooks/__tests__/remote-call-media-stall.test.ts
+++ b/packages/core/src/matrix/client/hooks/__tests__/remote-call-media-stall.test.ts
@@ -4,6 +4,7 @@ import {
   countMissingRemoteCallFeeds,
   countUnhealthyRemoteCallMedia,
   isRemoteCallFeedMediaHealthy,
+  isRemoteCallFeedMediaWarming,
 } from '../remote-call-media-stall';
 
 function mockFeed(
@@ -97,6 +98,27 @@ describe('isRemoteCallFeedMediaHealthy', () => {
   });
 });
 
+describe('isRemoteCallFeedMediaWarming', () => {
+  it('treats muted live video tracks as warming, not zombie', () => {
+    expect(
+      isRemoteCallFeedMediaWarming(
+        mockFeed('@a:hs', false, {
+          stream: mockStreamWithTracks([
+            {
+              kind: 'video',
+              readyState: 'live',
+              enabled: true,
+              muted: true,
+            } as MediaStreamTrack,
+          ]),
+          audioMuted: true,
+          videoMuted: false,
+        }),
+      ),
+    ).toBe(true);
+  });
+});
+
 describe('countUnhealthyRemoteCallMedia', () => {
   it('treats screenshare-only remote as connected for stall detection', () => {
     expect(
@@ -128,6 +150,31 @@ describe('countUnhealthyRemoteCallMedia', () => {
     ).toBe(1);
   });
 
+  it('ignores warming video feeds during ICE connect', () => {
+    expect(
+      countUnhealthyRemoteCallMedia(
+        {
+          userMediaFeeds: [
+            mockFeed('@a:hs', false, {
+              stream: mockStreamWithTracks([
+                {
+                  kind: 'video',
+                  readyState: 'live',
+                  enabled: true,
+                  muted: true,
+                } as MediaStreamTrack,
+              ]),
+              audioMuted: true,
+              videoMuted: false,
+            }),
+          ],
+          screenshareFeeds: [],
+        },
+        ['@a:hs'],
+      ),
+    ).toBe(0);
+  });
+
   it('is clear when remote has live audio', () => {
     expect(
       countUnhealthyRemoteCallMedia(
@@ -135,7 +182,11 @@ describe('countUnhealthyRemoteCallMedia', () => {
           userMediaFeeds: [
             mockFeed('@a:hs', false, {
               stream: mockStreamWithTracks([
-                { kind: 'audio', readyState: 'live' },
+                {
+                  kind: 'audio',
+                  readyState: 'live',
+                  muted: false,
+                } as MediaStreamTrack,
               ]),
               audioMuted: false,
               videoMuted: true,

--- a/packages/core/src/matrix/client/hooks/__tests__/remote-call-media-stall.test.ts
+++ b/packages/core/src/matrix/client/hooks/__tests__/remote-call-media-stall.test.ts
@@ -2,13 +2,35 @@ import { describe, expect, it } from 'vitest';
 import {
   collectRemoteCallFeedUserIds,
   countMissingRemoteCallFeeds,
+  countUnhealthyRemoteCallMedia,
+  isRemoteCallFeedMediaHealthy,
 } from '../remote-call-media-stall';
 
-function mockFeed(userId: string, local = false) {
+function mockFeed(
+  userId: string,
+  local = false,
+  options?: {
+    stream?: MediaStream | null;
+    audioMuted?: boolean;
+    videoMuted?: boolean;
+  },
+) {
   return {
     isLocal: () => local,
     userId,
+    stream: options?.stream ?? null,
+    isAudioMuted: () => options?.audioMuted ?? false,
+    isVideoMuted: () => options?.videoMuted ?? true,
   };
+}
+
+function mockStreamWithTracks(tracks: Partial<MediaStreamTrack>[]) {
+  return {
+    getAudioTracks: () =>
+      tracks.filter((t) => t.kind === 'audio') as MediaStreamTrack[],
+    getVideoTracks: () =>
+      tracks.filter((t) => t.kind === 'video') as MediaStreamTrack[],
+  } as MediaStream;
 }
 
 describe('collectRemoteCallFeedUserIds', () => {
@@ -35,14 +57,94 @@ describe('countMissingRemoteCallFeeds', () => {
       countMissingRemoteCallFeeds(['@a:hs', '@b:hs'], new Set(['@a:hs'])),
     ).toBe(1);
   });
+});
 
-  it('treats screenshare-only remote as connected for stall detection', () => {
-    const remoteIds = collectRemoteCallFeedUserIds({
-      userMediaFeeds: [],
-      screenshareFeeds: [mockFeed('@presenter:hs')],
-    });
+describe('isRemoteCallFeedMediaHealthy', () => {
+  it('is unhealthy when mic is on but no live audio track', () => {
     expect(
-      countMissingRemoteCallFeeds(['@presenter:hs', '@waiting:hs'], remoteIds),
+      isRemoteCallFeedMediaHealthy(
+        mockFeed('@a:hs', false, {
+          stream: mockStreamWithTracks([]),
+          audioMuted: false,
+          videoMuted: true,
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it('is healthy when both mic and camera are intentionally muted', () => {
+    expect(
+      isRemoteCallFeedMediaHealthy(
+        mockFeed('@a:hs', false, {
+          stream: null,
+          audioMuted: true,
+          videoMuted: true,
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('is healthy with live audio while camera is off', () => {
+    expect(
+      isRemoteCallFeedMediaHealthy(
+        mockFeed('@a:hs', false, {
+          stream: mockStreamWithTracks([{ kind: 'audio', readyState: 'live' }]),
+          audioMuted: false,
+          videoMuted: true,
+        }),
+      ),
+    ).toBe(true);
+  });
+});
+
+describe('countUnhealthyRemoteCallMedia', () => {
+  it('treats screenshare-only remote as connected for stall detection', () => {
+    expect(
+      countUnhealthyRemoteCallMedia(
+        {
+          userMediaFeeds: [],
+          screenshareFeeds: [mockFeed('@presenter:hs')],
+        },
+        ['@presenter:hs', '@waiting:hs'],
+      ),
     ).toBe(1);
+  });
+
+  it('counts zombie userMedia feeds with no live tracks', () => {
+    expect(
+      countUnhealthyRemoteCallMedia(
+        {
+          userMediaFeeds: [
+            mockFeed('@a:hs', false, {
+              stream: mockStreamWithTracks([]),
+              audioMuted: false,
+              videoMuted: true,
+            }),
+          ],
+          screenshareFeeds: [],
+        },
+        ['@a:hs'],
+      ),
+    ).toBe(1);
+  });
+
+  it('is clear when remote has live audio', () => {
+    expect(
+      countUnhealthyRemoteCallMedia(
+        {
+          userMediaFeeds: [
+            mockFeed('@a:hs', false, {
+              stream: mockStreamWithTracks([
+                { kind: 'audio', readyState: 'live' },
+              ]),
+              audioMuted: false,
+              videoMuted: true,
+            }),
+          ],
+          screenshareFeeds: [],
+        },
+        ['@a:hs'],
+      ),
+    ).toBe(0);
   });
 });

--- a/packages/core/src/matrix/client/hooks/__tests__/remote-call-media-stall.test.ts
+++ b/packages/core/src/matrix/client/hooks/__tests__/remote-call-media-stall.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import {
+  collectRemoteCallFeedUserIds,
+  countMissingRemoteCallFeeds,
+} from '../remote-call-media-stall';
+
+function mockFeed(userId: string, local = false) {
+  return {
+    isLocal: () => local,
+    userId,
+  };
+}
+
+describe('collectRemoteCallFeedUserIds', () => {
+  it('includes remote userMedia and screenshare feeds', () => {
+    const ids = collectRemoteCallFeedUserIds({
+      userMediaFeeds: [mockFeed('@a:hs')],
+      screenshareFeeds: [mockFeed('@b:hs')],
+    });
+    expect([...ids].sort()).toEqual(['@a:hs', '@b:hs']);
+  });
+
+  it('ignores local feeds', () => {
+    const ids = collectRemoteCallFeedUserIds({
+      userMediaFeeds: [mockFeed('@me:hs', true)],
+      screenshareFeeds: [mockFeed('@remote:hs')],
+    });
+    expect([...ids]).toEqual(['@remote:hs']);
+  });
+});
+
+describe('countMissingRemoteCallFeeds', () => {
+  it('counts participants without any inbound feed', () => {
+    expect(
+      countMissingRemoteCallFeeds(['@a:hs', '@b:hs'], new Set(['@a:hs'])),
+    ).toBe(1);
+  });
+
+  it('treats screenshare-only remote as connected for stall detection', () => {
+    const remoteIds = collectRemoteCallFeedUserIds({
+      userMediaFeeds: [],
+      screenshareFeeds: [mockFeed('@presenter:hs')],
+    });
+    expect(
+      countMissingRemoteCallFeeds(['@presenter:hs', '@waiting:hs'], remoteIds),
+    ).toBe(1);
+  });
+});

--- a/packages/core/src/matrix/client/hooks/__tests__/remote-call-media-stall.test.ts
+++ b/packages/core/src/matrix/client/hooks/__tests__/remote-call-media-stall.test.ts
@@ -89,7 +89,28 @@ describe('isRemoteCallFeedMediaHealthy', () => {
     expect(
       isRemoteCallFeedMediaHealthy(
         mockFeed('@a:hs', false, {
-          stream: mockStreamWithTracks([{ kind: 'audio', readyState: 'live' }]),
+          stream: mockStreamWithTracks([
+            { kind: 'audio', readyState: 'live', enabled: true },
+          ]),
+          audioMuted: false,
+          videoMuted: true,
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('is healthy when inbound audio is live but track.muted is still true', () => {
+    expect(
+      isRemoteCallFeedMediaHealthy(
+        mockFeed('@a:hs', false, {
+          stream: mockStreamWithTracks([
+            {
+              kind: 'audio',
+              readyState: 'live',
+              enabled: true,
+              muted: true,
+            } as MediaStreamTrack,
+          ]),
           audioMuted: false,
           videoMuted: true,
         }),
@@ -99,23 +120,21 @@ describe('isRemoteCallFeedMediaHealthy', () => {
 });
 
 describe('isRemoteCallFeedMediaWarming', () => {
-  it('treats muted live video tracks as warming, not zombie', () => {
-    expect(
-      isRemoteCallFeedMediaWarming(
-        mockFeed('@a:hs', false, {
-          stream: mockStreamWithTracks([
-            {
-              kind: 'video',
-              readyState: 'live',
-              enabled: true,
-              muted: true,
-            } as MediaStreamTrack,
-          ]),
-          audioMuted: true,
-          videoMuted: false,
-        }),
-      ),
-    ).toBe(true);
+  it('treats muted live enabled video as healthy (not warming or zombie)', () => {
+    const feed = mockFeed('@a:hs', false, {
+      stream: mockStreamWithTracks([
+        {
+          kind: 'video',
+          readyState: 'live',
+          enabled: true,
+          muted: true,
+        } as MediaStreamTrack,
+      ]),
+      audioMuted: true,
+      videoMuted: false,
+    });
+    expect(isRemoteCallFeedMediaHealthy(feed)).toBe(true);
+    expect(isRemoteCallFeedMediaWarming(feed)).toBe(false);
   });
 });
 
@@ -150,7 +169,7 @@ describe('countUnhealthyRemoteCallMedia', () => {
     ).toBe(1);
   });
 
-  it('ignores warming video feeds during ICE connect', () => {
+  it('ignores live enabled video feeds during ICE connect', () => {
     expect(
       countUnhealthyRemoteCallMedia(
         {
@@ -185,7 +204,8 @@ describe('countUnhealthyRemoteCallMedia', () => {
                 {
                   kind: 'audio',
                   readyState: 'live',
-                  muted: false,
+                  enabled: true,
+                  muted: true,
                 } as MediaStreamTrack,
               ]),
               audioMuted: false,

--- a/packages/core/src/matrix/client/hooks/call-camera-access.ts
+++ b/packages/core/src/matrix/client/hooks/call-camera-access.ts
@@ -6,8 +6,27 @@ export type LocalCameraAccessResult =
   | { ok: false; reason: 'unavailable' | 'permission_denied' | 'failed' };
 
 /**
- * Prompt for camera access so the browser registers the site permission and
- * Matrix can acquire a fresh video track afterward.
+ * Read camera permission without opening a second getUserMedia stream.
+ * When state is `prompt` or `granted`, Matrix `enter()` should be the only
+ * capture prompt during join.
+ */
+export async function isLocalCameraPermissionDenied(): Promise<boolean> {
+  if (typeof navigator === 'undefined') return false;
+  try {
+    const permissions = navigator.permissions;
+    if (!permissions?.query) return false;
+    const status = await permissions.query({
+      name: 'camera' as PermissionName,
+    });
+    return status.state === 'denied';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Prompt for camera access when the user turns the camera on mid-call.
+ * Avoid calling this before `GroupCall.enter()` — it causes a duplicate prompt.
  */
 export async function requestLocalCameraAccess(): Promise<LocalCameraAccessResult> {
   if (

--- a/packages/core/src/matrix/client/hooks/call-pairwise-republish-schedule.ts
+++ b/packages/core/src/matrix/client/hooks/call-pairwise-republish-schedule.ts
@@ -48,7 +48,7 @@ export function scheduleRepublishLocalMediaToPairwiseCalls(
   }
   republishDebounceTimer = setTimeout(() => {
     republishDebounceTimer = null;
-    void flushScheduledPairwiseRepublish();
+    void flushScheduledPairwiseRepublish().catch(() => undefined);
   }, republishPendingDelayMs);
 }
 

--- a/packages/core/src/matrix/client/hooks/call-pairwise-republish-schedule.ts
+++ b/packages/core/src/matrix/client/hooks/call-pairwise-republish-schedule.ts
@@ -1,0 +1,78 @@
+import { republishLocalMediaToPairwiseCalls } from './call-pairwise-restart';
+
+/** Avoid SDP renegotiation races while ICE is still connecting. */
+const REPUBLISH_DEBOUNCE_MS = 2_000;
+const REPUBLISH_MIN_INTERVAL_MS = 4_000;
+
+let republishDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+let republishPendingGc: unknown = null;
+let republishPendingForce = false;
+let republishPendingDelayMs = REPUBLISH_DEBOUNCE_MS;
+let lastRepublishCompletedAt = 0;
+
+export function resetPairwiseRepublishScheduleForTests(): void {
+  if (republishDebounceTimer != null) {
+    clearTimeout(republishDebounceTimer);
+    republishDebounceTimer = null;
+  }
+  republishPendingGc = null;
+  republishPendingForce = false;
+  republishPendingDelayMs = REPUBLISH_DEBOUNCE_MS;
+  lastRepublishCompletedAt = 0;
+}
+
+export function clearPairwiseRepublishSchedule(): void {
+  resetPairwiseRepublishScheduleForTests();
+}
+
+/**
+ * Debounced pairwise republish — `updateLocalUsermediaStream` on active
+ * `MatrixCall` sessions triggers SDP renegotiation; batching avoids
+ * `setRemoteDescription` races during initial ICE connect.
+ */
+export function scheduleRepublishLocalMediaToPairwiseCalls(
+  gc: unknown,
+  options?: { force?: boolean; delayMs?: number },
+): void {
+  if (typeof setTimeout === 'undefined') return;
+  republishPendingGc = gc;
+  if (options?.force) republishPendingForce = true;
+  if (options?.delayMs != null) {
+    republishPendingDelayMs = Math.max(
+      options.delayMs,
+      republishPendingDelayMs,
+    );
+  }
+  if (republishDebounceTimer != null) {
+    clearTimeout(republishDebounceTimer);
+  }
+  republishDebounceTimer = setTimeout(() => {
+    republishDebounceTimer = null;
+    void flushScheduledPairwiseRepublish();
+  }, republishPendingDelayMs);
+}
+
+async function flushScheduledPairwiseRepublish(): Promise<void> {
+  const gc = republishPendingGc;
+  const force = republishPendingForce;
+  republishPendingGc = null;
+  republishPendingForce = false;
+  republishPendingDelayMs = REPUBLISH_DEBOUNCE_MS;
+  if (!gc) return;
+
+  const now = Date.now();
+  const elapsed = now - lastRepublishCompletedAt;
+  if (!force && elapsed < REPUBLISH_MIN_INTERVAL_MS) {
+    scheduleRepublishLocalMediaToPairwiseCalls(gc, {
+      force,
+      delayMs: REPUBLISH_MIN_INTERVAL_MS - elapsed,
+    });
+    return;
+  }
+
+  await republishLocalMediaToPairwiseCalls(
+    gc,
+    force ? { force: true } : undefined,
+  );
+  lastRepublishCompletedAt = Date.now();
+}

--- a/packages/core/src/matrix/client/hooks/call-pairwise-restart.ts
+++ b/packages/core/src/matrix/client/hooks/call-pairwise-restart.ts
@@ -184,11 +184,18 @@ export async function restartAllPairwiseCallsForVideo(
 }
 
 const PAIRWISE_VIDEO_RESYNC_DEBOUNCE_MS = 5_000;
+/** Cap full hangup+re-place cycles — each one retriggers CallsChanged and SDP churn. */
+const MAX_PAIRWISE_VIDEO_RESYNC_PER_GROUP_CALL = 2;
 let pairwiseVideoResyncTimer: ReturnType<typeof setTimeout> | null = null;
 let pendingPairwiseVideoResync: {
   gc: unknown;
   nudgePlaceOutgoing: () => void;
 } | null = null;
+const pairwiseVideoResyncCountByGroupCallId = new Map<string, number>();
+
+function readGroupCallId(gc: unknown): string {
+  return String((gc as { groupCallId?: string })?.groupCallId ?? '');
+}
 
 export function clearPairwiseVideoResyncSchedule(): void {
   if (pairwiseVideoResyncTimer != null) {
@@ -198,8 +205,19 @@ export function clearPairwiseVideoResyncSchedule(): void {
   pendingPairwiseVideoResync = null;
 }
 
+export function clearPairwiseVideoResyncAttemptCounts(
+  groupCallId?: string,
+): void {
+  if (groupCallId) {
+    pairwiseVideoResyncCountByGroupCallId.delete(groupCallId);
+    return;
+  }
+  pairwiseVideoResyncCountByGroupCallId.clear();
+}
+
 export function resetPairwiseVideoResyncScheduleForTests(): void {
   clearPairwiseVideoResyncSchedule();
+  clearPairwiseVideoResyncAttemptCounts();
 }
 
 /**
@@ -212,6 +230,11 @@ export function schedulePairwiseVideoResync(
   delayMs = PAIRWISE_VIDEO_RESYNC_DEBOUNCE_MS,
 ): void {
   if (typeof setTimeout === 'undefined') return;
+  const groupCallId = readGroupCallId(gc);
+  const priorAttempts =
+    pairwiseVideoResyncCountByGroupCallId.get(groupCallId) ?? 0;
+  if (priorAttempts >= MAX_PAIRWISE_VIDEO_RESYNC_PER_GROUP_CALL) return;
+
   pendingPairwiseVideoResync = { gc, nudgePlaceOutgoing };
   if (pairwiseVideoResyncTimer != null) {
     clearTimeout(pairwiseVideoResyncTimer);
@@ -221,6 +244,11 @@ export function schedulePairwiseVideoResync(
     const pending = pendingPairwiseVideoResync;
     pendingPairwiseVideoResync = null;
     if (!pending) return;
+    const pendingGroupCallId = readGroupCallId(pending.gc);
+    const attempts =
+      pairwiseVideoResyncCountByGroupCallId.get(pendingGroupCallId) ?? 0;
+    if (attempts >= MAX_PAIRWISE_VIDEO_RESYNC_PER_GROUP_CALL) return;
+    pairwiseVideoResyncCountByGroupCallId.set(pendingGroupCallId, attempts + 1);
     void restartAllPairwiseCallsForVideo(
       pending.gc,
       pending.nudgePlaceOutgoing,

--- a/packages/core/src/matrix/client/hooks/call-pairwise-restart.ts
+++ b/packages/core/src/matrix/client/hooks/call-pairwise-restart.ts
@@ -2,9 +2,11 @@ type MatrixCallRestartLike = {
   hangup?: () => void;
   callHasEnded?: () => boolean;
   getOpponentMember?: () => { userId?: string } | null;
+  updateLocalUsermediaStream?: (stream: MediaStream) => Promise<void>;
 };
 
 type GroupCallCallsLike = {
+  localCallFeed?: { stream?: MediaStream | null };
   forEachCall?: (callback: (call: MatrixCallRestartLike) => void) => void;
   calls?: Map<string, Map<string, MatrixCallRestartLike>>;
 };
@@ -52,4 +54,29 @@ export function hangupPairwiseCallsForRemoteUsers(
     }
   });
   return hungUp;
+}
+
+/**
+ * matrix-js-sdk `GroupCall.updateLocalUsermediaStream()` updates the local feed
+ * only — it does not push new tracks into active pairwise peer connections. After
+ * the callee answers before camera warms up, the caller never receives video until
+ * each `MatrixCall` is updated explicitly.
+ */
+export async function republishLocalMediaToPairwiseCalls(
+  gc: unknown,
+): Promise<number> {
+  const groupCall = gc as GroupCallCallsLike;
+  const stream = groupCall.localCallFeed?.stream ?? null;
+  if (!stream || stream.getTracks().length === 0) return 0;
+
+  const tasks: Promise<void>[] = [];
+  let updated = 0;
+  forEachGroupCallMatrixCall(groupCall, (call) => {
+    if (call.callHasEnded?.()) return;
+    if (typeof call.updateLocalUsermediaStream !== 'function') return;
+    updated += 1;
+    tasks.push(call.updateLocalUsermediaStream(stream).catch(() => undefined));
+  });
+  await Promise.all(tasks);
+  return updated;
 }

--- a/packages/core/src/matrix/client/hooks/call-pairwise-restart.ts
+++ b/packages/core/src/matrix/client/hooks/call-pairwise-restart.ts
@@ -118,12 +118,34 @@ export function resetPairwiseRepublishFingerprintForTests(): void {
   lastPublishedFingerprintByCall.clear();
 }
 
-export function hasActivePairwiseCalls(gc: unknown): boolean {
-  let active = false;
+export function countActivePairwiseCalls(gc: unknown): number {
+  let active = 0;
   forEachGroupCallMatrixCall(gc, (call) => {
-    if (!call.callHasEnded?.()) active = true;
+    if (!call.callHasEnded?.()) active += 1;
   });
   return active;
+}
+
+export function hasActivePairwiseCalls(gc: unknown): boolean {
+  return countActivePairwiseCalls(gc) > 0;
+}
+
+/** `placeOutgoingCalls()` is async — wait before republishing into new MatrixCall sessions. */
+export async function waitForActivePairwiseCalls(
+  gc: unknown,
+  options?: { timeoutMs?: number; pollMs?: number; minCalls?: number },
+): Promise<boolean> {
+  const timeoutMs = options?.timeoutMs ?? 8_000;
+  const pollMs = options?.pollMs ?? 100;
+  const minCalls = options?.minCalls ?? 1;
+  const started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    if (countActivePairwiseCalls(gc) >= minCalls) return true;
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, pollMs);
+    });
+  }
+  return countActivePairwiseCalls(gc) >= minCalls;
 }
 
 /** Hang up every live pairwise session so `placeOutgoingCalls()` can rebuild with video. */
@@ -152,7 +174,12 @@ export async function restartAllPairwiseCallsForVideo(
 ): Promise<number> {
   const hungUp = hangupAllActivePairwiseCalls(gc);
   nudgePlaceOutgoing();
-  await republishLocalMediaToPairwiseCalls(gc, { force: true });
+  if (hungUp > 0) {
+    await waitForActivePairwiseCalls(gc);
+  }
+  if (hasActivePairwiseCalls(gc)) {
+    await republishLocalMediaToPairwiseCalls(gc, { force: true });
+  }
   return hungUp;
 }
 

--- a/packages/core/src/matrix/client/hooks/call-pairwise-restart.ts
+++ b/packages/core/src/matrix/client/hooks/call-pairwise-restart.ts
@@ -1,12 +1,32 @@
+type LocalCallFeedLike = {
+  stream?: MediaStream | null;
+  isVideoMuted?: () => boolean;
+  isAudioMuted?: () => boolean;
+};
+
 type MatrixCallRestartLike = {
   hangup?: () => void;
   callHasEnded?: () => boolean;
   getOpponentMember?: () => { userId?: string } | null;
-  updateLocalUsermediaStream?: (stream: MediaStream) => Promise<void>;
+  updateLocalUsermediaStream?: (
+    stream: MediaStream,
+    forceAudio?: boolean,
+    forceVideo?: boolean,
+  ) => Promise<void>;
+  setLocalVideoMuted?: (muted: boolean) => Promise<unknown>;
+  isLocalVideoMuted?: () => boolean;
+  hasUserMediaVideoSender?: boolean;
+  localUsermediaFeed?: {
+    setAudioVideoMuted?: (
+      audioMuted: boolean | null,
+      videoMuted: boolean | null,
+    ) => void;
+  };
+  sendMetadataUpdate?: () => Promise<void>;
 };
 
 type GroupCallCallsLike = {
-  localCallFeed?: { stream?: MediaStream | null };
+  localCallFeed?: LocalCallFeedLike;
   forEachCall?: (callback: (call: MatrixCallRestartLike) => void) => void;
   calls?: Map<string, Map<string, MatrixCallRestartLike>>;
 };
@@ -37,6 +57,53 @@ function streamRepublishFingerprint(stream: MediaStream): string {
           `${track.kind}:${track.id}:${track.readyState}:${track.muted}:${track.enabled}`,
       ),
   ].join('|');
+}
+
+function resolvePairwisePublishFlags(feed: LocalCallFeedLike | undefined): {
+  wantAudio: boolean;
+  wantVideo: boolean;
+} {
+  return {
+    wantAudio: !(feed?.isAudioMuted?.() ?? false),
+    wantVideo: !(feed?.isVideoMuted?.() ?? true),
+  };
+}
+
+/**
+ * matrix-js-sdk `MatrixCall.updateLocalUsermediaStream(stream)` without
+ * `forceVideo` leaves outbound video tracks disabled when the per-call feed was
+ * cloned from an audio-first session (`callFeed.isVideoMuted() === true`).
+ */
+async function pushStreamToMatrixCall(
+  call: MatrixCallRestartLike,
+  stream: MediaStream,
+  flags: { wantAudio: boolean; wantVideo: boolean },
+): Promise<void> {
+  if (call.callHasEnded?.()) return;
+
+  const needsVideoUpgrade =
+    flags.wantVideo &&
+    (call.isLocalVideoMuted?.() === true ||
+      call.hasUserMediaVideoSender === false);
+
+  if (needsVideoUpgrade && typeof call.setLocalVideoMuted === 'function') {
+    await call.setLocalVideoMuted(false).catch(() => undefined);
+  }
+
+  call.localUsermediaFeed?.setAudioVideoMuted?.(
+    flags.wantAudio ? false : null,
+    flags.wantVideo ? false : null,
+  );
+
+  if (typeof call.updateLocalUsermediaStream === 'function') {
+    await call
+      .updateLocalUsermediaStream(stream, flags.wantAudio, flags.wantVideo)
+      .catch(() => undefined);
+  }
+
+  if (flags.wantAudio || flags.wantVideo) {
+    await call.sendMetadataUpdate?.().catch(() => undefined);
+  }
 }
 
 /** Per pairwise call — new MatrixCall sessions must receive local A/V even when the stream fingerprint is unchanged. */
@@ -90,7 +157,12 @@ export async function republishLocalMediaToPairwiseCalls(
   const stream = groupCall.localCallFeed?.stream ?? null;
   if (!stream || stream.getTracks().length === 0) return 0;
 
-  const fingerprint = streamRepublishFingerprint(stream);
+  const publishFlags = resolvePairwisePublishFlags(groupCall.localCallFeed);
+  const fingerprint = [
+    streamRepublishFingerprint(stream),
+    publishFlags.wantAudio ? 'a1' : 'a0',
+    publishFlags.wantVideo ? 'v1' : 'v0',
+  ].join('|');
 
   const tasks: Promise<void>[] = [];
   let updated = 0;
@@ -104,12 +176,9 @@ export async function republishLocalMediaToPairwiseCalls(
     if (!options?.force && last === fingerprint) return;
     updated += 1;
     tasks.push(
-      call
-        .updateLocalUsermediaStream(stream)
-        .then(() => {
-          lastPublishedFingerprintByCall.set(call, fingerprint);
-        })
-        .catch(() => undefined),
+      pushStreamToMatrixCall(call, stream, publishFlags).then(() => {
+        lastPublishedFingerprintByCall.set(call, fingerprint);
+      }),
     );
   });
   await Promise.all(tasks);

--- a/packages/core/src/matrix/client/hooks/call-pairwise-restart.ts
+++ b/packages/core/src/matrix/client/hooks/call-pairwise-restart.ts
@@ -28,6 +28,8 @@ type MatrixCallRestartLike = {
 
 type GroupCallCallsLike = {
   localCallFeed?: LocalCallFeedLike;
+  isMicrophoneMuted?: () => boolean;
+  isLocalVideoMuted?: () => boolean;
   forEachCall?: (callback: (call: MatrixCallRestartLike) => void) => void;
   calls?: Map<string, Map<string, MatrixCallRestartLike>>;
 };
@@ -60,14 +62,24 @@ function streamRepublishFingerprint(stream: MediaStream): string {
   ].join('|');
 }
 
-function resolvePairwisePublishFlags(feed: LocalCallFeedLike | undefined): {
+/**
+ * Use GroupCall mute intent — `localCallFeed.isAudioMuted()` can lag during
+ * `recoverLocalMicrophoneFeed()` and wrongly disable outbound audio on republish.
+ */
+function resolvePairwisePublishFlags(gc: GroupCallCallsLike): {
   wantAudio: boolean;
   wantVideo: boolean;
 } {
-  return {
-    wantAudio: !(feed?.isAudioMuted?.() ?? false),
-    wantVideo: !(feed?.isVideoMuted?.() ?? true),
-  };
+  const feed = gc.localCallFeed;
+  const wantAudio =
+    typeof gc.isMicrophoneMuted === 'function'
+      ? !gc.isMicrophoneMuted()
+      : !(feed?.isAudioMuted?.() ?? false);
+  const wantVideo =
+    typeof gc.isLocalVideoMuted === 'function'
+      ? !gc.isLocalVideoMuted()
+      : !(feed?.isVideoMuted?.() ?? true);
+  return { wantAudio, wantVideo };
 }
 
 /**
@@ -300,7 +312,7 @@ export async function republishLocalMediaToPairwiseCalls(
   const stream = groupCall.localCallFeed?.stream ?? null;
   if (!stream || stream.getTracks().length === 0) return 0;
 
-  const publishFlags = resolvePairwisePublishFlags(groupCall.localCallFeed);
+  const publishFlags = resolvePairwisePublishFlags(groupCall);
   const fingerprint = [
     streamRepublishFingerprint(stream),
     publishFlags.wantAudio ? 'a1' : 'a0',

--- a/packages/core/src/matrix/client/hooks/call-pairwise-restart.ts
+++ b/packages/core/src/matrix/client/hooks/call-pairwise-restart.ts
@@ -32,14 +32,18 @@ function streamRepublishFingerprint(stream: MediaStream): string {
     stream.id,
     ...stream
       .getTracks()
-      .map((track) => `${track.kind}:${track.id}:${track.readyState}`),
+      .map(
+        (track) =>
+          `${track.kind}:${track.id}:${track.readyState}:${track.muted}:${track.enabled}`,
+      ),
   ].join('|');
 }
 
-let lastPairwiseRepublishFingerprint: string | null = null;
+/** Per pairwise call — new MatrixCall sessions must receive local A/V even when the stream fingerprint is unchanged. */
+const lastPublishedFingerprintByCall = new Map<MatrixCallRestartLike, string>();
 
 export function resetPairwiseRepublishFingerprintForTests(): void {
-  lastPairwiseRepublishFingerprint = null;
+  lastPublishedFingerprintByCall.clear();
 }
 
 /**
@@ -63,6 +67,7 @@ export function hangupPairwiseCallsForRemoteUsers(
     if (typeof call.hangup !== 'function') return;
     try {
       call.hangup();
+      lastPublishedFingerprintByCall.delete(call);
       hungUp += 1;
     } catch {
       /* best-effort */
@@ -86,21 +91,27 @@ export async function republishLocalMediaToPairwiseCalls(
   if (!stream || stream.getTracks().length === 0) return 0;
 
   const fingerprint = streamRepublishFingerprint(stream);
-  if (!options?.force && fingerprint === lastPairwiseRepublishFingerprint) {
-    return 0;
-  }
 
   const tasks: Promise<void>[] = [];
   let updated = 0;
   forEachGroupCallMatrixCall(groupCall, (call) => {
-    if (call.callHasEnded?.()) return;
+    if (call.callHasEnded?.()) {
+      lastPublishedFingerprintByCall.delete(call);
+      return;
+    }
     if (typeof call.updateLocalUsermediaStream !== 'function') return;
+    const last = lastPublishedFingerprintByCall.get(call);
+    if (!options?.force && last === fingerprint) return;
     updated += 1;
-    tasks.push(call.updateLocalUsermediaStream(stream).catch(() => undefined));
+    tasks.push(
+      call
+        .updateLocalUsermediaStream(stream)
+        .then(() => {
+          lastPublishedFingerprintByCall.set(call, fingerprint);
+        })
+        .catch(() => undefined),
+    );
   });
   await Promise.all(tasks);
-  if (updated > 0) {
-    lastPairwiseRepublishFingerprint = fingerprint;
-  }
   return updated;
 }

--- a/packages/core/src/matrix/client/hooks/call-pairwise-restart.ts
+++ b/packages/core/src/matrix/client/hooks/call-pairwise-restart.ts
@@ -27,6 +27,21 @@ function forEachGroupCallMatrixCall(
   }
 }
 
+function streamRepublishFingerprint(stream: MediaStream): string {
+  return [
+    stream.id,
+    ...stream
+      .getTracks()
+      .map((track) => `${track.kind}:${track.id}:${track.readyState}`),
+  ].join('|');
+}
+
+let lastPairwiseRepublishFingerprint: string | null = null;
+
+export function resetPairwiseRepublishFingerprintForTests(): void {
+  lastPairwiseRepublishFingerprint = null;
+}
+
 /**
  * Hang up stuck pairwise `MatrixCall` sessions for specific remote users, then
  * let `placeOutgoingCalls()` rebuild WebRTC without leaving the room GroupCall.
@@ -64,10 +79,16 @@ export function hangupPairwiseCallsForRemoteUsers(
  */
 export async function republishLocalMediaToPairwiseCalls(
   gc: unknown,
+  options?: { force?: boolean },
 ): Promise<number> {
   const groupCall = gc as GroupCallCallsLike;
   const stream = groupCall.localCallFeed?.stream ?? null;
   if (!stream || stream.getTracks().length === 0) return 0;
+
+  const fingerprint = streamRepublishFingerprint(stream);
+  if (!options?.force && fingerprint === lastPairwiseRepublishFingerprint) {
+    return 0;
+  }
 
   const tasks: Promise<void>[] = [];
   let updated = 0;
@@ -78,5 +99,8 @@ export async function republishLocalMediaToPairwiseCalls(
     tasks.push(call.updateLocalUsermediaStream(stream).catch(() => undefined));
   });
   await Promise.all(tasks);
+  if (updated > 0) {
+    lastPairwiseRepublishFingerprint = fingerprint;
+  }
   return updated;
 }

--- a/packages/core/src/matrix/client/hooks/call-pairwise-restart.ts
+++ b/packages/core/src/matrix/client/hooks/call-pairwise-restart.ts
@@ -1,0 +1,55 @@
+type MatrixCallRestartLike = {
+  hangup?: () => void;
+  callHasEnded?: () => boolean;
+  getOpponentMember?: () => { userId?: string } | null;
+};
+
+type GroupCallCallsLike = {
+  forEachCall?: (callback: (call: MatrixCallRestartLike) => void) => void;
+  calls?: Map<string, Map<string, MatrixCallRestartLike>>;
+};
+
+function forEachGroupCallMatrixCall(
+  gc: unknown,
+  callback: (call: MatrixCallRestartLike) => void,
+): void {
+  const groupCall = gc as GroupCallCallsLike;
+  if (typeof groupCall.forEachCall === 'function') {
+    groupCall.forEachCall(callback);
+    return;
+  }
+  for (const deviceMap of groupCall.calls?.values() ?? []) {
+    for (const call of deviceMap.values()) {
+      callback(call);
+    }
+  }
+}
+
+/**
+ * Hang up stuck pairwise `MatrixCall` sessions for specific remote users, then
+ * let `placeOutgoingCalls()` rebuild WebRTC without leaving the room GroupCall.
+ */
+export function hangupPairwiseCallsForRemoteUsers(
+  gc: unknown,
+  remoteUserIds: readonly string[],
+): number {
+  const targets = new Set(
+    remoteUserIds.map((id) => id?.trim()).filter((id): id is string => !!id),
+  );
+  if (targets.size === 0) return 0;
+
+  let hungUp = 0;
+  forEachGroupCallMatrixCall(gc, (call) => {
+    const opponentId = call.getOpponentMember?.()?.userId?.trim();
+    if (!opponentId || !targets.has(opponentId)) return;
+    if (call.callHasEnded?.()) return;
+    if (typeof call.hangup !== 'function') return;
+    try {
+      call.hangup();
+      hungUp += 1;
+    } catch {
+      /* best-effort */
+    }
+  });
+  return hungUp;
+}

--- a/packages/core/src/matrix/client/hooks/call-pairwise-restart.ts
+++ b/packages/core/src/matrix/client/hooks/call-pairwise-restart.ts
@@ -13,6 +13,7 @@ type MatrixCallRestartLike = {
     forceAudio?: boolean,
     forceVideo?: boolean,
   ) => Promise<void>;
+  upgradeCall?: (audio: boolean, video: boolean) => Promise<void>;
   setLocalVideoMuted?: (muted: boolean) => Promise<unknown>;
   isLocalVideoMuted?: () => boolean;
   hasUserMediaVideoSender?: boolean;
@@ -86,8 +87,12 @@ async function pushStreamToMatrixCall(
     (call.isLocalVideoMuted?.() === true ||
       call.hasUserMediaVideoSender === false);
 
-  if (needsVideoUpgrade && typeof call.setLocalVideoMuted === 'function') {
-    await call.setLocalVideoMuted(false).catch(() => undefined);
+  if (needsVideoUpgrade) {
+    if (typeof call.upgradeCall === 'function') {
+      await call.upgradeCall(false, true).catch(() => undefined);
+    } else if (typeof call.setLocalVideoMuted === 'function') {
+      await call.setLocalVideoMuted(false).catch(() => undefined);
+    }
   }
 
   call.localUsermediaFeed?.setAudioVideoMuted?.(
@@ -111,6 +116,89 @@ const lastPublishedFingerprintByCall = new Map<MatrixCallRestartLike, string>();
 
 export function resetPairwiseRepublishFingerprintForTests(): void {
   lastPublishedFingerprintByCall.clear();
+}
+
+export function hasActivePairwiseCalls(gc: unknown): boolean {
+  let active = false;
+  forEachGroupCallMatrixCall(gc, (call) => {
+    if (!call.callHasEnded?.()) active = true;
+  });
+  return active;
+}
+
+/** Hang up every live pairwise session so `placeOutgoingCalls()` can rebuild with video. */
+export function hangupAllActivePairwiseCalls(gc: unknown): number {
+  let hungUp = 0;
+  forEachGroupCallMatrixCall(gc, (call) => {
+    if (call.callHasEnded?.()) {
+      lastPublishedFingerprintByCall.delete(call);
+      return;
+    }
+    if (typeof call.hangup !== 'function') return;
+    try {
+      call.hangup();
+      lastPublishedFingerprintByCall.delete(call);
+      hungUp += 1;
+    } catch {
+      /* best-effort */
+    }
+  });
+  return hungUp;
+}
+
+export async function restartAllPairwiseCallsForVideo(
+  gc: unknown,
+  nudgePlaceOutgoing: () => void,
+): Promise<number> {
+  const hungUp = hangupAllActivePairwiseCalls(gc);
+  nudgePlaceOutgoing();
+  await republishLocalMediaToPairwiseCalls(gc, { force: true });
+  return hungUp;
+}
+
+const PAIRWISE_VIDEO_RESYNC_DEBOUNCE_MS = 5_000;
+let pairwiseVideoResyncTimer: ReturnType<typeof setTimeout> | null = null;
+let pendingPairwiseVideoResync: {
+  gc: unknown;
+  nudgePlaceOutgoing: () => void;
+} | null = null;
+
+export function clearPairwiseVideoResyncSchedule(): void {
+  if (pairwiseVideoResyncTimer != null) {
+    clearTimeout(pairwiseVideoResyncTimer);
+    pairwiseVideoResyncTimer = null;
+  }
+  pendingPairwiseVideoResync = null;
+}
+
+export function resetPairwiseVideoResyncScheduleForTests(): void {
+  clearPairwiseVideoResyncSchedule();
+}
+
+/**
+ * Debounced full pairwise restart — initial `placeOutgoingCalls()` often runs
+ * before the local camera track exists, leaving audio-only SDP on both sides.
+ */
+export function schedulePairwiseVideoResync(
+  gc: unknown,
+  nudgePlaceOutgoing: () => void,
+  delayMs = PAIRWISE_VIDEO_RESYNC_DEBOUNCE_MS,
+): void {
+  if (typeof setTimeout === 'undefined') return;
+  pendingPairwiseVideoResync = { gc, nudgePlaceOutgoing };
+  if (pairwiseVideoResyncTimer != null) {
+    clearTimeout(pairwiseVideoResyncTimer);
+  }
+  pairwiseVideoResyncTimer = setTimeout(() => {
+    pairwiseVideoResyncTimer = null;
+    const pending = pendingPairwiseVideoResync;
+    pendingPairwiseVideoResync = null;
+    if (!pending) return;
+    void restartAllPairwiseCallsForVideo(
+      pending.gc,
+      pending.nudgePlaceOutgoing,
+    ).catch(() => undefined);
+  }, delayMs);
 }
 
 /**

--- a/packages/core/src/matrix/client/hooks/call-pairwise-restart.ts
+++ b/packages/core/src/matrix/client/hooks/call-pairwise-restart.ts
@@ -26,6 +26,11 @@ type MatrixCallRestartLike = {
   sendMetadataUpdate?: () => Promise<void>;
 };
 
+export type PairwisePublishIntent = {
+  wantAudio: boolean;
+  wantVideo: boolean;
+};
+
 type GroupCallCallsLike = {
   localCallFeed?: LocalCallFeedLike;
   isMicrophoneMuted?: () => boolean;
@@ -33,6 +38,24 @@ type GroupCallCallsLike = {
   forEachCall?: (callback: (call: MatrixCallRestartLike) => void) => void;
   calls?: Map<string, Map<string, MatrixCallRestartLike>>;
 };
+
+/** Stable user intent — `gc.isMicrophoneMuted()` flips during device recovery. */
+const publishIntentByGroupCall = new WeakMap<object, PairwisePublishIntent>();
+
+export function syncPairwisePublishIntent(
+  gc: unknown,
+  intent: PairwisePublishIntent,
+): void {
+  if (gc && typeof gc === 'object') {
+    publishIntentByGroupCall.set(gc, intent);
+  }
+}
+
+export function clearPairwisePublishIntent(gc: unknown): void {
+  if (gc && typeof gc === 'object') {
+    publishIntentByGroupCall.delete(gc);
+  }
+}
 
 function forEachGroupCallMatrixCall(
   gc: unknown,
@@ -62,24 +85,29 @@ function streamRepublishFingerprint(stream: MediaStream): string {
   ].join('|');
 }
 
-/**
- * Use GroupCall mute intent — `localCallFeed.isAudioMuted()` can lag during
- * `recoverLocalMicrophoneFeed()` and wrongly disable outbound audio on republish.
- */
+/** Prefer synced user intent; fall back to GroupCall / CallFeed when unset. */
 function resolvePairwisePublishFlags(gc: GroupCallCallsLike): {
   wantAudio: boolean;
   wantVideo: boolean;
 } {
+  const intent = publishIntentByGroupCall.get(gc as object);
+  if (intent) {
+    return {
+      wantAudio: intent.wantAudio,
+      wantVideo: intent.wantVideo,
+    };
+  }
   const feed = gc.localCallFeed;
-  const wantAudio =
-    typeof gc.isMicrophoneMuted === 'function'
-      ? !gc.isMicrophoneMuted()
-      : !(feed?.isAudioMuted?.() ?? false);
-  const wantVideo =
-    typeof gc.isLocalVideoMuted === 'function'
-      ? !gc.isLocalVideoMuted()
-      : !(feed?.isVideoMuted?.() ?? true);
-  return { wantAudio, wantVideo };
+  return {
+    wantAudio:
+      typeof gc.isMicrophoneMuted === 'function'
+        ? !gc.isMicrophoneMuted()
+        : !(feed?.isAudioMuted?.() ?? false),
+    wantVideo:
+      typeof gc.isLocalVideoMuted === 'function'
+        ? !gc.isLocalVideoMuted()
+        : !(feed?.isVideoMuted?.() ?? true),
+  };
 }
 
 /**

--- a/packages/core/src/matrix/client/hooks/call-pairwise-retry-env.ts
+++ b/packages/core/src/matrix/client/hooks/call-pairwise-retry-env.ts
@@ -1,15 +1,20 @@
-/** CSH-MESH-1 — optional 20s `placeOutgoingCalls` nudge (staging diagnostics). */
-export const PLACE_OUTGOING_RETRY_BASE_MS = [1500, 4000, 8000, 12000] as const;
+/** CSH-MESH-1 — delayed `placeOutgoingCalls` nudges after join (pairwise WebRTC races). */
+export const PLACE_OUTGOING_RETRY_BASE_MS = [
+  1500, 4000, 8000, 12000, 20_000,
+] as const;
 
 export const PLACE_OUTGOING_RETRY_EXTENDED_MS = 20_000;
 
+/** When `false`, drops the final 20s nudge (diagnostics / noisy environments). */
 export function isCallPairwiseRetry20sEnabled(): boolean {
-  return process.env.NEXT_PUBLIC_CALL_PAIRWISE_RETRY_20S === 'true';
+  return process.env.NEXT_PUBLIC_CALL_PAIRWISE_RETRY_20S !== 'false';
 }
 
 export function resolvePlaceOutgoingRetryDelaysMs(): readonly number[] {
-  if (!isCallPairwiseRetry20sEnabled()) {
+  if (isCallPairwiseRetry20sEnabled()) {
     return PLACE_OUTGOING_RETRY_BASE_MS;
   }
-  return [...PLACE_OUTGOING_RETRY_BASE_MS, PLACE_OUTGOING_RETRY_EXTENDED_MS];
+  return PLACE_OUTGOING_RETRY_BASE_MS.filter(
+    (ms) => ms !== PLACE_OUTGOING_RETRY_EXTENDED_MS,
+  );
 }

--- a/packages/core/src/matrix/client/hooks/group-call-webrtc-diagnostics.ts
+++ b/packages/core/src/matrix/client/hooks/group-call-webrtc-diagnostics.ts
@@ -132,6 +132,134 @@ type InboundRtpVideoStats = {
   ssrc?: number;
 };
 
+type IceTransportSummary = {
+  iceConnectionState: RTCIceConnectionState;
+  iceGatheringState: RTCIceGatheringState;
+  connectionState: RTCPeerConnectionState;
+  localCandidateType?: string;
+  remoteCandidateType?: string;
+  pairState?: string;
+  inboundAudioBytes?: number;
+  inboundVideoBytes?: number;
+};
+
+function readIceTransportSummary(
+  peerConnection: RTCPeerConnection,
+  stats: RTCStatsReport,
+): IceTransportSummary {
+  const candidates = new Map<string, string>();
+  let selectedPairId: string | undefined;
+  let nominatedPair: {
+    id: string;
+    localCandidateId?: string;
+    remoteCandidateId?: string;
+    state?: string;
+  } | null = null;
+
+  stats.forEach((report) => {
+    if (
+      report.type === 'local-candidate' ||
+      report.type === 'remote-candidate'
+    ) {
+      const candidateType = report.candidateType;
+      if (typeof candidateType === 'string') {
+        candidates.set(report.id, candidateType);
+      }
+      return;
+    }
+    if (report.type === 'transport' && 'selectedCandidatePairId' in report) {
+      const id = report.selectedCandidatePairId;
+      if (typeof id === 'string' && id.length > 0) {
+        selectedPairId = id;
+      }
+      return;
+    }
+    if (report.type !== 'candidate-pair') return;
+    if (report.nominated === true && report.state === 'succeeded') {
+      nominatedPair = {
+        id: report.id,
+        localCandidateId:
+          typeof report.localCandidateId === 'string'
+            ? report.localCandidateId
+            : undefined,
+        remoteCandidateId:
+          typeof report.remoteCandidateId === 'string'
+            ? report.remoteCandidateId
+            : undefined,
+        state: typeof report.state === 'string' ? report.state : undefined,
+      };
+    }
+  });
+
+  const pairId = selectedPairId ?? nominatedPair?.id;
+  let localCandidateType: string | undefined;
+  let remoteCandidateType: string | undefined;
+  let pairState: string | undefined;
+
+  if (pairId) {
+    const pair = stats.get(pairId);
+    if (pair?.type === 'candidate-pair') {
+      pairState = typeof pair.state === 'string' ? pair.state : undefined;
+      const localId =
+        typeof pair.localCandidateId === 'string'
+          ? pair.localCandidateId
+          : nominatedPair?.localCandidateId;
+      const remoteId =
+        typeof pair.remoteCandidateId === 'string'
+          ? pair.remoteCandidateId
+          : nominatedPair?.remoteCandidateId;
+      if (localId) localCandidateType = candidates.get(localId);
+      if (remoteId) remoteCandidateType = candidates.get(remoteId);
+    }
+  }
+
+  let inboundAudioBytes = 0;
+  let inboundVideoBytes = 0;
+  stats.forEach((report) => {
+    if (report.type !== 'inbound-rtp') return;
+    const bytes = report.bytesReceived;
+    if (typeof bytes !== 'number' || bytes <= 0) return;
+    if (report.kind === 'audio') inboundAudioBytes += bytes;
+    if (report.kind === 'video') inboundVideoBytes += bytes;
+  });
+
+  return {
+    iceConnectionState: peerConnection.iceConnectionState,
+    iceGatheringState: peerConnection.iceGatheringState,
+    connectionState: peerConnection.connectionState,
+    localCandidateType,
+    remoteCandidateType,
+    pairState,
+    inboundAudioBytes: inboundAudioBytes || undefined,
+    inboundVideoBytes: inboundVideoBytes || undefined,
+  };
+}
+
+async function logIceTransportForPeerConnection(options: {
+  roomId: string;
+  groupCallId: string;
+  userId: string | null;
+  peerConnection: RTCPeerConnection;
+}): Promise<void> {
+  const { roomId, groupCallId, userId, peerConnection } = options;
+  const stats = await peerConnection.getStats();
+  const transport = readIceTransportSummary(peerConnection, stats);
+  logSpaceGroupCallEvent({
+    name: 'hypha.group_call.ice_transport',
+    roomId,
+    groupCallId,
+    remoteUserId: userId ?? undefined,
+    iceConnectionState: transport.iceConnectionState,
+    iceGatheringState: transport.iceGatheringState,
+    connectionState: transport.connectionState,
+    localCandidateType: transport.localCandidateType,
+    remoteCandidateType: transport.remoteCandidateType,
+    pairState: transport.pairState,
+    inboundAudioBytes: transport.inboundAudioBytes,
+    inboundVideoBytes: transport.inboundVideoBytes,
+  });
+}
+
 export function readInboundRtpVideoFrameSizes(
   stats: RTCStatsReport,
 ): InboundRtpVideoStats[] {
@@ -247,9 +375,28 @@ export function attachGroupCallWebRtcDiagnostics(options: {
     }
   };
 
+  const logIceTransport = () => {
+    if (!enumeratePeerConnections) return;
+    for (const { userId, peerConnection } of enumeratePeerConnections(gc)) {
+      void logIceTransportForPeerConnection({
+        roomId,
+        groupCallId: gc.groupCallId,
+        userId,
+        peerConnection,
+      });
+    }
+  };
+
   if (inboundRtpFrameLogIntervalMs > 0 && enumeratePeerConnections) {
     logFrameSizes();
-    frameLogInterval = setInterval(logFrameSizes, inboundRtpFrameLogIntervalMs);
+    logIceTransport();
+    frameLogInterval = setInterval(() => {
+      logFrameSizes();
+      logIceTransport();
+    }, inboundRtpFrameLogIntervalMs);
+  } else if (summaryStatsIntervalMs > 0 && enumeratePeerConnections) {
+    logIceTransport();
+    frameLogInterval = setInterval(logIceTransport, summaryStatsIntervalMs);
   }
 
   return () => {

--- a/packages/core/src/matrix/client/hooks/group-call-webrtc-diagnostics.ts
+++ b/packages/core/src/matrix/client/hooks/group-call-webrtc-diagnostics.ts
@@ -149,14 +149,11 @@ function readIceTransportSummary(
 ): IceTransportSummary {
   const candidates = new Map<string, string>();
   let selectedPairId: string | undefined;
-  let nominatedPair: {
-    id: string;
-    localCandidateId?: string;
-    remoteCandidateId?: string;
-    state?: string;
-  } | null = null;
+  let nominatedPairId: string | undefined;
+  let nominatedLocalCandidateId: string | undefined;
+  let nominatedRemoteCandidateId: string | undefined;
 
-  stats.forEach((report) => {
+  for (const report of stats.values()) {
     if (
       report.type === 'local-candidate' ||
       report.type === 'remote-candidate'
@@ -165,33 +162,30 @@ function readIceTransportSummary(
       if (typeof candidateType === 'string') {
         candidates.set(report.id, candidateType);
       }
-      return;
+      continue;
     }
     if (report.type === 'transport' && 'selectedCandidatePairId' in report) {
       const id = report.selectedCandidatePairId;
       if (typeof id === 'string' && id.length > 0) {
         selectedPairId = id;
       }
-      return;
+      continue;
     }
-    if (report.type !== 'candidate-pair') return;
+    if (report.type !== 'candidate-pair') continue;
     if (report.nominated === true && report.state === 'succeeded') {
-      nominatedPair = {
-        id: report.id,
-        localCandidateId:
-          typeof report.localCandidateId === 'string'
-            ? report.localCandidateId
-            : undefined,
-        remoteCandidateId:
-          typeof report.remoteCandidateId === 'string'
-            ? report.remoteCandidateId
-            : undefined,
-        state: typeof report.state === 'string' ? report.state : undefined,
-      };
+      nominatedPairId = report.id;
+      nominatedLocalCandidateId =
+        typeof report.localCandidateId === 'string'
+          ? report.localCandidateId
+          : undefined;
+      nominatedRemoteCandidateId =
+        typeof report.remoteCandidateId === 'string'
+          ? report.remoteCandidateId
+          : undefined;
     }
-  });
+  }
 
-  const pairId = selectedPairId ?? nominatedPair?.id;
+  const pairId = selectedPairId ?? nominatedPairId;
   let localCandidateType: string | undefined;
   let remoteCandidateType: string | undefined;
   let pairState: string | undefined;
@@ -203,11 +197,11 @@ function readIceTransportSummary(
       const localId =
         typeof pair.localCandidateId === 'string'
           ? pair.localCandidateId
-          : nominatedPair?.localCandidateId;
+          : nominatedLocalCandidateId;
       const remoteId =
         typeof pair.remoteCandidateId === 'string'
           ? pair.remoteCandidateId
-          : nominatedPair?.remoteCandidateId;
+          : nominatedRemoteCandidateId;
       if (localId) localCandidateType = candidates.get(localId);
       if (remoteId) remoteCandidateType = candidates.get(remoteId);
     }
@@ -250,7 +244,7 @@ async function logIceTransportForPeerConnection(options: {
     groupCallId,
     remoteUserId: userId ?? undefined,
     iceConnectionState: transport.iceConnectionState,
-    iceGatheringState: transport.iceGatheringState,
+    iceGatherState: transport.iceGatheringState,
     connectionState: transport.connectionState,
     localCandidateType: transport.localCandidateType,
     remoteCandidateType: transport.remoteCandidateType,

--- a/packages/core/src/matrix/client/hooks/remote-call-media-stall.ts
+++ b/packages/core/src/matrix/client/hooks/remote-call-media-stall.ts
@@ -28,6 +28,19 @@ function hasLiveMediaStreamTrack(
   return tracks.some((track) => track.readyState === 'live');
 }
 
+function hasWarmingMediaStreamTrack(
+  stream: MediaStream,
+  kind: 'audio' | 'video',
+): boolean {
+  const tracks =
+    kind === 'audio' ? stream.getAudioTracks() : stream.getVideoTracks();
+  return tracks.some((track) => {
+    if (!track.enabled) return false;
+    const state = track.readyState as string;
+    return state === 'live' || state === 'new';
+  });
+}
+
 /**
  * CallFeed exists in the SDK list but WebRTC never delivered live tracks (or they
  * ended). Intentionally muted participants still count as healthy presence.
@@ -43,10 +56,31 @@ export function isRemoteCallFeedMediaHealthy(
   const stream = feed.stream ?? null;
   if (!stream) return false;
 
-  const liveAudio = hasLiveMediaStreamTrack(stream, 'audio');
-  const liveVideo = hasLiveMediaStreamTrack(stream, 'video');
+  const liveAudio = stream
+    .getAudioTracks()
+    .some((track) => track.readyState === 'live' && !track.muted);
+  const liveVideo = stream
+    .getVideoTracks()
+    .some((track) => track.readyState === 'live' && !track.muted);
   if (wantsAudio && liveAudio) return true;
   if (wantsVideo && liveVideo) return true;
+  return false;
+}
+
+/** Feed exists with tracks warming up — do not hang up pairwise calls yet. */
+export function isRemoteCallFeedMediaWarming(
+  feed: RemoteCallFeedLike,
+): boolean {
+  const wantsAudio = !feed.isAudioMuted();
+  const wantsVideo = !feed.isVideoMuted();
+  if (!wantsAudio && !wantsVideo) return false;
+
+  const stream = feed.stream ?? null;
+  if (!stream) return false;
+  if (isRemoteCallFeedMediaHealthy(feed)) return false;
+
+  if (wantsAudio && hasWarmingMediaStreamTrack(stream, 'audio')) return true;
+  if (wantsVideo && hasWarmingMediaStreamTrack(stream, 'video')) return true;
   return false;
 }
 
@@ -99,6 +133,9 @@ export function listUnhealthyRemoteCallUserIds(
       continue;
     }
     const userMediaFeed = findRemoteUserMediaFeed(gc, id);
+    if (userMediaFeed && isRemoteCallFeedMediaWarming(userMediaFeed)) {
+      continue;
+    }
     if (userMediaFeed && !isRemoteCallFeedMediaHealthy(userMediaFeed)) {
       unhealthy.push(id);
     }

--- a/packages/core/src/matrix/client/hooks/remote-call-media-stall.ts
+++ b/packages/core/src/matrix/client/hooks/remote-call-media-stall.ts
@@ -19,6 +19,15 @@ type GroupCallRemoteMediaLike = {
   screenshareFeeds: CallFeedLike[];
 };
 
+function hasLiveEnabledMediaStreamTrack(
+  stream: MediaStream,
+  kind: 'audio' | 'video',
+): boolean {
+  const tracks =
+    kind === 'audio' ? stream.getAudioTracks() : stream.getVideoTracks();
+  return tracks.some((track) => track.enabled && track.readyState === 'live');
+}
+
 function hasLiveMediaStreamTrack(
   stream: MediaStream,
   kind: 'audio' | 'video',
@@ -56,14 +65,16 @@ export function isRemoteCallFeedMediaHealthy(
   const stream = feed.stream ?? null;
   if (!stream) return false;
 
-  const liveAudio = stream
-    .getAudioTracks()
-    .some((track) => track.readyState === 'live' && !track.muted);
-  const liveVideo = stream
-    .getVideoTracks()
-    .some((track) => track.readyState === 'live' && !track.muted);
-  if (wantsAudio && liveAudio) return true;
-  if (wantsVideo && liveVideo) return true;
+  /**
+   * Inbound WebRTC tracks often stay `muted: true` until the first RTP packet
+   * while audio/video already flows — do not require `!track.muted` here.
+   */
+  if (wantsAudio && hasLiveEnabledMediaStreamTrack(stream, 'audio')) {
+    return true;
+  }
+  if (wantsVideo && hasLiveEnabledMediaStreamTrack(stream, 'video')) {
+    return true;
+  }
   return false;
 }
 

--- a/packages/core/src/matrix/client/hooks/remote-call-media-stall.ts
+++ b/packages/core/src/matrix/client/hooks/remote-call-media-stall.ts
@@ -3,10 +3,52 @@ type CallFeedLike = {
   userId?: string | null;
 };
 
+export type RemoteCallFeedLike = CallFeedLike & {
+  stream?: MediaStream | null;
+  isAudioMuted: () => boolean;
+  isVideoMuted: () => boolean;
+};
+
 type GroupCallFeedsLike = {
   userMediaFeeds: CallFeedLike[];
   screenshareFeeds: CallFeedLike[];
 };
+
+type GroupCallRemoteMediaLike = {
+  userMediaFeeds: RemoteCallFeedLike[];
+  screenshareFeeds: CallFeedLike[];
+};
+
+function hasLiveMediaStreamTrack(
+  stream: MediaStream,
+  kind: 'audio' | 'video',
+): boolean {
+  const tracks =
+    kind === 'audio' ? stream.getAudioTracks() : stream.getVideoTracks();
+  return tracks.some((track) => track.readyState === 'live');
+}
+
+/**
+ * CallFeed exists in the SDK list but WebRTC never delivered live tracks (or they
+ * ended). Intentionally muted participants still count as healthy presence.
+ */
+export function isRemoteCallFeedMediaHealthy(
+  feed: RemoteCallFeedLike,
+): boolean {
+  const wantsAudio = !feed.isAudioMuted();
+  const wantsVideo = !feed.isVideoMuted();
+
+  if (!wantsAudio && !wantsVideo) return true;
+
+  const stream = feed.stream ?? null;
+  if (!stream) return false;
+
+  const liveAudio = hasLiveMediaStreamTrack(stream, 'audio');
+  const liveVideo = hasLiveMediaStreamTrack(stream, 'video');
+  if (wantsAudio && liveAudio) return true;
+  if (wantsVideo && liveVideo) return true;
+  return false;
+}
 
 /** Remote participants with at least one userMedia or screenshare CallFeed. */
 export function collectRemoteCallFeedUserIds(
@@ -21,10 +63,45 @@ export function collectRemoteCallFeedUserIds(
   return ids;
 }
 
+function findRemoteUserMediaFeed(
+  gc: GroupCallRemoteMediaLike,
+  userId: string,
+): RemoteCallFeedLike | null {
+  for (const feed of gc.userMediaFeeds) {
+    if (feed.isLocal()) continue;
+    if (feed.userId?.trim() === userId) return feed;
+  }
+  return null;
+}
+
 /** Others in the participant map who have no inbound userMedia or share feed yet. */
 export function countMissingRemoteCallFeeds(
   othersInCall: string[],
   remoteIdsWithFeed: ReadonlySet<string>,
 ): number {
   return othersInCall.filter((id) => id && !remoteIdsWithFeed.has(id)).length;
+}
+
+/**
+ * Participants in the map who lack inbound media: no CallFeed yet, or a zombie
+ * userMedia feed with no live tracks while mic/camera are supposed to be on.
+ */
+export function countUnhealthyRemoteCallMedia(
+  gc: GroupCallRemoteMediaLike,
+  othersInCall: string[],
+): number {
+  const remoteIdsWithFeed = collectRemoteCallFeedUserIds(gc);
+  let unhealthy = 0;
+  for (const id of othersInCall) {
+    if (!id) continue;
+    if (!remoteIdsWithFeed.has(id)) {
+      unhealthy += 1;
+      continue;
+    }
+    const userMediaFeed = findRemoteUserMediaFeed(gc, id);
+    if (userMediaFeed && !isRemoteCallFeedMediaHealthy(userMediaFeed)) {
+      unhealthy += 1;
+    }
+  }
+  return unhealthy;
 }

--- a/packages/core/src/matrix/client/hooks/remote-call-media-stall.ts
+++ b/packages/core/src/matrix/client/hooks/remote-call-media-stall.ts
@@ -86,22 +86,29 @@ export function countMissingRemoteCallFeeds(
  * Participants in the map who lack inbound media: no CallFeed yet, or a zombie
  * userMedia feed with no live tracks while mic/camera are supposed to be on.
  */
-export function countUnhealthyRemoteCallMedia(
+export function listUnhealthyRemoteCallUserIds(
   gc: GroupCallRemoteMediaLike,
   othersInCall: string[],
-): number {
+): string[] {
   const remoteIdsWithFeed = collectRemoteCallFeedUserIds(gc);
-  let unhealthy = 0;
+  const unhealthy: string[] = [];
   for (const id of othersInCall) {
     if (!id) continue;
     if (!remoteIdsWithFeed.has(id)) {
-      unhealthy += 1;
+      unhealthy.push(id);
       continue;
     }
     const userMediaFeed = findRemoteUserMediaFeed(gc, id);
     if (userMediaFeed && !isRemoteCallFeedMediaHealthy(userMediaFeed)) {
-      unhealthy += 1;
+      unhealthy.push(id);
     }
   }
   return unhealthy;
+}
+
+export function countUnhealthyRemoteCallMedia(
+  gc: GroupCallRemoteMediaLike,
+  othersInCall: string[],
+): number {
+  return listUnhealthyRemoteCallUserIds(gc, othersInCall).length;
 }

--- a/packages/core/src/matrix/client/hooks/remote-call-media-stall.ts
+++ b/packages/core/src/matrix/client/hooks/remote-call-media-stall.ts
@@ -1,0 +1,30 @@
+type CallFeedLike = {
+  isLocal: () => boolean;
+  userId?: string | null;
+};
+
+type GroupCallFeedsLike = {
+  userMediaFeeds: CallFeedLike[];
+  screenshareFeeds: CallFeedLike[];
+};
+
+/** Remote participants with at least one userMedia or screenshare CallFeed. */
+export function collectRemoteCallFeedUserIds(
+  gc: GroupCallFeedsLike,
+): Set<string> {
+  const ids = new Set<string>();
+  for (const feed of [...gc.userMediaFeeds, ...gc.screenshareFeeds]) {
+    if (feed.isLocal()) continue;
+    const userId = feed.userId?.trim();
+    if (userId) ids.add(userId);
+  }
+  return ids;
+}
+
+/** Others in the participant map who have no inbound userMedia or share feed yet. */
+export function countMissingRemoteCallFeeds(
+  othersInCall: string[],
+  remoteIdsWithFeed: ReadonlySet<string>,
+): number {
+  return othersInCall.filter((id) => id && !remoteIdsWithFeed.has(id)).length;
+}

--- a/packages/core/src/matrix/client/hooks/space-group-call-telemetry.ts
+++ b/packages/core/src/matrix/client/hooks/space-group-call-telemetry.ts
@@ -23,6 +23,7 @@ export type SpaceGroupCallTelemetryEvent = {
     | 'hypha.group_call.media_snapshot'
     | 'hypha.group_call.remote_media_stall'
     | 'hypha.group_call.remote_media_recover'
+    | 'hypha.group_call.pairwise_restart'
     | 'hypha.group_call.turn_probe'
     | 'hypha.group_call.ice_gather_probe'
     | 'hypha.group_call.webrtc_summary'
@@ -58,6 +59,14 @@ export type SpaceGroupCallTelemetryEvent = {
   /** Room state lists them in-call but no userMedia CallFeed yet (WebRTC lag / failure). */
   missingRemoteFeedCount?: number;
   waitedMs?: number;
+  /** Pairwise `MatrixCall.hangup()` invocations before re-placing outgoing calls. */
+  hungUp?: number;
+  /** Stall recovery targeted local publish (mic/camera) rather than inbound feeds only. */
+  localOutboundUnhealthy?: boolean;
+  /** Remote user ids whose pairwise calls were restarted. */
+  targetCount?: number;
+  /** User clicked Retry connection (vs automatic 25s watchdog). */
+  manual?: boolean;
   /** Result of `client.checkTurnServers()` — homeserver returned usable TURN URIs. */
   turnCredsOk?: boolean;
   /** Approximate seconds until TURN credential expiry (from client clock). */

--- a/packages/core/src/matrix/client/hooks/space-group-call-telemetry.ts
+++ b/packages/core/src/matrix/client/hooks/space-group-call-telemetry.ts
@@ -61,7 +61,6 @@ export type SpaceGroupCallTelemetryEvent = {
   /** Local camera mute at snapshot time (SDK `localCallFeed`). */
   localVideoMuted?: boolean;
   localVideoTrackCount?: number;
-  roomGroupCallType?: string;
   waitedMs?: number;
   /** Pairwise `MatrixCall.hangup()` invocations before re-placing outgoing calls. */
   hungUp?: number;

--- a/packages/core/src/matrix/client/hooks/space-group-call-telemetry.ts
+++ b/packages/core/src/matrix/client/hooks/space-group-call-telemetry.ts
@@ -58,6 +58,10 @@ export type SpaceGroupCallTelemetryEvent = {
   participantDeviceCount?: number;
   /** Room state lists them in-call but no userMedia CallFeed yet (WebRTC lag / failure). */
   missingRemoteFeedCount?: number;
+  /** Local camera mute at snapshot time (SDK `localCallFeed`). */
+  localVideoMuted?: boolean;
+  localVideoTrackCount?: number;
+  roomGroupCallType?: string;
   waitedMs?: number;
   /** Pairwise `MatrixCall.hangup()` invocations before re-placing outgoing calls. */
   hungUp?: number;

--- a/packages/core/src/matrix/client/hooks/space-group-call-telemetry.ts
+++ b/packages/core/src/matrix/client/hooks/space-group-call-telemetry.ts
@@ -26,6 +26,7 @@ export type SpaceGroupCallTelemetryEvent = {
     | 'hypha.group_call.pairwise_restart'
     | 'hypha.group_call.turn_probe'
     | 'hypha.group_call.ice_gather_probe'
+    | 'hypha.group_call.ice_transport'
     | 'hypha.group_call.webrtc_summary'
     | 'hypha.group_call.inbound_rtp_frame_size'
     | 'hypha.group_call.simulcast_audit'
@@ -85,6 +86,13 @@ export type SpaceGroupCallTelemetryEvent = {
   forceTurn?: boolean;
   fallbackIceAllowed?: boolean;
   iceGatherState?: RTCIceGatheringState | 'unsupported' | 'timeout';
+  iceConnectionState?: RTCIceConnectionState;
+  connectionState?: RTCPeerConnectionState;
+  localCandidateType?: string;
+  remoteCandidateType?: string;
+  pairState?: string;
+  inboundAudioBytes?: number;
+  inboundVideoBytes?: number;
   /** Matrix SDK summary stats (subset); see `SummaryStatsReport`. */
   percentageReceivedMedia?: number;
   percentageReceivedAudioMedia?: number;

--- a/packages/core/src/matrix/client/hooks/use-space-group-call.ts
+++ b/packages/core/src/matrix/client/hooks/use-space-group-call.ts
@@ -315,10 +315,9 @@ async function restartPairwiseCallsForRemoteUsers(
   gc: MatrixSdk.GroupCall,
   remoteUserIds: readonly string[],
 ): Promise<number> {
-  await republishLocalMediaToPairwiseCalls(gc);
   const hungUp = hangupPairwiseCallsForRemoteUsers(gc, remoteUserIds);
   nudgeGroupCallPlaceOutgoing(gc);
-  await republishLocalMediaToPairwiseCalls(gc);
+  await republishLocalMediaToPairwiseCalls(gc, { force: true });
   return hungUp;
 }
 
@@ -503,7 +502,6 @@ async function ensureLocalCallMediaPublished(
   } catch {
     /* keep call connected if device recovery fails */
   }
-  await republishLocalMediaToPairwiseCalls(gc);
   nudgeGroupCallPlaceOutgoing(gc);
 }
 
@@ -658,6 +656,8 @@ export function useSpaceGroupCall(
   const placeOutgoingPeriodicIntervalRef = useRef<number | null>(null);
   const localMediaBootstrapDebounceRef = useRef<number | null>(null);
   const localMediaBootstrapTimerRefs = useRef<number[]>([]);
+  /** Debounced pairwise republish after `CallsChanged` (avoid stream churn). */
+  const pairwiseRepublishTimerRef = useRef<number | null>(null);
   /**
    * Bumped when starting a join and when the stall watchdog fires — stale
    * `await gc.enter()` must not run success paths after forced cleanup.
@@ -847,6 +847,10 @@ export function useSpaceGroupCall(
     if (localMediaBootstrapDebounceRef.current != null) {
       clearTimeout(localMediaBootstrapDebounceRef.current);
       localMediaBootstrapDebounceRef.current = null;
+    }
+    if (pairwiseRepublishTimerRef.current != null) {
+      clearTimeout(pairwiseRepublishTimerRef.current);
+      pairwiseRepublishTimerRef.current = null;
     }
     if (localMediaBootstrapTimerRefs.current.length > 0) {
       for (const id of localMediaBootstrapTimerRefs.current) {
@@ -2160,8 +2164,16 @@ export function useSpaceGroupCall(
       };
       gc.on(GroupCallEvent.ParticipantsChanged, onParticipantsChanged);
       const onCallsChanged = () => {
-        /** New pairwise session — push warmed local A/V into the peer connection. */
-        scheduleLocalMediaBootstrap(gc);
+        /** New pairwise session — one debounced republish once local A/V has settled. */
+        if (typeof window === 'undefined') return;
+        if (pairwiseRepublishTimerRef.current != null) {
+          clearTimeout(pairwiseRepublishTimerRef.current);
+        }
+        pairwiseRepublishTimerRef.current = window.setTimeout(() => {
+          pairwiseRepublishTimerRef.current = null;
+          if (groupCallRef.current !== gc) return;
+          void republishLocalMediaToPairwiseCalls(gc);
+        }, 1500);
         nudgeGroupCallPlaceOutgoing(gc);
       };
       gc.on(GroupCallEvent.CallsChanged, onCallsChanged);

--- a/packages/core/src/matrix/client/hooks/use-space-group-call.ts
+++ b/packages/core/src/matrix/client/hooks/use-space-group-call.ts
@@ -102,6 +102,7 @@ import {
   republishLocalMediaToPairwiseCalls,
   restartAllPairwiseCallsForVideo,
   schedulePairwiseVideoResync,
+  waitForActivePairwiseCalls,
 } from './call-pairwise-restart';
 import {
   clearPairwiseRepublishSchedule,
@@ -326,7 +327,16 @@ async function restartPairwiseCallsForRemoteUsers(
 ): Promise<number> {
   const hungUp = hangupPairwiseCallsForRemoteUsers(gc, remoteUserIds);
   nudgeGroupCallPlaceOutgoing(gc);
-  await republishLocalMediaToPairwiseCalls(gc, { force: true });
+  if (hungUp > 0) {
+    await waitForActivePairwiseCalls(gc);
+  }
+  if (hasActivePairwiseCalls(gc)) {
+    await republishLocalMediaToPairwiseCalls(gc, { force: true });
+  }
+  scheduleRepublishLocalMediaToPairwiseCalls(gc, {
+    force: true,
+    delayMs: 3_000,
+  });
   return hungUp;
 }
 
@@ -740,6 +750,7 @@ export function useSpaceGroupCall(
   const remoteMediaGapSinceRef = useRef<number | null>(null);
   const remoteMediaStallLoggedRef = useRef(false);
   const remoteMediaPairwiseRestartAttemptedRef = useRef(false);
+  const localVideoRecoveryAttemptedRef = useRef(false);
   const remoteMediaStallBannerDismissedRef = useRef(false);
   const remoteMediaRepairNudgeIntervalRef = useRef<ReturnType<
     typeof setInterval
@@ -1896,6 +1907,24 @@ export function useSpaceGroupCall(
 
     const now = Date.now();
     if (mediaUnhealthy) {
+      if (
+        localOutboundUnhealthy &&
+        kind === 'video' &&
+        !gc.isLocalVideoMuted() &&
+        !localVideoRecoveryAttemptedRef.current
+      ) {
+        localVideoRecoveryAttemptedRef.current = true;
+        void ensureLocalVideoCaptureActive(gc, {
+          onCameraAccessBlocked: setCameraAccessBlocked,
+        })
+          .then(async () => {
+            if (groupCallRef.current !== gc) return;
+            await republishLocalMediaToPairwiseCalls(gc, { force: true });
+            refreshLocalPreview();
+            scheduleFeedBatched();
+          })
+          .catch(() => undefined);
+      }
       if (remoteMediaRepairNudgeIntervalRef.current == null) {
         remoteMediaRepairNudgeIntervalRef.current = setInterval(() => {
           if (groupCallRef.current !== gc) return;
@@ -1981,6 +2010,7 @@ export function useSpaceGroupCall(
       remoteMediaGapSinceRef.current = null;
       remoteMediaStallLoggedRef.current = false;
       remoteMediaPairwiseRestartAttemptedRef.current = false;
+      localVideoRecoveryAttemptedRef.current = false;
       remoteMediaStallBannerDismissedRef.current = false;
       if (remoteMediaRepairNudgeIntervalRef.current != null) {
         clearInterval(remoteMediaRepairNudgeIntervalRef.current);
@@ -2012,6 +2042,7 @@ export function useSpaceGroupCall(
     remoteMediaStallBannerDismissedRef.current = false;
     remoteMediaStallLoggedRef.current = false;
     remoteMediaPairwiseRestartAttemptedRef.current = false;
+    localVideoRecoveryAttemptedRef.current = false;
     remoteMediaGapSinceRef.current = null;
     setRemoteMediaStall(false);
     setRemoteMediaWarming(true);

--- a/packages/core/src/matrix/client/hooks/use-space-group-call.ts
+++ b/packages/core/src/matrix/client/hooks/use-space-group-call.ts
@@ -91,7 +91,11 @@ import {
   applyScreenShareCaptureRootRestrictionWithRetry,
   clearScreenShareCaptureRootRestriction,
 } from './screenshare-capture-exclusion';
-import { countUnhealthyRemoteCallMedia } from './remote-call-media-stall';
+import {
+  countUnhealthyRemoteCallMedia,
+  listUnhealthyRemoteCallUserIds,
+} from './remote-call-media-stall';
+import { hangupPairwiseCallsForRemoteUsers } from './call-pairwise-restart';
 import {
   applyScreenshareTrackContentHints,
   resolveScreenshareVoicePresetPlan,
@@ -176,6 +180,8 @@ const CONNECT_STALL_ABORT_MS = 90_000;
 
 /** Room shows others in-call but no remote userMedia CallFeed yet (signaling/WebRTC issue). */
 const REMOTE_MEDIA_STALL_MS = 45_000;
+/** One-shot pairwise hangup + re-place when nudges fail (no GroupCall.leave). */
+const REMOTE_MEDIA_PAIRWISE_RESTART_MS = 25_000;
 const REMOTE_MEDIA_REPAIR_NUDGE_MS = 1500;
 
 /** Dev console: periodic sample of feeds vs participant map (not every Matrix event). */
@@ -285,6 +291,30 @@ function nudgeGroupCallPlaceOutgoing(gc: MatrixSdk.GroupCall): void {
   } catch {
     /* ignore */
   }
+}
+
+function isLocalOutboundMediaUnhealthy(
+  gc: MatrixSdk.GroupCall,
+  kind: 'audio' | 'video',
+): boolean {
+  if (!gc.isMicrophoneMuted() && !getLiveLocalAudioTrack(gc)) return true;
+  if (
+    kind === 'video' &&
+    !gc.isLocalVideoMuted() &&
+    !getPublishableLocalVideoTrack(gc)
+  ) {
+    return true;
+  }
+  return false;
+}
+
+function restartPairwiseCallsForRemoteUsers(
+  gc: MatrixSdk.GroupCall,
+  remoteUserIds: readonly string[],
+): number {
+  const hungUp = hangupPairwiseCallsForRemoteUsers(gc, remoteUserIds);
+  nudgeGroupCallPlaceOutgoing(gc);
+  return hungUp;
 }
 
 function countGroupCallParticipantDevices(gc: MatrixSdk.GroupCall): number {
@@ -638,6 +668,7 @@ export function useSpaceGroupCall(
   /** First time we saw others in participant map but no remote CallFeed (ms since epoch). */
   const remoteMediaGapSinceRef = useRef<number | null>(null);
   const remoteMediaStallLoggedRef = useRef(false);
+  const remoteMediaPairwiseRestartAttemptedRef = useRef(false);
   const remoteMediaStallBannerDismissedRef = useRef(false);
   const remoteMediaRepairNudgeIntervalRef = useRef<ReturnType<
     typeof setInterval
@@ -1354,6 +1385,7 @@ export function useSpaceGroupCall(
       groupCallListenerCleanupRef.current = null;
       remoteMediaGapSinceRef.current = null;
       remoteMediaStallLoggedRef.current = false;
+      remoteMediaPairwiseRestartAttemptedRef.current = false;
       remoteMediaStallBannerDismissedRef.current = false;
       if (remoteMediaRepairNudgeIntervalRef.current != null) {
         clearInterval(remoteMediaRepairNudgeIntervalRef.current);
@@ -1777,13 +1809,16 @@ export function useSpaceGroupCall(
     const othersInCall = inCallUserIdsFromGroupCall(gc).filter(
       (id) => id && id !== myId,
     );
-    const missingRemoteFeedCount = countUnhealthyRemoteCallMedia(
-      gc,
-      othersInCall,
-    );
+    const unhealthyRemoteIds = listUnhealthyRemoteCallUserIds(gc, othersInCall);
+    const missingRemoteFeedCount = unhealthyRemoteIds.length;
+    const kind = lastJoinKindRef.current ?? 'audio';
+    const localOutboundUnhealthy = isLocalOutboundMediaUnhealthy(gc, kind);
+    const mediaUnhealthy =
+      (missingRemoteFeedCount > 0 || localOutboundUnhealthy) &&
+      othersInCall.length > 0;
 
     const now = Date.now();
-    if (missingRemoteFeedCount > 0 && othersInCall.length > 0) {
+    if (mediaUnhealthy) {
       if (remoteMediaRepairNudgeIntervalRef.current == null) {
         remoteMediaRepairNudgeIntervalRef.current = setInterval(() => {
           if (groupCallRef.current !== gc) return;
@@ -1812,7 +1847,33 @@ export function useSpaceGroupCall(
         remoteMediaGapSinceRef.current = now;
       }
       scheduleLocalMediaBootstrap(gc);
-      const waitedMs = now - remoteMediaGapSinceRef.current;
+      const waitedMs = now - (remoteMediaGapSinceRef.current ?? now);
+      if (
+        waitedMs >= REMOTE_MEDIA_PAIRWISE_RESTART_MS &&
+        !remoteMediaPairwiseRestartAttemptedRef.current
+      ) {
+        remoteMediaPairwiseRestartAttemptedRef.current = true;
+        const restartTargets = localOutboundUnhealthy
+          ? othersInCall
+          : unhealthyRemoteIds;
+        void ensurePublishedLocalMediaWithOrientation(gc, kind).then(() => {
+          if (groupCallRef.current !== gc) return;
+          const hungUp = restartPairwiseCallsForRemoteUsers(gc, restartTargets);
+          scheduleFeedBatched();
+          refreshLocalPreview();
+          if (roomId) {
+            logSpaceGroupCallEvent({
+              name: 'hypha.group_call.pairwise_restart',
+              roomId,
+              kind,
+              groupCallId: gc.groupCallId,
+              hungUp,
+              localOutboundUnhealthy,
+              targetCount: restartTargets.length,
+            });
+          }
+        });
+      }
       if (
         !remoteMediaStallBannerDismissedRef.current &&
         waitedMs < REMOTE_MEDIA_STALL_MS
@@ -1841,6 +1902,7 @@ export function useSpaceGroupCall(
     } else {
       remoteMediaGapSinceRef.current = null;
       remoteMediaStallLoggedRef.current = false;
+      remoteMediaPairwiseRestartAttemptedRef.current = false;
       remoteMediaStallBannerDismissedRef.current = false;
       if (remoteMediaRepairNudgeIntervalRef.current != null) {
         clearInterval(remoteMediaRepairNudgeIntervalRef.current);
@@ -1852,8 +1914,11 @@ export function useSpaceGroupCall(
   }, [
     applyTurnReadinessState,
     client,
+    ensurePublishedLocalMediaWithOrientation,
+    refreshLocalPreview,
     roomId,
     inCallUserIdsFromGroupCall,
+    scheduleFeedBatched,
     scheduleLocalMediaBootstrap,
   ]);
 
@@ -1868,26 +1933,45 @@ export function useSpaceGroupCall(
 
     remoteMediaStallBannerDismissedRef.current = false;
     remoteMediaStallLoggedRef.current = false;
+    remoteMediaPairwiseRestartAttemptedRef.current = false;
     remoteMediaGapSinceRef.current = null;
     setRemoteMediaStall(false);
     setRemoteMediaWarming(true);
 
+    const kind = lastJoinKindRef.current ?? 'audio';
+    const myId = client?.getUserId() ?? null;
+    const othersInCall = inCallUserIdsFromGroupCall(gc).filter(
+      (id) => id && id !== myId,
+    );
+
     logSpaceGroupCallEvent({
       name: 'hypha.group_call.remote_media_recover',
       roomId: roomId.trim(),
-      kind: lastJoinKindRef.current ?? undefined,
+      kind,
     });
 
-    nudgeGroupCallPlaceOutgoing(gc);
     scheduleLocalMediaBootstrap(gc);
     scheduleFeedBatched();
     refreshLocalPreview();
 
-    const kind = lastJoinKindRef.current ?? 'audio';
     void ensurePublishedLocalMediaWithOrientation(gc, kind).then(() => {
+      if (groupCallRef.current !== gc) return;
+      const hungUp = restartPairwiseCallsForRemoteUsers(gc, othersInCall);
       scheduleFeedBatched();
       refreshLocalPreview();
       evalRemoteMediaStall();
+      if (roomId) {
+        logSpaceGroupCallEvent({
+          name: 'hypha.group_call.pairwise_restart',
+          roomId: roomId.trim(),
+          kind,
+          groupCallId: gc.groupCallId,
+          hungUp,
+          localOutboundUnhealthy: isLocalOutboundMediaUnhealthy(gc, kind),
+          targetCount: othersInCall.length,
+          manual: true,
+        });
+      }
     });
 
     if (client) {
@@ -1904,6 +1988,7 @@ export function useSpaceGroupCall(
     client,
     ensurePublishedLocalMediaWithOrientation,
     evalRemoteMediaStall,
+    inCallUserIdsFromGroupCall,
     refreshLocalPreview,
     roomId,
     scheduleFeedBatched,

--- a/packages/core/src/matrix/client/hooks/use-space-group-call.ts
+++ b/packages/core/src/matrix/client/hooks/use-space-group-call.ts
@@ -96,6 +96,7 @@ import {
   listUnhealthyRemoteCallUserIds,
 } from './remote-call-media-stall';
 import {
+  clearPairwisePublishIntent,
   clearPairwiseVideoResyncAttemptCounts,
   clearPairwiseVideoResyncSchedule,
   hangupPairwiseCallsForRemoteUsers,
@@ -103,7 +104,9 @@ import {
   republishLocalMediaToPairwiseCalls,
   restartAllPairwiseCallsForVideo,
   schedulePairwiseVideoResync,
+  syncPairwisePublishIntent,
   waitForActivePairwiseCalls,
+  type PairwisePublishIntent,
 } from './call-pairwise-restart';
 import {
   clearPairwiseRepublishSchedule,
@@ -560,18 +563,21 @@ async function recoverLocalMicrophoneFeed(
   if (getLiveLocalAudioTrack(gc)) return;
 
   try {
+    await gc.setMicrophoneMuted(false);
+    if (await waitForLiveLocalAudioTrack(gc, 600)) return;
+  } catch {
+    /* best-effort device recovery */
+  }
+
+  try {
     await gc.setMicrophoneMuted(true);
     await gc.setMicrophoneMuted(false);
     await waitForLiveLocalAudioTrack(gc, 400);
   } catch {
     /* best-effort device recovery */
   } finally {
-    if (!gc.isMicrophoneMuted()) return;
-    try {
-      await gc.setMicrophoneMuted(false);
-      await waitForLiveLocalAudioTrack(gc, 400);
-    } catch {
-      /* keep call connected if unmute fails */
+    if (gc.isMicrophoneMuted()) {
+      await gc.setMicrophoneMuted(false).catch(() => undefined);
     }
   }
 }
@@ -595,6 +601,11 @@ async function ensureLocalCallMediaPublished(
     /* keep call connected if device recovery fails */
   }
   nudgeGroupCallPlaceOutgoing(gc);
+  try {
+    await republishLocalMediaToPairwiseCalls(gc, { force: true });
+  } catch {
+    /* best-effort pairwise push after local track recovery */
+  }
 }
 
 /** Matrix SDK group-call summary stats interval (`NEXT_PUBLIC_MATRIX_WEBRTC_GROUP_STATS_MS`). */
@@ -766,6 +777,10 @@ export function useSpaceGroupCall(
   const remoteMediaStallLoggedRef = useRef(false);
   const remoteMediaPairwiseRestartAttemptedRef = useRef(false);
   const localVideoRecoveryAttemptedRef = useRef(false);
+  const pairwisePublishIntentRef = useRef<PairwisePublishIntent>({
+    wantAudio: true,
+    wantVideo: false,
+  });
   const remoteMediaStallBannerDismissedRef = useRef(false);
   const remoteMediaRepairNudgeIntervalRef = useRef<ReturnType<
     typeof setInterval
@@ -1473,6 +1488,10 @@ export function useSpaceGroupCall(
       clearLocalMediaBootstrapTimers();
       clearPairwiseVideoResyncSchedule();
       clearPairwiseVideoResyncAttemptCounts();
+      if (groupCallRef.current) {
+        clearPairwisePublishIntent(groupCallRef.current);
+      }
+      pairwisePublishIntentRef.current = { wantAudio: true, wantVideo: false };
       webRtcDiagCleanupRef.current?.();
       webRtcDiagCleanupRef.current = null;
       turnRefreshCleanupRef.current?.();
@@ -1585,6 +1604,14 @@ export function useSpaceGroupCall(
     const feed = gc.localCallFeed;
     setLocalPreviewStream(feed?.stream ?? null);
   }, []);
+
+  const applyPairwisePublishIntent = useCallback(
+    (gc: MatrixSdk.GroupCall | null | undefined) => {
+      if (!gc) return;
+      syncPairwisePublishIntent(gc, pairwisePublishIntentRef.current);
+    },
+    [],
+  );
 
   const applyVoiceProcessingPresetToGroupCall = useCallback(
     async (
@@ -2273,15 +2300,22 @@ export function useSpaceGroupCall(
         nudgeGroupCallPlaceOutgoing(gc);
         scheduleLocalMediaBootstrap(gc);
         const kind = lastJoinKindRef.current ?? 'audio';
-        if (kind === 'video' && !gc.isLocalVideoMuted()) {
+        if (kind === 'video') {
           const myId = client?.getUserId() ?? null;
           const othersInCall = inCallUserIdsFromGroupCall(gc).filter(
             (id) => id && id !== myId,
           );
           if (othersInCall.length > 0) {
-            schedulePairwiseVideoResync(gc, () =>
-              nudgeGroupCallPlaceOutgoing(gc),
-            );
+            const intent = pairwisePublishIntentRef.current;
+            scheduleRepublishLocalMediaToPairwiseCalls(gc, {
+              force: intent.wantAudio || intent.wantVideo,
+              delayMs: 2_000,
+            });
+            if (!gc.isLocalVideoMuted()) {
+              schedulePairwiseVideoResync(gc, () =>
+                nudgeGroupCallPlaceOutgoing(gc),
+              );
+            }
           }
         }
       };
@@ -2290,7 +2324,9 @@ export function useSpaceGroupCall(
         /** New pairwise session — debounced republish after ICE has time to connect. */
         if (groupCallRef.current !== gc) return;
         const kind = lastJoinKindRef.current ?? 'audio';
+        const intent = pairwisePublishIntentRef.current;
         scheduleRepublishLocalMediaToPairwiseCalls(gc, {
+          force: intent.wantAudio || intent.wantVideo,
           delayMs: kind === 'video' ? 2_000 : 4_000,
         });
         nudgeGroupCallPlaceOutgoing(gc);
@@ -2611,6 +2647,10 @@ export function useSpaceGroupCall(
           setCameraAccessBlocked(false);
         }
       }
+      pairwisePublishIntentRef.current = {
+        wantAudio: true,
+        wantVideo: kind === 'video' && videoJoinWithCamera,
+      };
       /**
        * Refresh stale local member state after hard reloads. If the prior tab died
        * mid-call, old device entries can survive briefly and cause asymmetric media.
@@ -2628,6 +2668,7 @@ export function useSpaceGroupCall(
       groupCallRef.current = gc;
       activeGroupCallRoomIdRef.current = roomId;
       setGroupCall(gc);
+      applyPairwisePublishIntent(gc);
       attachGroupCallListeners(gc);
       updateParticipantCount();
       setCallState('connecting');
@@ -2754,9 +2795,10 @@ export function useSpaceGroupCall(
           });
         }
         await ensurePublishedLocalMediaWithOrientation(gc, kind);
-        if (kind === 'video' && !gc.isLocalVideoMuted()) {
+        if (kind === 'video') {
+          applyPairwisePublishIntent(gc);
           await republishLocalMediaToPairwiseCalls(gc, { force: true });
-          if (hasActivePairwiseCalls(gc)) {
+          if (!gc.isLocalVideoMuted() && hasActivePairwiseCalls(gc)) {
             await restartAllPairwiseCallsForVideo(gc, () =>
               nudgeGroupCallPlaceOutgoing(gc),
             );
@@ -2887,6 +2929,7 @@ export function useSpaceGroupCall(
       }
     },
     [
+      applyPairwisePublishIntent,
       attachGroupCallListeners,
       authToken,
       client,
@@ -3029,6 +3072,8 @@ export function useSpaceGroupCall(
     async (muted: boolean) => {
       const gc = groupCallRef.current;
       if (!gc) return;
+      pairwisePublishIntentRef.current.wantAudio = !muted;
+      applyPairwisePublishIntent(gc);
       await gc.setMicrophoneMuted(muted);
       if (!muted) {
         nudgeGroupCallPlaceOutgoing(gc);
@@ -3045,7 +3090,7 @@ export function useSpaceGroupCall(
       scheduleFeedBatched();
       window.setTimeout(scheduleFeedBatched, 350);
     },
-    [scheduleFeedBatched],
+    [applyPairwisePublishIntent, scheduleFeedBatched],
   );
 
   const setCameraMuted = useCallback(
@@ -3063,6 +3108,8 @@ export function useSpaceGroupCall(
             /* keep UI aligned with SDK */
           }
           setIsLocalVideoMuted(true);
+          pairwisePublishIntentRef.current.wantVideo = false;
+          applyPairwisePublishIntent(gc);
           if (access.reason === 'permission_denied') {
             setCameraAccessBlocked(true);
           }
@@ -3100,10 +3147,14 @@ export function useSpaceGroupCall(
             /* keep call connected */
           }
           setIsLocalVideoMuted(true);
+          pairwisePublishIntentRef.current.wantVideo = false;
+          applyPairwisePublishIntent(gc);
           return;
         }
       }
       await gc.setLocalVideoMuted(muted);
+      pairwisePublishIntentRef.current.wantVideo = !gc.isLocalVideoMuted();
+      applyPairwisePublishIntent(gc);
       if (!muted) {
         setCallKind('video');
         lastJoinKindRef.current = 'video';
@@ -3156,6 +3207,7 @@ export function useSpaceGroupCall(
       }, 350);
     },
     [
+      applyPairwisePublishIntent,
       client,
       inCallUserIdsFromGroupCall,
       refreshLocalPreview,

--- a/packages/core/src/matrix/client/hooks/use-space-group-call.ts
+++ b/packages/core/src/matrix/client/hooks/use-space-group-call.ts
@@ -197,7 +197,7 @@ const CONNECT_STALL_ABORT_MS = 90_000;
 /** Room shows others in-call but no remote userMedia CallFeed yet (signaling/WebRTC issue). */
 const REMOTE_MEDIA_STALL_MS = 45_000;
 /** One-shot pairwise hangup + re-place when nudges fail (no GroupCall.leave). */
-const REMOTE_MEDIA_PAIRWISE_RESTART_MS = 15_000;
+const REMOTE_MEDIA_PAIRWISE_RESTART_MS = 45_000;
 /** Avoid hammering `placeOutgoingCalls()` while ICE is still checking (negotiation glare). */
 const REMOTE_MEDIA_REPAIR_NUDGE_MS = 8_000;
 
@@ -590,21 +590,32 @@ async function ensureLocalCallMediaPublished(
   gc: MatrixSdk.GroupCall,
   kind: 'audio' | 'video',
 ): Promise<void> {
+  let republishNeeded = false;
   try {
     if (!gc.isMicrophoneMuted()) {
+      const hadAudio = Boolean(getLiveLocalAudioTrack(gc));
       await recoverLocalMicrophoneFeed(gc);
+      if (!hadAudio && getLiveLocalAudioTrack(gc)) {
+        republishNeeded = true;
+      }
     }
     if (kind === 'video' && !gc.isLocalVideoMuted()) {
+      const hadVideo = Boolean(getLocalVideoTrackPresence(gc));
       await recoverLocalCameraFeed(gc);
+      if (!hadVideo && getLocalVideoTrackPresence(gc)) {
+        republishNeeded = true;
+      }
     }
   } catch {
     /* keep call connected if device recovery fails */
   }
   nudgeGroupCallPlaceOutgoing(gc);
-  try {
-    await republishLocalMediaToPairwiseCalls(gc, { force: true });
-  } catch {
-    /* best-effort pairwise push after local track recovery */
+  if (republishNeeded) {
+    try {
+      await republishLocalMediaToPairwiseCalls(gc, { force: true });
+    } catch {
+      /* best-effort pairwise push after local track recovery */
+    }
   }
 }
 
@@ -2324,9 +2335,7 @@ export function useSpaceGroupCall(
         /** New pairwise session — debounced republish after ICE has time to connect. */
         if (groupCallRef.current !== gc) return;
         const kind = lastJoinKindRef.current ?? 'audio';
-        const intent = pairwisePublishIntentRef.current;
         scheduleRepublishLocalMediaToPairwiseCalls(gc, {
-          force: intent.wantAudio || intent.wantVideo,
           delayMs: kind === 'video' ? 2_000 : 4_000,
         });
         nudgeGroupCallPlaceOutgoing(gc);

--- a/packages/core/src/matrix/client/hooks/use-space-group-call.ts
+++ b/packages/core/src/matrix/client/hooks/use-space-group-call.ts
@@ -2183,7 +2183,11 @@ export function useSpaceGroupCall(
       const onCallsChanged = () => {
         /** New pairwise session — debounced republish after ICE has time to connect. */
         if (groupCallRef.current !== gc) return;
-        scheduleRepublishLocalMediaToPairwiseCalls(gc, { delayMs: 4_000 });
+        const kind = lastJoinKindRef.current ?? 'audio';
+        scheduleRepublishLocalMediaToPairwiseCalls(gc, {
+          force: kind === 'video' && !gc.isLocalVideoMuted(),
+          delayMs: kind === 'video' ? 2_000 : 4_000,
+        });
         nudgeGroupCallPlaceOutgoing(gc);
       };
       gc.on(GroupCallEvent.CallsChanged, onCallsChanged);

--- a/packages/core/src/matrix/client/hooks/use-space-group-call.ts
+++ b/packages/core/src/matrix/client/hooks/use-space-group-call.ts
@@ -95,7 +95,10 @@ import {
   countUnhealthyRemoteCallMedia,
   listUnhealthyRemoteCallUserIds,
 } from './remote-call-media-stall';
-import { hangupPairwiseCallsForRemoteUsers } from './call-pairwise-restart';
+import {
+  hangupPairwiseCallsForRemoteUsers,
+  republishLocalMediaToPairwiseCalls,
+} from './call-pairwise-restart';
 import {
   applyScreenshareTrackContentHints,
   resolveScreenshareVoicePresetPlan,
@@ -181,7 +184,7 @@ const CONNECT_STALL_ABORT_MS = 90_000;
 /** Room shows others in-call but no remote userMedia CallFeed yet (signaling/WebRTC issue). */
 const REMOTE_MEDIA_STALL_MS = 45_000;
 /** One-shot pairwise hangup + re-place when nudges fail (no GroupCall.leave). */
-const REMOTE_MEDIA_PAIRWISE_RESTART_MS = 25_000;
+const REMOTE_MEDIA_PAIRWISE_RESTART_MS = 10_000;
 const REMOTE_MEDIA_REPAIR_NUDGE_MS = 1500;
 
 /** Dev console: periodic sample of feeds vs participant map (not every Matrix event). */
@@ -308,12 +311,14 @@ function isLocalOutboundMediaUnhealthy(
   return false;
 }
 
-function restartPairwiseCallsForRemoteUsers(
+async function restartPairwiseCallsForRemoteUsers(
   gc: MatrixSdk.GroupCall,
   remoteUserIds: readonly string[],
-): number {
+): Promise<number> {
+  await republishLocalMediaToPairwiseCalls(gc);
   const hungUp = hangupPairwiseCallsForRemoteUsers(gc, remoteUserIds);
   nudgeGroupCallPlaceOutgoing(gc);
+  await republishLocalMediaToPairwiseCalls(gc);
   return hungUp;
 }
 
@@ -498,6 +503,7 @@ async function ensureLocalCallMediaPublished(
   } catch {
     /* keep call connected if device recovery fails */
   }
+  await republishLocalMediaToPairwiseCalls(gc);
   nudgeGroupCallPlaceOutgoing(gc);
 }
 
@@ -1856,23 +1862,28 @@ export function useSpaceGroupCall(
         const restartTargets = localOutboundUnhealthy
           ? othersInCall
           : unhealthyRemoteIds;
-        void ensurePublishedLocalMediaWithOrientation(gc, kind).then(() => {
-          if (groupCallRef.current !== gc) return;
-          const hungUp = restartPairwiseCallsForRemoteUsers(gc, restartTargets);
-          scheduleFeedBatched();
-          refreshLocalPreview();
-          if (roomId) {
-            logSpaceGroupCallEvent({
-              name: 'hypha.group_call.pairwise_restart',
-              roomId,
-              kind,
-              groupCallId: gc.groupCallId,
-              hungUp,
-              localOutboundUnhealthy,
-              targetCount: restartTargets.length,
-            });
-          }
-        });
+        void ensurePublishedLocalMediaWithOrientation(gc, kind).then(
+          async () => {
+            if (groupCallRef.current !== gc) return;
+            const hungUp = await restartPairwiseCallsForRemoteUsers(
+              gc,
+              restartTargets,
+            );
+            scheduleFeedBatched();
+            refreshLocalPreview();
+            if (roomId) {
+              logSpaceGroupCallEvent({
+                name: 'hypha.group_call.pairwise_restart',
+                roomId,
+                kind,
+                groupCallId: gc.groupCallId,
+                hungUp,
+                localOutboundUnhealthy,
+                targetCount: restartTargets.length,
+              });
+            }
+          },
+        );
       }
       if (
         !remoteMediaStallBannerDismissedRef.current &&
@@ -1954,9 +1965,9 @@ export function useSpaceGroupCall(
     scheduleFeedBatched();
     refreshLocalPreview();
 
-    void ensurePublishedLocalMediaWithOrientation(gc, kind).then(() => {
+    void ensurePublishedLocalMediaWithOrientation(gc, kind).then(async () => {
       if (groupCallRef.current !== gc) return;
-      const hungUp = restartPairwiseCallsForRemoteUsers(gc, othersInCall);
+      const hungUp = await restartPairwiseCallsForRemoteUsers(gc, othersInCall);
       scheduleFeedBatched();
       refreshLocalPreview();
       evalRemoteMediaStall();
@@ -2148,6 +2159,12 @@ export function useSpaceGroupCall(
         scheduleLocalMediaBootstrap(gc);
       };
       gc.on(GroupCallEvent.ParticipantsChanged, onParticipantsChanged);
+      const onCallsChanged = () => {
+        /** New pairwise session — push warmed local A/V into the peer connection. */
+        scheduleLocalMediaBootstrap(gc);
+        nudgeGroupCallPlaceOutgoing(gc);
+      };
+      gc.on(GroupCallEvent.CallsChanged, onCallsChanged);
       const onFeedsMaybeParticipants = () => {
         scheduleFeedBatched();
         updateParticipantCount();
@@ -2188,6 +2205,7 @@ export function useSpaceGroupCall(
           GroupCallEvent.ParticipantsChanged,
           onParticipantsChanged,
         );
+        gc.removeListener(GroupCallEvent.CallsChanged, onCallsChanged);
         gc.removeListener(
           GroupCallEvent.UserMediaFeedsChanged,
           onFeedsMaybeParticipants,

--- a/packages/core/src/matrix/client/hooks/use-space-group-call.ts
+++ b/packages/core/src/matrix/client/hooks/use-space-group-call.ts
@@ -92,6 +92,10 @@ import {
   clearScreenShareCaptureRootRestriction,
 } from './screenshare-capture-exclusion';
 import {
+  collectRemoteCallFeedUserIds,
+  countMissingRemoteCallFeeds,
+} from './remote-call-media-stall';
+import {
   applyScreenshareTrackContentHints,
   resolveScreenshareVoicePresetPlan,
 } from './screenshare-voice-boost';
@@ -176,7 +180,6 @@ const CONNECT_STALL_ABORT_MS = 90_000;
 /** Room shows others in-call but no remote userMedia CallFeed yet (signaling/WebRTC issue). */
 const REMOTE_MEDIA_STALL_MS = 45_000;
 const REMOTE_MEDIA_REPAIR_NUDGE_MS = 1500;
-const REMOTE_MEDIA_AUTO_RECOVER_MS = 70_000;
 
 /** Dev console: periodic sample of feeds vs participant map (not every Matrix event). */
 const MEDIA_SNAPSHOT_INTERVAL_MS = 12_000;
@@ -642,9 +645,6 @@ export function useSpaceGroupCall(
   const remoteMediaRepairNudgeIntervalRef = useRef<ReturnType<
     typeof setInterval
   > | null>(null);
-  const remoteMediaRecoverRequestedRef = useRef(false);
-  const remoteMediaRecoverAttemptedRef = useRef(false);
-  const remoteMediaRecoverInFlightRef = useRef(false);
   /** Throttle TURN probes during remote-media stall (avoids Dendrite 429 on /voip/turnServer). */
   const lastStallTurnProbeAtRef = useRef(0);
   const outboundVideoOrientationProcessedRef = useRef<Set<string>>(new Set());
@@ -669,23 +669,10 @@ export function useSpaceGroupCall(
   } | null>(null);
   const pendingRecordingUploadRef = useRef<PendingRecordingUpload | null>(null);
   const captureModeRef = useRef<SpaceGroupCallCaptureMode>('none');
-  const [remoteMediaRecoverNonce, setRemoteMediaRecoverNonce] = useState(0);
-  const [isCallRecovering, setIsCallRecovering] = useState(false);
   const [remoteMediaStall, setRemoteMediaStall] = useState(false);
   const [remoteMediaWarming, setRemoteMediaWarming] = useState(false);
   const [turnServerUnavailable, setTurnServerUnavailable] = useState(false);
   const turnServerBannerDismissedRef = useRef(false);
-
-  const retryRemoteMediaConnection = useCallback(() => {
-    if (callState !== 'connected' && callState !== 'awaiting_media') return;
-    remoteMediaStallBannerDismissedRef.current = false;
-    remoteMediaStallLoggedRef.current = false;
-    remoteMediaRecoverAttemptedRef.current = false;
-    remoteMediaRecoverRequestedRef.current = true;
-    setRemoteMediaStall(false);
-    setRemoteMediaWarming(false);
-    setRemoteMediaRecoverNonce((value) => value + 1);
-  }, [callState]);
 
   const dismissRemoteMediaStallBanner = useCallback(() => {
     remoteMediaStallBannerDismissedRef.current = true;
@@ -1375,11 +1362,7 @@ export function useSpaceGroupCall(
         clearInterval(remoteMediaRepairNudgeIntervalRef.current);
         remoteMediaRepairNudgeIntervalRef.current = null;
       }
-      remoteMediaRecoverRequestedRef.current = false;
-      remoteMediaRecoverAttemptedRef.current = false;
-      remoteMediaRecoverInFlightRef.current = false;
       lastStallTurnProbeAtRef.current = 0;
-      setIsCallRecovering(false);
       setRemoteMediaStall(false);
       setRemoteMediaWarming(false);
       if (feedUpdateRafRef.current != null) {
@@ -1789,21 +1772,19 @@ export function useSpaceGroupCall(
     [clearLocalMediaBootstrapTimers, ensurePublishedLocalMediaWithOrientation],
   );
 
-  /** Stall detection: others in participant map but no remote userMedia CallFeed (WebRTC lag). */
+  /** Stall detection: others in participant map but no remote media/share CallFeed (WebRTC lag). */
   const evalRemoteMediaStall = useCallback(() => {
     const gc = groupCallRef.current;
     if (!gc || !roomId?.trim() || !client) return;
     const myId = client.getUserId() ?? null;
-    const remoteFeeds = gc.userMediaFeeds.filter((f) => !f.isLocal());
-    const remoteIdsWithFeed = new Set(
-      remoteFeeds.map((f) => f.userId).filter(Boolean) as string[],
-    );
+    const remoteIdsWithFeed = collectRemoteCallFeedUserIds(gc);
     const othersInCall = inCallUserIdsFromGroupCall(gc).filter(
       (id) => id && id !== myId,
     );
-    const missingRemoteFeedCount = othersInCall.filter(
-      (id) => !remoteIdsWithFeed.has(id),
-    ).length;
+    const missingRemoteFeedCount = countMissingRemoteCallFeeds(
+      othersInCall,
+      remoteIdsWithFeed,
+    );
 
     const now = Date.now();
     if (missingRemoteFeedCount > 0 && othersInCall.length > 0) {
@@ -1861,17 +1842,6 @@ export function useSpaceGroupCall(
           setRemoteMediaStall(true);
         }
       }
-      if (
-        waitedMs >= REMOTE_MEDIA_AUTO_RECOVER_MS &&
-        !remoteMediaRecoverAttemptedRef.current &&
-        !remoteMediaRecoverInFlightRef.current &&
-        typeof document !== 'undefined' &&
-        !document.hidden
-      ) {
-        remoteMediaRecoverAttemptedRef.current = true;
-        remoteMediaRecoverRequestedRef.current = true;
-        setRemoteMediaRecoverNonce((value) => value + 1);
-      }
     } else {
       remoteMediaGapSinceRef.current = null;
       remoteMediaStallLoggedRef.current = false;
@@ -1891,27 +1861,79 @@ export function useSpaceGroupCall(
     scheduleLocalMediaBootstrap,
   ]);
 
+  /**
+   * Soft repair only — nudge pairwise WebRTC and republish local tracks without
+   * leaving the room GroupCall (avoids disconnect cascades and screenshare loss).
+   */
+  const retryRemoteMediaConnection = useCallback(() => {
+    if (callState !== 'connected' && callState !== 'awaiting_media') return;
+    const gc = groupCallRef.current;
+    if (!gc || !roomId?.trim()) return;
+
+    remoteMediaStallBannerDismissedRef.current = false;
+    remoteMediaStallLoggedRef.current = false;
+    remoteMediaGapSinceRef.current = null;
+    setRemoteMediaStall(false);
+    setRemoteMediaWarming(true);
+
+    logSpaceGroupCallEvent({
+      name: 'hypha.group_call.remote_media_recover',
+      roomId: roomId.trim(),
+      kind: lastJoinKindRef.current ?? undefined,
+    });
+
+    nudgeGroupCallPlaceOutgoing(gc);
+    scheduleLocalMediaBootstrap(gc);
+    scheduleFeedBatched();
+    refreshLocalPreview();
+
+    const kind = lastJoinKindRef.current ?? 'audio';
+    void ensurePublishedLocalMediaWithOrientation(gc, kind).then(() => {
+      scheduleFeedBatched();
+      refreshLocalPreview();
+      evalRemoteMediaStall();
+    });
+
+    if (client) {
+      const turnEpoch = joinEpochRef.current;
+      void evaluateMatrixTurnReadiness(client).then((readiness) => {
+        applyTurnReadinessState(readiness.turnServerUnavailable, turnEpoch);
+      });
+    }
+
+    evalRemoteMediaStall();
+  }, [
+    applyTurnReadinessState,
+    callState,
+    client,
+    ensurePublishedLocalMediaWithOrientation,
+    evalRemoteMediaStall,
+    refreshLocalPreview,
+    roomId,
+    scheduleFeedBatched,
+    scheduleLocalMediaBootstrap,
+  ]);
+
   const logDevMediaSnapshot = useCallback(() => {
     const gc = groupCallRef.current;
     if (!gc || !roomId?.trim() || !client) return;
     const myId = client.getUserId() ?? null;
-    const remoteFeeds = gc.userMediaFeeds.filter((f) => !f.isLocal());
-    const remoteIdsWithFeed = new Set(
-      remoteFeeds.map((f) => f.userId).filter(Boolean) as string[],
-    );
+    const remoteIdsWithFeed = collectRemoteCallFeedUserIds(gc);
     const othersInCall = inCallUserIdsFromGroupCall(gc).filter(
       (id) => id && id !== myId,
     );
-    const missingRemoteFeedCount = othersInCall.filter(
-      (id) => !remoteIdsWithFeed.has(id),
-    ).length;
+    const missingRemoteFeedCount = countMissingRemoteCallFeeds(
+      othersInCall,
+      remoteIdsWithFeed,
+    );
     logSpaceGroupCallEvent({
       name: 'hypha.group_call.media_snapshot',
       roomId,
       kind: lastJoinKindRef.current ?? undefined,
       groupCallId: gc.groupCallId,
       userMediaFeedCount: gc.userMediaFeeds.length,
-      remoteUserMediaFeedCount: remoteFeeds.length,
+      remoteUserMediaFeedCount: gc.userMediaFeeds.filter((f) => !f.isLocal())
+        .length,
       screenshareFeedCount: gc.screenshareFeeds.length,
       participantDeviceCount: readParticipantsFromGroupCall(gc).count,
       missingRemoteFeedCount,
@@ -2115,11 +2137,7 @@ export function useSpaceGroupCall(
   );
 
   const enterWithKind = useCallback(
-    async (
-      kind: 'audio' | 'video',
-      threadRootEventId?: string,
-      options?: { preserveRemoteMediaRecoverInFlight?: boolean },
-    ) => {
+    async (kind: 'audio' | 'video', threadRootEventId?: string) => {
       if (!client || !roomId?.trim()) {
         setErrorCode(!client ? 'NO_CLIENT' : 'NO_ROOM');
         setCallState('error');
@@ -2143,11 +2161,6 @@ export function useSpaceGroupCall(
       const joinEpoch = joinEpochRef.current;
 
       isJoiningRef.current = true;
-      remoteMediaRecoverRequestedRef.current = false;
-      remoteMediaRecoverAttemptedRef.current = false;
-      if (!options?.preserveRemoteMediaRecoverInFlight) {
-        remoteMediaRecoverInFlightRef.current = false;
-      }
       const newSessionId = newCallSessionId();
       setCallSessionId(newSessionId);
       lastJoinKindRef.current = kind;
@@ -3432,7 +3445,6 @@ export function useSpaceGroupCall(
       if (!gc) return;
       remoteMediaGapSinceRef.current = null;
       remoteMediaStallLoggedRef.current = false;
-      remoteMediaRecoverAttemptedRef.current = false;
       nudgeGroupCallPlaceOutgoing(gc);
       scheduleLocalMediaBootstrap(gc);
       scheduleFeedBatched();
@@ -3527,48 +3539,6 @@ export function useSpaceGroupCall(
       runCleanupRef.current();
     };
   }, [emitCallSessionEnd]);
-
-  useEffect(() => {
-    if (!remoteMediaRecoverRequestedRef.current) return;
-    if (callState !== 'connected' && callState !== 'awaiting_media') return;
-    if (isJoiningRef.current || remoteMediaRecoverInFlightRef.current) return;
-    const retryKind = lastJoinKindRef.current;
-    if (!retryKind) return;
-    const retryThreadRootEventId = lastThreadRootEventIdRef.current;
-    remoteMediaRecoverRequestedRef.current = false;
-    if (roomId) {
-      logSpaceGroupCallEvent({
-        name: 'hypha.group_call.remote_media_recover',
-        roomId,
-        kind: retryKind,
-      });
-    }
-    abortInFlightJoin(joinEpochRef, isJoiningRef);
-    runCleanup();
-    remoteMediaRecoverInFlightRef.current = true;
-    setIsCallRecovering(true);
-    setCallState('idle');
-    setErrorCode(null);
-    setCallKind(null);
-    setIsScreensharing(false);
-    setScreenshareTakeoverIncoming(null);
-    setScreenshareTakeoverPendingId(null);
-    setScreenshareTakeoverDenied(false);
-    screenshareTakeoverPendingIdRef.current = null;
-    setThreadContext(null);
-    setParticipantCount(0);
-    setScreenshareErrorCode(null);
-    setTabBackgroundWhileInCall(false);
-    void enterWithKind(retryKind, retryThreadRootEventId, {
-      preserveRemoteMediaRecoverInFlight: true,
-    }).finally(() => {
-      setIsCallRecovering(false);
-      if (!groupCallRef.current) {
-        remoteMediaRecoverAttemptedRef.current = false;
-      }
-      remoteMediaRecoverInFlightRef.current = false;
-    });
-  }, [callState, enterWithKind, remoteMediaRecoverNonce, roomId, runCleanup]);
 
   const idleGroupCallUnsubRef = useRef<(() => void) | null>(null);
 
@@ -3853,7 +3823,8 @@ export function useSpaceGroupCall(
     dismissRemoteMediaStallBanner,
     retryRemoteMediaConnection,
     tabBackgroundWhileInCall,
-    isCallRecovering,
+    /** @deprecated Auto leave/re-enter recovery removed — always false. */
+    isCallRecovering: false,
     activeSpeakerKey,
     threadContext,
     callKind,

--- a/packages/core/src/matrix/client/hooks/use-space-group-call.ts
+++ b/packages/core/src/matrix/client/hooks/use-space-group-call.ts
@@ -421,6 +421,47 @@ async function recoverLocalCameraFeed(gc: MatrixSdk.GroupCall): Promise<void> {
   await waitForPublishableLocalVideoTrack(gc, 400);
 }
 
+/**
+ * Video joins can finish with an audio-only local feed when room state was
+ * `m.voice`, `getUserMedia` raced voice-preset refresh, or camera permission
+ * was not warmed before Matrix `initLocalCallFeed`.
+ */
+async function ensureLocalVideoCaptureActive(
+  gc: MatrixSdk.GroupCall,
+  options?: { onCameraAccessBlocked?: (blocked: boolean) => void },
+): Promise<void> {
+  if (!gc.isLocalVideoMuted() && getLocalVideoTrackPresence(gc)) {
+    return;
+  }
+
+  const access = await requestLocalCameraAccess();
+  if (!access.ok) {
+    options?.onCameraAccessBlocked?.(access.reason === 'permission_denied');
+    return;
+  }
+  options?.onCameraAccessBlocked?.(false);
+
+  if (gc.type !== GroupCallType.Video) {
+    const gcSync = gc as unknown as {
+      type: MatrixSdk.GroupCall['type'];
+      sendCallStateEvent(): Promise<void>;
+    };
+    gcSync.type = GroupCallType.Video;
+    try {
+      await gcSync.sendCallStateEvent();
+    } catch {
+      return;
+    }
+  }
+
+  try {
+    await gc.setLocalVideoMuted(false);
+  } catch {
+    return;
+  }
+  await recoverLocalCameraFeed(gc);
+}
+
 async function ensureOutboundLocalVideoOrientationForGroupCall(
   gc: MatrixSdk.GroupCall,
   processedSourceTrackIds: Set<string>,
@@ -2049,6 +2090,10 @@ export function useSpaceGroupCall(
       screenshareFeedCount: gc.screenshareFeeds.length,
       participantDeviceCount: readParticipantsFromGroupCall(gc).count,
       missingRemoteFeedCount,
+      localVideoMuted: gc.isLocalVideoMuted(),
+      localVideoTrackCount:
+        gc.localCallFeed?.stream?.getVideoTracks().length ?? 0,
+      roomGroupCallType: String(gc.type),
     });
   }, [
     client,
@@ -2493,6 +2538,17 @@ export function useSpaceGroupCall(
       const gci = gc as unknown as GroupCallPreEnterMute;
       gci.initWithVideoMuted = kind === 'audio';
       gci.initWithAudioMuted = false;
+      let videoJoinWithCamera = kind === 'video';
+      if (kind === 'video') {
+        const access = await requestLocalCameraAccess();
+        if (!access.ok) {
+          setCameraAccessBlocked(access.reason === 'permission_denied');
+          gci.initWithVideoMuted = true;
+          videoJoinWithCamera = false;
+        } else {
+          setCameraAccessBlocked(false);
+        }
+      }
       /**
        * Refresh stale local member state after hard reloads. If the prior tab died
        * mid-call, old device entries can survive briefly and cause asymmetric media.
@@ -2617,7 +2673,7 @@ export function useSpaceGroupCall(
         return;
       }
 
-      if (kind === 'video' && !gc.isLocalVideoMuted()) {
+      if (videoJoinWithCamera) {
         await waitForLocalVideoTrackPresence(gc, 2500);
       }
       try {
@@ -2630,6 +2686,11 @@ export function useSpaceGroupCall(
        * are live and retry pairwise call placement so remote peers receive A/V.
        */
       try {
+        if (videoJoinWithCamera) {
+          await ensureLocalVideoCaptureActive(gc, {
+            onCameraAccessBlocked: setCameraAccessBlocked,
+          });
+        }
         await ensurePublishedLocalMediaWithOrientation(gc, kind);
         if (kind === 'video' && !gc.isLocalVideoMuted()) {
           await republishLocalMediaToPairwiseCalls(gc, { force: true });

--- a/packages/core/src/matrix/client/hooks/use-space-group-call.ts
+++ b/packages/core/src/matrix/client/hooks/use-space-group-call.ts
@@ -2991,6 +2991,17 @@ export function useSpaceGroupCall(
            * push the camera track into each active MatrixCall after unmute.
            */
           await republishLocalMediaToPairwiseCalls(gc, { force: true });
+          const myId = client?.getUserId()?.trim() ?? null;
+          const remoteIds = inCallUserIdsFromGroupCall(gc).filter(
+            (id) => id && id !== myId,
+          );
+          if (remoteIds.length > 0) {
+            /**
+             * Republish alone may not add a video m-line to audio-first pairwise
+             * sessions — hang up and re-place so both sides renegotiate with video.
+             */
+            await restartPairwiseCallsForRemoteUsers(gc, remoteIds);
+          }
           scheduleRepublishLocalMediaToPairwiseCalls(gc, {
             force: true,
             delayMs: 2_000,
@@ -3009,7 +3020,13 @@ export function useSpaceGroupCall(
         scheduleFeedBatched();
       }, 350);
     },
-    [refreshLocalPreview, roomId, scheduleFeedBatched],
+    [
+      client,
+      inCallUserIdsFromGroupCall,
+      refreshLocalPreview,
+      roomId,
+      scheduleFeedBatched,
+    ],
   );
 
   const setScreensharingEnabled = useCallback(

--- a/packages/core/src/matrix/client/hooks/use-space-group-call.ts
+++ b/packages/core/src/matrix/client/hooks/use-space-group-call.ts
@@ -100,6 +100,10 @@ import {
   republishLocalMediaToPairwiseCalls,
 } from './call-pairwise-restart';
 import {
+  clearPairwiseRepublishSchedule,
+  scheduleRepublishLocalMediaToPairwiseCalls,
+} from './call-pairwise-republish-schedule';
+import {
   applyScreenshareTrackContentHints,
   resolveScreenshareVoicePresetPlan,
 } from './screenshare-voice-boost';
@@ -184,7 +188,7 @@ const CONNECT_STALL_ABORT_MS = 90_000;
 /** Room shows others in-call but no remote userMedia CallFeed yet (signaling/WebRTC issue). */
 const REMOTE_MEDIA_STALL_MS = 45_000;
 /** One-shot pairwise hangup + re-place when nudges fail (no GroupCall.leave). */
-const REMOTE_MEDIA_PAIRWISE_RESTART_MS = 10_000;
+const REMOTE_MEDIA_PAIRWISE_RESTART_MS = 45_000;
 const REMOTE_MEDIA_REPAIR_NUDGE_MS = 1500;
 
 /** Dev console: periodic sample of feeds vs participant map (not every Matrix event). */
@@ -304,7 +308,7 @@ function isLocalOutboundMediaUnhealthy(
   if (
     kind === 'video' &&
     !gc.isLocalVideoMuted() &&
-    !getPublishableLocalVideoTrack(gc)
+    !getLocalVideoTrackPresence(gc)
   ) {
     return true;
   }
@@ -356,7 +360,24 @@ function getLocalVideoTrackPresence(
   gc: MatrixSdk.GroupCall,
 ): MediaStreamTrack | null {
   const track = gc.localCallFeed?.stream.getVideoTracks()[0];
-  return track && track.readyState === 'live' ? track : null;
+  if (!track?.enabled) return null;
+  const state = track.readyState as string;
+  return state === 'live' || state === 'new' ? track : null;
+}
+
+async function waitForLocalVideoTrackPresence(
+  gc: MatrixSdk.GroupCall,
+  timeoutMs = 400,
+): Promise<boolean> {
+  if (getLocalVideoTrackPresence(gc)) return true;
+  const started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 50);
+    });
+    if (getLocalVideoTrackPresence(gc)) return true;
+  }
+  return false;
 }
 
 function getPublishableLocalVideoTrack(
@@ -656,8 +677,6 @@ export function useSpaceGroupCall(
   const placeOutgoingPeriodicIntervalRef = useRef<number | null>(null);
   const localMediaBootstrapDebounceRef = useRef<number | null>(null);
   const localMediaBootstrapTimerRefs = useRef<number[]>([]);
-  /** Debounced pairwise republish after `CallsChanged` (avoid stream churn). */
-  const pairwiseRepublishTimerRef = useRef<number | null>(null);
   /**
    * Bumped when starting a join and when the stall watchdog fires — stale
    * `await gc.enter()` must not run success paths after forced cleanup.
@@ -848,10 +867,7 @@ export function useSpaceGroupCall(
       clearTimeout(localMediaBootstrapDebounceRef.current);
       localMediaBootstrapDebounceRef.current = null;
     }
-    if (pairwiseRepublishTimerRef.current != null) {
-      clearTimeout(pairwiseRepublishTimerRef.current);
-      pairwiseRepublishTimerRef.current = null;
-    }
+    clearPairwiseRepublishSchedule();
     if (localMediaBootstrapTimerRefs.current.length > 0) {
       for (const id of localMediaBootstrapTimerRefs.current) {
         clearTimeout(id);
@@ -870,7 +886,6 @@ export function useSpaceGroupCall(
           outboundVideoOrientationDisposersRef.current,
         );
       }
-      await republishLocalMediaToPairwiseCalls(gc);
     },
     [],
   );
@@ -1544,7 +1559,7 @@ export function useSpaceGroupCall(
       }
       try {
         await gc.updateLocalUsermediaStream(nextStream);
-        await republishLocalMediaToPairwiseCalls(gc);
+        scheduleRepublishLocalMediaToPairwiseCalls(gc);
       } catch (error) {
         for (const track of refreshedAudioStream.getTracks()) {
           track.stop();
@@ -2169,16 +2184,9 @@ export function useSpaceGroupCall(
       };
       gc.on(GroupCallEvent.ParticipantsChanged, onParticipantsChanged);
       const onCallsChanged = () => {
-        /** New pairwise session — one debounced republish once local A/V has settled. */
-        if (typeof window === 'undefined') return;
-        if (pairwiseRepublishTimerRef.current != null) {
-          clearTimeout(pairwiseRepublishTimerRef.current);
-        }
-        pairwiseRepublishTimerRef.current = window.setTimeout(() => {
-          pairwiseRepublishTimerRef.current = null;
-          if (groupCallRef.current !== gc) return;
-          void republishLocalMediaToPairwiseCalls(gc);
-        }, 1500);
+        /** New pairwise session — debounced republish after ICE has time to connect. */
+        if (groupCallRef.current !== gc) return;
+        scheduleRepublishLocalMediaToPairwiseCalls(gc, { delayMs: 4_000 });
         nudgeGroupCallPlaceOutgoing(gc);
       };
       gc.on(GroupCallEvent.CallsChanged, onCallsChanged);
@@ -2609,7 +2617,7 @@ export function useSpaceGroupCall(
       }
 
       if (kind === 'video' && !gc.isLocalVideoMuted()) {
-        await waitForPublishableLocalVideoTrack(gc, 2500);
+        await waitForLocalVideoTrackPresence(gc, 2500);
       }
       try {
         await applyVoiceProcessingPresetToGroupCall(gc, voiceProcessingPreset);
@@ -2622,7 +2630,7 @@ export function useSpaceGroupCall(
        */
       try {
         await ensurePublishedLocalMediaWithOrientation(gc, kind);
-        await republishLocalMediaToPairwiseCalls(gc, { force: true });
+        scheduleRepublishLocalMediaToPairwiseCalls(gc, { delayMs: 4_000 });
       } catch {
         /* best-effort local media bootstrap */
       }
@@ -2975,7 +2983,7 @@ export function useSpaceGroupCall(
             outboundVideoOrientationProcessedRef.current,
             outboundVideoOrientationDisposersRef.current,
           );
-          await republishLocalMediaToPairwiseCalls(gc, { force: true });
+          scheduleRepublishLocalMediaToPairwiseCalls(gc, { delayMs: 2_000 });
         }
       }
       setIsLocalVideoMuted(gc.isLocalVideoMuted());
@@ -2984,7 +2992,7 @@ export function useSpaceGroupCall(
       window.setTimeout(() => {
         if (groupCallRef.current === gc && !gc.isLocalVideoMuted()) {
           nudgeGroupCallPlaceOutgoing(gc);
-          void republishLocalMediaToPairwiseCalls(gc);
+          scheduleRepublishLocalMediaToPairwiseCalls(gc);
         }
         refreshLocalPreview();
         scheduleFeedBatched();
@@ -3593,11 +3601,10 @@ export function useSpaceGroupCall(
 
     const republishIfCameraReady = () => {
       if (gc.isLocalVideoMuted()) return;
-      if (!getPublishableLocalVideoTrack(gc)) return;
-      void republishLocalMediaToPairwiseCalls(gc).then(() => {
-        scheduleFeedBatched();
-        refreshLocalPreview();
-      });
+      if (!getLocalVideoTrackPresence(gc)) return;
+      scheduleRepublishLocalMediaToPairwiseCalls(gc);
+      scheduleFeedBatched();
+      refreshLocalPreview();
     };
 
     const recoverIfNeeded = () => {

--- a/packages/core/src/matrix/client/hooks/use-space-group-call.ts
+++ b/packages/core/src/matrix/client/hooks/use-space-group-call.ts
@@ -532,7 +532,9 @@ function getLiveLocalAudioTrack(
   gc: MatrixSdk.GroupCall,
 ): MediaStreamTrack | null {
   const track = gc.localCallFeed?.stream.getAudioTracks()[0];
-  return track && track.readyState === 'live' ? track : null;
+  if (!track?.enabled) return null;
+  const state = track.readyState as string;
+  return state === 'live' || state === 'new' ? track : null;
 }
 
 async function waitForLiveLocalAudioTrack(
@@ -557,9 +559,21 @@ async function recoverLocalMicrophoneFeed(
   if (gc.isMicrophoneMuted()) return;
   if (getLiveLocalAudioTrack(gc)) return;
 
-  await gc.setMicrophoneMuted(true);
-  await gc.setMicrophoneMuted(false);
-  await waitForLiveLocalAudioTrack(gc, 400);
+  try {
+    await gc.setMicrophoneMuted(true);
+    await gc.setMicrophoneMuted(false);
+    await waitForLiveLocalAudioTrack(gc, 400);
+  } catch {
+    /* best-effort device recovery */
+  } finally {
+    if (!gc.isMicrophoneMuted()) return;
+    try {
+      await gc.setMicrophoneMuted(false);
+      await waitForLiveLocalAudioTrack(gc, 400);
+    } catch {
+      /* keep call connected if unmute fails */
+    }
+  }
 }
 
 /**
@@ -1609,9 +1623,7 @@ export function useSpaceGroupCall(
         refreshedAudioStream.getTracks().forEach((track) => track.stop());
         return false;
       }
-      if (previousAudioTrack) {
-        nextAudioTrack.enabled = previousAudioTrack.enabled;
-      }
+      nextAudioTrack.enabled = !gc.isMicrophoneMuted();
       const nextStream = new MediaStream();
       nextStream.addTrack(nextAudioTrack);
       for (const videoTrack of videoTracks) {

--- a/packages/core/src/matrix/client/hooks/use-space-group-call.ts
+++ b/packages/core/src/matrix/client/hooks/use-space-group-call.ts
@@ -96,6 +96,7 @@ import {
   listUnhealthyRemoteCallUserIds,
 } from './remote-call-media-stall';
 import {
+  clearPairwiseVideoResyncAttemptCounts,
   clearPairwiseVideoResyncSchedule,
   hangupPairwiseCallsForRemoteUsers,
   hasActivePairwiseCalls,
@@ -1457,6 +1458,7 @@ export function useSpaceGroupCall(
       stopPlaceOutgoingPeriodicNudge(placeOutgoingPeriodicIntervalRef);
       clearLocalMediaBootstrapTimers();
       clearPairwiseVideoResyncSchedule();
+      clearPairwiseVideoResyncAttemptCounts();
       webRtcDiagCleanupRef.current?.();
       webRtcDiagCleanupRef.current = null;
       turnRefreshCleanupRef.current?.();
@@ -2011,7 +2013,6 @@ export function useSpaceGroupCall(
       remoteMediaStallLoggedRef.current = false;
       remoteMediaPairwiseRestartAttemptedRef.current = false;
       localVideoRecoveryAttemptedRef.current = false;
-      remoteMediaStallBannerDismissedRef.current = false;
       if (remoteMediaRepairNudgeIntervalRef.current != null) {
         clearInterval(remoteMediaRepairNudgeIntervalRef.current);
         remoteMediaRepairNudgeIntervalRef.current = null;
@@ -2259,6 +2260,18 @@ export function useSpaceGroupCall(
         /** Pairwise VoIP: roster changes can arrive after the internal nudge — retry outbound setup. */
         nudgeGroupCallPlaceOutgoing(gc);
         scheduleLocalMediaBootstrap(gc);
+        const kind = lastJoinKindRef.current ?? 'audio';
+        if (kind === 'video' && !gc.isLocalVideoMuted()) {
+          const myId = client?.getUserId() ?? null;
+          const othersInCall = inCallUserIdsFromGroupCall(gc).filter(
+            (id) => id && id !== myId,
+          );
+          if (othersInCall.length > 0) {
+            schedulePairwiseVideoResync(gc, () =>
+              nudgeGroupCallPlaceOutgoing(gc),
+            );
+          }
+        }
       };
       gc.on(GroupCallEvent.ParticipantsChanged, onParticipantsChanged);
       const onCallsChanged = () => {
@@ -2266,15 +2279,9 @@ export function useSpaceGroupCall(
         if (groupCallRef.current !== gc) return;
         const kind = lastJoinKindRef.current ?? 'audio';
         scheduleRepublishLocalMediaToPairwiseCalls(gc, {
-          force: kind === 'video' && !gc.isLocalVideoMuted(),
           delayMs: kind === 'video' ? 2_000 : 4_000,
         });
         nudgeGroupCallPlaceOutgoing(gc);
-        if (kind === 'video' && !gc.isLocalVideoMuted()) {
-          schedulePairwiseVideoResync(gc, () =>
-            nudgeGroupCallPlaceOutgoing(gc),
-          );
-        }
       };
       gc.on(GroupCallEvent.CallsChanged, onCallsChanged);
       const onFeedsMaybeParticipants = () => {
@@ -2334,6 +2341,8 @@ export function useSpaceGroupCall(
       };
     },
     [
+      client,
+      inCallUserIdsFromGroupCall,
       roomId,
       refreshLocalPreview,
       runCleanup,

--- a/packages/core/src/matrix/client/hooks/use-space-group-call.ts
+++ b/packages/core/src/matrix/client/hooks/use-space-group-call.ts
@@ -91,10 +91,7 @@ import {
   applyScreenShareCaptureRootRestrictionWithRetry,
   clearScreenShareCaptureRootRestriction,
 } from './screenshare-capture-exclusion';
-import {
-  collectRemoteCallFeedUserIds,
-  countMissingRemoteCallFeeds,
-} from './remote-call-media-stall';
+import { countUnhealthyRemoteCallMedia } from './remote-call-media-stall';
 import {
   applyScreenshareTrackContentHints,
   resolveScreenshareVoicePresetPlan,
@@ -1777,13 +1774,12 @@ export function useSpaceGroupCall(
     const gc = groupCallRef.current;
     if (!gc || !roomId?.trim() || !client) return;
     const myId = client.getUserId() ?? null;
-    const remoteIdsWithFeed = collectRemoteCallFeedUserIds(gc);
     const othersInCall = inCallUserIdsFromGroupCall(gc).filter(
       (id) => id && id !== myId,
     );
-    const missingRemoteFeedCount = countMissingRemoteCallFeeds(
+    const missingRemoteFeedCount = countUnhealthyRemoteCallMedia(
+      gc,
       othersInCall,
-      remoteIdsWithFeed,
     );
 
     const now = Date.now();
@@ -1918,13 +1914,12 @@ export function useSpaceGroupCall(
     const gc = groupCallRef.current;
     if (!gc || !roomId?.trim() || !client) return;
     const myId = client.getUserId() ?? null;
-    const remoteIdsWithFeed = collectRemoteCallFeedUserIds(gc);
     const othersInCall = inCallUserIdsFromGroupCall(gc).filter(
       (id) => id && id !== myId,
     );
-    const missingRemoteFeedCount = countMissingRemoteCallFeeds(
+    const missingRemoteFeedCount = countUnhealthyRemoteCallMedia(
+      gc,
       othersInCall,
-      remoteIdsWithFeed,
     );
     logSpaceGroupCallEvent({
       name: 'hypha.group_call.media_snapshot',

--- a/packages/core/src/matrix/client/hooks/use-space-group-call.ts
+++ b/packages/core/src/matrix/client/hooks/use-space-group-call.ts
@@ -189,7 +189,8 @@ const CONNECT_STALL_ABORT_MS = 90_000;
 const REMOTE_MEDIA_STALL_MS = 45_000;
 /** One-shot pairwise hangup + re-place when nudges fail (no GroupCall.leave). */
 const REMOTE_MEDIA_PAIRWISE_RESTART_MS = 45_000;
-const REMOTE_MEDIA_REPAIR_NUDGE_MS = 1500;
+/** Avoid hammering `placeOutgoingCalls()` while ICE is still checking (negotiation glare). */
+const REMOTE_MEDIA_REPAIR_NUDGE_MS = 8_000;
 
 /** Dev console: periodic sample of feeds vs participant map (not every Matrix event). */
 const MEDIA_SNAPSHOT_INTERVAL_MS = 12_000;
@@ -1559,7 +1560,7 @@ export function useSpaceGroupCall(
       }
       try {
         await gc.updateLocalUsermediaStream(nextStream);
-        scheduleRepublishLocalMediaToPairwiseCalls(gc);
+        scheduleRepublishLocalMediaToPairwiseCalls(gc, { force: true });
       } catch (error) {
         for (const track of refreshedAudioStream.getTracks()) {
           track.stop();
@@ -1855,13 +1856,6 @@ export function useSpaceGroupCall(
           nudgeGroupCallPlaceOutgoing(gc);
         }, REMOTE_MEDIA_REPAIR_NUDGE_MS);
       }
-      /**
-       * The SDK can know the remote participant from group-call member state
-       * while the pairwise `MatrixCall` never finishes selecting an opponent
-       * (candidates get buffered, no CallFeed arrives). Retry placement from
-       * the stalled side as well as from ParticipantsChanged/room-state bumps.
-       */
-      nudgeGroupCallPlaceOutgoing(gc);
       if (
         client &&
         now - lastStallTurnProbeAtRef.current >=
@@ -1876,8 +1870,11 @@ export function useSpaceGroupCall(
       if (remoteMediaGapSinceRef.current == null) {
         remoteMediaGapSinceRef.current = now;
       }
-      scheduleLocalMediaBootstrap(gc);
       const waitedMs = now - (remoteMediaGapSinceRef.current ?? now);
+      /** Let the first pairwise ICE check finish before re-publishing local tracks. */
+      if (waitedMs >= 12_000) {
+        scheduleLocalMediaBootstrap(gc);
+      }
       if (
         waitedMs >= REMOTE_MEDIA_PAIRWISE_RESTART_MS &&
         !remoteMediaPairwiseRestartAttemptedRef.current
@@ -2630,7 +2627,13 @@ export function useSpaceGroupCall(
        */
       try {
         await ensurePublishedLocalMediaWithOrientation(gc, kind);
-        scheduleRepublishLocalMediaToPairwiseCalls(gc, { delayMs: 4_000 });
+        if (kind === 'video' && !gc.isLocalVideoMuted()) {
+          await republishLocalMediaToPairwiseCalls(gc, { force: true });
+        }
+        scheduleRepublishLocalMediaToPairwiseCalls(gc, {
+          force: kind === 'video',
+          delayMs: kind === 'video' ? 2_000 : 4_000,
+        });
       } catch {
         /* best-effort local media bootstrap */
       }
@@ -2983,7 +2986,15 @@ export function useSpaceGroupCall(
             outboundVideoOrientationProcessedRef.current,
             outboundVideoOrientationDisposersRef.current,
           );
-          scheduleRepublishLocalMediaToPairwiseCalls(gc, { delayMs: 2_000 });
+          /**
+           * Audio-first pairwise sessions negotiate without a video m-line; force
+           * push the camera track into each active MatrixCall after unmute.
+           */
+          await republishLocalMediaToPairwiseCalls(gc, { force: true });
+          scheduleRepublishLocalMediaToPairwiseCalls(gc, {
+            force: true,
+            delayMs: 2_000,
+          });
         }
       }
       setIsLocalVideoMuted(gc.isLocalVideoMuted());
@@ -2992,7 +3003,7 @@ export function useSpaceGroupCall(
       window.setTimeout(() => {
         if (groupCallRef.current === gc && !gc.isLocalVideoMuted()) {
           nudgeGroupCallPlaceOutgoing(gc);
-          scheduleRepublishLocalMediaToPairwiseCalls(gc);
+          void republishLocalMediaToPairwiseCalls(gc, { force: true });
         }
         refreshLocalPreview();
         scheduleFeedBatched();
@@ -3136,6 +3147,9 @@ export function useSpaceGroupCall(
             } catch {
               /* keep call connected if camera recovery fails */
             }
+          }
+          if (!gc.isLocalVideoMuted()) {
+            scheduleRepublishLocalMediaToPairwiseCalls(gc, { force: true });
           }
           scheduleFeedBatched();
           refreshLocalPreview();

--- a/packages/core/src/matrix/client/hooks/use-space-group-call.ts
+++ b/packages/core/src/matrix/client/hooks/use-space-group-call.ts
@@ -85,7 +85,10 @@ import {
   withEnhancedScreenshareCapture,
   type CallScreenshareSurfaceMode,
 } from './screenshare-capture';
-import { requestLocalCameraAccess } from './call-camera-access';
+import {
+  isLocalCameraPermissionDenied,
+  requestLocalCameraAccess,
+} from './call-camera-access';
 import { applyOutboundLocalVideoOrientation } from './call-local-video-orientation';
 import {
   applyScreenShareCaptureRootRestrictionWithRetry,
@@ -452,9 +455,8 @@ async function ensureLocalVideoCaptureActive(
     return;
   }
 
-  const access = await requestLocalCameraAccess();
-  if (!access.ok) {
-    options?.onCameraAccessBlocked?.(access.reason === 'permission_denied');
+  if (await isLocalCameraPermissionDenied()) {
+    options?.onCameraAccessBlocked?.(true);
     return;
   }
   options?.onCameraAccessBlocked?.(false);
@@ -1648,13 +1650,27 @@ export function useSpaceGroupCall(
       const audioConstraints = constraintsForVoicePreset(preset, {
         isScreensharing,
       });
+      const constraintPayload = {
+        autoGainControl: { ideal: audioConstraints.autoGainControl },
+        echoCancellation: { ideal: audioConstraints.echoCancellation },
+        noiseSuppression: { ideal: audioConstraints.noiseSuppression },
+      };
+      if (
+        previousAudioTrack &&
+        ((previousAudioTrack.readyState as string) === 'live' ||
+          (previousAudioTrack.readyState as string) === 'new')
+      ) {
+        try {
+          await previousAudioTrack.applyConstraints(constraintPayload);
+          previousAudioTrack.enabled = !gc.isMicrophoneMuted();
+          return true;
+        } catch {
+          /* open a new mic stream only when constraints cannot be applied */
+        }
+      }
       const refreshedAudioStream = await navigator.mediaDevices.getUserMedia({
         video: false,
-        audio: {
-          autoGainControl: { ideal: audioConstraints.autoGainControl },
-          echoCancellation: { ideal: audioConstraints.echoCancellation },
-          noiseSuppression: { ideal: audioConstraints.noiseSuppression },
-        },
+        audio: constraintPayload,
       });
       const nextAudioTrack = refreshedAudioStream.getAudioTracks()[0];
       if (!nextAudioTrack) {
@@ -2647,9 +2663,8 @@ export function useSpaceGroupCall(
       gci.initWithAudioMuted = false;
       let videoJoinWithCamera = kind === 'video';
       if (kind === 'video') {
-        const access = await requestLocalCameraAccess();
-        if (!access.ok) {
-          setCameraAccessBlocked(access.reason === 'permission_denied');
+        if (await isLocalCameraPermissionDenied()) {
+          setCameraAccessBlocked(true);
           gci.initWithVideoMuted = true;
           videoJoinWithCamera = false;
         } else {

--- a/packages/core/src/matrix/client/hooks/use-space-group-call.ts
+++ b/packages/core/src/matrix/client/hooks/use-space-group-call.ts
@@ -96,8 +96,12 @@ import {
   listUnhealthyRemoteCallUserIds,
 } from './remote-call-media-stall';
 import {
+  clearPairwiseVideoResyncSchedule,
   hangupPairwiseCallsForRemoteUsers,
+  hasActivePairwiseCalls,
   republishLocalMediaToPairwiseCalls,
+  restartAllPairwiseCallsForVideo,
+  schedulePairwiseVideoResync,
 } from './call-pairwise-restart';
 import {
   clearPairwiseRepublishSchedule,
@@ -188,7 +192,7 @@ const CONNECT_STALL_ABORT_MS = 90_000;
 /** Room shows others in-call but no remote userMedia CallFeed yet (signaling/WebRTC issue). */
 const REMOTE_MEDIA_STALL_MS = 45_000;
 /** One-shot pairwise hangup + re-place when nudges fail (no GroupCall.leave). */
-const REMOTE_MEDIA_PAIRWISE_RESTART_MS = 45_000;
+const REMOTE_MEDIA_PAIRWISE_RESTART_MS = 15_000;
 /** Avoid hammering `placeOutgoingCalls()` while ICE is still checking (negotiation glare). */
 const REMOTE_MEDIA_REPAIR_NUDGE_MS = 8_000;
 
@@ -1441,6 +1445,7 @@ export function useSpaceGroupCall(
       }
       stopPlaceOutgoingPeriodicNudge(placeOutgoingPeriodicIntervalRef);
       clearLocalMediaBootstrapTimers();
+      clearPairwiseVideoResyncSchedule();
       webRtcDiagCleanupRef.current?.();
       webRtcDiagCleanupRef.current = null;
       turnRefreshCleanupRef.current?.();
@@ -2234,6 +2239,11 @@ export function useSpaceGroupCall(
           delayMs: kind === 'video' ? 2_000 : 4_000,
         });
         nudgeGroupCallPlaceOutgoing(gc);
+        if (kind === 'video' && !gc.isLocalVideoMuted()) {
+          schedulePairwiseVideoResync(gc, () =>
+            nudgeGroupCallPlaceOutgoing(gc),
+          );
+        }
       };
       gc.on(GroupCallEvent.CallsChanged, onCallsChanged);
       const onFeedsMaybeParticipants = () => {
@@ -2694,6 +2704,14 @@ export function useSpaceGroupCall(
         await ensurePublishedLocalMediaWithOrientation(gc, kind);
         if (kind === 'video' && !gc.isLocalVideoMuted()) {
           await republishLocalMediaToPairwiseCalls(gc, { force: true });
+          if (hasActivePairwiseCalls(gc)) {
+            await restartAllPairwiseCallsForVideo(gc, () =>
+              nudgeGroupCallPlaceOutgoing(gc),
+            );
+          }
+          schedulePairwiseVideoResync(gc, () =>
+            nudgeGroupCallPlaceOutgoing(gc),
+          );
         }
         scheduleRepublishLocalMediaToPairwiseCalls(gc, {
           force: kind === 'video',

--- a/packages/core/src/matrix/client/hooks/use-space-group-call.ts
+++ b/packages/core/src/matrix/client/hooks/use-space-group-call.ts
@@ -870,6 +870,7 @@ export function useSpaceGroupCall(
           outboundVideoOrientationDisposersRef.current,
         );
       }
+      await republishLocalMediaToPairwiseCalls(gc);
     },
     [],
   );
@@ -2966,6 +2967,7 @@ export function useSpaceGroupCall(
             outboundVideoOrientationProcessedRef.current,
             outboundVideoOrientationDisposersRef.current,
           );
+          await republishLocalMediaToPairwiseCalls(gc, { force: true });
         }
       }
       setIsLocalVideoMuted(gc.isLocalVideoMuted());
@@ -2974,6 +2976,7 @@ export function useSpaceGroupCall(
       window.setTimeout(() => {
         if (groupCallRef.current === gc && !gc.isLocalVideoMuted()) {
           nudgeGroupCallPlaceOutgoing(gc);
+          void republishLocalMediaToPairwiseCalls(gc);
         }
         refreshLocalPreview();
         scheduleFeedBatched();
@@ -3580,9 +3583,22 @@ export function useSpaceGroupCall(
     const gc = groupCallRef.current;
     if (!gc || gc.isLocalVideoMuted()) return;
 
+    const republishIfCameraReady = () => {
+      if (gc.isLocalVideoMuted()) return;
+      if (!getPublishableLocalVideoTrack(gc)) return;
+      void republishLocalMediaToPairwiseCalls(gc).then(() => {
+        scheduleFeedBatched();
+        refreshLocalPreview();
+      });
+    };
+
     const recoverIfNeeded = () => {
       if (typeof document !== 'undefined' && document.hidden) return;
-      if (gc.isLocalVideoMuted() || getPublishableLocalVideoTrack(gc)) return;
+      if (gc.isLocalVideoMuted()) return;
+      if (getPublishableLocalVideoTrack(gc)) {
+        republishIfCameraReady();
+        return;
+      }
       const kind = lastJoinKindRef.current ?? 'video';
       void ensurePublishedLocalMediaWithOrientation(gc, kind).then(() => {
         scheduleFeedBatched();

--- a/packages/core/src/matrix/client/hooks/use-space-group-call.ts
+++ b/packages/core/src/matrix/client/hooks/use-space-group-call.ts
@@ -1513,7 +1513,10 @@ export function useSpaceGroupCall(
       const previousAudioTrack = existingStream?.getAudioTracks()[0] ?? null;
       const videoTracks =
         existingStream?.getVideoTracks().filter((track) => {
-          return track.readyState === 'live';
+          if (!track.enabled) return false;
+          const state = track.readyState as string;
+          /** Camera tracks can still be `new` right after `enter()` — do not drop them. */
+          return state === 'live' || state === 'new';
         }) ?? [];
       const audioConstraints = constraintsForVoicePreset(preset, {
         isScreensharing,
@@ -1541,6 +1544,7 @@ export function useSpaceGroupCall(
       }
       try {
         await gc.updateLocalUsermediaStream(nextStream);
+        await republishLocalMediaToPairwiseCalls(gc);
       } catch (error) {
         for (const track of refreshedAudioStream.getTracks()) {
           track.stop();
@@ -2604,6 +2608,9 @@ export function useSpaceGroupCall(
         return;
       }
 
+      if (kind === 'video' && !gc.isLocalVideoMuted()) {
+        await waitForPublishableLocalVideoTrack(gc, 2500);
+      }
       try {
         await applyVoiceProcessingPresetToGroupCall(gc, voiceProcessingPreset);
       } catch {
@@ -2615,6 +2622,7 @@ export function useSpaceGroupCall(
        */
       try {
         await ensurePublishedLocalMediaWithOrientation(gc, kind);
+        await republishLocalMediaToPairwiseCalls(gc, { force: true });
       } catch {
         /* best-effort local media bootstrap */
       }

--- a/packages/epics/src/common/global-call-dock-context.tsx
+++ b/packages/epics/src/common/global-call-dock-context.tsx
@@ -8,6 +8,7 @@ import {
 } from '@hypha-platform/core/client';
 import { revalidateSpaceMemoryOrg } from '../coherence/hooks/use-space-memory-org';
 import { useCallReactions } from './human-chat-panel/use-call-reactions';
+import { resumeCallPlayback } from './human-chat-panel/call-playback-registry';
 import {
   clearCallDismissedByUser,
   clearCallResumeSnapshot,
@@ -602,6 +603,11 @@ function useGlobalCallDockValue() {
     };
   }, []);
 
+  const retryRemoteMediaConnection = React.useCallback(() => {
+    call.retryRemoteMediaConnection();
+    void resumeCallPlayback();
+  }, [call.retryRemoteMediaConnection]);
+
   return {
     bindRoomContext,
     boundRoomId,
@@ -615,6 +621,7 @@ function useGlobalCallDockValue() {
     startAudioForRoom,
     startVideoForRoom,
     ...call,
+    retryRemoteMediaConnection,
     ...callReactions,
     leave: leaveCall,
   };

--- a/packages/epics/src/common/global-call-dock-context.tsx
+++ b/packages/epics/src/common/global-call-dock-context.tsx
@@ -603,10 +603,11 @@ function useGlobalCallDockValue() {
     };
   }, []);
 
+  const spaceCallRetryRemoteMedia = call.retryRemoteMediaConnection;
   const retryRemoteMediaConnection = React.useCallback(() => {
-    call.retryRemoteMediaConnection();
+    spaceCallRetryRemoteMedia();
     void resumeCallPlayback();
-  }, [call.retryRemoteMediaConnection]);
+  }, [spaceCallRetryRemoteMedia]);
 
   return {
     bindRoomContext,

--- a/packages/epics/src/common/human-chat-panel/__tests__/call-feed-tile-video.test.ts
+++ b/packages/epics/src/common/human-chat-panel/__tests__/call-feed-tile-video.test.ts
@@ -72,13 +72,13 @@ describe('resolveCallFeedLiveVideoTrack', () => {
     ).toBe(track);
   });
 
-  it('does not bind live muted remote camera tracks before the first frame', () => {
+  it('binds live muted remote camera tracks before the first frame', () => {
     const track = mockTrack({ muted: true });
-    expect(
-      resolveCallFeedLiveVideoTrack(mockFeed({ tracks: [track] })),
-    ).toBeNull();
+    expect(resolveCallFeedLiveVideoTrack(mockFeed({ tracks: [track] }))).toBe(
+      track,
+    );
     expect(hasWarmingCallFeedVideoTrack(mockFeed({ tracks: [track] }))).toBe(
-      true,
+      false,
     );
   });
 
@@ -184,16 +184,16 @@ describe('shouldMarkCallFeedVideoSurfaceReady', () => {
 });
 
 describe('shouldPaintCallFeedVideoSurface', () => {
-  it('does not paint remote muted tracks (show avatar instead)', () => {
+  it('paints remote muted live tracks while frames warm up', () => {
     expect(
       shouldPaintCallFeedVideoSurface({
         hasVideo: true,
         warmingVideoTrack: false,
         videoSurfaceReady: true,
-        liveVideoTrack: mockTrack({ muted: true }),
+        liveVideoTrack: mockTrack({ muted: true, readyState: 'live' }),
         isLocalFeed: false,
       }),
-    ).toBe(false);
+    ).toBe(true);
   });
 
   it('paints unmuted tracks when the surface is ready', () => {

--- a/packages/epics/src/common/human-chat-panel/__tests__/call-feed-tile-video.test.ts
+++ b/packages/epics/src/common/human-chat-panel/__tests__/call-feed-tile-video.test.ts
@@ -166,6 +166,21 @@ describe('shouldMarkCallFeedVideoSurfaceReady', () => {
       ),
     ).toBe(false);
   });
+
+  it('accepts muted tracks once intrinsic dimensions are present', () => {
+    expect(
+      shouldMarkCallFeedVideoSurfaceReady(
+        {
+          videoWidth: 640,
+          videoHeight: 360,
+          clientWidth: 240,
+          clientHeight: 135,
+          readyState: 2,
+        },
+        { muted: true },
+      ),
+    ).toBe(true);
+  });
 });
 
 describe('shouldPaintCallFeedVideoSurface', () => {
@@ -179,6 +194,30 @@ describe('shouldPaintCallFeedVideoSurface', () => {
         isLocalFeed: false,
       }),
     ).toBe(false);
+  });
+
+  it('paints unmuted tracks when the surface is ready', () => {
+    expect(
+      shouldPaintCallFeedVideoSurface({
+        hasVideo: true,
+        warmingVideoTrack: false,
+        videoSurfaceReady: true,
+        liveVideoTrack: mockTrack({ muted: false }),
+        isLocalFeed: false,
+      }),
+    ).toBe(true);
+  });
+
+  it('paints local muted camera tracks while warming (readyState live)', () => {
+    expect(
+      shouldPaintCallFeedVideoSurface({
+        hasVideo: true,
+        warmingVideoTrack: false,
+        videoSurfaceReady: true,
+        liveVideoTrack: mockTrack({ muted: true, readyState: 'live' }),
+        isLocalFeed: true,
+      }),
+    ).toBe(true);
   });
 });
 

--- a/packages/epics/src/common/human-chat-panel/__tests__/call-feed-tile-video.test.ts
+++ b/packages/epics/src/common/human-chat-panel/__tests__/call-feed-tile-video.test.ts
@@ -7,6 +7,8 @@ import {
   isCallFeedVideoSurfaceReady,
   resolveCallFeedLiveVideoTrack,
   resolveCallFeedVideoSurfaceClassName,
+  shouldMarkCallFeedVideoSurfaceReady,
+  shouldPaintCallFeedVideoSurface,
 } from '../call-feed-tile-video';
 
 function mockTrack(args: {
@@ -146,6 +148,37 @@ describe('isCallFeedVideoSurfaceReady', () => {
         readyState: 2,
       }),
     ).toBe(true);
+  });
+});
+
+describe('shouldMarkCallFeedVideoSurfaceReady', () => {
+  it('rejects muted tracks with zero intrinsic dimensions', () => {
+    expect(
+      shouldMarkCallFeedVideoSurfaceReady(
+        {
+          videoWidth: 0,
+          videoHeight: 0,
+          clientWidth: 240,
+          clientHeight: 135,
+          readyState: 2,
+        },
+        { muted: true },
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('shouldPaintCallFeedVideoSurface', () => {
+  it('does not paint remote muted tracks (show avatar instead)', () => {
+    expect(
+      shouldPaintCallFeedVideoSurface({
+        hasVideo: true,
+        warmingVideoTrack: false,
+        videoSurfaceReady: true,
+        liveVideoTrack: mockTrack({ muted: true }),
+        isLocalFeed: false,
+      }),
+    ).toBe(false);
   });
 });
 

--- a/packages/epics/src/common/human-chat-panel/call-feed-tile-video.ts
+++ b/packages/epics/src/common/human-chat-panel/call-feed-tile-video.ts
@@ -107,6 +107,43 @@ export function isCallFeedVideoSurfaceReady(
   );
 }
 
+/** Avoid marking a black `<video>` ready when WebRTC track is muted with no frames yet. */
+export function shouldMarkCallFeedVideoSurfaceReady(
+  video: Pick<
+    HTMLVideoElement,
+    'videoWidth' | 'videoHeight' | 'clientWidth' | 'clientHeight' | 'readyState'
+  >,
+  track: Pick<MediaStreamTrack, 'muted'> | null | undefined,
+): boolean {
+  if (!isCallFeedVideoSurfaceReady(video)) return false;
+  if (track?.muted && video.videoWidth <= 0 && video.videoHeight <= 0) {
+    return false;
+  }
+  return true;
+}
+
+/** Hide the `<video>` layer when the track is muted without pixels (show avatar instead). */
+export function shouldPaintCallFeedVideoSurface(options: {
+  hasVideo: boolean;
+  warmingVideoTrack: boolean;
+  videoSurfaceReady: boolean;
+  liveVideoTrack: Pick<MediaStreamTrack, 'muted' | 'readyState'> | null;
+  isLocalFeed: boolean;
+}): boolean {
+  const {
+    hasVideo,
+    warmingVideoTrack,
+    videoSurfaceReady,
+    liveVideoTrack,
+    isLocalFeed,
+  } = options;
+  if (!hasVideo || warmingVideoTrack || !videoSurfaceReady || !liveVideoTrack) {
+    return false;
+  }
+  if (!liveVideoTrack.muted) return true;
+  return isLocalFeed && liveVideoTrack.readyState === 'live';
+}
+
 /** WCUX-QUALITY-3: letterbox instead of upscaling beyond intrinsic frame size. */
 export function resolveCallFeedVideoSurfaceClassName(options: {
   mirrorLocalPreview: boolean;

--- a/packages/epics/src/common/human-chat-panel/call-feed-tile-video.ts
+++ b/packages/epics/src/common/human-chat-panel/call-feed-tile-video.ts
@@ -45,20 +45,16 @@ export function resolveCallFeedLiveVideoTrack(
       null
     );
   }
-  const isLocal = isLocalCallFeedForTile(feed, options?.currentUserId);
   const liveUnmuted = tracks.find(
     (track) => track.readyState === 'live' && !track.muted,
   );
   if (liveUnmuted) return liveUnmuted;
   /**
-   * Local camera (Safari/iOS) may stay `muted: true` until the first frame — bind
-   * early so `<video>` can paint. Remote tracks in that state show avatar via
-   * `hasWarmingCallFeedVideoTrack` instead of a black tile.
+   * Camera tracks (local or remote) may stay `muted: true` until the first frame
+   * — bind early so `<video>` can paint once WebRTC delivers pixels.
    */
-  if (isLocal) {
-    const liveMuted = tracks.find((track) => track.readyState === 'live');
-    if (liveMuted) return liveMuted;
-  }
+  const liveMuted = tracks.find((track) => track.readyState === 'live');
+  if (liveMuted) return liveMuted;
   return tracks.find((track) => (track.readyState as string) === 'new') ?? null;
 }
 
@@ -141,7 +137,7 @@ export function shouldPaintCallFeedVideoSurface(options: {
     return false;
   }
   if (!liveVideoTrack.muted) return true;
-  return isLocalFeed && liveVideoTrack.readyState === 'live';
+  return liveVideoTrack.readyState === 'live';
 }
 
 /** WCUX-QUALITY-3: letterbox instead of upscaling beyond intrinsic frame size. */

--- a/packages/epics/src/common/human-chat-panel/human-chat-panel-call-stage.tsx
+++ b/packages/epics/src/common/human-chat-panel/human-chat-panel-call-stage.tsx
@@ -2880,12 +2880,15 @@ const FeedContent = ({
   }, [liveVideoTrack?.id, mountRemoteAudio, stream]);
 
   /** Analyse mic/remote line whenever the tile has a live audio track (not just Matrix `isSpeaking`, which lags and hid real levels). */
+  const hasLiveAudioTrack =
+    stream?.getAudioTracks().some((track) => track.readyState === 'live') ??
+    false;
   const canVoiceWave =
     showAudioScrim &&
     !isShare &&
     !audioMuted &&
-    (feed.isLocal() ||
-      (!feed.isAudioMuted() && (stream?.getAudioTracks().length ?? 0) > 0));
+    hasLiveAudioTrack &&
+    (isLocalCallFeedForTile(feed, currentUserId) || !feed.isAudioMuted());
 
   const tileAvatarSizePx = compactTileLayout
     ? 48

--- a/packages/epics/src/common/human-chat-panel/human-chat-panel-call-stage.tsx
+++ b/packages/epics/src/common/human-chat-panel/human-chat-panel-call-stage.tsx
@@ -80,15 +80,17 @@ import {
 import {
   feedReportsAudioMutedForTile,
   formatCallShareTileLabel,
+  isLocalCallFeedForTile,
   resolveCallAudioPortalTarget,
   shouldMountRemoteCallAudioSink,
 } from './call-feed-tile-audio';
 import {
   createCallFeedVideoStream,
   hasWarmingCallFeedVideoTrack,
-  isCallFeedVideoSurfaceReady,
   resolveCallFeedLiveVideoTrack,
   resolveCallFeedVideoSurfaceClassName,
+  shouldMarkCallFeedVideoSurfaceReady,
+  shouldPaintCallFeedVideoSurface,
 } from './call-feed-tile-video';
 import { registerCallPlaybackElement } from './call-playback-registry';
 import { callAccentAlertOnDarkText } from './call-accent-alert-styles';
@@ -2693,8 +2695,10 @@ const FeedContent = ({
     el.disablePictureInPicture = true;
 
     const markReady = () => {
-      if (isCallFeedVideoSurfaceReady(el)) {
+      if (shouldMarkCallFeedVideoSurfaceReady(el, liveVideoTrack)) {
         setVideoSurfaceReady(true);
+      } else if (liveVideoTrack?.muted) {
+        setVideoSurfaceReady(false);
       }
     };
 
@@ -2723,14 +2727,14 @@ const FeedContent = ({
 
     playVideo();
     const retryTimer = window.setInterval(() => {
-      if (isCallFeedVideoSurfaceReady(el)) {
+      if (shouldMarkCallFeedVideoSurfaceReady(el, liveVideoTrack)) {
         setVideoSurfaceReady(true);
         return;
       }
       playVideo();
     }, 750);
     const giveUpTimer = window.setTimeout(() => {
-      if (!isCallFeedVideoSurfaceReady(el)) {
+      if (!shouldMarkCallFeedVideoSurfaceReady(el, liveVideoTrack)) {
         rebindStream();
       }
     }, 4000);
@@ -2760,10 +2764,18 @@ const FeedContent = ({
     };
   }, [liveVideoTrack?.id, streamBindVersion]);
 
-  const showVideoElement = hasVideo && !warmingVideoTrack;
-  /** Avatar until video paints — avoids black tiles while remote/local tracks warm up. */
-  const showAudioScrim = !showVideoElement || !videoSurfaceReady;
-  const showParticipantVideoLabel = showVideoElement && !isPip;
+  const isLocalFeedTile = isLocalCallFeedForTile(feed, currentUserId);
+  const showPaintedVideo = shouldPaintCallFeedVideoSurface({
+    hasVideo,
+    warmingVideoTrack,
+    videoSurfaceReady,
+    liveVideoTrack,
+    isLocalFeed: isLocalFeedTile,
+  });
+  const showVideoElement = showPaintedVideo;
+  /** Avatar until real frames paint — avoids black tiles after stream churn. */
+  const showAudioScrim = !showPaintedVideo;
+  const showParticipantVideoLabel = showPaintedVideo && !isPip;
 
   useEffect(() => {
     const el = audioRef.current;


### PR DESCRIPTION
## Summary

- Removes the 70s **auto-recover** path that called `GroupCall.leave()`, reset call state, and `enterWithKind()` again when remote media appeared stalled.
- That full leave/re-enter was causing **disconnect cascades** (one peer recovering forced the other to stall), **UI jumping**, and **lost screenshare** (cleanup cleared screenshare state before rejoin).
- **Retry connection** now only does a soft repair: nudge pairwise WebRTC, bootstrap local media, TURN probe, and republish local tracks — without leaving the GroupCall.
- Stall detection now counts inbound **screenshare feeds** as connected remote media, so a call with only screenshare no longer triggers a false stall.

## Context

After recent call stability work, production calls were still unstable: participants disconnected one after another and the stage kept rearranging. Screen sharing was lost on disconnect with no way to recover the shared screen. This matches the auto leave/re-enter recovery introduced for remote media stalls.

## Test plan

- [ ] Two-person video call on production/staging — confirm no ping-pong disconnects over 5+ minutes
- [ ] Start screenshare, simulate brief network blip — shared screen should persist (no full rejoin)
- [ ] If remote media stalls, **Retry connection** banner still appears; clicking it should repair without dropping the call for the other party
- [ ] `pnpm --filter @hypha-platform/core exec vitest run src/matrix/client/hooks/__tests__/remote-call-media-stall.test.ts src/matrix/client/hooks/__tests__/use-space-group-call.test.ts`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More accurate detection of missing/unhealthy remote feeds (screenshare-only treated as connected; warming feeds excluded; zombie feeds counted as unhealthy).
* **New Features**
  * One-shot in-place pairwise restart to recover calls without leaving; global retry callback exposed.
  * Debounced republish scheduler and utilities to hang up, republish, and restart pairwise sessions.
  * New video-surface predicates to avoid painting black/muted frames.
* **Tests**
  * Expanded coverage for remote-media stall detection, pairwise restart/republish scheduling, retry delays, and video-surface readiness.
* **Telemetry**
  * Added pairwise-restart event and diagnostic fields.
* **Docs**
  * TURN runbook troubleshooting for CREATE_PERMISSION/403 issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->