### PR TITLE
fix(calls): apply CodeRabbit diagnostics and test hygiene from #2310

### DIFF
--- a/packages/core/src/matrix/client/hooks/__tests__/call-camera-access.test.ts
+++ b/packages/core/src/matrix/client/hooks/__tests__/call-camera-access.test.ts
@@ -1,9 +1,18 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { resolveMatrixCameraVideoConstraints } from '../call-video-capture-constraints';
 import {
   isLocalCameraPermissionDenied,
   requestLocalCameraAccess,
 } from '../call-camera-access';
+
+const originalPermissions = navigator.permissions;
+
+afterEach(() => {
+  Object.defineProperty(navigator, 'permissions', {
+    configurable: true,
+    value: originalPermissions,
+  });
+});
 
 describe('isLocalCameraPermissionDenied', () => {
   it('returns true when the Permissions API reports denied', async () => {

--- a/packages/core/src/matrix/client/hooks/group-call-webrtc-diagnostics.ts
+++ b/packages/core/src/matrix/client/hooks/group-call-webrtc-diagnostics.ts
@@ -236,22 +236,26 @@ async function logIceTransportForPeerConnection(options: {
   peerConnection: RTCPeerConnection;
 }): Promise<void> {
   const { roomId, groupCallId, userId, peerConnection } = options;
-  const stats = await peerConnection.getStats();
-  const transport = readIceTransportSummary(peerConnection, stats);
-  logSpaceGroupCallEvent({
-    name: 'hypha.group_call.ice_transport',
-    roomId,
-    groupCallId,
-    remoteUserId: userId ?? undefined,
-    iceConnectionState: transport.iceConnectionState,
-    iceGatherState: transport.iceGatheringState,
-    connectionState: transport.connectionState,
-    localCandidateType: transport.localCandidateType,
-    remoteCandidateType: transport.remoteCandidateType,
-    pairState: transport.pairState,
-    inboundAudioBytes: transport.inboundAudioBytes,
-    inboundVideoBytes: transport.inboundVideoBytes,
-  });
+  try {
+    const stats = await peerConnection.getStats();
+    const transport = readIceTransportSummary(peerConnection, stats);
+    logSpaceGroupCallEvent({
+      name: 'hypha.group_call.ice_transport',
+      roomId,
+      groupCallId,
+      remoteUserId: userId ?? undefined,
+      iceConnectionState: transport.iceConnectionState,
+      iceGatherState: transport.iceGatheringState,
+      connectionState: transport.connectionState,
+      localCandidateType: transport.localCandidateType,
+      remoteCandidateType: transport.remoteCandidateType,
+      pairState: transport.pairState,
+      inboundAudioBytes: transport.inboundAudioBytes,
+      inboundVideoBytes: transport.inboundVideoBytes,
+    });
+  } catch {
+    // Peer connection may close between interval ticks; ignore transient diagnostics failure.
+  }
 }
 
 export function readInboundRtpVideoFrameSizes(

--- a/packages/core/src/matrix/client/hooks/group-call-webrtc-diagnostics.ts
+++ b/packages/core/src/matrix/client/hooks/group-call-webrtc-diagnostics.ts
@@ -229,33 +229,29 @@ function readIceTransportSummary(
   };
 }
 
-async function logIceTransportForPeerConnection(options: {
+function logIceTransportFromStats(options: {
   roomId: string;
   groupCallId: string;
   userId: string | null;
   peerConnection: RTCPeerConnection;
-}): Promise<void> {
-  const { roomId, groupCallId, userId, peerConnection } = options;
-  try {
-    const stats = await peerConnection.getStats();
-    const transport = readIceTransportSummary(peerConnection, stats);
-    logSpaceGroupCallEvent({
-      name: 'hypha.group_call.ice_transport',
-      roomId,
-      groupCallId,
-      remoteUserId: userId ?? undefined,
-      iceConnectionState: transport.iceConnectionState,
-      iceGatherState: transport.iceGatheringState,
-      connectionState: transport.connectionState,
-      localCandidateType: transport.localCandidateType,
-      remoteCandidateType: transport.remoteCandidateType,
-      pairState: transport.pairState,
-      inboundAudioBytes: transport.inboundAudioBytes,
-      inboundVideoBytes: transport.inboundVideoBytes,
-    });
-  } catch {
-    // Peer connection may close between interval ticks; ignore transient diagnostics failure.
-  }
+  stats: RTCStatsReport;
+}): void {
+  const { roomId, groupCallId, userId, peerConnection, stats } = options;
+  const transport = readIceTransportSummary(peerConnection, stats);
+  logSpaceGroupCallEvent({
+    name: 'hypha.group_call.ice_transport',
+    roomId,
+    groupCallId,
+    remoteUserId: userId ?? undefined,
+    iceConnectionState: transport.iceConnectionState,
+    iceGatherState: transport.iceGatheringState,
+    connectionState: transport.connectionState,
+    localCandidateType: transport.localCandidateType,
+    remoteCandidateType: transport.remoteCandidateType,
+    pairState: transport.pairState,
+    inboundAudioBytes: transport.inboundAudioBytes,
+    inboundVideoBytes: transport.inboundVideoBytes,
+  });
 }
 
 export function readInboundRtpVideoFrameSizes(
@@ -283,16 +279,14 @@ export function readInboundRtpVideoFrameSizes(
   return rows;
 }
 
-async function logInboundRtpFrameSizesForPeerConnection(options: {
+function logInboundRtpFrameSizesFromStats(options: {
   roomId: string;
   groupCallId: string;
   userId: string | null;
-  peerConnection: RTCPeerConnection;
   activeSpeakerUserId: string | null;
-}): Promise<void> {
-  const { roomId, groupCallId, userId, peerConnection, activeSpeakerUserId } =
-    options;
-  const stats = await peerConnection.getStats();
+  stats: RTCStatsReport;
+}): void {
+  const { roomId, groupCallId, userId, activeSpeakerUserId, stats } = options;
   const frames = readInboundRtpVideoFrameSizes(stats);
   for (const frame of frames) {
     logSpaceGroupCallEvent({
@@ -308,6 +302,45 @@ async function logInboundRtpFrameSizesForPeerConnection(options: {
       frameHeight: frame.frameHeight,
       ssrc: frame.ssrc,
     });
+  }
+}
+
+async function logPeerConnectionDiagnostics(options: {
+  roomId: string;
+  groupCallId: string;
+  userId: string | null;
+  peerConnection: RTCPeerConnection;
+  activeSpeakerUserId: string | null;
+  includeFrameSizes: boolean;
+}): Promise<void> {
+  const {
+    roomId,
+    groupCallId,
+    userId,
+    peerConnection,
+    activeSpeakerUserId,
+    includeFrameSizes,
+  } = options;
+  try {
+    const stats = await peerConnection.getStats();
+    if (includeFrameSizes) {
+      logInboundRtpFrameSizesFromStats({
+        roomId,
+        groupCallId,
+        userId,
+        activeSpeakerUserId,
+        stats,
+      });
+    }
+    logIceTransportFromStats({
+      roomId,
+      groupCallId,
+      userId,
+      peerConnection,
+      stats,
+    });
+  } catch {
+    // Peer connection may close between interval ticks; ignore transient diagnostics failure.
   }
 }
 
@@ -359,42 +392,33 @@ export function attachGroupCallWebRtcDiagnostics(options: {
   gc.on(GroupCallStatsReportEvent.SummaryStats, onSummary);
 
   let frameLogInterval: ReturnType<typeof setInterval> | null = null;
-  const logFrameSizes = () => {
+  const logPeerDiagnostics = (includeFrameSizes: boolean) => {
     if (!enumeratePeerConnections) return;
     const activeSpeakerUserId = resolveActiveSpeakerUserId?.() ?? null;
     for (const { userId, peerConnection } of enumeratePeerConnections(gc)) {
-      void logInboundRtpFrameSizesForPeerConnection({
+      void logPeerConnectionDiagnostics({
         roomId,
         groupCallId: gc.groupCallId,
         userId,
         peerConnection,
         activeSpeakerUserId,
-      });
-    }
-  };
-
-  const logIceTransport = () => {
-    if (!enumeratePeerConnections) return;
-    for (const { userId, peerConnection } of enumeratePeerConnections(gc)) {
-      void logIceTransportForPeerConnection({
-        roomId,
-        groupCallId: gc.groupCallId,
-        userId,
-        peerConnection,
+        includeFrameSizes,
       });
     }
   };
 
   if (inboundRtpFrameLogIntervalMs > 0 && enumeratePeerConnections) {
-    logFrameSizes();
-    logIceTransport();
-    frameLogInterval = setInterval(() => {
-      logFrameSizes();
-      logIceTransport();
-    }, inboundRtpFrameLogIntervalMs);
+    logPeerDiagnostics(true);
+    frameLogInterval = setInterval(
+      () => logPeerDiagnostics(true),
+      inboundRtpFrameLogIntervalMs,
+    );
   } else if (summaryStatsIntervalMs > 0 && enumeratePeerConnections) {
-    logIceTransport();
-    frameLogInterval = setInterval(logIceTransport, summaryStatsIntervalMs);
+    logPeerDiagnostics(false);
+    frameLogInterval = setInterval(
+      () => logPeerDiagnostics(false),
+      summaryStatsIntervalMs,
+    );
   }
 
   return () => {

--- a/packages/epics/src/common/human-chat-panel/__tests__/call-regression-manual-gates.test.ts
+++ b/packages/epics/src/common/human-chat-panel/__tests__/call-regression-manual-gates.test.ts
@@ -125,9 +125,7 @@ describe('CSH-SHARE-3 single presenter (one share at a time)', () => {
       'utf8',
     );
     expect(source).toContain('getRemoteScreenshareOwner(gc)');
-    expect(source).toContain(
-      "sendScreenshareTakeoverEvent(\n              'request'",
-    );
+    expect(source).toMatch(/sendScreenshareTakeoverEvent\(\s*'request'/);
     expect(source).toContain('resolveIncomingScreenshareTakeover');
     expect(source).toContain('resolveScreenshareTakeoverOutcome');
   });
@@ -143,7 +141,7 @@ describe('CSH-SHARE-3 single presenter (one share at a time)', () => {
     const sidebar = readCommonSource('human-right-panel.tsx');
     expect(controls).toContain('remoteScreenshareActive');
     expect(menu).toContain('callScreenshareRequestTakeover');
-    expect(menu).toContain('const shareStartDisabled = disabled;');
+    expect(menu).toMatch(/\bshareStartDisabled\s*=\s*disabled\b/);
     expect(dock).toContain('HumanChatPanelScreenshareTakeoverDialog');
     expect(sidebar).toContain('HumanChatPanelScreenshareTakeoverDialog');
   });


### PR DESCRIPTION
## Summary
- Restore `navigator.permissions` between camera access unit tests to avoid global-state bleed
- Guard WebRTC diagnostics `getStats()` calls during peer teardown and reuse one stats snapshot per peer per tick
- Make screenshare takeover regression gate assertions whitespace-tolerant

Follow-up to merged #2310 — addresses unresolved CodeRabbit review threads that landed after that PR was merged.

## Test plan
- [x] `pnpm --filter @hypha-platform/core exec vitest run src/matrix/client/hooks/__tests__/call-camera-access.test.ts`
- [x] `pnpm --filter @hypha-platform/epics exec vitest run src/common/human-chat-panel/__tests__/call-regression-manual-gates.test.ts`
- [ ] CI green on this PR


Made with [Cursor](https://cursor.com)