### PR TITLE
fix(governance): encode authorized minters by value, not dirty key

### DIFF
--- a/apps/web/src/app/[lang]/dho/[id]/@tab/overview/_components/home-token-holdings-dashboard.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@tab/overview/_components/home-token-holdings-dashboard.tsx
@@ -1687,7 +1687,7 @@ export function HomeTokenHoldingsDashboard({
                                   <span className="text-muted-foreground">
                                     {tTokenHoldings('tooltip.address')}
                                   </span>
-                                  <span className="max-w-[160px] truncate">
+                                  <span className="break-all font-mono">
                                     {token.token_address}
                                   </span>
                                 </div>

--- a/packages/core/src/governance/client/hooks/useUpdateIssuedTokenOrchestrator.ts
+++ b/packages/core/src/governance/client/hooks/useUpdateIssuedTokenOrchestrator.ts
@@ -438,10 +438,18 @@ function buildPartialUpdateIssuedTokenWeb3Input(
    * mapping, so the update form is action-based: `authorizedMinters` grants and
    * `authorizedMintersToRevoke` revokes. Both are merged into a single
    * `batchSetAuthorizedMinters(accounts, allowed)` call. Grant wins on conflicts.
+   *
+   * Gate on the actual submitted values rather than React Hook Form's dirty-key
+   * set: the minter editor writes via bare `setValue` on an unregistered field,
+   * so `dirtyFields.authorizedMinters` is unreliable (especially across the
+   * form's repeated DB/on-chain hydration + `reset`). Relying on `changed` here
+   * silently dropped the minter call, leaving the proposal with an empty tx list
+   * that got padded to a no-op `setTokenName`. Grants are idempotent, so encoding
+   * whenever addresses are present is safe.
    */
   const mintersTouched =
-    changed.has('authorizedMinters') ||
-    changed.has('authorizedMintersToRevoke');
+    (arg.authorizedMinters?.length ?? 0) > 0 ||
+    (arg.authorizedMintersToRevoke?.length ?? 0) > 0;
   if (mintersTouched) {
     const accounts: `0x${string}`[] = [];
     const allowed: boolean[] = [];

--- a/packages/epics/src/treasury/components/common/authorized-minters-section.tsx
+++ b/packages/epics/src/treasury/components/common/authorized-minters-section.tsx
@@ -52,7 +52,13 @@ const MinterList = ({
   const [error, setError] = useState<string | null>(null);
 
   const handleAdd = useCallback(() => {
-    const normalized = normalize(draft);
+    const trimmed = draft.trim();
+    // Nothing pending — used by the onBlur flush so clicking away (e.g. "Publish")
+    // with an empty input is a no-op rather than an "invalid address" error.
+    if (trimmed === '') {
+      return;
+    }
+    const normalized = normalize(trimmed);
     if (!normalized) {
       setError(
         tAgreementFlow('plugins.issueNewToken.authorizedMinters.invalid'),
@@ -136,6 +142,7 @@ const MinterList = ({
                 handleAdd();
               }
             }}
+            onBlur={handleAdd}
           />
           {error ? <span className="text-1 text-error-11">{error}</span> : null}
         </div>
@@ -143,6 +150,9 @@ const MinterList = ({
           type="button"
           variant="outline"
           size="icon"
+          // Keep input focus so blur doesn't fire before this click — otherwise
+          // the onBlur flush and the click would both try to add the address.
+          onMouseDown={(e) => e.preventDefault()}
           onClick={handleAdd}
           aria-label={tAgreementFlow(
             'plugins.issueNewToken.authorizedMinters.add',


### PR DESCRIPTION
## Summary

When updating a token through a proposal, the **Authorized Minters** address you entered was silently dropped — the proposal got created/passed/executed "successfully" but never actually granted the minter on-chain.

### Root cause
The update-token orchestrator gated the `batchSetAuthorizedMinters` encoding on React Hook Form's **dirty-key set** (`changed.has('authorizedMinters')`):

```ts
const mintersTouched =
  changed.has('authorizedMinters') ||
  changed.has('authorizedMintersToRevoke');
```

But the minter editor (`AuthorizedMintersSection` / `MinterList`) writes its value via bare `setValue` on an **unregistered** field (no `FormField`/`Controller`/`register`, unlike every other field in the form). As a result `dirtyFields.authorizedMinters` is unreliable — particularly because the update form repeatedly hydrates from DB + on-chain and calls `reset(...)` while editing. When the dirty key was missing at submit:

1. `collectChangedTopLevelKeys` omitted `authorizedMinters`
2. `mintersTouched` was `false` → encoder skipped the minter call
3. `buildUpdateIssuedTokenTxData` returned an empty list
4. `padUpdateIssuedTokenInputIfNoTxs` padded it with a no-op `setTokenName(currentName)`

### Evidence (Base mainnet)
Reading the **stored** transactions of the affected proposals (via `getProposalCore`) confirms only the no-op pad was stored — no `batchSetAuthorizedMinters`:

- Proposal 5425 (token `0x58Feb841…`): 1 tx, `setTokenName(string)` only
- Proposal 5424 (token `0xdD9fB148…`): 1 tx, `setTokenName(string)` only

### Fix
Gate the minter encoding on the **actual submitted values** instead of the fragile dirty-key set. Grants are idempotent (re-granting an existing minter just re-emits the event), so encoding whenever addresses are present is safe.

## Test plan
- [ ] Create an "update token" proposal, add an authorized minter address, publish → the proposal contains a `batchSetAuthorizedMinters([addr],[true])` transaction (not a no-op `setTokenName`).
- [ ] After the proposal passes/executes, `isAuthorizedMinter(addr)` is `true` and an `AuthorizedMinterUpdated` event is emitted.
- [ ] Revoke flow: adding an address to "revoke" encodes `allowed=false`.
- [ ] Regression: an update with no minter changes still behaves as before (no spurious minter tx).

## Follow-ups (out of scope for this PR)
- Register the minter field properly (`useController`/`useFieldArray`) so dirty tracking is correct.
- Flush the editor's pending `draft` input on submit (typing an address without pressing Enter / `+` currently loses it).
- Avoid silently padding an update to a no-op `setTokenName` when the user actually intended a change — surface a validation error instead.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed unreliable detection of authorized minter updates in governance proposals. The system now consistently includes minter address changes in on-chain updates, ensuring submissions are processed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->