### PR TITLE
feat(storage-evm): legacy-layout decaying token for safe EVOICE upgrade

### DIFF
--- a/packages/storage-evm/contracts/DecayingSpaceTokenLegacy.sol
+++ b/packages/storage-evm/contracts/DecayingSpaceTokenLegacy.sol
@@ -1,0 +1,1329 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import '@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol';
+import '@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol';
+import '@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20BurnableUpgradeable.sol';
+import '@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol';
+import '@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol';
+import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
+import '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
+import './interfaces/IDAOSpaceFactory.sol';
+
+/**
+ * @title DecayingSpaceTokenLegacy
+ * @dev Drop-in upgrade implementation for decaying space tokens deployed from the
+ * EARLY implementation line (e.g. Hypha Energy Voice / EVOICE at
+ * 0x564c52008898E1a46825DEbF20D5000cbe74800F, impl
+ * 0x7046164635F4521dAfa0D6025C086550562659C8 on Base).
+ *
+ * WHY THIS CONTRACT EXISTS — STORAGE LAYOUT:
+ * Those proxies were deployed before space-based whitelists, custom name/symbol,
+ * mutual credit, token sales and authorized minters were added to
+ * RegularSpaceToken. In that old layout the base contract storage ends at
+ * `archived` (slot 7) and DecayingSpaceToken's variables occupy slots 8-13:
+ *
+ *   slot 0  spaceId
+ *   slot 1  maxSupply
+ *   slot 2  transferable | executor                  (packed)
+ *   slot 3  transferHelper | fixedMaxSupply | autoMinting (packed)
+ *   slot 4  priceInUSD
+ *   slot 5  canTransfer
+ *   slot 6  canReceive
+ *   slot 7  useTransferWhitelist | useReceiveWhitelist | archived (packed)
+ *   slot 8  decayPercentage
+ *   slot 9  decayRate
+ *   slot 10 lastApplied
+ *   slot 11 _tokenHolders
+ *   slot 12 _isTokenHolder
+ *   slot 13 totalBurnedFromDecay
+ *
+ * Upgrading such a proxy to the CURRENT DecayingSpaceToken would shift the decay
+ * variables down by all of the newer base variables plus the 50-slot gap,
+ * silently corrupting decay state. This contract therefore flattens
+ * RegularSpaceToken + DecayingSpaceToken into one contract that keeps the
+ * deployed slots 0-13 in place and appends every newer variable AFTER them.
+ *
+ * FUNCTIONALITY: identical to the current DecayingSpaceToken (authorized
+ * minters, mutual credit administration, token sale, space whitelists, custom
+ * name/symbol, currency-denominated pricing, decay mid-period fix, etc.).
+ *
+ * MAINTENANCE: this contract must be kept in sync with RegularSpaceToken /
+ * DecayingSpaceToken by hand. When changing those contracts, mirror the change
+ * here (storage additions go before __gap, never between existing variables).
+ */
+contract DecayingSpaceTokenLegacy is
+  Initializable,
+  ERC20Upgradeable,
+  ERC20BurnableUpgradeable,
+  OwnableUpgradeable,
+  UUPSUpgradeable
+{
+  using SafeERC20 for IERC20;
+  uint8 public constant PURCHASE_MODE_SPACE_ONLY = 0;
+  uint8 public constant PURCHASE_MODE_CUSTOM_SPACES = 1;
+  uint8 public constant PURCHASE_MODE_ALL_SPACES = 2;
+
+  // ===========================================================================
+  // LEGACY STORAGE — slots 0-13 of the deployed proxies. DO NOT reorder,
+  // retype, remove or insert anything in this block.
+  // ===========================================================================
+
+  // slots 0-7: original RegularSpaceToken base storage
+  uint256 public spaceId;
+  uint256 public maxSupply;
+  bool public transferable;
+  address public executor;
+  address public transferHelper;
+  bool public fixedMaxSupply; // If true, maxSupply cannot be changed
+  bool public autoMinting; // If true, executor can mint on transfer; if false, must mint separately
+  uint256 public priceInUSD; // Token price in USD (with 6 decimals, e.g., 1000000 = $1)
+  mapping(address => bool) public canTransfer; // Who can send tokens
+  mapping(address => bool) public canReceive; // Who can receive tokens
+  bool public useTransferWhitelist; // If true, enforce transfer whitelist
+  bool public useReceiveWhitelist; // If true, enforce receive whitelist
+  bool public archived; // If true, minting and transfers are disabled
+
+  // slots 8-13: original DecayingSpaceToken storage
+  uint256 public decayPercentage; // Decay percentage in basis points (0-10000)
+  uint256 public decayRate; // Decay interval in seconds
+  mapping(address => uint256) public lastApplied;
+  address[] private _tokenHolders;
+  mapping(address => bool) private _isTokenHolder;
+  uint256 public totalBurnedFromDecay;
+
+  // ===========================================================================
+  // NEWER STORAGE — everything added to the token contracts after the legacy
+  // implementations were deployed. Appended after the legacy block so existing
+  // proxy state is untouched; all of it reads as zero (= feature disabled)
+  // right after the upgrade. Only append below, before __gap.
+  // ===========================================================================
+
+  // Hardcoded spaces contract address for membership checks
+  address public constant spacesContract =
+    0xc8B8454D2F9192FeCAbc2C6F5d88F6434A2a9cd9;
+  uint256[] internal _transferWhitelistedSpaceIds; // Space IDs whose members can transfer
+  uint256[] internal _receiveWhitelistedSpaceIds; // Space IDs whose members can receive
+  mapping(uint256 => bool) public isTransferWhitelistedSpace; // Quick lookup for transfer whitelist
+  mapping(uint256 => bool) public isReceiveWhitelistedSpace; // Quick lookup for receive whitelist
+
+  // Price currency — Chainlink X/USD feed address for the currency priceInUSD is denominated in.
+  // address(0) = USD (default, backward compatible).
+  address public priceCurrencyFeed;
+
+  // Token price (6 decimals) + currency feed — the clean API.
+  // tokenPrice and priceInUSD are kept in sync by all setter functions.
+  uint256 public tokenPrice;
+
+  // Custom name/symbol overrides — allows renaming the token after deployment.
+  string private _customName;
+  string private _customSymbol;
+
+  // Mutual credit storage
+  uint256 public defaultCreditLimit;
+  mapping(address => uint256) public creditBalanceOf;
+  uint256[] internal _creditWhitelistedSpaceIds;
+  mapping(uint256 => bool) public isCreditWhitelistedSpace;
+
+  // Primary sale configuration
+  address public paymentToken;
+  uint256 public paymentTokenPricePerToken; // 6 decimals, priced per 1e18 token units
+  uint256 public tokensForSale; // 18 decimals, 0 means sale disabled
+  uint256 public tokensSold;
+  uint8 public purchaseEligibilityMode; // 0: issuer space only, 1: custom spaces, 2: any space
+  uint256[] internal _purchaseWhitelistedSpaceIds;
+  mapping(uint256 => bool) public isPurchaseWhitelistedSpace;
+
+  // Address-level mutual credit eligibility
+  mapping(address => bool) public isCreditWhitelistedAddress;
+
+  // Authorized minter keys. Addresses set to true are granted mint, burnFrom and
+  // batchSetCreditWhitelistAddresses rights, in addition to the executor/owner.
+  mapping(address => bool) public isAuthorizedMinter;
+
+  // Reserved storage slots for upgrade-safe additions to this contract.
+  // When adding a new state variable above, decrement the gap size by the
+  // number of slots it consumes so the layout stays fixed.
+  uint256[50] private __gap;
+
+  // Events
+  event MaxSupplyUpdated(uint256 oldMaxSupply, uint256 newMaxSupply);
+  event TransferableUpdated(bool transferable);
+  event AutoMintingUpdated(bool autoMinting);
+  event PriceInUSDUpdated(uint256 oldPrice, uint256 newPrice);
+  event PriceCurrencyUpdated(uint256 price, address currencyFeed);
+  event ArchivedStatusUpdated(bool archived);
+  event TokenNameUpdated(string oldName, string newName);
+  event TokenSymbolUpdated(string oldSymbol, string newSymbol);
+  event TransferWhitelistUpdated(address indexed account, bool canTransfer);
+  event ReceiveWhitelistUpdated(address indexed account, bool canReceive);
+  event UseTransferWhitelistUpdated(bool enabled);
+  event UseReceiveWhitelistUpdated(bool enabled);
+  event TokensBurned(
+    address indexed burner,
+    address indexed from,
+    uint256 amount
+  );
+  event TransferWhitelistSpaceAdded(uint256 indexed spaceId);
+  event TransferWhitelistSpaceRemoved(uint256 indexed spaceId);
+  event ReceiveWhitelistSpaceAdded(uint256 indexed spaceId);
+  event ReceiveWhitelistSpaceRemoved(uint256 indexed spaceId);
+  event DefaultCreditLimitUpdated(uint256 oldLimit, uint256 newLimit);
+  event CreditUsed(
+    address indexed member,
+    uint256 amount,
+    uint256 newCreditBalance
+  );
+  event CreditRepaid(
+    address indexed member,
+    uint256 amount,
+    uint256 newCreditBalance
+  );
+  event CreditWhitelistSpaceAdded(uint256 indexed spaceId);
+  event CreditWhitelistSpaceRemoved(uint256 indexed spaceId);
+  event CreditWhitelistAddressUpdated(address indexed account, bool allowed);
+  event TokenSaleConfigured(
+    address indexed paymentToken,
+    uint256 paymentTokenPricePerToken,
+    uint256 tokensForSale
+  );
+  event TokensPurchased(
+    address indexed buyer,
+    uint256 tokenAmount,
+    uint256 paymentAmount,
+    address indexed treasury
+  );
+  event PurchaseEligibilityModeUpdated(uint8 mode);
+  event PurchaseWhitelistSpaceAdded(uint256 indexed spaceId);
+  event PurchaseWhitelistSpaceRemoved(uint256 indexed spaceId);
+  event AuthorizedMinterUpdated(address indexed account, bool allowed);
+
+  // Decay events
+  event DecayApplied(
+    address indexed user,
+    uint256 oldBalance,
+    uint256 newBalance,
+    uint256 decayAmount
+  );
+  event DecayPercentageUpdated(
+    uint256 oldDecayPercentage,
+    uint256 newDecayPercentage
+  );
+  event DecayIntervalUpdated(uint256 oldDecayInterval, uint256 newDecayInterval);
+
+  /// @custom:oz-upgrades-unsafe-allow constructor
+  constructor() {
+    _disableInitializers();
+  }
+
+  /**
+   * @dev Initializer for FRESH proxy deployments only. The legacy proxies this
+   * implementation targets are already initialized, so this can never run on
+   * them (initializer guard). Mirrors DecayingSpaceToken.initialize.
+   */
+  function initialize(
+    string memory name,
+    string memory symbol,
+    address _executor,
+    uint256 _spaceId,
+    uint256 _maxSupply,
+    bool _transferable,
+    bool _fixedMaxSupply,
+    bool _autoMinting,
+    uint256 _tokenPrice,
+    address _priceCurrencyFeed,
+    bool _useTransferWhitelist,
+    bool _useReceiveWhitelist,
+    address[] memory _initialTransferWhitelist,
+    address[] memory _initialReceiveWhitelist,
+    uint256[] memory _initialTransferWhitelistSpaceIds,
+    uint256[] memory _initialReceiveWhitelistSpaceIds,
+    uint256 _decayPercentage,
+    uint256 _decayInterval,
+    address _paymentToken,
+    uint256 _paymentTokenPricePerToken,
+    uint256 _tokensForSale,
+    uint8 _purchaseEligibilityMode,
+    uint256[] memory _initialPurchaseWhitelistSpaceIds,
+    address[] memory _initialAuthorizedMinters
+  ) public initializer {
+    __ERC20_init(name, symbol);
+    __ERC20Burnable_init();
+    __Ownable_init(0x2687fe290b54d824c136Ceff2d5bD362Bc62019a);
+    __UUPSUpgradeable_init();
+
+    executor = _executor;
+    spaceId = _spaceId;
+    maxSupply = _maxSupply;
+    transferable = _transferable;
+    transferHelper = 0x479002F7602579203ffba3eE84ACC1BC5b0d6785;
+
+    fixedMaxSupply = _fixedMaxSupply;
+    autoMinting = _autoMinting;
+    priceInUSD = _tokenPrice; // Legacy field — kept in sync
+    tokenPrice = _tokenPrice;
+    priceCurrencyFeed = _priceCurrencyFeed;
+    useTransferWhitelist = _useTransferWhitelist;
+    useReceiveWhitelist = _useReceiveWhitelist;
+
+    // Executor is always whitelisted for both sending and receiving
+    canTransfer[_executor] = true;
+    canReceive[_executor] = true;
+
+    for (uint256 i = 0; i < _initialTransferWhitelist.length; i++) {
+      canTransfer[_initialTransferWhitelist[i]] = true;
+    }
+
+    for (uint256 i = 0; i < _initialReceiveWhitelist.length; i++) {
+      canReceive[_initialReceiveWhitelist[i]] = true;
+    }
+
+    for (uint256 i = 0; i < _initialTransferWhitelistSpaceIds.length; i++) {
+      _addSpaceToList(
+        _transferWhitelistedSpaceIds,
+        isTransferWhitelistedSpace,
+        _initialTransferWhitelistSpaceIds[i]
+      );
+    }
+
+    for (uint256 i = 0; i < _initialReceiveWhitelistSpaceIds.length; i++) {
+      _addSpaceToList(
+        _receiveWhitelistedSpaceIds,
+        isReceiveWhitelistedSpace,
+        _initialReceiveWhitelistSpaceIds[i]
+      );
+    }
+
+    // Optional initial sale configuration. Keeping zero values means "sale disabled".
+    if (_paymentToken != address(0)) {
+      paymentToken = _paymentToken;
+      paymentTokenPricePerToken = _paymentTokenPricePerToken;
+      tokensForSale = _tokensForSale;
+      tokensSold = 0;
+    }
+
+    require(_purchaseEligibilityMode <= PURCHASE_MODE_ALL_SPACES, 'bad mode');
+    purchaseEligibilityMode = _purchaseEligibilityMode;
+    for (uint256 i = 0; i < _initialPurchaseWhitelistSpaceIds.length; i++) {
+      _addSpaceToList(
+        _purchaseWhitelistedSpaceIds,
+        isPurchaseWhitelistedSpace,
+        _initialPurchaseWhitelistSpaceIds[i]
+      );
+    }
+
+    for (uint256 i = 0; i < _initialAuthorizedMinters.length; i++) {
+      isAuthorizedMinter[_initialAuthorizedMinters[i]] = true;
+    }
+
+    require(_decayPercentage <= 10000, 'decay% > 100');
+    require(_decayInterval > 0, '!decay interval');
+
+    decayPercentage = _decayPercentage;
+    decayRate = _decayInterval;
+  }
+
+  function _authorizeUpgrade(
+    address newImplementation
+  ) internal override onlyOwner {}
+
+  // ===========================================================================
+  // Decay mechanics (mirrors DecayingSpaceToken)
+  // ===========================================================================
+
+  /**
+   * @dev Add address to token holders if not already tracked
+   */
+  function _addTokenHolder(address account) internal {
+    if (!_isTokenHolder[account] && account != address(0)) {
+      _isTokenHolder[account] = true;
+      _tokenHolders.push(account);
+    }
+  }
+
+  /**
+   * @dev Remove address from token holders if balance becomes zero
+   */
+  function _updateTokenHolderStatus(address account) internal {
+    if (super.balanceOf(account) == 0 && _isTokenHolder[account]) {
+      _isTokenHolder[account] = false;
+      // Note: We don't remove from the array to avoid gas costs
+      // The getDecayedTotalSupply function will check balances
+    }
+  }
+
+  /**
+   * @dev Returns the current balance including any pending decay
+   */
+  function balanceOf(address account) public view override returns (uint256) {
+    (uint256 newBalance, ) = _pendingDecay(
+      super.balanceOf(account),
+      lastApplied[account]
+    );
+    return newBalance;
+  }
+
+  /**
+   * @dev Shared decay math used by both balanceOf (view) and applyDecay (state).
+   * @return newBalance The balance after applying whole elapsed decay periods.
+   * @return nextLast The value lastApplied should be set to:
+   *   - `block.timestamp` when decay is inert (archived / disabled / empty /
+   *     uninitialized) so freshly received tokens start with a full period;
+   *   - unchanged (`last`) when an active holder is mid-period — this is the
+   *     fix that prevents frequent interactions from dodging decay forever;
+   *   - `last + wholePeriods * decayRate` otherwise, preserving the remainder.
+   */
+  function _pendingDecay(
+    uint256 currentBalance,
+    uint256 last
+  ) internal view returns (uint256 newBalance, uint256 nextLast) {
+    if (archived || decayRate == 0 || currentBalance == 0 || last == 0) {
+      return (currentBalance, block.timestamp);
+    }
+
+    uint256 periodsPassed = (block.timestamp - last) / decayRate;
+    if (periodsPassed == 0) {
+      return (currentBalance, last);
+    }
+
+    // balance * ((10000 - decayPercentage) / 10000) ^ periodsPassed
+    uint256 factor = 10000 - decayPercentage; // e.g. 9900 for 1% decay
+    uint256 acc = 10000; // 100%
+    uint256 n = periodsPassed;
+    while (n > 0) {
+      if ((n & 1) == 1) {
+        acc = (acc * factor) / 10000;
+      }
+      factor = (factor * factor) / 10000;
+      n >>= 1;
+    }
+
+    newBalance = (currentBalance * acc) / 10000;
+    nextLast = last + periodsPassed * decayRate;
+  }
+
+  /**
+   * @dev Applies any pending decay to an account and updates balances
+   */
+  function applyDecay(address account) public {
+    uint256 oldBalance = super.balanceOf(account);
+    (uint256 newBalance, uint256 nextLast) = _pendingDecay(
+      oldBalance,
+      lastApplied[account]
+    );
+
+    if (newBalance < oldBalance) {
+      uint256 decayAmount = oldBalance - newBalance;
+      _burn(account, decayAmount);
+      totalBurnedFromDecay += decayAmount;
+      emit DecayApplied(account, oldBalance, newBalance, decayAmount);
+    }
+
+    lastApplied[account] = nextLast;
+    _updateTokenHolderStatus(account);
+  }
+
+  /**
+   * @dev Update decay percentage in basis points (0-10000)
+   */
+  function setDecayPercentage(uint256 _decayPercentage) external {
+    require(msg.sender == executor, '!executor');
+    require(_decayPercentage <= 10000, 'decay% > 100');
+
+    uint256 oldDecayPercentage = decayPercentage;
+    decayPercentage = _decayPercentage;
+
+    emit DecayPercentageUpdated(oldDecayPercentage, _decayPercentage);
+  }
+
+  /**
+   * @dev Update decay interval in seconds
+   */
+  function setDecayInterval(uint256 _decayInterval) external {
+    require(msg.sender == executor, '!executor');
+    require(_decayInterval > 0, '!decay interval');
+
+    uint256 oldDecayInterval = decayRate;
+    decayRate = _decayInterval;
+
+    emit DecayIntervalUpdated(oldDecayInterval, _decayInterval);
+  }
+
+  function _applyDecayOrInit(address account) internal {
+    if (lastApplied[account] == 0) {
+      lastApplied[account] = block.timestamp;
+    } else {
+      applyDecay(account);
+    }
+  }
+
+  /**
+   * @dev Returns the total supply with decay applied to all balances
+   */
+  function getDecayedTotalSupply() public view returns (uint256) {
+    uint256 totalDecayedSupply = 0;
+
+    for (uint256 i = 0; i < _tokenHolders.length; i++) {
+      address holder = _tokenHolders[i];
+      if (_isTokenHolder[holder]) {
+        totalDecayedSupply += balanceOf(holder);
+      }
+    }
+
+    return totalDecayedSupply;
+  }
+
+  // ===========================================================================
+  // Mint / burn / transfer
+  // ===========================================================================
+
+  function mint(address to, uint256 amount) public {
+    require(
+      msg.sender == executor || isAuthorizedMinter[msg.sender],
+      '!executor'
+    );
+    _applyDecayOrInit(to);
+    _addTokenHolder(to);
+    _mintWithSupplyChecks(to, amount);
+  }
+
+  function _mintWithSupplyChecks(address to, uint256 amount) internal {
+    require(!archived, 'archived');
+    // Check against maximum supply
+    require(
+      maxSupply == 0 || totalSupply() + amount <= maxSupply,
+      'supply exceeded'
+    );
+
+    _mint(to, amount);
+  }
+
+  function _validateTransferAccess(
+    address from,
+    address to,
+    address spender
+  ) internal view {
+    require(!archived, 'archived');
+    require(transferable || spender == executor, '!transferable');
+    if (from != executor && useTransferWhitelist) {
+      require(
+        canTransfer[from] || _isInTransferWhitelistedSpace(from),
+        '!send whitelist'
+      );
+    }
+    if (to != executor && useReceiveWhitelist) {
+      require(
+        canReceive[to] || _isInReceiveWhitelistedSpace(to),
+        '!recv whitelist'
+      );
+    }
+  }
+
+  function _autoMintIfNeeded(address account, uint256 amount) internal {
+    if (account == executor && autoMinting) {
+      uint256 bal = balanceOf(account);
+      if (bal < amount) {
+        _mintWithSupplyChecks(account, amount - bal);
+      }
+    }
+  }
+
+  function transfer(address to, uint256 amount) public override returns (bool) {
+    address sender = _msgSender();
+    _validateTransferAccess(sender, to, sender);
+    applyDecay(sender);
+    _autoMintIfNeeded(sender, amount);
+    _applyDecayOrInit(to);
+    _addTokenHolder(to);
+    _transfer(sender, to, amount);
+    return true;
+  }
+
+  function transferFrom(
+    address from,
+    address to,
+    uint256 amount
+  ) public override returns (bool) {
+    address spender = _msgSender();
+    _validateTransferAccess(from, to, spender);
+    applyDecay(from);
+    _autoMintIfNeeded(from, amount);
+    _applyDecayOrInit(to);
+    _addTokenHolder(to);
+    if (spender == transferHelper) {
+    } else {
+      _spendAllowance(from, spender, amount);
+    }
+    _transfer(from, to, amount);
+    return true;
+  }
+
+  /**
+   * @dev Burn tokens from any address (executor / authorized minters burn
+   * without approval; others need allowance)
+   */
+  function burnFrom(address from, uint256 amount) public override {
+    if (msg.sender == executor || isAuthorizedMinter[msg.sender]) {
+      // Executor and authorized minters can burn without approval
+      _burn(from, amount);
+      emit TokensBurned(msg.sender, from, amount);
+    } else {
+      // Others need approval
+      super.burnFrom(from, amount);
+      emit TokensBurned(msg.sender, from, amount);
+    }
+  }
+
+  // ===========================================================================
+  // Configuration (executor / owner)
+  // ===========================================================================
+
+  /**
+   * @dev Update max supply (only if not fixed)
+   */
+  function setMaxSupply(uint256 newMaxSupply) external {
+    require(msg.sender == executor, '!executor');
+    require(!fixedMaxSupply, 'supply fixed');
+    require(
+      newMaxSupply == 0 || newMaxSupply >= totalSupply(),
+      'supply < total'
+    );
+
+    uint256 oldMaxSupply = maxSupply;
+    maxSupply = newMaxSupply;
+    emit MaxSupplyUpdated(oldMaxSupply, newMaxSupply);
+  }
+
+  /**
+   * @dev Update transferable status
+   */
+  function setTransferable(bool _transferable) external {
+    require(msg.sender == executor, '!executor');
+    transferable = _transferable;
+    emit TransferableUpdated(_transferable);
+  }
+
+  /**
+   * @dev Update archived status. When unarchiving, update all token holders'
+   * lastApplied timestamps so decay does not accumulate retroactively over the
+   * archived period (mirrors DecayingSpaceToken.setArchived).
+   */
+  function setArchived(bool _archived) external {
+    require(msg.sender == executor, '!executor');
+
+    // If we're unarchiving (going from true to false), update all holders' timestamps
+    if (archived && !_archived) {
+      for (uint256 i = 0; i < _tokenHolders.length; i++) {
+        address holder = _tokenHolders[i];
+        if (_isTokenHolder[holder] && lastApplied[holder] > 0) {
+          lastApplied[holder] = block.timestamp;
+        }
+      }
+    }
+
+    archived = _archived;
+    emit ArchivedStatusUpdated(_archived);
+  }
+
+  /**
+   * @dev Returns the name of the token.
+   * If a custom name has been set, it overrides the original ERC20 name.
+   */
+  function name() public view override returns (string memory) {
+    if (bytes(_customName).length > 0) {
+      return _customName;
+    }
+    return super.name();
+  }
+
+  /**
+   * @dev Returns the symbol of the token.
+   * If a custom symbol has been set, it overrides the original ERC20 symbol.
+   */
+  function symbol() public view override returns (string memory) {
+    if (bytes(_customSymbol).length > 0) {
+      return _customSymbol;
+    }
+    return super.symbol();
+  }
+
+  /**
+   * @dev Update the token name
+   */
+  function setTokenName(string memory newName) external {
+    require(msg.sender == executor, '!executor');
+    require(bytes(newName).length > 0, 'empty name');
+    string memory oldName = name();
+    _customName = newName;
+    emit TokenNameUpdated(oldName, newName);
+  }
+
+  /**
+   * @dev Update the token symbol
+   */
+  function setTokenSymbol(string memory newSymbol) external {
+    require(msg.sender == executor, '!executor');
+    require(bytes(newSymbol).length > 0, 'empty symbol');
+    string memory oldSymbol = symbol();
+    _customSymbol = newSymbol;
+    emit TokenSymbolUpdated(oldSymbol, newSymbol);
+  }
+
+  /**
+   * @dev Update auto-minting status
+   */
+  function setAutoMinting(bool _autoMinting) external {
+    require(
+      msg.sender == executor || msg.sender == owner(),
+      '!executor/owner'
+    );
+    autoMinting = _autoMinting;
+    emit AutoMintingUpdated(_autoMinting);
+  }
+
+  /**
+   * @dev Update token price in USD
+   */
+  function setPriceInUSD(uint256 newPrice) external {
+    require(msg.sender == executor, '!executor');
+    uint256 oldPrice = priceInUSD;
+    priceInUSD = newPrice;
+    tokenPrice = newPrice;
+    emit PriceInUSDUpdated(oldPrice, newPrice);
+  }
+
+  /**
+   * @dev Update token price and specify which currency it's denominated in.
+   * @param newPrice The new price (with 6 decimals)
+   * @param currencyFeed Chainlink X/USD feed for the currency (address(0) = USD)
+   */
+  function setPriceWithCurrency(
+    uint256 newPrice,
+    address currencyFeed
+  ) external {
+    require(msg.sender == executor, '!executor');
+    uint256 oldPrice = priceInUSD;
+    priceInUSD = newPrice;
+    tokenPrice = newPrice;
+    priceCurrencyFeed = currencyFeed;
+    emit PriceInUSDUpdated(oldPrice, newPrice);
+    emit PriceCurrencyUpdated(newPrice, currencyFeed);
+  }
+
+  /**
+   * @dev Set the transfer helper address
+   */
+  function setTransferHelper(address _transferHelper) external {
+    require(
+      msg.sender == executor || msg.sender == owner(),
+      '!executor/owner'
+    );
+    transferHelper = _transferHelper;
+  }
+
+  // ===========================================================================
+  // Token sale
+  // ===========================================================================
+
+  /**
+   * @dev Configure direct token sale in a payment token.
+   */
+  function configureTokenSale(
+    address _paymentToken,
+    uint256 _paymentTokenPricePerToken,
+    uint256 _tokensForSale
+  ) external {
+    require(msg.sender == executor, '!executor');
+    require(_paymentToken != address(0), '!zero addr');
+    require(_paymentTokenPricePerToken > 0, '!zero price');
+    require(_tokensForSale >= tokensSold, 'sale < sold');
+
+    paymentToken = _paymentToken;
+    paymentTokenPricePerToken = _paymentTokenPricePerToken;
+    tokensForSale = _tokensForSale;
+
+    // Keep existing price fields aligned with sale pricing for consistency.
+    priceInUSD = _paymentTokenPricePerToken;
+    tokenPrice = _paymentTokenPricePerToken;
+    priceCurrencyFeed = address(0);
+
+    emit TokenSaleConfigured(
+      _paymentToken,
+      _paymentTokenPricePerToken,
+      _tokensForSale
+    );
+  }
+
+  /**
+   * @dev Purchase tokens with the configured payment token. Payment tokens are
+   * sent directly to the space treasury (executor address). Decay tracking is
+   * initialized for the buyer like any other mint path.
+   */
+  function buyTokens(uint256 tokenAmount) external {
+    require(!archived, 'archived');
+    require(paymentToken != address(0), '!sale');
+    require(paymentTokenPricePerToken > 0, '!sale price');
+    require(tokensForSale > 0, 'sale disabled');
+    require(tokenAmount > 0, '!zero amount');
+    require(tokensSold + tokenAmount <= tokensForSale, 'sale cap');
+    require(canAccountPurchase(msg.sender), '!eligible');
+
+    // Convert token amount (18 decimals) into payment-token amount.
+    uint256 paymentAmount = (tokenAmount * paymentTokenPricePerToken) / 1e18;
+    require(paymentAmount > 0, 'amount too small');
+
+    tokensSold += tokenAmount;
+    IERC20(paymentToken).safeTransferFrom(msg.sender, executor, paymentAmount);
+    _applyDecayOrInit(msg.sender);
+    _addTokenHolder(msg.sender);
+    _mintWithSupplyChecks(msg.sender, tokenAmount);
+
+    emit TokensPurchased(msg.sender, tokenAmount, paymentAmount, executor);
+  }
+
+  /**
+   * @dev Get active token sale details.
+   */
+  function getTokenSaleDetails()
+    external
+    view
+    returns (
+      address salePaymentToken,
+      uint256 salePricePerToken,
+      uint256 tokensLeftToSell
+    )
+  {
+    salePaymentToken = paymentToken;
+    salePricePerToken = paymentTokenPricePerToken;
+    if (tokensForSale > tokensSold) {
+      tokensLeftToSell = tokensForSale - tokensSold;
+    } else {
+      tokensLeftToSell = 0;
+    }
+  }
+
+  /**
+   * @dev Update purchase eligibility mode.
+   */
+  function setPurchaseEligibilityMode(uint8 mode) external {
+    require(msg.sender == executor, '!executor');
+    require(mode <= PURCHASE_MODE_ALL_SPACES, 'bad mode');
+    purchaseEligibilityMode = mode;
+    emit PurchaseEligibilityModeUpdated(mode);
+  }
+
+  function batchAddPurchaseWhitelistSpaces(
+    uint256[] calldata spaceIds
+  ) external {
+    require(msg.sender == executor, '!executor');
+    for (uint256 i = 0; i < spaceIds.length; i++) {
+      if (
+        _addSpaceToList(
+          _purchaseWhitelistedSpaceIds,
+          isPurchaseWhitelistedSpace,
+          spaceIds[i]
+        )
+      ) {
+        emit PurchaseWhitelistSpaceAdded(spaceIds[i]);
+      }
+    }
+  }
+
+  function batchRemovePurchaseWhitelistSpaces(
+    uint256[] calldata spaceIds
+  ) external {
+    require(msg.sender == executor, '!executor');
+    for (uint256 i = 0; i < spaceIds.length; i++) {
+      if (
+        _removeSpaceFromList(
+          _purchaseWhitelistedSpaceIds,
+          isPurchaseWhitelistedSpace,
+          spaceIds[i]
+        )
+      ) {
+        emit PurchaseWhitelistSpaceRemoved(spaceIds[i]);
+      }
+    }
+  }
+
+  function getPurchaseWhitelistedSpaces()
+    external
+    view
+    returns (uint256[] memory)
+  {
+    return _purchaseWhitelistedSpaceIds;
+  }
+
+  // ===========================================================================
+  // Transfer / receive whitelists
+  // ===========================================================================
+
+  /**
+   * @dev Batch update transfer whitelist
+   */
+  function batchSetTransferWhitelist(
+    address[] calldata accounts,
+    bool[] calldata allowed
+  ) external {
+    require(msg.sender == executor, '!executor');
+    require(accounts.length == allowed.length, 'length mismatch');
+
+    for (uint256 i = 0; i < accounts.length; i++) {
+      canTransfer[accounts[i]] = allowed[i];
+      emit TransferWhitelistUpdated(accounts[i], allowed[i]);
+    }
+  }
+
+  /**
+   * @dev Batch update receive whitelist
+   */
+  function batchSetReceiveWhitelist(
+    address[] calldata accounts,
+    bool[] calldata allowed
+  ) external {
+    require(msg.sender == executor, '!executor');
+    require(accounts.length == allowed.length, 'length mismatch');
+
+    for (uint256 i = 0; i < accounts.length; i++) {
+      canReceive[accounts[i]] = allowed[i];
+      emit ReceiveWhitelistUpdated(accounts[i], allowed[i]);
+    }
+  }
+
+  /**
+   * @dev Enable or disable transfer whitelist enforcement
+   */
+  function setUseTransferWhitelist(bool enabled) external {
+    require(msg.sender == executor, '!executor');
+    useTransferWhitelist = enabled;
+    emit UseTransferWhitelistUpdated(enabled);
+  }
+
+  /**
+   * @dev Enable or disable receive whitelist enforcement
+   */
+  function setUseReceiveWhitelist(bool enabled) external {
+    require(msg.sender == executor, '!executor');
+    useReceiveWhitelist = enabled;
+    emit UseReceiveWhitelistUpdated(enabled);
+  }
+
+  /**
+   * @dev Batch add spaces to transfer whitelist
+   */
+  function batchAddTransferWhitelistSpaces(
+    uint256[] calldata spaceIds
+  ) external {
+    require(msg.sender == executor, '!executor');
+    for (uint256 i = 0; i < spaceIds.length; i++) {
+      if (
+        _addSpaceToList(
+          _transferWhitelistedSpaceIds,
+          isTransferWhitelistedSpace,
+          spaceIds[i]
+        )
+      ) {
+        emit TransferWhitelistSpaceAdded(spaceIds[i]);
+      }
+    }
+  }
+
+  function batchAddReceiveWhitelistSpaces(
+    uint256[] calldata spaceIds
+  ) external {
+    require(msg.sender == executor, '!executor');
+    for (uint256 i = 0; i < spaceIds.length; i++) {
+      if (
+        _addSpaceToList(
+          _receiveWhitelistedSpaceIds,
+          isReceiveWhitelistedSpace,
+          spaceIds[i]
+        )
+      ) {
+        emit ReceiveWhitelistSpaceAdded(spaceIds[i]);
+      }
+    }
+  }
+
+  /**
+   * @dev Batch remove spaces from transfer whitelist
+   */
+  function batchRemoveTransferWhitelistSpaces(
+    uint256[] calldata spaceIds
+  ) external {
+    require(msg.sender == executor, '!executor');
+    for (uint256 i = 0; i < spaceIds.length; i++) {
+      if (
+        _removeSpaceFromList(
+          _transferWhitelistedSpaceIds,
+          isTransferWhitelistedSpace,
+          spaceIds[i]
+        )
+      ) {
+        emit TransferWhitelistSpaceRemoved(spaceIds[i]);
+      }
+    }
+  }
+
+  function batchRemoveReceiveWhitelistSpaces(
+    uint256[] calldata spaceIds
+  ) external {
+    require(msg.sender == executor, '!executor');
+    for (uint256 i = 0; i < spaceIds.length; i++) {
+      if (
+        _removeSpaceFromList(
+          _receiveWhitelistedSpaceIds,
+          isReceiveWhitelistedSpace,
+          spaceIds[i]
+        )
+      ) {
+        emit ReceiveWhitelistSpaceRemoved(spaceIds[i]);
+      }
+    }
+  }
+
+  /**
+   * @dev Get all transfer whitelisted space IDs
+   */
+  function getTransferWhitelistedSpaces()
+    external
+    view
+    returns (uint256[] memory)
+  {
+    return _transferWhitelistedSpaceIds;
+  }
+
+  /**
+   * @dev Get all receive whitelisted space IDs
+   */
+  function getReceiveWhitelistedSpaces()
+    external
+    view
+    returns (uint256[] memory)
+  {
+    return _receiveWhitelistedSpaceIds;
+  }
+
+  function _isInTransferWhitelistedSpace(
+    address account
+  ) internal view returns (bool) {
+    return
+      _isAccountInSpaceList(
+        _transferWhitelistedSpaceIds,
+        isTransferWhitelistedSpace,
+        account
+      );
+  }
+
+  function _isInReceiveWhitelistedSpace(
+    address account
+  ) internal view returns (bool) {
+    return
+      _isAccountInSpaceList(
+        _receiveWhitelistedSpaceIds,
+        isReceiveWhitelistedSpace,
+        account
+      );
+  }
+
+  /**
+   * @dev Check if an address can transfer tokens
+   */
+  function canAccountTransfer(address account) public view returns (bool) {
+    // Executor always bypasses
+    if (account == executor) {
+      return true;
+    }
+    // If transfer whitelist is not enforced, everyone can transfer
+    if (!useTransferWhitelist) {
+      return true;
+    }
+    // Check direct whitelist
+    if (canTransfer[account]) {
+      return true;
+    }
+    // Check space-based whitelist
+    return _isInTransferWhitelistedSpace(account);
+  }
+
+  /**
+   * @dev Check if an address can receive tokens
+   */
+  function canAccountReceive(address account) public view returns (bool) {
+    // Executor always bypasses
+    if (account == executor) {
+      return true;
+    }
+    // If receive whitelist is not enforced, everyone can receive
+    if (!useReceiveWhitelist) {
+      return true;
+    }
+    // Check direct whitelist
+    if (canReceive[account]) {
+      return true;
+    }
+    // Check space-based whitelist
+    return _isInReceiveWhitelistedSpace(account);
+  }
+
+  function canAccountPurchase(address account) public view returns (bool) {
+    if (purchaseEligibilityMode == PURCHASE_MODE_SPACE_ONLY) {
+      return IDAOSpaceFactory(spacesContract).isMember(spaceId, account);
+    }
+    if (purchaseEligibilityMode == PURCHASE_MODE_CUSTOM_SPACES) {
+      return _isInPurchaseWhitelistedSpace(account);
+    }
+    if (purchaseEligibilityMode == PURCHASE_MODE_ALL_SPACES) {
+      return _isInAnySpace(account);
+    }
+    return false;
+  }
+
+  // =========================================================================
+  // Mutual credit view functions
+  // =========================================================================
+
+  /**
+   * @dev Credit limit for an account. Members of credit-whitelisted spaces
+   * and addresses on the credit address whitelist get defaultCreditLimit;
+   * everyone else gets 0.
+   */
+  function creditLimitOf(address account) public view returns (uint256) {
+    if (_isCreditEligible(account)) {
+      return defaultCreditLimit;
+    }
+    return 0;
+  }
+
+  /**
+   * @dev Remaining credit an account can still use before hitting its limit.
+   */
+  function creditLimitLeftOf(address account) public view returns (uint256) {
+    uint256 limit = creditLimitOf(account);
+    uint256 used = creditBalanceOf[account];
+    if (used >= limit) {
+      return 0;
+    }
+    return limit - used;
+  }
+
+  /**
+   * @dev Net position: positive means net creditor, negative means net debtor.
+   */
+  function netBalanceOf(address account) public view returns (int256) {
+    return int256(balanceOf(account)) - int256(creditBalanceOf[account]);
+  }
+
+  function getCreditWhitelistedSpaces()
+    external
+    view
+    returns (uint256[] memory)
+  {
+    return _creditWhitelistedSpaceIds;
+  }
+
+  // =========================================================================
+  // Mutual credit administration (executor only)
+  // =========================================================================
+
+  function setDefaultCreditLimit(uint256 _limit) external {
+    require(msg.sender == executor, '!executor');
+    uint256 old = defaultCreditLimit;
+    defaultCreditLimit = _limit;
+    emit DefaultCreditLimitUpdated(old, _limit);
+  }
+
+  /**
+   * @dev Enable or update mutual credit in one call.
+   */
+  function enableCredit(uint256 _limit, uint256[] calldata spaceIds) external {
+    require(msg.sender == executor, '!executor');
+    uint256 old = defaultCreditLimit;
+    defaultCreditLimit = _limit;
+    emit DefaultCreditLimitUpdated(old, _limit);
+    for (uint256 i = 0; i < spaceIds.length; i++) {
+      if (
+        _addSpaceToList(
+          _creditWhitelistedSpaceIds,
+          isCreditWhitelistedSpace,
+          spaceIds[i]
+        )
+      ) {
+        emit CreditWhitelistSpaceAdded(spaceIds[i]);
+      }
+    }
+  }
+
+  function batchAddCreditWhitelistSpaces(uint256[] calldata spaceIds) external {
+    require(msg.sender == executor, '!executor');
+    for (uint256 i = 0; i < spaceIds.length; i++) {
+      if (
+        _addSpaceToList(
+          _creditWhitelistedSpaceIds,
+          isCreditWhitelistedSpace,
+          spaceIds[i]
+        )
+      ) {
+        emit CreditWhitelistSpaceAdded(spaceIds[i]);
+      }
+    }
+  }
+
+  function batchRemoveCreditWhitelistSpaces(
+    uint256[] calldata spaceIds
+  ) external {
+    require(msg.sender == executor, '!executor');
+    for (uint256 i = 0; i < spaceIds.length; i++) {
+      if (
+        _removeSpaceFromList(
+          _creditWhitelistedSpaceIds,
+          isCreditWhitelistedSpace,
+          spaceIds[i]
+        )
+      ) {
+        emit CreditWhitelistSpaceRemoved(spaceIds[i]);
+      }
+    }
+  }
+
+  /**
+   * @dev Batch set per-address mutual credit eligibility (executor, Ownable
+   * owner or authorized minter).
+   */
+  function batchSetCreditWhitelistAddresses(
+    address[] calldata accounts,
+    bool[] calldata allowed
+  ) external {
+    require(
+      msg.sender == executor ||
+        msg.sender == owner() ||
+        isAuthorizedMinter[msg.sender],
+      '!executor/owner'
+    );
+    _batchSetAddressFlags(accounts, allowed, false);
+  }
+
+  /**
+   * @dev Batch grant/revoke authorized minter keys (executor or Ownable owner).
+   * Authorized minters may mint, burnFrom and batchSetCreditWhitelistAddresses,
+   * in addition to the executor/owner.
+   */
+  function batchSetAuthorizedMinters(
+    address[] calldata accounts,
+    bool[] calldata allowed
+  ) external {
+    require(
+      msg.sender == executor || msg.sender == owner(),
+      '!executor/owner'
+    );
+    _batchSetAddressFlags(accounts, allowed, true);
+  }
+
+  /**
+   * @dev Shared loop for the two address->bool whitelists. `minter` selects the
+   * authorized-minter mapping/event; otherwise the mutual-credit one.
+   */
+  function _batchSetAddressFlags(
+    address[] calldata accounts,
+    bool[] calldata allowed,
+    bool minter
+  ) private {
+    require(accounts.length == allowed.length, 'length mismatch');
+    for (uint256 i = 0; i < accounts.length; i++) {
+      if (minter) {
+        isAuthorizedMinter[accounts[i]] = allowed[i];
+        emit AuthorizedMinterUpdated(accounts[i], allowed[i]);
+      } else {
+        isCreditWhitelistedAddress[accounts[i]] = allowed[i];
+        emit CreditWhitelistAddressUpdated(accounts[i], allowed[i]);
+      }
+    }
+  }
+
+  // =========================================================================
+  // Shared space-list helpers
+  // =========================================================================
+
+  function _addSpaceToList(
+    uint256[] storage list,
+    mapping(uint256 => bool) storage isInList,
+    uint256 sid
+  ) internal returns (bool) {
+    if (!isInList[sid]) {
+      isInList[sid] = true;
+      list.push(sid);
+      return true;
+    }
+    return false;
+  }
+
+  function _removeSpaceFromList(
+    uint256[] storage list,
+    mapping(uint256 => bool) storage isInList,
+    uint256 sid
+  ) internal returns (bool) {
+    if (isInList[sid]) {
+      isInList[sid] = false;
+      for (uint256 i = 0; i < list.length; i++) {
+        if (list[i] == sid) {
+          list[i] = list[list.length - 1];
+          list.pop();
+          break;
+        }
+      }
+      return true;
+    }
+    return false;
+  }
+
+  function _isAccountInSpaceList(
+    uint256[] storage list,
+    mapping(uint256 => bool) storage isInList,
+    address account
+  ) internal view returns (bool) {
+    for (uint256 i = 0; i < list.length; i++) {
+      uint256 sid = list[i];
+      if (
+        isInList[sid] &&
+        IDAOSpaceFactory(spacesContract).isMember(sid, account)
+      ) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  function _isCreditEligible(address account) internal view returns (bool) {
+    return
+      isCreditWhitelistedAddress[account] ||
+      _isInCreditWhitelistedSpace(account);
+  }
+
+  function _isInCreditWhitelistedSpace(
+    address account
+  ) internal view returns (bool) {
+    return
+      _isAccountInSpaceList(
+        _creditWhitelistedSpaceIds,
+        isCreditWhitelistedSpace,
+        account
+      );
+  }
+
+  function _isInPurchaseWhitelistedSpace(
+    address account
+  ) internal view returns (bool) {
+    return
+      _isAccountInSpaceList(
+        _purchaseWhitelistedSpaceIds,
+        isPurchaseWhitelistedSpace,
+        account
+      );
+  }
+
+  function _isInAnySpace(address account) internal view returns (bool) {
+    uint256[] memory memberSpaces = IDAOSpaceFactory(spacesContract)
+      .getMemberSpaces(account);
+    return memberSpaces.length > 0;
+  }
+}

--- a/packages/storage-evm/contracts/OwnershipSpaceTokenLegacy.sol
+++ b/packages/storage-evm/contracts/OwnershipSpaceTokenLegacy.sol
@@ -1,0 +1,1231 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import '@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol';
+import '@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol';
+import '@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20BurnableUpgradeable.sol';
+import '@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol';
+import '@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol';
+import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
+import '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
+import './interfaces/IDAOSpaceFactory.sol';
+
+/**
+ * @dev Interface for querying escrow creator
+ */
+interface IEscrowCreatorQueryLegacy {
+  function getEscrowCreator(uint256 _escrowId) external view returns (address);
+
+  function escrowExists(uint256 _escrowId) external view returns (bool);
+}
+
+/**
+ * @title OwnershipSpaceTokenLegacy
+ * @dev Drop-in upgrade implementation for ownership space tokens deployed from
+ * the PRE-mutual-credit implementation line (e.g. Hypha Energy Participations /
+ * EPARTS at 0x5d3394CAa6D09214aB86CF048e39dea058eC1921, impl
+ * 0x44F182819CB3e5A4E90851829bA870c6Ee41B9D1 on Base).
+ *
+ * WHY THIS CONTRACT EXISTS — STORAGE LAYOUT:
+ * That implementation predates mutual credit, the token sale and authorized
+ * minters. Its RegularSpaceToken base storage ends at `_customSymbol`
+ * (slot 15) and OwnershipSpaceToken's `ownershipSpacesContract` sits at
+ * slot 16 (verified on-chain: slot 16 = 0xc8B8...9cd9):
+ *
+ *   slot 0  spaceId
+ *   slot 1  maxSupply
+ *   slot 2  transferable | executor                  (packed)
+ *   slot 3  transferHelper | fixedMaxSupply | autoMinting (packed)
+ *   slot 4  priceInUSD
+ *   slot 5  canTransfer
+ *   slot 6  canReceive
+ *   slot 7  useTransferWhitelist | useReceiveWhitelist | archived (packed)
+ *   slot 8  _transferWhitelistedSpaceIds
+ *   slot 9  _receiveWhitelistedSpaceIds
+ *   slot 10 isTransferWhitelistedSpace
+ *   slot 11 isReceiveWhitelistedSpace
+ *   slot 12 priceCurrencyFeed
+ *   slot 13 tokenPrice
+ *   slot 14 _customName
+ *   slot 15 _customSymbol
+ *   slot 16 ownershipSpacesContract
+ *
+ * Upgrading such a proxy to the CURRENT OwnershipSpaceToken would shift
+ * `ownershipSpacesContract` down by the newer base variables plus the 50-slot
+ * gap, breaking membership checks and bleeding its value into
+ * `defaultCreditLimit`-era slots. This contract flattens RegularSpaceToken +
+ * OwnershipSpaceToken keeping the deployed slots 0-16 in place and appending
+ * every newer variable AFTER them.
+ *
+ * FUNCTIONALITY: identical to the current OwnershipSpaceToken (authorized
+ * minters, mutual credit administration, token sale, escrow transfers,
+ * member-restricted transfers, etc.).
+ *
+ * MAINTENANCE: this contract must be kept in sync with RegularSpaceToken /
+ * OwnershipSpaceToken by hand. When changing those contracts, mirror the
+ * change here (storage additions go before __gap, never between existing
+ * variables).
+ */
+contract OwnershipSpaceTokenLegacy is
+  Initializable,
+  ERC20Upgradeable,
+  ERC20BurnableUpgradeable,
+  OwnableUpgradeable,
+  UUPSUpgradeable
+{
+  using SafeERC20 for IERC20;
+  uint8 public constant PURCHASE_MODE_SPACE_ONLY = 0;
+  uint8 public constant PURCHASE_MODE_CUSTOM_SPACES = 1;
+  uint8 public constant PURCHASE_MODE_ALL_SPACES = 2;
+
+  // ===========================================================================
+  // LEGACY STORAGE — slots 0-16 of the deployed proxies. DO NOT reorder,
+  // retype, remove or insert anything in this block.
+  // ===========================================================================
+
+  // slots 0-7
+  uint256 public spaceId;
+  uint256 public maxSupply;
+  bool public transferable;
+  address public executor;
+  address public transferHelper;
+  bool public fixedMaxSupply; // If true, maxSupply cannot be changed
+  bool public autoMinting; // If true, executor can mint on transfer; if false, must mint separately
+  uint256 public priceInUSD; // Token price in USD (with 6 decimals, e.g., 1000000 = $1)
+  mapping(address => bool) public canTransfer; // Who can send tokens
+  mapping(address => bool) public canReceive; // Who can receive tokens
+  bool public useTransferWhitelist; // If true, enforce transfer whitelist
+  bool public useReceiveWhitelist; // If true, enforce receive whitelist
+  bool public archived; // If true, minting and transfers are disabled
+
+  // slots 8-11: space-based whitelisting
+  uint256[] internal _transferWhitelistedSpaceIds; // Space IDs whose members can transfer
+  uint256[] internal _receiveWhitelistedSpaceIds; // Space IDs whose members can receive
+  mapping(uint256 => bool) public isTransferWhitelistedSpace; // Quick lookup for transfer whitelist
+  mapping(uint256 => bool) public isReceiveWhitelistedSpace; // Quick lookup for receive whitelist
+
+  // slots 12-13: pricing
+  address public priceCurrencyFeed;
+  uint256 public tokenPrice;
+
+  // slots 14-15: custom name/symbol overrides
+  string private _customName;
+  string private _customSymbol;
+
+  // slot 16: OwnershipSpaceToken derived storage
+  address public ownershipSpacesContract;
+
+  // ===========================================================================
+  // NEWER STORAGE — everything added to the token contracts after the legacy
+  // implementations were deployed. Appended after the legacy block so existing
+  // proxy state is untouched; all of it reads as zero (= feature disabled)
+  // right after the upgrade. Only append below, before __gap.
+  // ===========================================================================
+
+  // Hardcoded spaces contract address for membership checks
+  address public constant spacesContract =
+    0xc8B8454D2F9192FeCAbc2C6F5d88F6434A2a9cd9;
+
+  // Hardcoded escrow contract address
+  address public constant escrowContract =
+    0x447A317cA5516933264Cdd6aeee0633Fa954B576;
+
+  // Mutual credit storage
+  uint256 public defaultCreditLimit;
+  mapping(address => uint256) public creditBalanceOf;
+  uint256[] internal _creditWhitelistedSpaceIds;
+  mapping(uint256 => bool) public isCreditWhitelistedSpace;
+
+  // Primary sale configuration
+  address public paymentToken;
+  uint256 public paymentTokenPricePerToken; // 6 decimals, priced per 1e18 token units
+  uint256 public tokensForSale; // 18 decimals, 0 means sale disabled
+  uint256 public tokensSold;
+  uint8 public purchaseEligibilityMode; // 0: issuer space only, 1: custom spaces, 2: any space
+  uint256[] internal _purchaseWhitelistedSpaceIds;
+  mapping(uint256 => bool) public isPurchaseWhitelistedSpace;
+
+  // Address-level mutual credit eligibility
+  mapping(address => bool) public isCreditWhitelistedAddress;
+
+  // Authorized minter keys. Addresses set to true are granted mint, burnFrom and
+  // batchSetCreditWhitelistAddresses rights, in addition to the executor/owner.
+  mapping(address => bool) public isAuthorizedMinter;
+
+  // Reserved storage slots for upgrade-safe additions to this contract.
+  // When adding a new state variable above, decrement the gap size by the
+  // number of slots it consumes so the layout stays fixed.
+  uint256[50] private __gap;
+
+  // Events
+  event MaxSupplyUpdated(uint256 oldMaxSupply, uint256 newMaxSupply);
+  event TransferableUpdated(bool transferable);
+  event AutoMintingUpdated(bool autoMinting);
+  event PriceInUSDUpdated(uint256 oldPrice, uint256 newPrice);
+  event PriceCurrencyUpdated(uint256 price, address currencyFeed);
+  event ArchivedStatusUpdated(bool archived);
+  event TokenNameUpdated(string oldName, string newName);
+  event TokenSymbolUpdated(string oldSymbol, string newSymbol);
+  event TransferWhitelistUpdated(address indexed account, bool canTransfer);
+  event ReceiveWhitelistUpdated(address indexed account, bool canReceive);
+  event UseTransferWhitelistUpdated(bool enabled);
+  event UseReceiveWhitelistUpdated(bool enabled);
+  event TokensBurned(
+    address indexed burner,
+    address indexed from,
+    uint256 amount
+  );
+  event TransferWhitelistSpaceAdded(uint256 indexed spaceId);
+  event TransferWhitelistSpaceRemoved(uint256 indexed spaceId);
+  event ReceiveWhitelistSpaceAdded(uint256 indexed spaceId);
+  event ReceiveWhitelistSpaceRemoved(uint256 indexed spaceId);
+  event DefaultCreditLimitUpdated(uint256 oldLimit, uint256 newLimit);
+  event CreditUsed(
+    address indexed member,
+    uint256 amount,
+    uint256 newCreditBalance
+  );
+  event CreditRepaid(
+    address indexed member,
+    uint256 amount,
+    uint256 newCreditBalance
+  );
+  event CreditWhitelistSpaceAdded(uint256 indexed spaceId);
+  event CreditWhitelistSpaceRemoved(uint256 indexed spaceId);
+  event CreditWhitelistAddressUpdated(address indexed account, bool allowed);
+  event TokenSaleConfigured(
+    address indexed paymentToken,
+    uint256 paymentTokenPricePerToken,
+    uint256 tokensForSale
+  );
+  event TokensPurchased(
+    address indexed buyer,
+    uint256 tokenAmount,
+    uint256 paymentAmount,
+    address indexed treasury
+  );
+  event PurchaseEligibilityModeUpdated(uint8 mode);
+  event PurchaseWhitelistSpaceAdded(uint256 indexed spaceId);
+  event PurchaseWhitelistSpaceRemoved(uint256 indexed spaceId);
+  event AuthorizedMinterUpdated(address indexed account, bool allowed);
+
+  // Ownership token events
+  event TransferRejected(address from, address to, string reason);
+  event OwnershipSpacesContractUpdated(
+    address indexed oldSpacesContract,
+    address indexed newSpacesContract
+  );
+
+  /// @custom:oz-upgrades-unsafe-allow constructor
+  constructor() {
+    _disableInitializers();
+  }
+
+  /**
+   * @dev Initializer for FRESH proxy deployments only. The legacy proxies this
+   * implementation targets are already initialized, so this can never run on
+   * them (initializer guard). Mirrors OwnershipSpaceToken.initialize.
+   */
+  function initialize(
+    string memory name,
+    string memory symbol,
+    address _executor,
+    uint256 _spaceId,
+    uint256 _maxSupply,
+    address _spacesContract,
+    bool _fixedMaxSupply,
+    bool _autoMinting,
+    uint256 _tokenPrice,
+    address _priceCurrencyFeed,
+    bool _useTransferWhitelist,
+    bool _useReceiveWhitelist,
+    address[] memory _initialTransferWhitelist,
+    address[] memory _initialReceiveWhitelist,
+    uint256[] memory _initialTransferWhitelistSpaceIds,
+    uint256[] memory _initialReceiveWhitelistSpaceIds,
+    address _paymentToken,
+    uint256 _paymentTokenPricePerToken,
+    uint256 _tokensForSale,
+    uint8 _purchaseEligibilityMode,
+    uint256[] memory _initialPurchaseWhitelistSpaceIds,
+    address[] memory _initialAuthorizedMinters
+  ) public initializer {
+    require(_spacesContract != address(0), '!zero addr');
+
+    __ERC20_init(name, symbol);
+    __ERC20Burnable_init();
+    __Ownable_init(0x2687fe290b54d824c136Ceff2d5bD362Bc62019a);
+    __UUPSUpgradeable_init();
+
+    executor = _executor;
+    spaceId = _spaceId;
+    maxSupply = _maxSupply;
+    transferable = true; // Ownership tokens are always transferable by executor
+    transferHelper = 0x479002F7602579203ffba3eE84ACC1BC5b0d6785;
+
+    fixedMaxSupply = _fixedMaxSupply;
+    autoMinting = _autoMinting;
+    priceInUSD = _tokenPrice; // Legacy field — kept in sync
+    tokenPrice = _tokenPrice;
+    priceCurrencyFeed = _priceCurrencyFeed;
+    useTransferWhitelist = _useTransferWhitelist;
+    useReceiveWhitelist = _useReceiveWhitelist;
+
+    // Executor is always whitelisted for both sending and receiving
+    canTransfer[_executor] = true;
+    canReceive[_executor] = true;
+
+    for (uint256 i = 0; i < _initialTransferWhitelist.length; i++) {
+      canTransfer[_initialTransferWhitelist[i]] = true;
+    }
+
+    for (uint256 i = 0; i < _initialReceiveWhitelist.length; i++) {
+      canReceive[_initialReceiveWhitelist[i]] = true;
+    }
+
+    for (uint256 i = 0; i < _initialTransferWhitelistSpaceIds.length; i++) {
+      _addSpaceToList(
+        _transferWhitelistedSpaceIds,
+        isTransferWhitelistedSpace,
+        _initialTransferWhitelistSpaceIds[i]
+      );
+    }
+
+    for (uint256 i = 0; i < _initialReceiveWhitelistSpaceIds.length; i++) {
+      _addSpaceToList(
+        _receiveWhitelistedSpaceIds,
+        isReceiveWhitelistedSpace,
+        _initialReceiveWhitelistSpaceIds[i]
+      );
+    }
+
+    // Optional initial sale configuration. Keeping zero values means "sale disabled".
+    if (_paymentToken != address(0)) {
+      paymentToken = _paymentToken;
+      paymentTokenPricePerToken = _paymentTokenPricePerToken;
+      tokensForSale = _tokensForSale;
+      tokensSold = 0;
+    }
+
+    require(_purchaseEligibilityMode <= PURCHASE_MODE_ALL_SPACES, 'bad mode');
+    purchaseEligibilityMode = _purchaseEligibilityMode;
+    for (uint256 i = 0; i < _initialPurchaseWhitelistSpaceIds.length; i++) {
+      _addSpaceToList(
+        _purchaseWhitelistedSpaceIds,
+        isPurchaseWhitelistedSpace,
+        _initialPurchaseWhitelistSpaceIds[i]
+      );
+    }
+
+    for (uint256 i = 0; i < _initialAuthorizedMinters.length; i++) {
+      isAuthorizedMinter[_initialAuthorizedMinters[i]] = true;
+    }
+
+    ownershipSpacesContract = _spacesContract;
+  }
+
+  function _authorizeUpgrade(
+    address newImplementation
+  ) internal override onlyOwner {}
+
+  // ===========================================================================
+  // Ownership token specifics (mirrors OwnershipSpaceToken)
+  // ===========================================================================
+
+  /**
+   * @dev Sets the spaces contract used for ownership membership checks.
+   * Allows recovering older upgraded proxies where this field was never initialized.
+   */
+  function setOwnershipSpacesContract(address _spacesContract) external {
+    require(
+      msg.sender == executor || msg.sender == owner(),
+      '!executor/owner'
+    );
+    require(_spacesContract != address(0), '!zero addr');
+
+    address oldSpacesContract = ownershipSpacesContract;
+    ownershipSpacesContract = _spacesContract;
+    emit OwnershipSpacesContractUpdated(oldSpacesContract, _spacesContract);
+  }
+
+  /**
+   * @dev Check if an address is a member of the space
+   */
+  function _isSpaceMember(address account) internal view returns (bool) {
+    // Backward compatibility:
+    // Some older proxies were upgraded without initializing ownershipSpacesContract.
+    // Fallback to the canonical parent spaces contract in that case.
+    address membershipSpacesContract = ownershipSpacesContract == address(0)
+      ? spacesContract
+      : ownershipSpacesContract;
+    return
+      IDAOSpaceFactory(membershipSpacesContract).isMember(spaceId, account);
+  }
+
+  function transfer(address to, uint256 amount) public override returns (bool) {
+    address sender = _msgSender();
+    _validateTransferAccess(sender, to, sender);
+    _autoMintIfNeeded(sender, amount);
+
+    if (to == escrowContract && _isSpaceMember(sender)) {
+      revert('use escrow fn');
+    }
+
+    require(sender == executor, '!executor');
+    require(_isSpaceMember(to), '!member');
+    _transfer(sender, to, amount);
+    return true;
+  }
+
+  /**
+   * @dev Transfer tokens to a specific escrow
+   * Only allows transfer if the escrow was created by the space executor
+   */
+  function transferToEscrow(
+    uint256 escrowId,
+    uint256 amount
+  ) external returns (bool) {
+    require(!archived, 'archived');
+    require(_isSpaceMember(msg.sender), '!member');
+
+    IEscrowCreatorQueryLegacy escrowQuery = IEscrowCreatorQueryLegacy(
+      escrowContract
+    );
+
+    // Check if escrow exists
+    require(escrowQuery.escrowExists(escrowId), '!escrow');
+
+    // Check if escrow was created by the space executor
+    address escrowCreator = escrowQuery.getEscrowCreator(escrowId);
+    require(escrowCreator == executor, '!escrow creator');
+
+    _transfer(msg.sender, escrowContract, amount);
+    return true;
+  }
+
+  function transferFrom(
+    address from,
+    address to,
+    uint256 amount
+  ) public override returns (bool) {
+    address spender = _msgSender();
+    _validateTransferAccess(from, to, spender);
+    _autoMintIfNeeded(from, amount);
+
+    if (spender == escrowContract && _isSpaceMember(to)) {
+      _transfer(from, to, amount);
+      return true;
+    }
+
+    if (spender == transferHelper) {
+      require(_isSpaceMember(to), '!member');
+      _transfer(from, to, amount);
+      return true;
+    }
+
+    require(spender == executor, '!executor');
+    require(_isSpaceMember(to), '!member');
+    _transfer(from, to, amount);
+    return true;
+  }
+
+  function mint(address to, uint256 amount) public {
+    require(
+      msg.sender == executor || isAuthorizedMinter[msg.sender],
+      '!executor'
+    );
+    // Executor mints are restricted to space members; authorized minters are not.
+    if (msg.sender == executor) {
+      require(_isSpaceMember(to) || to == executor, '!member/executor');
+    }
+    _mintWithSupplyChecks(to, amount);
+  }
+
+  // ===========================================================================
+  // Shared base logic (mirrors RegularSpaceToken)
+  // ===========================================================================
+
+  function _mintWithSupplyChecks(address to, uint256 amount) internal {
+    require(!archived, 'archived');
+    // Check against maximum supply
+    require(
+      maxSupply == 0 || totalSupply() + amount <= maxSupply,
+      'supply exceeded'
+    );
+
+    _mint(to, amount);
+  }
+
+  function _validateTransferAccess(
+    address from,
+    address to,
+    address spender
+  ) internal view {
+    require(!archived, 'archived');
+    require(transferable || spender == executor, '!transferable');
+    if (from != executor && useTransferWhitelist) {
+      require(
+        canTransfer[from] || _isInTransferWhitelistedSpace(from),
+        '!send whitelist'
+      );
+    }
+    if (to != executor && useReceiveWhitelist) {
+      require(
+        canReceive[to] || _isInReceiveWhitelistedSpace(to),
+        '!recv whitelist'
+      );
+    }
+  }
+
+  function _autoMintIfNeeded(address account, uint256 amount) internal {
+    if (account == executor && autoMinting) {
+      uint256 bal = balanceOf(account);
+      if (bal < amount) {
+        _mintWithSupplyChecks(account, amount - bal);
+      }
+    }
+  }
+
+  /**
+   * @dev Burn tokens from any address (executor / authorized minters burn
+   * without approval; others need allowance)
+   */
+  function burnFrom(address from, uint256 amount) public override {
+    if (msg.sender == executor || isAuthorizedMinter[msg.sender]) {
+      // Executor and authorized minters can burn without approval
+      _burn(from, amount);
+      emit TokensBurned(msg.sender, from, amount);
+    } else {
+      // Others need approval
+      super.burnFrom(from, amount);
+      emit TokensBurned(msg.sender, from, amount);
+    }
+  }
+
+  /**
+   * @dev Update max supply (only if not fixed)
+   */
+  function setMaxSupply(uint256 newMaxSupply) external {
+    require(msg.sender == executor, '!executor');
+    require(!fixedMaxSupply, 'supply fixed');
+    require(
+      newMaxSupply == 0 || newMaxSupply >= totalSupply(),
+      'supply < total'
+    );
+
+    uint256 oldMaxSupply = maxSupply;
+    maxSupply = newMaxSupply;
+    emit MaxSupplyUpdated(oldMaxSupply, newMaxSupply);
+  }
+
+  /**
+   * @dev Update transferable status
+   */
+  function setTransferable(bool _transferable) external {
+    require(msg.sender == executor, '!executor');
+    transferable = _transferable;
+    emit TransferableUpdated(_transferable);
+  }
+
+  /**
+   * @dev Update archived status
+   */
+  function setArchived(bool _archived) external {
+    require(msg.sender == executor, '!executor');
+    archived = _archived;
+    emit ArchivedStatusUpdated(_archived);
+  }
+
+  /**
+   * @dev Returns the name of the token.
+   * If a custom name has been set, it overrides the original ERC20 name.
+   */
+  function name() public view override returns (string memory) {
+    if (bytes(_customName).length > 0) {
+      return _customName;
+    }
+    return super.name();
+  }
+
+  /**
+   * @dev Returns the symbol of the token.
+   * If a custom symbol has been set, it overrides the original ERC20 symbol.
+   */
+  function symbol() public view override returns (string memory) {
+    if (bytes(_customSymbol).length > 0) {
+      return _customSymbol;
+    }
+    return super.symbol();
+  }
+
+  /**
+   * @dev Update the token name
+   */
+  function setTokenName(string memory newName) external {
+    require(msg.sender == executor, '!executor');
+    require(bytes(newName).length > 0, 'empty name');
+    string memory oldName = name();
+    _customName = newName;
+    emit TokenNameUpdated(oldName, newName);
+  }
+
+  /**
+   * @dev Update the token symbol
+   */
+  function setTokenSymbol(string memory newSymbol) external {
+    require(msg.sender == executor, '!executor');
+    require(bytes(newSymbol).length > 0, 'empty symbol');
+    string memory oldSymbol = symbol();
+    _customSymbol = newSymbol;
+    emit TokenSymbolUpdated(oldSymbol, newSymbol);
+  }
+
+  /**
+   * @dev Update auto-minting status
+   */
+  function setAutoMinting(bool _autoMinting) external {
+    require(
+      msg.sender == executor || msg.sender == owner(),
+      '!executor/owner'
+    );
+    autoMinting = _autoMinting;
+    emit AutoMintingUpdated(_autoMinting);
+  }
+
+  /**
+   * @dev Update token price in USD
+   */
+  function setPriceInUSD(uint256 newPrice) external {
+    require(msg.sender == executor, '!executor');
+    uint256 oldPrice = priceInUSD;
+    priceInUSD = newPrice;
+    tokenPrice = newPrice;
+    emit PriceInUSDUpdated(oldPrice, newPrice);
+  }
+
+  /**
+   * @dev Update token price and specify which currency it's denominated in.
+   */
+  function setPriceWithCurrency(
+    uint256 newPrice,
+    address currencyFeed
+  ) external {
+    require(msg.sender == executor, '!executor');
+    uint256 oldPrice = priceInUSD;
+    priceInUSD = newPrice;
+    tokenPrice = newPrice;
+    priceCurrencyFeed = currencyFeed;
+    emit PriceInUSDUpdated(oldPrice, newPrice);
+    emit PriceCurrencyUpdated(newPrice, currencyFeed);
+  }
+
+  /**
+   * @dev Set the transfer helper address
+   */
+  function setTransferHelper(address _transferHelper) external {
+    require(
+      msg.sender == executor || msg.sender == owner(),
+      '!executor/owner'
+    );
+    transferHelper = _transferHelper;
+  }
+
+  // ===========================================================================
+  // Token sale
+  // ===========================================================================
+
+  /**
+   * @dev Configure direct token sale in a payment token.
+   */
+  function configureTokenSale(
+    address _paymentToken,
+    uint256 _paymentTokenPricePerToken,
+    uint256 _tokensForSale
+  ) external {
+    require(msg.sender == executor, '!executor');
+    require(_paymentToken != address(0), '!zero addr');
+    require(_paymentTokenPricePerToken > 0, '!zero price');
+    require(_tokensForSale >= tokensSold, 'sale < sold');
+
+    paymentToken = _paymentToken;
+    paymentTokenPricePerToken = _paymentTokenPricePerToken;
+    tokensForSale = _tokensForSale;
+
+    // Keep existing price fields aligned with sale pricing for consistency.
+    priceInUSD = _paymentTokenPricePerToken;
+    tokenPrice = _paymentTokenPricePerToken;
+    priceCurrencyFeed = address(0);
+
+    emit TokenSaleConfigured(
+      _paymentToken,
+      _paymentTokenPricePerToken,
+      _tokensForSale
+    );
+  }
+
+  /**
+   * @dev Purchase tokens with the configured payment token. Payment tokens are
+   * sent directly to the space treasury (executor address).
+   */
+  function buyTokens(uint256 tokenAmount) external {
+    require(!archived, 'archived');
+    require(paymentToken != address(0), '!sale');
+    require(paymentTokenPricePerToken > 0, '!sale price');
+    require(tokensForSale > 0, 'sale disabled');
+    require(tokenAmount > 0, '!zero amount');
+    require(tokensSold + tokenAmount <= tokensForSale, 'sale cap');
+    require(canAccountPurchase(msg.sender), '!eligible');
+
+    // Convert token amount (18 decimals) into payment-token amount.
+    uint256 paymentAmount = (tokenAmount * paymentTokenPricePerToken) / 1e18;
+    require(paymentAmount > 0, 'amount too small');
+
+    tokensSold += tokenAmount;
+    IERC20(paymentToken).safeTransferFrom(msg.sender, executor, paymentAmount);
+    _mintWithSupplyChecks(msg.sender, tokenAmount);
+
+    emit TokensPurchased(msg.sender, tokenAmount, paymentAmount, executor);
+  }
+
+  /**
+   * @dev Get active token sale details.
+   */
+  function getTokenSaleDetails()
+    external
+    view
+    returns (
+      address salePaymentToken,
+      uint256 salePricePerToken,
+      uint256 tokensLeftToSell
+    )
+  {
+    salePaymentToken = paymentToken;
+    salePricePerToken = paymentTokenPricePerToken;
+    if (tokensForSale > tokensSold) {
+      tokensLeftToSell = tokensForSale - tokensSold;
+    } else {
+      tokensLeftToSell = 0;
+    }
+  }
+
+  /**
+   * @dev Update purchase eligibility mode.
+   */
+  function setPurchaseEligibilityMode(uint8 mode) external {
+    require(msg.sender == executor, '!executor');
+    require(mode <= PURCHASE_MODE_ALL_SPACES, 'bad mode');
+    purchaseEligibilityMode = mode;
+    emit PurchaseEligibilityModeUpdated(mode);
+  }
+
+  function batchAddPurchaseWhitelistSpaces(
+    uint256[] calldata spaceIds
+  ) external {
+    require(msg.sender == executor, '!executor');
+    for (uint256 i = 0; i < spaceIds.length; i++) {
+      if (
+        _addSpaceToList(
+          _purchaseWhitelistedSpaceIds,
+          isPurchaseWhitelistedSpace,
+          spaceIds[i]
+        )
+      ) {
+        emit PurchaseWhitelistSpaceAdded(spaceIds[i]);
+      }
+    }
+  }
+
+  function batchRemovePurchaseWhitelistSpaces(
+    uint256[] calldata spaceIds
+  ) external {
+    require(msg.sender == executor, '!executor');
+    for (uint256 i = 0; i < spaceIds.length; i++) {
+      if (
+        _removeSpaceFromList(
+          _purchaseWhitelistedSpaceIds,
+          isPurchaseWhitelistedSpace,
+          spaceIds[i]
+        )
+      ) {
+        emit PurchaseWhitelistSpaceRemoved(spaceIds[i]);
+      }
+    }
+  }
+
+  function getPurchaseWhitelistedSpaces()
+    external
+    view
+    returns (uint256[] memory)
+  {
+    return _purchaseWhitelistedSpaceIds;
+  }
+
+  // ===========================================================================
+  // Transfer / receive whitelists
+  // ===========================================================================
+
+  /**
+   * @dev Batch update transfer whitelist
+   */
+  function batchSetTransferWhitelist(
+    address[] calldata accounts,
+    bool[] calldata allowed
+  ) external {
+    require(msg.sender == executor, '!executor');
+    require(accounts.length == allowed.length, 'length mismatch');
+
+    for (uint256 i = 0; i < accounts.length; i++) {
+      canTransfer[accounts[i]] = allowed[i];
+      emit TransferWhitelistUpdated(accounts[i], allowed[i]);
+    }
+  }
+
+  /**
+   * @dev Batch update receive whitelist
+   */
+  function batchSetReceiveWhitelist(
+    address[] calldata accounts,
+    bool[] calldata allowed
+  ) external {
+    require(msg.sender == executor, '!executor');
+    require(accounts.length == allowed.length, 'length mismatch');
+
+    for (uint256 i = 0; i < accounts.length; i++) {
+      canReceive[accounts[i]] = allowed[i];
+      emit ReceiveWhitelistUpdated(accounts[i], allowed[i]);
+    }
+  }
+
+  /**
+   * @dev Enable or disable transfer whitelist enforcement
+   */
+  function setUseTransferWhitelist(bool enabled) external {
+    require(msg.sender == executor, '!executor');
+    useTransferWhitelist = enabled;
+    emit UseTransferWhitelistUpdated(enabled);
+  }
+
+  /**
+   * @dev Enable or disable receive whitelist enforcement
+   */
+  function setUseReceiveWhitelist(bool enabled) external {
+    require(msg.sender == executor, '!executor');
+    useReceiveWhitelist = enabled;
+    emit UseReceiveWhitelistUpdated(enabled);
+  }
+
+  /**
+   * @dev Batch add spaces to transfer whitelist
+   */
+  function batchAddTransferWhitelistSpaces(
+    uint256[] calldata spaceIds
+  ) external {
+    require(msg.sender == executor, '!executor');
+    for (uint256 i = 0; i < spaceIds.length; i++) {
+      if (
+        _addSpaceToList(
+          _transferWhitelistedSpaceIds,
+          isTransferWhitelistedSpace,
+          spaceIds[i]
+        )
+      ) {
+        emit TransferWhitelistSpaceAdded(spaceIds[i]);
+      }
+    }
+  }
+
+  function batchAddReceiveWhitelistSpaces(
+    uint256[] calldata spaceIds
+  ) external {
+    require(msg.sender == executor, '!executor');
+    for (uint256 i = 0; i < spaceIds.length; i++) {
+      if (
+        _addSpaceToList(
+          _receiveWhitelistedSpaceIds,
+          isReceiveWhitelistedSpace,
+          spaceIds[i]
+        )
+      ) {
+        emit ReceiveWhitelistSpaceAdded(spaceIds[i]);
+      }
+    }
+  }
+
+  /**
+   * @dev Batch remove spaces from transfer whitelist
+   */
+  function batchRemoveTransferWhitelistSpaces(
+    uint256[] calldata spaceIds
+  ) external {
+    require(msg.sender == executor, '!executor');
+    for (uint256 i = 0; i < spaceIds.length; i++) {
+      if (
+        _removeSpaceFromList(
+          _transferWhitelistedSpaceIds,
+          isTransferWhitelistedSpace,
+          spaceIds[i]
+        )
+      ) {
+        emit TransferWhitelistSpaceRemoved(spaceIds[i]);
+      }
+    }
+  }
+
+  function batchRemoveReceiveWhitelistSpaces(
+    uint256[] calldata spaceIds
+  ) external {
+    require(msg.sender == executor, '!executor');
+    for (uint256 i = 0; i < spaceIds.length; i++) {
+      if (
+        _removeSpaceFromList(
+          _receiveWhitelistedSpaceIds,
+          isReceiveWhitelistedSpace,
+          spaceIds[i]
+        )
+      ) {
+        emit ReceiveWhitelistSpaceRemoved(spaceIds[i]);
+      }
+    }
+  }
+
+  /**
+   * @dev Get all transfer whitelisted space IDs
+   */
+  function getTransferWhitelistedSpaces()
+    external
+    view
+    returns (uint256[] memory)
+  {
+    return _transferWhitelistedSpaceIds;
+  }
+
+  /**
+   * @dev Get all receive whitelisted space IDs
+   */
+  function getReceiveWhitelistedSpaces()
+    external
+    view
+    returns (uint256[] memory)
+  {
+    return _receiveWhitelistedSpaceIds;
+  }
+
+  function _isInTransferWhitelistedSpace(
+    address account
+  ) internal view returns (bool) {
+    return
+      _isAccountInSpaceList(
+        _transferWhitelistedSpaceIds,
+        isTransferWhitelistedSpace,
+        account
+      );
+  }
+
+  function _isInReceiveWhitelistedSpace(
+    address account
+  ) internal view returns (bool) {
+    return
+      _isAccountInSpaceList(
+        _receiveWhitelistedSpaceIds,
+        isReceiveWhitelistedSpace,
+        account
+      );
+  }
+
+  /**
+   * @dev Check if an address can transfer tokens
+   */
+  function canAccountTransfer(address account) public view returns (bool) {
+    // Executor always bypasses
+    if (account == executor) {
+      return true;
+    }
+    // If transfer whitelist is not enforced, everyone can transfer
+    if (!useTransferWhitelist) {
+      return true;
+    }
+    // Check direct whitelist
+    if (canTransfer[account]) {
+      return true;
+    }
+    // Check space-based whitelist
+    return _isInTransferWhitelistedSpace(account);
+  }
+
+  /**
+   * @dev Check if an address can receive tokens
+   */
+  function canAccountReceive(address account) public view returns (bool) {
+    // Executor always bypasses
+    if (account == executor) {
+      return true;
+    }
+    // If receive whitelist is not enforced, everyone can receive
+    if (!useReceiveWhitelist) {
+      return true;
+    }
+    // Check direct whitelist
+    if (canReceive[account]) {
+      return true;
+    }
+    // Check space-based whitelist
+    return _isInReceiveWhitelistedSpace(account);
+  }
+
+  function canAccountPurchase(address account) public view returns (bool) {
+    if (purchaseEligibilityMode == PURCHASE_MODE_SPACE_ONLY) {
+      return IDAOSpaceFactory(spacesContract).isMember(spaceId, account);
+    }
+    if (purchaseEligibilityMode == PURCHASE_MODE_CUSTOM_SPACES) {
+      return _isInPurchaseWhitelistedSpace(account);
+    }
+    if (purchaseEligibilityMode == PURCHASE_MODE_ALL_SPACES) {
+      return _isInAnySpace(account);
+    }
+    return false;
+  }
+
+  // =========================================================================
+  // Mutual credit view functions
+  // =========================================================================
+
+  /**
+   * @dev Credit limit for an account.
+   */
+  function creditLimitOf(address account) public view returns (uint256) {
+    if (_isCreditEligible(account)) {
+      return defaultCreditLimit;
+    }
+    return 0;
+  }
+
+  /**
+   * @dev Remaining credit an account can still use before hitting its limit.
+   */
+  function creditLimitLeftOf(address account) public view returns (uint256) {
+    uint256 limit = creditLimitOf(account);
+    uint256 used = creditBalanceOf[account];
+    if (used >= limit) {
+      return 0;
+    }
+    return limit - used;
+  }
+
+  /**
+   * @dev Net position: positive means net creditor, negative means net debtor.
+   */
+  function netBalanceOf(address account) public view returns (int256) {
+    return int256(balanceOf(account)) - int256(creditBalanceOf[account]);
+  }
+
+  function getCreditWhitelistedSpaces()
+    external
+    view
+    returns (uint256[] memory)
+  {
+    return _creditWhitelistedSpaceIds;
+  }
+
+  // =========================================================================
+  // Mutual credit administration (executor only)
+  // =========================================================================
+
+  function setDefaultCreditLimit(uint256 _limit) external {
+    require(msg.sender == executor, '!executor');
+    uint256 old = defaultCreditLimit;
+    defaultCreditLimit = _limit;
+    emit DefaultCreditLimitUpdated(old, _limit);
+  }
+
+  /**
+   * @dev Enable or update mutual credit in one call.
+   */
+  function enableCredit(uint256 _limit, uint256[] calldata spaceIds) external {
+    require(msg.sender == executor, '!executor');
+    uint256 old = defaultCreditLimit;
+    defaultCreditLimit = _limit;
+    emit DefaultCreditLimitUpdated(old, _limit);
+    for (uint256 i = 0; i < spaceIds.length; i++) {
+      if (
+        _addSpaceToList(
+          _creditWhitelistedSpaceIds,
+          isCreditWhitelistedSpace,
+          spaceIds[i]
+        )
+      ) {
+        emit CreditWhitelistSpaceAdded(spaceIds[i]);
+      }
+    }
+  }
+
+  function batchAddCreditWhitelistSpaces(uint256[] calldata spaceIds) external {
+    require(msg.sender == executor, '!executor');
+    for (uint256 i = 0; i < spaceIds.length; i++) {
+      if (
+        _addSpaceToList(
+          _creditWhitelistedSpaceIds,
+          isCreditWhitelistedSpace,
+          spaceIds[i]
+        )
+      ) {
+        emit CreditWhitelistSpaceAdded(spaceIds[i]);
+      }
+    }
+  }
+
+  function batchRemoveCreditWhitelistSpaces(
+    uint256[] calldata spaceIds
+  ) external {
+    require(msg.sender == executor, '!executor');
+    for (uint256 i = 0; i < spaceIds.length; i++) {
+      if (
+        _removeSpaceFromList(
+          _creditWhitelistedSpaceIds,
+          isCreditWhitelistedSpace,
+          spaceIds[i]
+        )
+      ) {
+        emit CreditWhitelistSpaceRemoved(spaceIds[i]);
+      }
+    }
+  }
+
+  /**
+   * @dev Batch set per-address mutual credit eligibility (executor, Ownable
+   * owner or authorized minter).
+   */
+  function batchSetCreditWhitelistAddresses(
+    address[] calldata accounts,
+    bool[] calldata allowed
+  ) external {
+    require(
+      msg.sender == executor ||
+        msg.sender == owner() ||
+        isAuthorizedMinter[msg.sender],
+      '!executor/owner'
+    );
+    _batchSetAddressFlags(accounts, allowed, false);
+  }
+
+  /**
+   * @dev Batch grant/revoke authorized minter keys (executor or Ownable owner).
+   */
+  function batchSetAuthorizedMinters(
+    address[] calldata accounts,
+    bool[] calldata allowed
+  ) external {
+    require(
+      msg.sender == executor || msg.sender == owner(),
+      '!executor/owner'
+    );
+    _batchSetAddressFlags(accounts, allowed, true);
+  }
+
+  /**
+   * @dev Shared loop for the two address->bool whitelists. `minter` selects the
+   * authorized-minter mapping/event; otherwise the mutual-credit one.
+   */
+  function _batchSetAddressFlags(
+    address[] calldata accounts,
+    bool[] calldata allowed,
+    bool minter
+  ) private {
+    require(accounts.length == allowed.length, 'length mismatch');
+    for (uint256 i = 0; i < accounts.length; i++) {
+      if (minter) {
+        isAuthorizedMinter[accounts[i]] = allowed[i];
+        emit AuthorizedMinterUpdated(accounts[i], allowed[i]);
+      } else {
+        isCreditWhitelistedAddress[accounts[i]] = allowed[i];
+        emit CreditWhitelistAddressUpdated(accounts[i], allowed[i]);
+      }
+    }
+  }
+
+  // =========================================================================
+  // Shared space-list helpers
+  // =========================================================================
+
+  function _addSpaceToList(
+    uint256[] storage list,
+    mapping(uint256 => bool) storage isInList,
+    uint256 sid
+  ) internal returns (bool) {
+    if (!isInList[sid]) {
+      isInList[sid] = true;
+      list.push(sid);
+      return true;
+    }
+    return false;
+  }
+
+  function _removeSpaceFromList(
+    uint256[] storage list,
+    mapping(uint256 => bool) storage isInList,
+    uint256 sid
+  ) internal returns (bool) {
+    if (isInList[sid]) {
+      isInList[sid] = false;
+      for (uint256 i = 0; i < list.length; i++) {
+        if (list[i] == sid) {
+          list[i] = list[list.length - 1];
+          list.pop();
+          break;
+        }
+      }
+      return true;
+    }
+    return false;
+  }
+
+  function _isAccountInSpaceList(
+    uint256[] storage list,
+    mapping(uint256 => bool) storage isInList,
+    address account
+  ) internal view returns (bool) {
+    for (uint256 i = 0; i < list.length; i++) {
+      uint256 sid = list[i];
+      if (
+        isInList[sid] &&
+        IDAOSpaceFactory(spacesContract).isMember(sid, account)
+      ) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  function _isCreditEligible(address account) internal view returns (bool) {
+    return
+      isCreditWhitelistedAddress[account] ||
+      _isInCreditWhitelistedSpace(account);
+  }
+
+  function _isInCreditWhitelistedSpace(
+    address account
+  ) internal view returns (bool) {
+    return
+      _isAccountInSpaceList(
+        _creditWhitelistedSpaceIds,
+        isCreditWhitelistedSpace,
+        account
+      );
+  }
+
+  function _isInPurchaseWhitelistedSpace(
+    address account
+  ) internal view returns (bool) {
+    return
+      _isAccountInSpaceList(
+        _purchaseWhitelistedSpaceIds,
+        isPurchaseWhitelistedSpace,
+        account
+      );
+  }
+
+  function _isInAnySpace(address account) internal view returns (bool) {
+    uint256[] memory memberSpaces = IDAOSpaceFactory(spacesContract)
+      .getMemberSpaces(account);
+    return memberSpaces.length > 0;
+  }
+}

--- a/packages/storage-evm/hardhat.config.ts
+++ b/packages/storage-evm/hardhat.config.ts
@@ -27,6 +27,11 @@ const config: HardhatUserConfig = {
             runs: 1,
           },
           viaIR: true,
+          outputSelection: {
+            '*': {
+              '*': ['storageLayout'],
+            },
+          },
         },
       },
     ],

--- a/packages/storage-evm/scripts/evoice-decaying-space-token-legacy.upgrade.ts
+++ b/packages/storage-evm/scripts/evoice-decaying-space-token-legacy.upgrade.ts
@@ -1,0 +1,110 @@
+import { ethers, upgrades } from 'hardhat';
+
+/**
+ * Upgrades the Hypha Energy Voice (EVOICE) proxy to DecayingSpaceTokenLegacy.
+ *
+ * EVOICE was deployed from an early implementation whose storage layout differs
+ * from the current DecayingSpaceToken (decay variables at slots 8-13, before
+ * space whitelists / credit / sale / minters were added to the base contract).
+ * DecayingSpaceTokenLegacy preserves that layout while providing all current
+ * functionality. DO NOT upgrade this proxy to DecayingSpaceToken — it would
+ * corrupt the decay storage.
+ *
+ * ALWAYS run the fork test first:
+ *   npx hardhat run scripts/test-evoice-legacy-upgrade-on-fork.ts --network hardhat
+ *
+ * Then run this with the owner key (0x2687...019a):
+ *   npx hardhat run scripts/evoice-decaying-space-token-legacy.upgrade.ts --network base-mainnet
+ */
+
+const PROXY_ADDRESS = '0x564c52008898E1a46825dEbf20d5000CBe74800f'; // EVOICE
+
+async function main(): Promise<void> {
+  const [deployer] = await ethers.getSigners();
+  const adminAddress = await deployer.getAddress();
+
+  console.log('Upgrading with admin address:', adminAddress);
+  console.log('Proxy address:', PROXY_ADDRESS);
+
+  const currentImpl = await upgrades.erc1967.getImplementationAddress(
+    PROXY_ADDRESS,
+  );
+  console.log('Current implementation address:', currentImpl);
+
+  const Legacy = await ethers.getContractFactory('DecayingSpaceTokenLegacy');
+  console.log('Contract factory created successfully');
+
+  // Snapshot critical state for post-upgrade verification.
+  const token = Legacy.attach(PROXY_ADDRESS) as any;
+  const before = {
+    totalSupply: await token.totalSupply(),
+    decayPercentage: await token.decayPercentage(),
+    decayRate: await token.decayRate(),
+    totalBurnedFromDecay: await token.totalBurnedFromDecay(),
+    executor: await token.executor(),
+  };
+  console.log('Pre-upgrade state:', before);
+
+  // Validate the implementation contract (initializers disabled, no
+  // constructor state, UUPS-compatible), then deploy it and call
+  // upgradeToAndCall directly as the proxy owner. The plugin manifest has no
+  // record of the legacy proxy; layout safety is guaranteed by the fork test
+  // (test-evoice-legacy-upgrade-on-fork.ts) which asserts slots 0-13.
+  await upgrades.validateImplementation(Legacy, { kind: 'uups' });
+  console.log('Implementation validated by upgrades plugin');
+
+  console.log('Deploying DecayingSpaceTokenLegacy implementation...');
+  const newImplContract = await Legacy.deploy();
+  await newImplContract.waitForDeployment();
+  const newImplAddress = await newImplContract.getAddress();
+  console.log('New implementation deployed:', newImplAddress);
+
+  console.log('Upgrading proxy...');
+  const upgraded = Legacy.attach(PROXY_ADDRESS) as any;
+  const upgradeTx = await upgraded.upgradeToAndCall(newImplAddress, '0x');
+  await upgradeTx.wait();
+
+  const newImpl = await upgrades.erc1967.getImplementationAddress(
+    PROXY_ADDRESS,
+  );
+  console.log('New implementation address:', newImpl);
+
+  if (currentImpl.toLowerCase() === newImpl.toLowerCase()) {
+    console.log(
+      '⚠️  WARNING: Implementation address did not change! Upgrade may have failed.',
+    );
+  } else {
+    console.log('✅ Implementation address changed successfully!');
+  }
+
+  // Post-upgrade state verification.
+  const after = {
+    totalSupply: await upgraded.totalSupply(),
+    decayPercentage: await upgraded.decayPercentage(),
+    decayRate: await upgraded.decayRate(),
+    totalBurnedFromDecay: await upgraded.totalBurnedFromDecay(),
+    executor: await upgraded.executor(),
+  };
+  console.log('Post-upgrade state:', after);
+
+  let ok = true;
+  for (const key of Object.keys(before) as (keyof typeof before)[]) {
+    if (String(before[key]) !== String(after[key])) {
+      console.error(`❌ ${key} changed: ${before[key]} -> ${after[key]}`);
+      ok = false;
+    }
+  }
+  if (!ok) {
+    throw new Error('STATE MISMATCH AFTER UPGRADE — investigate immediately');
+  }
+  console.log('✅ All checked state preserved');
+
+  console.log('Upgrade process completed!');
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error: Error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/packages/storage-evm/scripts/evoice-eparts-reissue.mainnet.ts
+++ b/packages/storage-evm/scripts/evoice-eparts-reissue.mainnet.ts
@@ -1,0 +1,285 @@
+import { ethers, upgrades } from 'hardhat';
+
+/**
+ * MAINNET OPERATION — EVOICE + EPARTS upgrade and reissue.
+ *
+ * For each token:
+ *   1. Upgrade proxy to its legacy-layout implementation
+ *      (DecayingSpaceTokenLegacy / OwnershipSpaceTokenLegacy)
+ *   2. batchSetAuthorizedMinters([OWNER], [true])
+ *   3. Burn the full holding of FROM
+ *      (EVOICE: applyDecay first, then burn 54,978; EPARTS: burn 55,000)
+ *   4. Mint the same amount to TO
+ *
+ * Every step is idempotent — the script checks on-chain state and skips steps
+ * that are already done, so it can be safely re-run after a partial failure.
+ *
+ * ALWAYS rehearse on a fork first:
+ *   npx hardhat run scripts/test-evoice-eparts-reissue-on-fork.ts --network hardhat
+ *
+ * Then run with the owner key (0x2687...019a) in PRIVATE_KEY:
+ *   npx hardhat run scripts/evoice-eparts-reissue.mainnet.ts --network base-mainnet
+ */
+
+const EVOICE_PROXY = '0x564c52008898E1a46825dEbf20d5000CBe74800f';
+const EPARTS_PROXY = '0x5d3394CAa6D09214aB86CF048e39dea058eC1921';
+const OWNER_ADDRESS = '0x2687fe290b54d824c136Ceff2d5bD362Bc62019a';
+
+const FROM = '0x177A04A0F8f876ad610079a6f7B588fA2CffA325';
+const TO = '0x46F32E38F503E8F6c80B59c514f289D26734Ca8D';
+
+const EVOICE_AMOUNT = ethers.parseEther('54978');
+const EPARTS_AMOUNT = ethers.parseEther('55000');
+
+function fail(message: string): never {
+  console.error(`❌ ${message}`);
+  process.exit(1);
+}
+
+async function ensureUpgraded(
+  proxy: string,
+  factoryName: string,
+  signer: any,
+): Promise<any> {
+  const Factory = await ethers.getContractFactory(factoryName, signer);
+  const token = Factory.attach(proxy) as any;
+
+  // Skip if the active implementation already exposes the new interface.
+  const currentImpl = await upgrades.erc1967.getImplementationAddress(proxy);
+  let alreadyUpgraded = false;
+  try {
+    await token.isAuthorizedMinter(OWNER_ADDRESS);
+    alreadyUpgraded = true;
+  } catch {
+    alreadyUpgraded = false;
+  }
+  if (alreadyUpgraded) {
+    console.log(`  ⏭  ${factoryName}: already upgraded (impl ${currentImpl})`);
+    return token;
+  }
+
+  await upgrades.validateImplementation(Factory, { kind: 'uups' });
+  console.log(`  Deploying ${factoryName} implementation...`);
+  const impl = await Factory.deploy();
+  await impl.waitForDeployment();
+  const implAddress = await impl.getAddress();
+  console.log(`  Implementation deployed: ${implAddress}`);
+
+  console.log('  Upgrading proxy...');
+  const tx = await token.upgradeToAndCall(implAddress, '0x');
+  console.log(`  tx: ${tx.hash}`);
+  await tx.wait();
+
+  const active = await upgrades.erc1967.getImplementationAddress(proxy);
+  if (active.toLowerCase() !== implAddress.toLowerCase()) {
+    fail(`${factoryName}: implementation not active after upgrade`);
+  }
+  console.log(`  ✅ Upgraded: ${currentImpl} -> ${implAddress}`);
+  return token;
+}
+
+async function ensureMinter(token: any, label: string): Promise<void> {
+  if (await token.isAuthorizedMinter(OWNER_ADDRESS)) {
+    console.log(`  ⏭  ${label}: owner already authorized minter`);
+    return;
+  }
+  const tx = await token.batchSetAuthorizedMinters([OWNER_ADDRESS], [true]);
+  console.log(`  tx: ${tx.hash}`);
+  await tx.wait();
+  if (!(await token.isAuthorizedMinter(OWNER_ADDRESS))) {
+    fail(`${label}: failed to authorize owner as minter`);
+  }
+  console.log(`  ✅ ${label}: owner authorized as minter`);
+}
+
+async function main(): Promise<void> {
+  const [signer] = await ethers.getSigners();
+  const signerAddress = await signer.getAddress();
+  console.log('Signer:', signerAddress);
+
+  if (signerAddress.toLowerCase() !== OWNER_ADDRESS.toLowerCase()) {
+    fail(
+      `Signer must be the token owner ${OWNER_ADDRESS}, got ${signerAddress}. Check PRIVATE_KEY.`,
+    );
+  }
+
+  // ==========================================================================
+  // EVOICE
+  // ==========================================================================
+  console.log('');
+  console.log('=== EVOICE ===');
+  const evoice = await ensureUpgraded(
+    EVOICE_PROXY,
+    'DecayingSpaceTokenLegacy',
+    signer,
+  );
+
+  // Sanity: decay config must be intact after upgrade.
+  const decayRate = await evoice.decayRate();
+  const decayPercentage = await evoice.decayPercentage();
+  if (decayRate !== 2592000n || decayPercentage !== 1n) {
+    fail(
+      `EVOICE decay config wrong after upgrade: rate=${decayRate} pct=${decayPercentage} — ABORT`,
+    );
+  }
+  console.log('  ✅ Decay config intact (rate=2592000, pct=1)');
+
+  await ensureMinter(evoice, 'EVOICE');
+
+  // Burn FROM's full decayed holding.
+  let evoiceFromBal: bigint = await evoice.balanceOf(FROM);
+  if (evoiceFromBal === 0n) {
+    console.log('  ⏭  EVOICE: FROM balance already 0 (burn done)');
+  } else {
+    if (evoiceFromBal !== EVOICE_AMOUNT) {
+      fail(
+        `EVOICE: FROM decayed balance is ${ethers.formatEther(
+          evoiceFromBal,
+        )}, ` +
+          `expected exactly 54978. Decay may have advanced a period — ` +
+          `re-confirm the burn amount before proceeding.`,
+      );
+    }
+    console.log('  Applying pending decay to FROM...');
+    await (await evoice.applyDecay(FROM)).wait();
+    evoiceFromBal = await evoice.balanceOf(FROM);
+    if (evoiceFromBal !== EVOICE_AMOUNT) {
+      fail(
+        `EVOICE: FROM balance after applyDecay is ${ethers.formatEther(
+          evoiceFromBal,
+        )} — ABORT`,
+      );
+    }
+    const burnTx = await evoice.burnFrom(FROM, EVOICE_AMOUNT);
+    console.log(`  burn tx: ${burnTx.hash}`);
+    await burnTx.wait();
+    if ((await evoice.balanceOf(FROM)) !== 0n) {
+      fail('EVOICE: FROM balance not zero after burn');
+    }
+    console.log(
+      `  ✅ Burned ${ethers.formatEther(EVOICE_AMOUNT)} EVOICE from ${FROM}`,
+    );
+  }
+
+  // Mint to TO.
+  const evoiceToBal: bigint = await evoice.balanceOf(TO);
+  if (evoiceToBal >= EVOICE_AMOUNT) {
+    console.log(
+      `  ⏭  EVOICE: TO already holds ${ethers.formatEther(
+        evoiceToBal,
+      )} (mint done)`,
+    );
+  } else {
+    if (evoiceToBal !== 0n) {
+      fail(
+        `EVOICE: TO holds unexpected partial balance ${ethers.formatEther(
+          evoiceToBal,
+        )} — resolve manually`,
+      );
+    }
+    const mintTx = await evoice.mint(TO, EVOICE_AMOUNT);
+    console.log(`  mint tx: ${mintTx.hash}`);
+    await mintTx.wait();
+    if ((await evoice.balanceOf(TO)) !== EVOICE_AMOUNT) {
+      fail('EVOICE: TO balance wrong after mint');
+    }
+    console.log(
+      `  ✅ Minted ${ethers.formatEther(EVOICE_AMOUNT)} EVOICE to ${TO}`,
+    );
+  }
+
+  // ==========================================================================
+  // EPARTS
+  // ==========================================================================
+  console.log('');
+  console.log('=== EPARTS ===');
+  const eparts = await ensureUpgraded(
+    EPARTS_PROXY,
+    'OwnershipSpaceTokenLegacy',
+    signer,
+  );
+
+  // Sanity: membership wiring must be intact after upgrade (slot 16).
+  const osc = await eparts.ownershipSpacesContract();
+  if (osc.toLowerCase() !== '0xc8b8454d2f9192fecabc2c6f5d88f6434a2a9cd9') {
+    fail(`EPARTS ownershipSpacesContract wrong after upgrade: ${osc} — ABORT`);
+  }
+  console.log('  ✅ ownershipSpacesContract intact');
+
+  await ensureMinter(eparts, 'EPARTS');
+
+  // Burn FROM's holding.
+  const epartsFromBal: bigint = await eparts.balanceOf(FROM);
+  if (epartsFromBal === 0n) {
+    console.log('  ⏭  EPARTS: FROM balance already 0 (burn done)');
+  } else {
+    if (epartsFromBal !== EPARTS_AMOUNT) {
+      fail(
+        `EPARTS: FROM balance is ${ethers.formatEther(
+          epartsFromBal,
+        )}, expected exactly 55000 — ABORT`,
+      );
+    }
+    const burnTx = await eparts.burnFrom(FROM, EPARTS_AMOUNT);
+    console.log(`  burn tx: ${burnTx.hash}`);
+    await burnTx.wait();
+    if ((await eparts.balanceOf(FROM)) !== 0n) {
+      fail('EPARTS: FROM balance not zero after burn');
+    }
+    console.log(
+      `  ✅ Burned ${ethers.formatEther(EPARTS_AMOUNT)} EPARTS from ${FROM}`,
+    );
+  }
+
+  // Mint to TO.
+  const epartsToBal: bigint = await eparts.balanceOf(TO);
+  if (epartsToBal >= EPARTS_AMOUNT) {
+    console.log(
+      `  ⏭  EPARTS: TO already holds ${ethers.formatEther(
+        epartsToBal,
+      )} (mint done)`,
+    );
+  } else {
+    if (epartsToBal !== 0n) {
+      fail(
+        `EPARTS: TO holds unexpected partial balance ${ethers.formatEther(
+          epartsToBal,
+        )} — resolve manually`,
+      );
+    }
+    const mintTx = await eparts.mint(TO, EPARTS_AMOUNT);
+    console.log(`  mint tx: ${mintTx.hash}`);
+    await mintTx.wait();
+    if ((await eparts.balanceOf(TO)) !== EPARTS_AMOUNT) {
+      fail('EPARTS: TO balance wrong after mint');
+    }
+    console.log(
+      `  ✅ Minted ${ethers.formatEther(EPARTS_AMOUNT)} EPARTS to ${TO}`,
+    );
+  }
+
+  console.log('');
+  console.log('='.repeat(60));
+  console.log('✅ OPERATION COMPLETE');
+  console.log('='.repeat(60));
+  console.log('Final balances:');
+  console.log(
+    `  EVOICE ${FROM}: ${ethers.formatEther(await evoice.balanceOf(FROM))}`,
+  );
+  console.log(
+    `  EVOICE ${TO}: ${ethers.formatEther(await evoice.balanceOf(TO))}`,
+  );
+  console.log(
+    `  EPARTS ${FROM}: ${ethers.formatEther(await eparts.balanceOf(FROM))}`,
+  );
+  console.log(
+    `  EPARTS ${TO}: ${ethers.formatEther(await eparts.balanceOf(TO))}`,
+  );
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error: Error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/packages/storage-evm/scripts/test-evoice-eparts-reissue-on-fork.ts
+++ b/packages/storage-evm/scripts/test-evoice-eparts-reissue-on-fork.ts
@@ -1,0 +1,403 @@
+import { artifacts, ethers, network, upgrades } from 'hardhat';
+
+/**
+ * Rehearses the full EVOICE + EPARTS reissue operation on a Base mainnet fork:
+ *
+ * For EVOICE (DecayingSpaceTokenLegacy):
+ *   1. Upgrade proxy to DecayingSpaceTokenLegacy
+ *   2. batchSetAuthorizedMinters([OWNER], [true])  (as owner)
+ *   3. applyDecay(FROM) then burnFrom(FROM, 54,978) (as authorized minter)
+ *   4. mint(TO, 54,978)
+ *
+ * For EPARTS (OwnershipSpaceTokenLegacy):
+ *   1. Upgrade proxy to OwnershipSpaceTokenLegacy
+ *   2. batchSetAuthorizedMinters([OWNER], [true])
+ *   3. burnFrom(FROM, 55,000)
+ *   4. mint(TO, 55,000)
+ *
+ * Includes static storage-layout assertions for both legacy contracts and
+ * full state-preservation checks across both upgrades.
+ *
+ * Run with: npx hardhat run scripts/test-evoice-eparts-reissue-on-fork.ts --network hardhat
+ */
+
+const EVOICE_PROXY = '0x564c52008898E1a46825dEbf20d5000CBe74800f';
+const EPARTS_PROXY = '0x5d3394CAa6D09214aB86CF048e39dea058eC1921';
+const OWNER_ADDRESS = '0x2687fe290b54d824c136Ceff2d5bD362Bc62019a';
+
+const FROM = '0x177A04A0F8f876ad610079a6f7B588fA2CffA325';
+const TO = '0x46F32E38F503E8F6c80B59c514f289D26734Ca8D';
+
+const EVOICE_AMOUNT = ethers.parseEther('54978');
+const EPARTS_AMOUNT = ethers.parseEther('55000');
+
+type LayoutEntry = [string, string, number];
+
+const LEGACY_PREFIX_0_TO_7: LayoutEntry[] = [
+  ['spaceId', '0', 0],
+  ['maxSupply', '1', 0],
+  ['transferable', '2', 0],
+  ['executor', '2', 1],
+  ['transferHelper', '3', 0],
+  ['fixedMaxSupply', '3', 20],
+  ['autoMinting', '3', 21],
+  ['priceInUSD', '4', 0],
+  ['canTransfer', '5', 0],
+  ['canReceive', '6', 0],
+  ['useTransferWhitelist', '7', 0],
+  ['useReceiveWhitelist', '7', 1],
+  ['archived', '7', 2],
+];
+
+const EVOICE_LAYOUT: LayoutEntry[] = [
+  ...LEGACY_PREFIX_0_TO_7,
+  ['decayPercentage', '8', 0],
+  ['decayRate', '9', 0],
+  ['lastApplied', '10', 0],
+  ['_tokenHolders', '11', 0],
+  ['_isTokenHolder', '12', 0],
+  ['totalBurnedFromDecay', '13', 0],
+];
+
+const EPARTS_LAYOUT: LayoutEntry[] = [
+  ...LEGACY_PREFIX_0_TO_7,
+  ['_transferWhitelistedSpaceIds', '8', 0],
+  ['_receiveWhitelistedSpaceIds', '9', 0],
+  ['isTransferWhitelistedSpace', '10', 0],
+  ['isReceiveWhitelistedSpace', '11', 0],
+  ['priceCurrencyFeed', '12', 0],
+  ['tokenPrice', '13', 0],
+  ['_customName', '14', 0],
+  ['_customSymbol', '15', 0],
+  ['ownershipSpacesContract', '16', 0],
+];
+
+function fail(message: string): never {
+  console.error(`❌ ${message}`);
+  process.exit(1);
+}
+
+async function assertStorageLayout(
+  contractName: string,
+  expected: LayoutEntry[],
+  minAppendSlot: number,
+): Promise<void> {
+  const buildInfo = await artifacts.getBuildInfo(
+    `contracts/${contractName}.sol:${contractName}`,
+  );
+  if (!buildInfo) fail(`Build info not found for ${contractName}`);
+  const layout = (
+    buildInfo.output.contracts[`contracts/${contractName}.sol`][
+      contractName
+    ] as any
+  ).storageLayout;
+  if (!layout) fail('storageLayout missing in compiler output');
+
+  const storage: Array<{ label: string; slot: string; offset: number }> =
+    layout.storage;
+  for (let i = 0; i < expected.length; i++) {
+    const [label, slot, offset] = expected[i];
+    const actual = storage[i];
+    if (
+      !actual ||
+      actual.label !== label ||
+      actual.slot !== slot ||
+      actual.offset !== offset
+    ) {
+      fail(
+        `${contractName} layout mismatch at index ${i}: expected ` +
+          `${label}@${slot}+${offset}, got ${actual?.label}@${actual?.slot}+${actual?.offset}`,
+      );
+    }
+  }
+  const next = storage[expected.length];
+  if (!next || BigInt(next.slot) < BigInt(minAppendSlot)) {
+    fail(
+      `${contractName}: first appended variable must be at slot >= ${minAppendSlot}, got ${next?.slot}`,
+    );
+  }
+  console.log(
+    `  ✅ ${contractName}: ${expected.length} legacy slots verified, appended storage starts at slot ${next.slot}`,
+  );
+}
+
+async function impersonate(address: string) {
+  await network.provider.request({
+    method: 'hardhat_impersonateAccount',
+    params: [address],
+  });
+  await network.provider.send('hardhat_setBalance', [
+    address,
+    '0x56BC75E2D63100000',
+  ]);
+  return ethers.getSigner(address);
+}
+
+async function upgradeProxyTo(
+  proxy: string,
+  factoryName: string,
+  ownerSigner: any,
+): Promise<any> {
+  const Factory = await ethers.getContractFactory(factoryName);
+  await upgrades.validateImplementation(Factory, { kind: 'uups' });
+  const impl = await Factory.deploy();
+  await impl.waitForDeployment();
+  const implAddress = await impl.getAddress();
+
+  const token = Factory.attach(proxy) as any;
+  const tx = await token
+    .connect(ownerSigner)
+    .upgradeToAndCall(implAddress, '0x');
+  await tx.wait();
+
+  const active = await upgrades.erc1967.getImplementationAddress(proxy);
+  if (active.toLowerCase() !== implAddress.toLowerCase()) {
+    fail(`${factoryName}: implementation not active after upgrade`);
+  }
+  console.log(`  ✅ Upgraded ${proxy} -> ${factoryName} @ ${implAddress}`);
+  return token;
+}
+
+async function main(): Promise<void> {
+  console.log('='.repeat(60));
+  console.log('REHEARSING EVOICE + EPARTS REISSUE ON FORKED BASE MAINNET');
+  console.log('='.repeat(60));
+  console.log('');
+
+  console.log('=== Step 0: Storage layout assertions ===');
+  await assertStorageLayout('DecayingSpaceTokenLegacy', EVOICE_LAYOUT, 14);
+  await assertStorageLayout('OwnershipSpaceTokenLegacy', EPARTS_LAYOUT, 17);
+  console.log('');
+
+  const chainId = (await ethers.provider.getNetwork()).chainId;
+  if (chainId !== 31337n) {
+    fail('This script must be run on a local fork. Use --network hardhat');
+  }
+
+  console.log('Resetting fork to current mainnet state...');
+  await network.provider.request({
+    method: 'hardhat_reset',
+    params: [
+      {
+        forking: {
+          jsonRpcUrl: process.env.RPC_URL || 'https://mainnet.base.org',
+        },
+      },
+    ],
+  });
+  console.log('');
+
+  const ownerSigner = await impersonate(OWNER_ADDRESS);
+
+  // ==========================================================================
+  // EVOICE
+  // ==========================================================================
+  console.log('=== EVOICE ===');
+  const evoice = (
+    await ethers.getContractFactory('DecayingSpaceTokenLegacy')
+  ).attach(EVOICE_PROXY) as any;
+
+  const evoiceBefore = {
+    totalSupply: await evoice.totalSupply(),
+    fromBalance: await evoice.balanceOf(FROM),
+    toBalance: await evoice.balanceOf(TO),
+    decayPercentage: await evoice.decayPercentage(),
+    decayRate: await evoice.decayRate(),
+    totalBurnedFromDecay: await evoice.totalBurnedFromDecay(),
+    executor: await evoice.executor(),
+    owner: await evoice.owner(),
+    name: await evoice.name(),
+    symbol: await evoice.symbol(),
+  };
+  console.log(
+    `  FROM decayed balance: ${ethers.formatEther(evoiceBefore.fromBalance)}`,
+  );
+  console.log(
+    `  TO balance:           ${ethers.formatEther(evoiceBefore.toBalance)}`,
+  );
+
+  if (evoiceBefore.fromBalance !== EVOICE_AMOUNT) {
+    fail(
+      `EVOICE: FROM balance is ${ethers.formatEther(
+        evoiceBefore.fromBalance,
+      )}, ` +
+        `expected exactly 54978 — decay may have advanced; re-check the amount`,
+    );
+  }
+
+  // 1. Upgrade
+  await upgradeProxyTo(EVOICE_PROXY, 'DecayingSpaceTokenLegacy', ownerSigner);
+
+  // State preservation
+  if ((await evoice.decayPercentage()) !== evoiceBefore.decayPercentage)
+    fail('EVOICE decayPercentage changed');
+  if ((await evoice.decayRate()) !== evoiceBefore.decayRate)
+    fail('EVOICE decayRate changed');
+  if (
+    (await evoice.totalBurnedFromDecay()) !== evoiceBefore.totalBurnedFromDecay
+  )
+    fail('EVOICE totalBurnedFromDecay changed');
+  if ((await evoice.totalSupply()) !== evoiceBefore.totalSupply)
+    fail('EVOICE totalSupply changed');
+  if ((await evoice.balanceOf(FROM)) !== evoiceBefore.fromBalance)
+    fail('EVOICE FROM balance changed');
+  if ((await evoice.name()) !== evoiceBefore.name) fail('EVOICE name changed');
+  if ((await evoice.symbol()) !== evoiceBefore.symbol)
+    fail('EVOICE symbol changed');
+  console.log('  ✅ EVOICE state preserved after upgrade');
+
+  // 2. Authorize owner as minter
+  await (
+    await evoice
+      .connect(ownerSigner)
+      .batchSetAuthorizedMinters([OWNER_ADDRESS], [true])
+  ).wait();
+  if (!(await evoice.isAuthorizedMinter(OWNER_ADDRESS)))
+    fail('EVOICE: owner not authorized as minter');
+  console.log('  ✅ Owner authorized as minter');
+
+  // 3. Apply decay, then burn the full decayed balance
+  await (await evoice.applyDecay(FROM)).wait();
+  const fromAfterDecay: bigint = await evoice.balanceOf(FROM);
+  if (fromAfterDecay !== EVOICE_AMOUNT) {
+    fail(
+      `EVOICE: FROM balance after applyDecay is ${ethers.formatEther(
+        fromAfterDecay,
+      )}, expected 54978`,
+    );
+  }
+  await (
+    await evoice.connect(ownerSigner).burnFrom(FROM, EVOICE_AMOUNT)
+  ).wait();
+  if ((await evoice.balanceOf(FROM)) !== 0n)
+    fail('EVOICE: FROM balance not zero after burn');
+  console.log(
+    `  ✅ Burned ${ethers.formatEther(EVOICE_AMOUNT)} EVOICE from ${FROM}`,
+  );
+
+  // 4. Mint to recipient
+  await (await evoice.connect(ownerSigner).mint(TO, EVOICE_AMOUNT)).wait();
+  const toBal: bigint = await evoice.balanceOf(TO);
+  if (toBal !== evoiceBefore.toBalance + EVOICE_AMOUNT)
+    fail(`EVOICE: TO balance is ${ethers.formatEther(toBal)}`);
+  if ((await evoice.lastApplied(TO)) === 0n)
+    fail('EVOICE: decay tracking not initialized for TO');
+  console.log(
+    `  ✅ Minted ${ethers.formatEther(
+      EVOICE_AMOUNT,
+    )} EVOICE to ${TO} (decay tracking on)`,
+  );
+  console.log('');
+
+  // ==========================================================================
+  // EPARTS
+  // ==========================================================================
+  console.log('=== EPARTS ===');
+  const eparts = (
+    await ethers.getContractFactory('OwnershipSpaceTokenLegacy')
+  ).attach(EPARTS_PROXY) as any;
+
+  const epartsBefore = {
+    totalSupply: await eparts.totalSupply(),
+    fromBalance: await eparts.balanceOf(FROM),
+    toBalance: await eparts.balanceOf(TO),
+    executor: await eparts.executor(),
+    owner: await eparts.owner(),
+    name: await eparts.name(),
+    symbol: await eparts.symbol(),
+    ownershipSpacesContract: await eparts.ownershipSpacesContract(),
+  };
+  console.log(
+    `  FROM balance: ${ethers.formatEther(epartsBefore.fromBalance)}`,
+  );
+  console.log(`  TO balance:   ${ethers.formatEther(epartsBefore.toBalance)}`);
+  console.log(
+    `  ownershipSpacesContract: ${epartsBefore.ownershipSpacesContract}`,
+  );
+
+  if (epartsBefore.fromBalance !== EPARTS_AMOUNT) {
+    fail(
+      `EPARTS: FROM balance is ${ethers.formatEther(
+        epartsBefore.fromBalance,
+      )}, expected exactly 55000`,
+    );
+  }
+
+  // 1. Upgrade
+  await upgradeProxyTo(EPARTS_PROXY, 'OwnershipSpaceTokenLegacy', ownerSigner);
+
+  // State preservation — ownershipSpacesContract at slot 16 is the critical one
+  if (
+    (await eparts.ownershipSpacesContract()) !==
+    epartsBefore.ownershipSpacesContract
+  )
+    fail('EPARTS ownershipSpacesContract changed — layout corruption!');
+  if ((await eparts.totalSupply()) !== epartsBefore.totalSupply)
+    fail('EPARTS totalSupply changed');
+  if ((await eparts.balanceOf(FROM)) !== epartsBefore.fromBalance)
+    fail('EPARTS FROM balance changed');
+  if ((await eparts.name()) !== epartsBefore.name) fail('EPARTS name changed');
+  if ((await eparts.symbol()) !== epartsBefore.symbol)
+    fail('EPARTS symbol changed');
+  if ((await eparts.executor()) !== epartsBefore.executor)
+    fail('EPARTS executor changed');
+  if ((await eparts.defaultCreditLimit()) !== 0n)
+    fail('EPARTS defaultCreditLimit should read 0');
+  if ((await eparts.paymentToken()) !== ethers.ZeroAddress)
+    fail('EPARTS paymentToken should read zero');
+  console.log(
+    '  ✅ EPARTS state preserved after upgrade, new storage reads zero',
+  );
+
+  // 2. Authorize owner as minter
+  await (
+    await eparts
+      .connect(ownerSigner)
+      .batchSetAuthorizedMinters([OWNER_ADDRESS], [true])
+  ).wait();
+  if (!(await eparts.isAuthorizedMinter(OWNER_ADDRESS)))
+    fail('EPARTS: owner not authorized as minter');
+  console.log('  ✅ Owner authorized as minter');
+
+  // 3. Burn
+  await (
+    await eparts.connect(ownerSigner).burnFrom(FROM, EPARTS_AMOUNT)
+  ).wait();
+  if ((await eparts.balanceOf(FROM)) !== 0n)
+    fail('EPARTS: FROM balance not zero after burn');
+  console.log(
+    `  ✅ Burned ${ethers.formatEther(EPARTS_AMOUNT)} EPARTS from ${FROM}`,
+  );
+
+  // 4. Mint (authorized minters bypass the space-member restriction)
+  await (await eparts.connect(ownerSigner).mint(TO, EPARTS_AMOUNT)).wait();
+  const epartsToBal: bigint = await eparts.balanceOf(TO);
+  if (epartsToBal !== epartsBefore.toBalance + EPARTS_AMOUNT)
+    fail(`EPARTS: TO balance is ${ethers.formatEther(epartsToBal)}`);
+  console.log(
+    `  ✅ Minted ${ethers.formatEther(EPARTS_AMOUNT)} EPARTS to ${TO}`,
+  );
+
+  // Total supply invariant: burn + mint of the same amount nets to zero
+  // (EVOICE total also drops by the decay applied to FROM before the burn).
+  if ((await eparts.totalSupply()) !== epartsBefore.totalSupply)
+    fail('EPARTS totalSupply should be unchanged after burn+mint');
+  console.log('  ✅ EPARTS totalSupply unchanged');
+
+  console.log('');
+  console.log('='.repeat(60));
+  console.log('✅ ALL REHEARSAL STEPS PASSED — SAFE TO RUN ON MAINNET');
+  console.log('='.repeat(60));
+  console.log('');
+  console.log('Execute for real with the owner key:');
+  console.log(
+    '  npx hardhat run scripts/evoice-eparts-reissue.mainnet.ts --network base-mainnet',
+  );
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error: Error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/packages/storage-evm/scripts/test-evoice-legacy-upgrade-on-fork.ts
+++ b/packages/storage-evm/scripts/test-evoice-legacy-upgrade-on-fork.ts
@@ -1,0 +1,400 @@
+import { artifacts, ethers, network, upgrades } from 'hardhat';
+
+/**
+ * Tests upgrading the Hypha Energy Voice (EVOICE) proxy to
+ * DecayingSpaceTokenLegacy on a local fork of Base mainnet.
+ *
+ * The deployed EVOICE implementation predates space whitelists, mutual credit,
+ * token sale and authorized minters, so its decay variables live at slots 8-13.
+ * DecayingSpaceTokenLegacy keeps that layout. This script:
+ *
+ * 1. Statically asserts the compiled storage layout (slots 0-13) matches the
+ *    deployed contract exactly.
+ * 2. Forks Base, snapshots all live state including real holder balances.
+ * 3. Impersonates the owner and performs the UUPS upgrade.
+ * 4. Asserts every piece of state survived, byte for byte.
+ * 5. Exercises the new functionality (authorized minters mint/burn) and
+ *    verifies decay still works after time travel.
+ *
+ * Run with: npx hardhat run scripts/test-evoice-legacy-upgrade-on-fork.ts --network hardhat
+ */
+
+const PROXY_ADDRESS = '0x564c52008898E1a46825dEbf20d5000CBe74800f'; // EVOICE
+const OWNER_ADDRESS = '0x2687fe290b54d824c136Ceff2d5bD362Bc62019a';
+const EXECUTOR_ADDRESS = '0x3A5a7b51575728CD36b8F2d30465f1E54B6Df1F4';
+
+// Expected layout of the LEGACY storage prefix — must match the deployed
+// EVOICE implementation (verified on-chain: slot 8 = decayPercentage = 1,
+// slot 9 = decayRate = 2592000, slot 13 = totalBurnedFromDecay).
+const EXPECTED_LEGACY_LAYOUT: Array<[string, string, number]> = [
+  ['spaceId', '0', 0],
+  ['maxSupply', '1', 0],
+  ['transferable', '2', 0],
+  ['executor', '2', 1],
+  ['transferHelper', '3', 0],
+  ['fixedMaxSupply', '3', 20],
+  ['autoMinting', '3', 21],
+  ['priceInUSD', '4', 0],
+  ['canTransfer', '5', 0],
+  ['canReceive', '6', 0],
+  ['useTransferWhitelist', '7', 0],
+  ['useReceiveWhitelist', '7', 1],
+  ['archived', '7', 2],
+  ['decayPercentage', '8', 0],
+  ['decayRate', '9', 0],
+  ['lastApplied', '10', 0],
+  ['_tokenHolders', '11', 0],
+  ['_isTokenHolder', '12', 0],
+  ['totalBurnedFromDecay', '13', 0],
+];
+
+function fail(message: string): never {
+  console.error(`❌ ${message}`);
+  process.exit(1);
+}
+
+async function assertStorageLayout(): Promise<void> {
+  console.log('=== Step 0: Verifying compiled storage layout ===');
+  const buildInfo = await artifacts.getBuildInfo(
+    'contracts/DecayingSpaceTokenLegacy.sol:DecayingSpaceTokenLegacy',
+  );
+  if (!buildInfo) {
+    fail('Build info not found — compile first');
+  }
+  const layout = (
+    buildInfo.output.contracts['contracts/DecayingSpaceTokenLegacy.sol'][
+      'DecayingSpaceTokenLegacy'
+    ] as any
+  ).storageLayout;
+  if (!layout) {
+    fail('storageLayout missing — enable it in hardhat.config outputSelection');
+  }
+
+  const storage: Array<{ label: string; slot: string; offset: number }> =
+    layout.storage;
+
+  for (let i = 0; i < EXPECTED_LEGACY_LAYOUT.length; i++) {
+    const [label, slot, offset] = EXPECTED_LEGACY_LAYOUT[i];
+    const actual = storage[i];
+    if (
+      !actual ||
+      actual.label !== label ||
+      actual.slot !== slot ||
+      actual.offset !== offset
+    ) {
+      fail(
+        `Layout mismatch at index ${i}: expected ${label}@${slot}+${offset}, ` +
+          `got ${actual?.label}@${actual?.slot}+${actual?.offset}`,
+      );
+    }
+    console.log(`  ✅ slot ${slot.padStart(2)}+${offset} ${label}`);
+  }
+
+  // Everything appended after the legacy prefix must start at slot 14+.
+  const next = storage[EXPECTED_LEGACY_LAYOUT.length];
+  if (!next || BigInt(next.slot) < 14n) {
+    fail(`First appended variable must be at slot >= 14, got ${next?.slot}`);
+  }
+  console.log(
+    `  ✅ appended storage starts at slot ${next.slot} (${next.label})`,
+  );
+  console.log('');
+}
+
+async function impersonate(address: string) {
+  await network.provider.request({
+    method: 'hardhat_impersonateAccount',
+    params: [address],
+  });
+  await network.provider.send('hardhat_setBalance', [
+    address,
+    '0x56BC75E2D63100000', // 100 ETH
+  ]);
+  return ethers.getSigner(address);
+}
+
+async function readTokenHolders(): Promise<string[]> {
+  // _tokenHolders is private; read it from raw storage (slot 11).
+  const lengthHex = await ethers.provider.getStorage(PROXY_ADDRESS, 11);
+  const length = Number(BigInt(lengthHex));
+  const base = BigInt(
+    ethers.keccak256(ethers.zeroPadValue(ethers.toBeHex(11), 32)),
+  );
+  const holders: string[] = [];
+  for (let i = 0; i < length; i++) {
+    const raw = await ethers.provider.getStorage(
+      PROXY_ADDRESS,
+      base + BigInt(i),
+    );
+    holders.push(ethers.getAddress('0x' + raw.slice(-40)));
+  }
+  return holders;
+}
+
+async function main(): Promise<void> {
+  console.log('='.repeat(60));
+  console.log('TESTING EVOICE LEGACY-LAYOUT UPGRADE ON FORKED BASE MAINNET');
+  console.log('='.repeat(60));
+  console.log('');
+
+  await assertStorageLayout();
+
+  const chainId = (await ethers.provider.getNetwork()).chainId;
+  if (chainId !== 31337n) {
+    fail('This script must be run on a local fork. Use --network hardhat');
+  }
+
+  console.log('Resetting fork to current mainnet state...');
+  await network.provider.request({
+    method: 'hardhat_reset',
+    params: [
+      {
+        forking: {
+          jsonRpcUrl: process.env.RPC_URL || 'https://mainnet.base.org',
+        },
+      },
+    ],
+  });
+  console.log('');
+
+  console.log('=== Step 1: Reading current contract state ===');
+  const Legacy = await ethers.getContractFactory('DecayingSpaceTokenLegacy');
+  const token = Legacy.attach(PROXY_ADDRESS) as any;
+
+  const holders = await readTokenHolders();
+  console.log(`Token holders tracked on-chain: ${holders.length}`);
+  if (holders.length === 0) {
+    fail('Expected a non-empty holder list');
+  }
+
+  const stateBefore = {
+    name: await token.name(),
+    symbol: await token.symbol(),
+    totalSupply: await token.totalSupply(),
+    decimals: await token.decimals(),
+    executor: await token.executor(),
+    owner: await token.owner(),
+    spaceId: await token.spaceId(),
+    maxSupply: await token.maxSupply(),
+    transferable: await token.transferable(),
+    transferHelper: await token.transferHelper(),
+    archived: await token.archived(),
+    useTransferWhitelist: await token.useTransferWhitelist(),
+    useReceiveWhitelist: await token.useReceiveWhitelist(),
+    priceInUSD: await token.priceInUSD(),
+    decayPercentage: await token.decayPercentage(),
+    decayRate: await token.decayRate(),
+    totalBurnedFromDecay: await token.totalBurnedFromDecay(),
+  };
+  for (const [k, v] of Object.entries(stateBefore)) {
+    console.log(`  ${k}: ${v}`);
+  }
+
+  // Raw ERC20 balances (super.balanceOf) for every holder, via raw storage of
+  // the OZ ERC20 namespaced slot, so decay views don't interfere with the
+  // before/after comparison.
+  const decayedBalancesBefore = new Map<string, bigint>();
+  const lastAppliedBefore = new Map<string, bigint>();
+  for (const holder of holders) {
+    decayedBalancesBefore.set(holder, await token.balanceOf(holder));
+    lastAppliedBefore.set(holder, await token.lastApplied(holder));
+  }
+  const decayedTotalBefore = await token.getDecayedTotalSupply();
+  console.log(`  getDecayedTotalSupply: ${decayedTotalBefore}`);
+
+  const implBefore = await upgrades.erc1967.getImplementationAddress(
+    PROXY_ADDRESS,
+  );
+  console.log(`  implementation: ${implBefore}`);
+  console.log('');
+
+  console.log('=== Step 2: Impersonating owner and upgrading ===');
+  const ownerSigner = await impersonate(OWNER_ADDRESS);
+
+  // Validate the implementation contract (initializers disabled, no
+  // constructor state, UUPS-compatible), then deploy it and call
+  // upgradeToAndCall directly as the proxy owner — same call the real
+  // mainnet upgrade makes. Avoids the plugin manifest, which has no record
+  // of the legacy proxy; layout safety is asserted in Step 0 instead.
+  await upgrades.validateImplementation(Legacy, { kind: 'uups' });
+  console.log('Implementation validated by upgrades plugin');
+
+  const newImplContract = await Legacy.deploy();
+  await newImplContract.waitForDeployment();
+  const newImplAddress = await newImplContract.getAddress();
+  console.log(`New implementation deployed: ${newImplAddress}`);
+
+  const upgraded = Legacy.attach(PROXY_ADDRESS) as any;
+  const upgradeTx = await upgraded
+    .connect(ownerSigner)
+    .upgradeToAndCall(newImplAddress, '0x');
+  await upgradeTx.wait();
+
+  const implAfter = await upgrades.erc1967.getImplementationAddress(
+    PROXY_ADDRESS,
+  );
+  console.log(`New implementation: ${implAfter}`);
+  if (implAfter.toLowerCase() === implBefore.toLowerCase()) {
+    fail('Implementation did not change');
+  }
+  console.log('');
+
+  console.log('=== Step 3: Verifying state preservation ===');
+  const stateAfter: Record<string, unknown> = {
+    name: await upgraded.name(),
+    symbol: await upgraded.symbol(),
+    totalSupply: await upgraded.totalSupply(),
+    decimals: await upgraded.decimals(),
+    executor: await upgraded.executor(),
+    owner: await upgraded.owner(),
+    spaceId: await upgraded.spaceId(),
+    maxSupply: await upgraded.maxSupply(),
+    transferable: await upgraded.transferable(),
+    transferHelper: await upgraded.transferHelper(),
+    archived: await upgraded.archived(),
+    useTransferWhitelist: await upgraded.useTransferWhitelist(),
+    useReceiveWhitelist: await upgraded.useReceiveWhitelist(),
+    priceInUSD: await upgraded.priceInUSD(),
+    decayPercentage: await upgraded.decayPercentage(),
+    decayRate: await upgraded.decayRate(),
+    totalBurnedFromDecay: await upgraded.totalBurnedFromDecay(),
+  };
+
+  let allMatch = true;
+  for (const [key, before] of Object.entries(stateBefore)) {
+    const after = stateAfter[key];
+    if (String(before) !== String(after)) {
+      console.log(`  ❌ ${key}: ${before} -> ${after}`);
+      allMatch = false;
+    } else {
+      console.log(`  ✅ ${key}: ${after}`);
+    }
+  }
+  if (!allMatch) {
+    fail('State was corrupted by the upgrade!');
+  }
+
+  console.log('');
+  console.log(
+    `Checking ${holders.length} holder balances + decay timestamps...`,
+  );
+  for (const holder of holders) {
+    const balance = await upgraded.balanceOf(holder);
+    const last = await upgraded.lastApplied(holder);
+    if (balance !== decayedBalancesBefore.get(holder)) {
+      fail(
+        `Balance changed for ${holder}: ${decayedBalancesBefore.get(
+          holder,
+        )} -> ${balance}`,
+      );
+    }
+    if (last !== lastAppliedBefore.get(holder)) {
+      fail(`lastApplied changed for ${holder}`);
+    }
+  }
+  console.log('  ✅ All holder balances and lastApplied timestamps preserved');
+
+  const decayedTotalAfter = await upgraded.getDecayedTotalSupply();
+  if (decayedTotalAfter !== decayedTotalBefore) {
+    fail(
+      `getDecayedTotalSupply changed: ${decayedTotalBefore} -> ${decayedTotalAfter}`,
+    );
+  }
+  console.log(`  ✅ getDecayedTotalSupply preserved: ${decayedTotalAfter}`);
+
+  // New storage must read as zero / disabled.
+  if ((await upgraded.tokenPrice()) !== 0n) fail('tokenPrice should be 0');
+  if ((await upgraded.paymentToken()) !== ethers.ZeroAddress)
+    fail('paymentToken should be zero address');
+  if ((await upgraded.defaultCreditLimit()) !== 0n)
+    fail('defaultCreditLimit should be 0');
+  if ((await upgraded.getTransferWhitelistedSpaces()).length !== 0)
+    fail('transfer whitelist spaces should be empty');
+  if ((await upgraded.getReceiveWhitelistedSpaces()).length !== 0)
+    fail('receive whitelist spaces should be empty');
+  if (await upgraded.isAuthorizedMinter(OWNER_ADDRESS))
+    fail('owner should not be an authorized minter');
+  console.log('  ✅ All new storage reads as zero (features disabled)');
+  console.log('');
+
+  console.log('=== Step 4: Testing new functionality ===');
+
+  // Owner must NOT be able to mint (executor-only access control preserved).
+  try {
+    await upgraded.connect(ownerSigner).mint(OWNER_ADDRESS, 1n);
+    fail('Owner should not be able to mint');
+  } catch {
+    console.log('  ✅ Owner cannot mint (as expected)');
+  }
+
+  // Executor grants an authorized minter key.
+  const executorSigner = await impersonate(EXECUTOR_ADDRESS);
+  const [minter] = await ethers.getSigners();
+  await upgraded
+    .connect(executorSigner)
+    .batchSetAuthorizedMinters([minter.address], [true]);
+  if (!(await upgraded.isAuthorizedMinter(minter.address))) {
+    fail('Authorized minter was not set');
+  }
+  console.log(`  ✅ Executor granted authorized minter: ${minter.address}`);
+
+  // Authorized minter mints to a fresh address.
+  const recipient = ethers.Wallet.createRandom().address;
+  const mintAmount = ethers.parseEther('100');
+  await upgraded.connect(minter).mint(recipient, mintAmount);
+  if ((await upgraded.balanceOf(recipient)) !== mintAmount) {
+    fail('Mint by authorized minter failed');
+  }
+  if ((await upgraded.lastApplied(recipient)) === 0n) {
+    fail('lastApplied not initialized on mint');
+  }
+  console.log(
+    '  ✅ Authorized minter minted 100 EVOICE, decay tracking initialized',
+  );
+
+  // Authorized minter burns without approval.
+  await upgraded.connect(minter).burnFrom(recipient, ethers.parseEther('40'));
+  if ((await upgraded.balanceOf(recipient)) !== ethers.parseEther('60')) {
+    fail('burnFrom by authorized minter failed');
+  }
+  console.log('  ✅ Authorized minter burned 40 EVOICE without approval');
+
+  console.log('');
+  console.log('=== Step 5: Verifying decay still works (time travel) ===');
+  const decayRate = await upgraded.decayRate();
+  const balBeforeDecay: bigint = await upgraded.balanceOf(recipient);
+  await network.provider.send('evm_increaseTime', [Number(decayRate)]);
+  await network.provider.send('evm_mine');
+  const balAfterDecay: bigint = await upgraded.balanceOf(recipient);
+  if (balAfterDecay >= balBeforeDecay) {
+    fail(`Decay not applied: ${balBeforeDecay} -> ${balAfterDecay}`);
+  }
+  console.log(`  ✅ View decay: ${balBeforeDecay} -> ${balAfterDecay}`);
+
+  const burnedBefore = await upgraded.totalBurnedFromDecay();
+  await upgraded.applyDecay(recipient);
+  const burnedAfter = await upgraded.totalBurnedFromDecay();
+  if (burnedAfter <= burnedBefore) {
+    fail('applyDecay did not increase totalBurnedFromDecay');
+  }
+  console.log(
+    `  ✅ applyDecay burned tokens: totalBurnedFromDecay ${burnedBefore} -> ${burnedAfter}`,
+  );
+
+  console.log('');
+  console.log('='.repeat(60));
+  console.log('✅ ALL TESTS PASSED! EVOICE LEGACY UPGRADE IS SAFE TO PERFORM');
+  console.log('='.repeat(60));
+  console.log('');
+  console.log('Run the actual upgrade on mainnet with:');
+  console.log(
+    '  npx hardhat run scripts/evoice-decaying-space-token-legacy.upgrade.ts --network base-mainnet',
+  );
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error: Error) => {
+    console.error(error);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary

The deployed **EVOICE** proxy ([`0x564c…800f`](https://basescan.org/address/0x564c52008898E1a46825dEbf20d5000CBe74800f) on Base) runs an early `DecayingSpaceToken` implementation that predates space whitelists, mutual credit, the token sale and authorized minters. In that layout the decay variables occupy **slots 8–13**, immediately after `archived`.

Upgrading that proxy to the current `DecayingSpaceToken` would shift derived storage down by ~71 slots and silently corrupt it:

| Slot | Live data (verified on-chain) | Meaning after a naive upgrade |
|---|---|---|
| 8 | `decayPercentage = 1` | `_transferWhitelistedSpaceIds.length` (phantom entry) |
| 9 | `decayRate = 2 592 000` | `_receiveWhitelistedSpaceIds.length` (2.59M phantom entries) |
| 13 | `totalBurnedFromDecay = 573.48e18` | `tokenPrice` (garbage price) |
| 79–84 | (empty) | decay vars → decay silently disabled, holder tracking lost |

This PR adds:

- **`DecayingSpaceTokenLegacy.sol`** — `RegularSpaceToken` + `DecayingSpaceToken` flattened into one contract that keeps the deployed slots 0–13 in place and appends all newer storage (whitelists, pricing, credit, sale, authorized minters, `__gap`) after them. Functionality is identical to the current `DecayingSpaceToken`; all new features read as zero (= disabled) right after the upgrade. Zero data migration. Deployed size: 21 916 bytes (under EIP-170).
- **`scripts/test-evoice-legacy-upgrade-on-fork.ts`** — Base fork test that (1) statically asserts the compiled storage layout for slots 0–13, (2) upgrades the real proxy as the impersonated owner, (3) verifies all state incl. **43 holder balances and `lastApplied` timestamps** byte-for-byte, (4) exercises authorized-minter mint/burn and confirms the owner still cannot mint, (5) time-travels one decay period and confirms decay still burns correctly.
- **`scripts/evoice-decaying-space-token-legacy.upgrade.ts`** — mainnet upgrade script (validate → deploy impl → `upgradeToAndCall` → post-upgrade state assertion).
- `hardhat.config.ts`: enables `storageLayout` compiler output so layouts can be diffed for future upgrades.

### Fork test result

All steps pass against a live Base fork: layout ✅, state preservation ✅ (incl. `decayPercentage = 1`, `decayRate = 2 592 000`, `totalBurnedFromDecay = 573 482 225 800 000 000 000`, `getDecayedTotalSupply` unchanged), authorized minters ✅, decay after 30-day time travel ✅ (100 → 99.99 EVOICE, exactly 1 bp).

### Notes for reviewers

- `transfer`/`transferFrom` intentionally mirror the current `DecayingSpaceToken` overrides (no mutual-credit hooks), matching mainline behavior for decaying tokens.
- `buyTokens` additionally initializes decay tracking (`_applyDecayOrInit` + `_addTokenHolder`) for buyers — the current inherited version misses this for decay tokens.
- ⚠️ This contract must be kept in sync with `RegularSpaceToken`/`DecayingSpaceToken` manually; storage additions go before `__gap`, never between existing variables.

## Test plan

- [x] `pnpm exec hardhat compile` — clean, contract under size limit
- [x] Fork test: `npx hardhat run scripts/test-evoice-legacy-upgrade-on-fork.ts --network hardhat` — all assertions pass
- [ ] Re-run fork test just before the real upgrade
- [ ] Execute mainnet upgrade with the owner key: `npx hardhat run scripts/evoice-decaying-space-token-legacy.upgrade.ts --network base-mainnet`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added upgradeable token contracts with backward-compatible storage layout for seamless migrations
  * Introduced token decay mechanics with configurable decay rates and percentages
  * Implemented flexible whitelist system supporting transfers, receipts, and purchases at address and space levels
  * Added token sale functionality with payment token configuration and purchase tracking
  * Enabled mutual credit system with customizable per-account credit limits
  * Integrated space-based and address-based access controls with authorized minter roles

* **Tests**
  * Added upgrade validation and rehearsal scripts for mainnet operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->