### PR TITLE
feat(tokens): hide legacy non-upgradeable Hypha Platform tokens (HCREDITS, HVOICE)

### DIFF
--- a/apps/web/src/app/api/v1/people/[personSlug]/assets/route.ts
+++ b/apps/web/src/app/api/v1/people/[personSlug]/assets/route.ts
@@ -19,6 +19,7 @@ import {
   getTokenDecimals,
   getEnergyBalances,
   getMemberSpaces,
+  isHiddenToken,
 } from '@hypha-platform/core/client';
 import { headers } from 'next/headers';
 import { hasEmojiOrLink, tryDecodeUriPart } from '@hypha-platform/ui-utils';
@@ -220,7 +221,9 @@ export async function GET(
       });
     });
 
-    const allTokens: Token[] = Array.from(addressMap.values());
+    const allTokens: Token[] = Array.from(addressMap.values()).filter(
+      (token) => !isHiddenToken(token.address),
+    );
 
     let prices: Record<string, number | undefined> = {};
     try {

--- a/apps/web/src/app/api/v1/spaces/[spaceSlug]/assets-without-balances/route.ts
+++ b/apps/web/src/app/api/v1/spaces/[spaceSlug]/assets-without-balances/route.ts
@@ -13,6 +13,7 @@ import {
   Token,
   TOKENS,
   ALLOWED_SPACES,
+  isHiddenToken,
 } from '@hypha-platform/core/client';
 import { db } from '@hypha-platform/storage-postgres';
 import { hasEmojiOrLink } from '@hypha-platform/ui-utils';
@@ -208,7 +209,9 @@ export async function GET(
       }
     });
 
-    const allTokens: Token[] = Array.from(addressMap.values());
+    const allTokens: Token[] = Array.from(addressMap.values()).filter(
+      (token) => !isHiddenToken(token.address),
+    );
 
     const assets = await Promise.all(
       allTokens.map(async (token) => {

--- a/apps/web/src/app/api/v1/spaces/[spaceSlug]/assets/route.ts
+++ b/apps/web/src/app/api/v1/spaces/[spaceSlug]/assets/route.ts
@@ -18,6 +18,7 @@ import {
   Token,
   ALLOWED_SPACES,
   getTokenDecimals,
+  isHiddenToken,
 } from '@hypha-platform/core/client';
 import { db } from '@hypha-platform/storage-postgres';
 import { canConvertToBigInt, hasEmojiOrLink } from '@hypha-platform/ui-utils';
@@ -199,7 +200,9 @@ export async function GET(
       }
     });
 
-    const allTokens: Token[] = Array.from(addressMap.values());
+    const allTokens: Token[] = Array.from(addressMap.values()).filter(
+      (token) => !isHiddenToken(token.address),
+    );
 
     let prices: Record<string, number | undefined> = {};
     try {

--- a/apps/web/src/app/api/v1/spaces/[spaceSlug]/vaults/route.ts
+++ b/apps/web/src/app/api/v1/spaces/[spaceSlug]/vaults/route.ts
@@ -11,6 +11,7 @@ import {
   getSpaceRegularTokens,
   getSpaceDecayingTokens,
   getSpaceOwnershipTokens,
+  isHiddenToken,
 } from '@hypha-platform/core/client';
 import {
   tokenBackingVaultImplementationAbi,
@@ -110,11 +111,13 @@ export async function GET(
         decayingResult.result.length !== 0
           ? decayingResult.result
           : [];
-      spaceTokens = [
-        ...regularTokens,
-        ...ownershipTokens,
-        ...decayingTokens,
-      ] as `0x${string}`[];
+      spaceTokens = (
+        [
+          ...regularTokens,
+          ...ownershipTokens,
+          ...decayingTokens,
+        ] as `0x${string}`[]
+      ).filter((address) => !isHiddenToken(address));
     } catch (err: any) {
       const errorMessage =
         err?.message || err?.shortMessage || JSON.stringify(err);

--- a/apps/web/src/app/api/v1/spaces/[spaceSlug]/wallet-transferable-tokens/route.ts
+++ b/apps/web/src/app/api/v1/spaces/[spaceSlug]/wallet-transferable-tokens/route.ts
@@ -6,7 +6,12 @@ import {
   getTokenMeta,
   findAllTokens,
 } from '@hypha-platform/core/server';
-import { Token, validTokenTypes, TokenType } from '@hypha-platform/core/client';
+import {
+  Token,
+  validTokenTypes,
+  TokenType,
+  isHiddenToken,
+} from '@hypha-platform/core/client';
 import { db } from '@hypha-platform/storage-postgres';
 import { hasEmojiOrLink } from '@hypha-platform/ui-utils';
 import { checkSpaceAccess } from '@web/utils/check-space-access';
@@ -99,7 +104,9 @@ export async function GET(
       addressMap.set(token.address.toLowerCase(), token);
     });
 
-    const allTokens: Token[] = Array.from(addressMap.values());
+    const allTokens: Token[] = Array.from(addressMap.values()).filter(
+      (token) => !isHiddenToken(token.address),
+    );
 
     const assets = await Promise.all(
       allTokens.map(async (token) => {

--- a/packages/core/src/assets/server/queries.ts
+++ b/packages/core/src/assets/server/queries.ts
@@ -1,6 +1,7 @@
 import { asc, eq, sql, and } from 'drizzle-orm';
 import { documents, tokens } from '@hypha-platform/storage-postgres';
 import { DbConfig } from '@hypha-platform/core/server';
+import { isHiddenToken } from '../../common/web3/tokens';
 
 type FindAllTokensProps = {
   search?: string;
@@ -73,7 +74,8 @@ export const findAllTokens = async (
     )
     .orderBy(asc(tokens.name));
 
-  return results;
+  // Exclude retired/hidden token deployments from every DB-token-driven surface.
+  return results.filter((token) => !isHiddenToken(token.address));
 };
 
 export const findTokenByAddress = async (address: string, { db }: DbConfig) => {

--- a/packages/core/src/common/web3/tokens.ts
+++ b/packages/core/src/common/web3/tokens.ts
@@ -73,6 +73,10 @@ export const HIDDEN_TOKEN_ADDRESSES: ReadonlySet<string> = new Set<string>([
   // (Hypha Platform). Superseded by a new HCREDITS token issued through the current
   // RegularTokenFactory. The old contract cannot be upgraded or burned via proposal.
   '0xb8591ade4ceda2dd14b1924dc81d23b765c2820d',
+  // Hypha Voice (HVOICE) — legacy non-upgradeable deployment for space 241 (Hypha
+  // Platform), same older contract generation as HCREDITS. Not a proxy, so it cannot
+  // be upgraded or burned via proposal.
+  '0x24e0b2bfee025d57a19f9dae4c3849a4a6bf9626',
 ]);
 
 /** True when `address` is on the {@link HIDDEN_TOKEN_ADDRESSES} denylist. */

--- a/packages/core/src/common/web3/tokens.ts
+++ b/packages/core/src/common/web3/tokens.ts
@@ -57,6 +57,30 @@ export const TOKENS: Token[] = [
   },
 ];
 
+/**
+ * Token contract addresses that must never be surfaced in the UI — treasury asset
+ * lists, profile holdings, holder breakdowns, transfer pickers, vaults, etc.
+ *
+ * Use this to retire deprecated token deployments that can no longer be managed
+ * through governance (e.g. legacy non-upgradeable contracts whose `burnFrom` lacks
+ * the executor privilege the current proposal flow relies on). The on-chain token
+ * still exists; this only stops the platform from displaying it.
+ *
+ * Addresses MUST be stored lowercased. Compare via {@link isHiddenToken}.
+ */
+export const HIDDEN_TOKEN_ADDRESSES: ReadonlySet<string> = new Set<string>([
+  // Hypha Cash Credits (HCREDITS) — legacy non-upgradeable deployment for space 241
+  // (Hypha Platform). Superseded by a new HCREDITS token issued through the current
+  // RegularTokenFactory. The old contract cannot be upgraded or burned via proposal.
+  '0xb8591ade4ceda2dd14b1924dc81d23b765c2820d',
+]);
+
+/** True when `address` is on the {@link HIDDEN_TOKEN_ADDRESSES} denylist. */
+export function isHiddenToken(address?: string | null): boolean {
+  if (!address) return false;
+  return HIDDEN_TOKEN_ADDRESSES.has(address.toLowerCase());
+}
+
 export const ERC20_TOKEN_TRANSFER_ADDRESSES = [
   '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
   '0x60a3E35Cc302bFA44Cb288Bc5a4F316Fdb1adb42',

--- a/packages/core/src/governance/server/get-token-holdings-by-space-slug.ts
+++ b/packages/core/src/governance/server/get-token-holdings-by-space-slug.ts
@@ -9,6 +9,7 @@ import { findSpaceHostFieldsBySlug } from '../../space/server/queries';
 import { computeSpaceMemberEntries } from '../../space/server/get-space-members-roster';
 import { fetchSpaceDetails } from '../../space/client/web3/fetch/fetchSpaceDetails';
 import { web3Client } from '../../common/server/web3-rpc/client';
+import { isHiddenToken } from '../../common/web3/tokens';
 import { tokens } from '@hypha-platform/storage-postgres';
 
 type HolderKind = 'person' | 'space' | 'treasury' | 'other';
@@ -356,6 +357,9 @@ export async function getTokenHoldingsBySpaceSlug(
       normalizeAddress(HVOICE_SHARED_TOKEN_ADDRESS),
     ]);
   }
+
+  // Drop retired/hidden tokens so they never appear in holder breakdowns.
+  tokenAddresses = tokenAddresses.filter((address) => !isHiddenToken(address));
 
   const computedRoster = await computeSpaceMemberEntries(spaceSlug, { db });
   const holderMap = new Map<`0x${string}`, HolderDescriptor>();


### PR DESCRIPTION
## Summary

The Hypha Platform space (web3 space id **241**) has two legacy space tokens — **HCREDITS** (`0xb8591aDE4ceDA2dd14B1924dC81D23B765C2820d`) and **HVOICE** (`0x24e0b2bfee025d57a19f9dae4c3849a4a6bf9626`). On-chain investigation showed both are **directly-deployed, non-proxy contracts**:

- All ERC1967 proxy slots are empty; no `upgradeTo` / `upgradeToAndCall` / `proxiableUUID` → **not upgradeable**.
- They're an older contract generation (no `isAuthorizedMinter`), and their `burnFrom` lacks the executor privilege the current burn-proposal flow relies on, so they **can't be burned via a DAO proposal** either.

Since they can't be upgraded or retired through governance, this PR hides them from the UI so they no longer appear in treasuries, profiles, holder breakdowns, transfer pickers, or vaults. (New replacement tokens issued through the current factory get new addresses and are unaffected.)

## Changes

- Add a centralized `HIDDEN_TOKEN_ADDRESSES` denylist + `isHiddenToken()` helper in `packages/core/src/common/web3/tokens.ts`.
- Apply the filter at every token-listing surface:
  - Treasury assets (`spaces/[spaceSlug]/assets` and `assets-without-balances`)
  - Profile assets (`people/[personSlug]/assets`)
  - Holder breakdown (`getTokenHoldingsBySpaceSlug`)
  - Transfer pickers (`wallet-transferable-tokens`)
  - Vaults (`spaces/[spaceSlug]/vaults`)
  - All DB-token-driven lists (`findAllTokens`)

Filters run after the Hypha-Platform shared-token injection in `getTokenHoldingsBySpaceSlug`, so the denylist still wins there. Filters are placed before the per-token RPC/multicall work, so the heavier endpoints make slightly fewer calls.

## Test plan

- [ ] Hypha Platform treasury no longer lists HCREDITS / HVOICE
- [ ] Member profiles no longer show HCREDITS / HVOICE balances
- [ ] Token holdings view for `hypha-platform` excludes both tokens
- [ ] Transfer / mint / burn token pickers don't offer them
- [ ] Other spaces' tokens are unaffected

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Hidden and retired token deployments are now properly excluded from asset lists, vault displays, transferable token selections, and token holding breakdowns across the application, so users only see active tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->