### PR TITLE
feat(storage-evm): execute proposals instantly on unanimous full-participation vote

### DIFF
--- a/packages/storage-evm/.openzeppelin/base.json
+++ b/packages/storage-evm/.openzeppelin/base.json
@@ -54405,6 +54405,415 @@
           ]
         }
       }
+    },
+    "2b6f71228e5e39fd9aaabea69cf8e87a04dd97d6d3705fd63e1f5522fe79e173": {
+      "address": "0x69Bd861C7A2B5d65052B007572C1761452e514f4",
+      "txHash": "0xbaccbd8d30f519f5bbc79423408d894a5e5e1850c34e91ec482a70624c842bc8",
+      "layout": {
+        "solcVersion": "0.8.28",
+        "storage": [
+          {
+            "label": "spaceFactory",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_contract(IDAOSpaceFactory)4145",
+            "contract": "DAOProposalsStorage",
+            "src": "contracts/storage/DAOProposalsStorage.sol:87"
+          },
+          {
+            "label": "directoryContract",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_contract(IDirectory)4153",
+            "contract": "DAOProposalsStorage",
+            "src": "contracts/storage/DAOProposalsStorage.sol:88"
+          },
+          {
+            "label": "proposalCounter",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_uint256",
+            "contract": "DAOProposalsStorage",
+            "src": "contracts/storage/DAOProposalsStorage.sol:90"
+          },
+          {
+            "label": "proposalsCoreData",
+            "offset": 0,
+            "slot": "3",
+            "type": "t_mapping(t_uint256,t_struct(ProposalCore)4214_storage)",
+            "contract": "DAOProposalsStorage",
+            "src": "contracts/storage/DAOProposalsStorage.sol:116"
+          },
+          {
+            "label": "proposalValues",
+            "offset": 0,
+            "slot": "4",
+            "type": "t_mapping(t_uint256,t_uint256)",
+            "contract": "DAOProposalsStorage",
+            "src": "contracts/storage/DAOProposalsStorage.sol:118"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "5",
+            "type": "t_array(t_uint256)48_storage",
+            "contract": "DAOProposalsStorage",
+            "src": "contracts/storage/DAOProposalsStorage.sol:124"
+          },
+          {
+            "label": "spaceAddresses",
+            "offset": 0,
+            "slot": "53",
+            "type": "t_mapping(t_uint256,t_address)",
+            "contract": "DAOProposalsStorage",
+            "src": "contracts/storage/DAOProposalsStorage.sol:127"
+          },
+          {
+            "label": "spaceTrialActivated",
+            "offset": 0,
+            "slot": "54",
+            "type": "t_mapping(t_uint256,t_bool)",
+            "contract": "DAOProposalsStorage",
+            "src": "contracts/storage/DAOProposalsStorage.sol:130"
+          },
+          {
+            "label": "paymentTracker",
+            "offset": 0,
+            "slot": "55",
+            "type": "t_contract(ISpacePaymentTracker)3986",
+            "contract": "DAOProposalsStorage",
+            "src": "contracts/storage/DAOProposalsStorage.sol:132"
+          },
+          {
+            "label": "spaceExecutedProposals",
+            "offset": 0,
+            "slot": "56",
+            "type": "t_mapping(t_uint256,t_array(t_uint256)dyn_storage)",
+            "contract": "DAOProposalsStorage",
+            "src": "contracts/storage/DAOProposalsStorage.sol:135"
+          },
+          {
+            "label": "allExecutedProposals",
+            "offset": 0,
+            "slot": "57",
+            "type": "t_array(t_uint256)dyn_storage",
+            "contract": "DAOProposalsStorage",
+            "src": "contracts/storage/DAOProposalsStorage.sol:138"
+          },
+          {
+            "label": "spaceAcceptedProposals",
+            "offset": 0,
+            "slot": "58",
+            "type": "t_mapping(t_uint256,t_array(t_uint256)dyn_storage)",
+            "contract": "DAOProposalsStorage",
+            "src": "contracts/storage/DAOProposalsStorage.sol:141"
+          },
+          {
+            "label": "spaceRejectedProposals",
+            "offset": 0,
+            "slot": "59",
+            "type": "t_mapping(t_uint256,t_array(t_uint256)dyn_storage)",
+            "contract": "DAOProposalsStorage",
+            "src": "contracts/storage/DAOProposalsStorage.sol:142"
+          },
+          {
+            "label": "proposalYesVoters",
+            "offset": 0,
+            "slot": "60",
+            "type": "t_mapping(t_uint256,t_array(t_address)dyn_storage)",
+            "contract": "DAOProposalsStorage",
+            "src": "contracts/storage/DAOProposalsStorage.sol:145"
+          },
+          {
+            "label": "proposalNoVoters",
+            "offset": 0,
+            "slot": "61",
+            "type": "t_mapping(t_uint256,t_array(t_address)dyn_storage)",
+            "contract": "DAOProposalsStorage",
+            "src": "contracts/storage/DAOProposalsStorage.sol:146"
+          },
+          {
+            "label": "spaceMinProposalDuration",
+            "offset": 0,
+            "slot": "62",
+            "type": "t_mapping(t_uint256,t_uint256)",
+            "contract": "DAOProposalsStorage",
+            "src": "contracts/storage/DAOProposalsStorage.sol:149"
+          },
+          {
+            "label": "delegationContract",
+            "offset": 0,
+            "slot": "63",
+            "type": "t_contract(IVotingPowerDelegation)4086",
+            "contract": "DAOProposalsStorage",
+            "src": "contracts/storage/DAOProposalsStorage.sol:150"
+          },
+          {
+            "label": "proposalWithdrawn",
+            "offset": 0,
+            "slot": "64",
+            "type": "t_mapping(t_uint256,t_bool)",
+            "contract": "DAOProposalsStorage",
+            "src": "contracts/storage/DAOProposalsStorage.sol:153"
+          },
+          {
+            "label": "spaceWithdrawnProposals",
+            "offset": 0,
+            "slot": "65",
+            "type": "t_mapping(t_uint256,t_array(t_uint256)dyn_storage)",
+            "contract": "DAOProposalsStorage",
+            "src": "contracts/storage/DAOProposalsStorage.sol:154"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_struct(InitializableStorage)73_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(OwnableStorage)13_storage": {
+            "label": "struct OwnableUpgradeable.OwnableStorage",
+            "members": [
+              {
+                "label": "_owner",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_struct(Transaction)3593_storage)dyn_storage": {
+            "label": "struct IDAOProposals.Transaction[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)48_storage": {
+            "label": "uint256[48]",
+            "numberOfBytes": "1536"
+          },
+          "t_array(t_uint256)dyn_storage": {
+            "label": "uint256[]",
+            "numberOfBytes": "32"
+          },
+          "t_bytes_storage": {
+            "label": "bytes",
+            "numberOfBytes": "32"
+          },
+          "t_contract(IDAOSpaceFactory)4145": {
+            "label": "contract IDAOSpaceFactory",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IDirectory)4153": {
+            "label": "contract IDirectory",
+            "numberOfBytes": "20"
+          },
+          "t_contract(ISpacePaymentTracker)3986": {
+            "label": "contract ISpacePaymentTracker",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IVotingPowerDelegation)4086": {
+            "label": "contract IVotingPowerDelegation",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_address)": {
+            "label": "mapping(uint256 => address)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_array(t_address)dyn_storage)": {
+            "label": "mapping(uint256 => address[])",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_array(t_uint256)dyn_storage)": {
+            "label": "mapping(uint256 => uint256[])",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_bool)": {
+            "label": "mapping(uint256 => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_struct(ProposalCore)4214_storage)": {
+            "label": "mapping(uint256 => struct DAOProposalsStorage.ProposalCore)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_uint256)": {
+            "label": "mapping(uint256 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(ProposalCore)4214_storage": {
+            "label": "struct DAOProposalsStorage.ProposalCore",
+            "members": [
+              {
+                "label": "spaceId",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "startTime",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "duration",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "executed",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "expired",
+                "type": "t_bool",
+                "offset": 1,
+                "slot": "3"
+              },
+              {
+                "label": "yesVotes",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "4"
+              },
+              {
+                "label": "noVotes",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "5"
+              },
+              {
+                "label": "totalVotingPowerAtSnapshot",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "6"
+              },
+              {
+                "label": "creator",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "7"
+              },
+              {
+                "label": "hasVoted",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "8"
+              },
+              {
+                "label": "votingPowerAtSnapshot",
+                "type": "t_mapping(t_address,t_uint256)",
+                "offset": 0,
+                "slot": "9"
+              },
+              {
+                "label": "transactions",
+                "type": "t_array(t_struct(Transaction)3593_storage)dyn_storage",
+                "offset": 0,
+                "slot": "10"
+              }
+            ],
+            "numberOfBytes": "352"
+          },
+          "t_struct(Transaction)3593_storage": {
+            "label": "struct IDAOProposals.Transaction",
+            "members": [
+              {
+                "label": "target",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "value",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "data",
+                "type": "t_bytes_storage",
+                "offset": 0,
+                "slot": "2"
+              }
+            ],
+            "numberOfBytes": "96"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.Ownable": [
+            {
+              "contract": "OwnableUpgradeable",
+              "label": "_owner",
+              "type": "t_address",
+              "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:24",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
     }
   }
 }

--- a/packages/storage-evm/contracts/DAOProposalsImplementation.sol
+++ b/packages/storage-evm/contracts/DAOProposalsImplementation.sol
@@ -316,9 +316,17 @@ contract DAOProposalsImplementation is
     // Handle case where votes exceed snapshot (e.g., members acquired tokens after proposal creation)
     // This prevents underflow errors and treats it as "full participation"
     if (totalVotesCast >= proposal.totalVotingPowerAtSnapshot) {
-      uint256 minDuration = spaceMinProposalDuration[proposal.spaceId];
-      if (block.timestamp < proposal.startTime + minDuration) {
-        return;
+      // Unanimous approval with full participation: no remaining or dissenting
+      // voting power could change the outcome, so resolve immediately without
+      // waiting out the space's minimum proposal duration. Contested outcomes
+      // still wait, preserving the window for voters to change their vote.
+      bool unanimousApproval = proposal.yesVotes > 0 && proposal.noVotes == 0;
+
+      if (!unanimousApproval) {
+        uint256 minDuration = spaceMinProposalDuration[proposal.spaceId];
+        if (block.timestamp < proposal.startTime + minDuration) {
+          return;
+        }
       }
 
       // All possible votes have been cast (or exceeded) - resolve based on current votes

--- a/packages/storage-evm/contracts/DAOProposalsImplementation.sol
+++ b/packages/storage-evm/contracts/DAOProposalsImplementation.sol
@@ -316,11 +316,17 @@ contract DAOProposalsImplementation is
     // Handle case where votes exceed snapshot (e.g., members acquired tokens after proposal creation)
     // This prevents underflow errors and treats it as "full participation"
     if (totalVotesCast >= proposal.totalVotingPowerAtSnapshot) {
-      // Unanimous approval with full participation: no remaining or dissenting
-      // voting power could change the outcome, so resolve immediately without
-      // waiting out the space's minimum proposal duration. Contested outcomes
-      // still wait, preserving the window for voters to change their vote.
-      bool unanimousApproval = proposal.yesVotes > 0 && proposal.noVotes == 0;
+      // Unanimous approval with exact full participation: no remaining or
+      // dissenting voting power could change the outcome, so resolve
+      // immediately without waiting out the space's minimum proposal duration.
+      // Contested outcomes still wait, preserving the window for voters to
+      // change their vote. Overshoot (votes exceeding the snapshot because
+      // voting power grew after proposal creation) does not fast-track, since
+      // it does not prove full participation.
+      bool unanimousApproval = totalVotesCast ==
+        proposal.totalVotingPowerAtSnapshot &&
+        proposal.yesVotes > 0 &&
+        proposal.noVotes == 0;
 
       if (!unanimousApproval) {
         uint256 minDuration = spaceMinProposalDuration[proposal.spaceId];

--- a/packages/storage-evm/test/ProposalUnanimousEarlyExecution.test.ts
+++ b/packages/storage-evm/test/ProposalUnanimousEarlyExecution.test.ts
@@ -1,0 +1,326 @@
+import { ethers, upgrades } from 'hardhat';
+import { expect } from 'chai';
+import {
+  loadFixture,
+  time,
+} from '@nomicfoundation/hardhat-toolbox/network-helpers';
+import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
+
+describe('Proposal Unanimous Early Execution', function () {
+  let daoSpaceFactory: any;
+  let daoProposals: any;
+  let owner: SignerWithAddress;
+  let members: SignerWithAddress[];
+
+  const SEVENTY_TWO_HOURS = 72 * 60 * 60;
+
+  async function deployFixture() {
+    const signers = await ethers.getSigners();
+    const [owner, ...members] = signers;
+
+    const VotingPowerDelegation = await ethers.getContractFactory(
+      'VotingPowerDelegationImplementation',
+    );
+    const votingPowerDelegation = await upgrades.deployProxy(
+      VotingPowerDelegation,
+      [owner.address],
+      { initializer: 'initialize', kind: 'uups' },
+    );
+
+    const DAOSpaceFactory = await ethers.getContractFactory(
+      'DAOSpaceFactoryImplementation',
+    );
+    const daoSpaceFactory = await upgrades.deployProxy(
+      DAOSpaceFactory,
+      [owner.address],
+      { initializer: 'initialize', kind: 'uups' },
+    );
+
+    const JoinMethodDirectory = await ethers.getContractFactory(
+      'JoinMethodDirectoryImplementation',
+    );
+    const joinMethodDirectory = await upgrades.deployProxy(
+      JoinMethodDirectory,
+      [owner.address],
+      { initializer: 'initialize', kind: 'uups' },
+    );
+    const OpenJoin = await ethers.getContractFactory('OpenJoin');
+    const openJoin = await OpenJoin.deploy();
+    await joinMethodDirectory.addJoinMethod(1, await openJoin.getAddress());
+
+    const ExitMethodDirectory = await ethers.getContractFactory(
+      'ExitMethodDirectoryImplementation',
+    );
+    const exitMethodDirectory = await upgrades.deployProxy(
+      ExitMethodDirectory,
+      [owner.address],
+      { initializer: 'initialize', kind: 'uups' },
+    );
+    const NoExit = await ethers.getContractFactory('NoExit');
+    const noExit = await NoExit.deploy();
+    await exitMethodDirectory.addExitMethod(1, await noExit.getAddress());
+
+    const DAOProposals = await ethers.getContractFactory(
+      'DAOProposalsImplementation',
+    );
+    const daoProposals = await upgrades.deployProxy(
+      DAOProposals,
+      [owner.address],
+      { initializer: 'initialize', kind: 'uups' },
+    );
+
+    const SpaceVotingPower = await ethers.getContractFactory(
+      'SpaceVotingPowerImplementation',
+    );
+    const spaceVotingPower = await upgrades.deployProxy(
+      SpaceVotingPower,
+      [owner.address],
+      { initializer: 'initialize', kind: 'uups' },
+    );
+
+    const VotingPowerDirectory = await ethers.getContractFactory(
+      'VotingPowerDirectoryImplementation',
+    );
+    const votingPowerDirectory = await upgrades.deployProxy(
+      VotingPowerDirectory,
+      [owner.address],
+      { initializer: 'initialize', kind: 'uups' },
+    );
+
+    await spaceVotingPower.setSpaceFactory(await daoSpaceFactory.getAddress());
+    await (spaceVotingPower as any).setDelegationContract(
+      await votingPowerDelegation.getAddress(),
+    );
+
+    // Space membership voting power source (ID: 1)
+    await votingPowerDirectory.addVotingPowerSource(
+      await spaceVotingPower.getAddress(),
+    );
+
+    await daoProposals.setContracts(
+      await daoSpaceFactory.getAddress(),
+      await votingPowerDirectory.getAddress(),
+    );
+    await daoProposals.setDelegationContract(
+      await votingPowerDelegation.getAddress(),
+    );
+    await daoSpaceFactory.setContracts(
+      await joinMethodDirectory.getAddress(),
+      await exitMethodDirectory.getAddress(),
+      await daoProposals.getAddress(),
+    );
+    await joinMethodDirectory.setSpaceFactory(
+      await daoSpaceFactory.getAddress(),
+    );
+    await exitMethodDirectory.setSpaceFactory(
+      await daoSpaceFactory.getAddress(),
+    );
+
+    return { daoSpaceFactory, daoProposals, owner, members };
+  }
+
+  beforeEach(async function () {
+    const fixture = await loadFixture(deployFixture);
+    daoSpaceFactory = fixture.daoSpaceFactory;
+    daoProposals = fixture.daoProposals;
+    owner = fixture.owner;
+    members = fixture.members;
+  });
+
+  // Creates a space with 1-member-1-vote governance. Quorum below 20 forces
+  // the default 72h minimum proposal duration inside createProposal.
+  async function createSpace(params: {
+    unity: number;
+    quorum: number;
+    memberCount: number;
+  }) {
+    const { unity, quorum, memberCount } = params;
+
+    await daoSpaceFactory.createSpace({
+      unity,
+      quorum,
+      votingPowerSource: 1,
+      exitMethod: 1,
+      joinMethod: 1,
+      access: 0,
+      discoverability: 0,
+    });
+    const spaceId = await daoSpaceFactory.spaceCounter();
+
+    for (let i = 0; i < memberCount - 1; i++) {
+      await daoSpaceFactory.connect(members[i]).joinSpace(spaceId);
+    }
+
+    const spaceMembers = await daoSpaceFactory.getSpaceMembers(spaceId);
+    expect(spaceMembers.length).to.equal(memberCount);
+
+    return spaceId;
+  }
+
+  async function createTestProposal(
+    proposer: SignerWithAddress,
+    spaceId: bigint,
+  ) {
+    const calldata = daoSpaceFactory.interface.encodeFunctionData(
+      'getSpaceDetails',
+      [spaceId],
+    );
+    await daoProposals.connect(proposer).createProposal({
+      spaceId,
+      duration: 3600,
+      transactions: [
+        {
+          target: await daoSpaceFactory.getAddress(),
+          value: 0,
+          data: calldata,
+        },
+      ],
+    });
+    return await daoProposals.proposalCounter();
+  }
+
+  async function getProposalState(proposalId: bigint) {
+    const core = await daoProposals.getProposalCore(proposalId);
+    return { executed: core[3] as boolean, expired: core[4] as boolean };
+  }
+
+  it('executes immediately when all voting power votes yes (unanimous)', async function () {
+    const spaceId = await createSpace({
+      unity: 51,
+      quorum: 10,
+      memberCount: 3,
+    });
+    const proposalId = await createTestProposal(owner, spaceId);
+
+    await daoProposals.connect(owner).vote(proposalId, true);
+    await daoProposals.connect(members[0]).vote(proposalId, true);
+
+    // 2 of 3 voted — quorum and unity are met but participation is not full,
+    // so the proposal must still wait out the minimum duration
+    let state = await getProposalState(proposalId);
+    expect(state.executed).to.equal(false);
+    expect(state.expired).to.equal(false);
+
+    // Final voter completes 100% unanimous participation — executes instantly
+    await expect(
+      daoProposals.connect(members[1]).vote(proposalId, true),
+    ).to.emit(daoProposals, 'ProposalExecuted');
+
+    state = await getProposalState(proposalId);
+    expect(state.executed).to.equal(true);
+  });
+
+  it('does not execute early when quorum/unity are met without full participation', async function () {
+    const spaceId = await createSpace({
+      unity: 51,
+      quorum: 10,
+      memberCount: 5,
+    });
+    const proposalId = await createTestProposal(owner, spaceId);
+
+    // 3 of 5 vote yes: 60% participation > 10% quorum, 100% yes > 51% unity
+    await daoProposals.connect(owner).vote(proposalId, true);
+    await daoProposals.connect(members[0]).vote(proposalId, true);
+    await daoProposals.connect(members[1]).vote(proposalId, true);
+
+    const state = await getProposalState(proposalId);
+    expect(state.executed).to.equal(false);
+    expect(state.expired).to.equal(false);
+  });
+
+  it('does not bypass the minimum duration for contested full participation', async function () {
+    const spaceId = await createSpace({
+      unity: 51,
+      quorum: 10,
+      memberCount: 3,
+    });
+    const proposalId = await createTestProposal(owner, spaceId);
+
+    // Full participation but contested: 2 yes, 1 no
+    await daoProposals.connect(owner).vote(proposalId, true);
+    await daoProposals.connect(members[0]).vote(proposalId, false);
+    await daoProposals.connect(members[1]).vote(proposalId, true);
+
+    // Outcome is decided (66% yes > 51% unity) but the reconsideration
+    // window must still apply because the vote was not unanimous
+    let state = await getProposalState(proposalId);
+    expect(state.executed).to.equal(false);
+    expect(state.expired).to.equal(false);
+
+    // After the minimum duration the proposal resolves normally
+    await time.increase(SEVENTY_TWO_HOURS + 1);
+    await daoProposals.connect(owner).triggerExecutionCheck(proposalId);
+
+    state = await getProposalState(proposalId);
+    expect(state.executed).to.equal(true);
+  });
+
+  it('executes when a dissenting voter flips to yes, making the vote unanimous', async function () {
+    const spaceId = await createSpace({
+      unity: 51,
+      quorum: 10,
+      memberCount: 3,
+    });
+    const proposalId = await createTestProposal(owner, spaceId);
+
+    await daoProposals.connect(owner).vote(proposalId, true);
+    await daoProposals.connect(members[0]).vote(proposalId, false);
+    await daoProposals.connect(members[1]).vote(proposalId, true);
+
+    let state = await getProposalState(proposalId);
+    expect(state.executed).to.equal(false);
+
+    // The no-voter changes their vote to yes — now unanimous, executes instantly
+    await expect(
+      daoProposals.connect(members[0]).vote(proposalId, true),
+    ).to.emit(daoProposals, 'ProposalExecuted');
+
+    state = await getProposalState(proposalId);
+    expect(state.executed).to.equal(true);
+  });
+
+  it('rejects (not executes) full unanimous-no participation only after the minimum duration', async function () {
+    const spaceId = await createSpace({
+      unity: 51,
+      quorum: 10,
+      memberCount: 3,
+    });
+    const proposalId = await createTestProposal(owner, spaceId);
+
+    await daoProposals.connect(owner).vote(proposalId, false);
+    await daoProposals.connect(members[0]).vote(proposalId, false);
+    await daoProposals.connect(members[1]).vote(proposalId, false);
+
+    // Unanimous NO must not fast-track — voters keep the window to reconsider
+    let state = await getProposalState(proposalId);
+    expect(state.executed).to.equal(false);
+    expect(state.expired).to.equal(false);
+
+    await time.increase(SEVENTY_TWO_HOURS + 1);
+    await daoProposals.connect(owner).triggerExecutionCheck(proposalId);
+
+    state = await getProposalState(proposalId);
+    expect(state.executed).to.equal(false);
+    expect(state.expired).to.equal(true);
+  });
+
+  it('keeps immediate execution for spaces without a minimum duration (quorum >= 20)', async function () {
+    const spaceId = await createSpace({
+      unity: 51,
+      quorum: 50,
+      memberCount: 3,
+    });
+    const proposalId = await createTestProposal(owner, spaceId);
+
+    await daoProposals.connect(owner).vote(proposalId, true);
+
+    // No forced min duration: quorum (66% >= 50%) + unity (100% >= 51%)
+    // already execute on the second vote, as before this change
+    await expect(
+      daoProposals.connect(members[0]).vote(proposalId, true),
+    ).to.emit(daoProposals, 'ProposalExecuted');
+
+    const state = await getProposalState(proposalId);
+    expect(state.executed).to.equal(true);
+  });
+});

--- a/packages/storage-evm/test/ProposalUnanimousEarlyExecution.test.ts
+++ b/packages/storage-evm/test/ProposalUnanimousEarlyExecution.test.ts
@@ -9,6 +9,7 @@ import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
 describe('Proposal Unanimous Early Execution', function () {
   let daoSpaceFactory: any;
   let daoProposals: any;
+  let votingPowerDelegation: any;
   let owner: SignerWithAddress;
   let members: SignerWithAddress[];
 
@@ -116,13 +117,20 @@ describe('Proposal Unanimous Early Execution', function () {
       await daoSpaceFactory.getAddress(),
     );
 
-    return { daoSpaceFactory, daoProposals, owner, members };
+    return {
+      daoSpaceFactory,
+      daoProposals,
+      votingPowerDelegation,
+      owner,
+      members,
+    };
   }
 
   beforeEach(async function () {
     const fixture = await loadFixture(deployFixture);
     daoSpaceFactory = fixture.daoSpaceFactory;
     daoProposals = fixture.daoProposals;
+    votingPowerDelegation = fixture.votingPowerDelegation;
     owner = fixture.owner;
     members = fixture.members;
   });
@@ -321,6 +329,42 @@ describe('Proposal Unanimous Early Execution', function () {
     ).to.emit(daoProposals, 'ProposalExecuted');
 
     const state = await getProposalState(proposalId);
+    expect(state.executed).to.equal(true);
+  });
+
+  it('does not fast-track when unanimous yes votes overshoot the snapshot', async function () {
+    // Snapshot is taken at proposal creation with 2 members
+    const spaceId = await createSpace({
+      unity: 51,
+      quorum: 10,
+      memberCount: 2,
+    });
+    const proposalId = await createTestProposal(owner, spaceId);
+
+    // Voting power grows after creation: two new members join and delegate
+    // to members[0], whose single yes vote (power 3) overshoots the snapshot (2)
+    await daoSpaceFactory.connect(members[1]).joinSpace(spaceId);
+    await daoSpaceFactory.connect(members[2]).joinSpace(spaceId);
+    await votingPowerDelegation
+      .connect(members[1])
+      .delegate(members[0].address, spaceId);
+    await votingPowerDelegation
+      .connect(members[2])
+      .delegate(members[0].address, spaceId);
+
+    await daoProposals.connect(members[0]).vote(proposalId, true);
+
+    // Overshoot (3 > 2) is unanimous yes but does not prove full
+    // participation, so the minimum duration must still be respected
+    let state = await getProposalState(proposalId);
+    expect(state.executed).to.equal(false);
+    expect(state.expired).to.equal(false);
+
+    // After the minimum duration the proposal resolves normally
+    await time.increase(SEVENTY_TWO_HOURS + 1);
+    await daoProposals.connect(owner).triggerExecutionCheck(proposalId);
+
+    state = await getProposalState(proposalId);
     expect(state.executed).to.equal(true);
   });
 });

--- a/packages/storage-evm/test/ProposalVotingComprehensive.test.ts
+++ b/packages/storage-evm/test/ProposalVotingComprehensive.test.ts
@@ -2829,11 +2829,21 @@ describe('Comprehensive Proposal Creation and Voting Tests with Delegation', fun
         true, // transferable
         false, // fixedMaxSupply
         true, // autoMinting
-        0, // priceInUSD
+        0, // tokenPrice
+        ethers.ZeroAddress, // priceCurrencyFeed (USD)
         false, // useTransferWhitelist
         false, // useReceiveWhitelist
         [], // initialTransferWhitelist
         [], // initialReceiveWhitelist
+        [], // initialTransferWhitelistSpaceIds
+        [], // initialReceiveWhitelistSpaceIds
+        0, // defaultCreditLimit
+        [], // initialCreditWhitelistSpaceIds
+        ethers.ZeroAddress, // paymentToken
+        0, // paymentTokenPricePerToken
+        0, // tokensForSale
+        0, // purchaseEligibilityMode
+        [], // initialPurchaseWhitelistSpaceIds
       );
       const receipt = await tx.wait();
 
@@ -2979,15 +2989,18 @@ describe('Comprehensive Proposal Creation and Voting Tests with Delegation', fun
       await daoProposals.connect(owner).createProposal(proposalParams);
       const proposalId = await daoProposals.proposalCounter();
 
-      // Voting should succeed even without an active subscription
+      // Voting should succeed even without an active subscription.
+      // The second vote is "no" so quorum+unity don't trigger execution of the
+      // mock HyphaToken calldata (which would revert inside the Executor).
       await expect(daoProposals.connect(members[0]).vote(proposalId, true)).to
         .not.be.reverted;
 
-      await expect(daoProposals.connect(members[1]).vote(proposalId, true)).to
+      await expect(daoProposals.connect(members[1]).vote(proposalId, false)).to
         .not.be.reverted;
 
       const proposalState = await daoProposals.getProposalCore(proposalId);
-      expect(proposalState.yesVotes).to.equal(2);
+      expect(proposalState.yesVotes).to.equal(1);
+      expect(proposalState.noVotes).to.equal(1);
 
       console.log(
         `✅ Successfully voted on proposal targeting HyphaToken without subscription`,
@@ -3107,11 +3120,19 @@ describe('Comprehensive Proposal Creation and Voting Tests with Delegation', fun
             0, // maxSupply (0 = unlimited)
             false, // fixedMaxSupply
             true, // autoMinting
-            0, // priceInUSD
+            0, // tokenPrice
+            ethers.ZeroAddress, // priceCurrencyFeed (USD)
             false, // useTransferWhitelist
             false, // useReceiveWhitelist
             [], // initialTransferWhitelist
             [], // initialReceiveWhitelist
+            [], // initialTransferWhitelistSpaceIds
+            [], // initialReceiveWhitelistSpaceIds
+            ethers.ZeroAddress, // paymentToken
+            0, // paymentTokenPricePerToken
+            0, // tokensForSale
+            0, // purchaseEligibilityMode
+            [], // initialPurchaseWhitelistSpaceIds
           );
         const receipt = await tx.wait();
         const tokenDeployedEvent = receipt?.logs
@@ -3177,7 +3198,7 @@ describe('Comprehensive Proposal Creation and Voting Tests with Delegation', fun
         // Try to transfer as the member
         await expect(
           ownershipToken.connect(member).transfer(recipient.address, amount),
-        ).to.be.revertedWith('Only executor can transfer tokens');
+        ).to.be.revertedWith('!executor');
       });
 
       it('should prevent executor from transferring to a non-member', async function () {
@@ -3187,7 +3208,7 @@ describe('Comprehensive Proposal Creation and Voting Tests with Delegation', fun
           ownershipToken
             .connect(executorSigner)
             .transfer(nonMember.address, amount),
-        ).to.be.revertedWith('Can only transfer to space members');
+        ).to.be.revertedWith('!member');
       });
 
       it('should allow executor to use transferFrom for their own tokens, minting if needed', async function () {
@@ -3264,7 +3285,7 @@ describe('Comprehensive Proposal Creation and Voting Tests with Delegation', fun
           ownershipToken
             .connect(executorSigner)
             .transferFrom(sender.address, nonMember.address, amount),
-        ).to.be.revertedWith('Can only transfer to space members');
+        ).to.be.revertedWith('!member');
       });
 
       it('should prevent a non-executor from calling transferFrom', async function () {
@@ -3283,7 +3304,7 @@ describe('Comprehensive Proposal Creation and Voting Tests with Delegation', fun
           ownershipToken
             .connect(sender)
             .transferFrom(sender.address, recipient.address, amount),
-        ).to.be.revertedWith('Only executor can transfer tokens');
+        ).to.be.revertedWith('!executor');
       });
     });
 
@@ -3332,13 +3353,21 @@ describe('Comprehensive Proposal Creation and Voting Tests with Delegation', fun
             transferable,
             false, // fixedMaxSupply
             true, // autoMinting
-            0, // priceInUSD
+            0, // tokenPrice
+            ethers.ZeroAddress, // priceCurrencyFeed (USD)
             false, // useTransferWhitelist
             false, // useReceiveWhitelist
             [], // initialTransferWhitelist
             [], // initialReceiveWhitelist
+            [], // initialTransferWhitelistSpaceIds
+            [], // initialReceiveWhitelistSpaceIds
             100, // 1% decay (100 basis points)
             60 * 60, // per hour
+            ethers.ZeroAddress, // paymentToken
+            0, // paymentTokenPricePerToken
+            0, // tokensForSale
+            0, // purchaseEligibilityMode
+            [], // initialPurchaseWhitelistSpaceIds
           );
         const receipt = await tx.wait();
         const tokenDeployedEvent = receipt?.logs
@@ -3380,7 +3409,7 @@ describe('Comprehensive Proposal Creation and Voting Tests with Delegation', fun
 
         await expect(
           decayingToken.connect(sender).transfer(recipient.address, amount),
-        ).to.be.revertedWith('Token transfers are disabled');
+        ).to.be.revertedWith('!transferable');
       });
 
       it('should allow non-executor to transfer when enabled', async function () {
@@ -4226,10 +4255,20 @@ describe('Comprehensive Proposal Creation and Voting Tests with Delegation', fun
             false,
             true,
             0,
+            ethers.ZeroAddress, // priceCurrencyFeed (USD)
             false,
             false,
             [], // initialTransferWhitelist
             [], // initialReceiveWhitelist
+            [], // initialTransferWhitelistSpaceIds
+            [], // initialReceiveWhitelistSpaceIds
+            0, // defaultCreditLimit
+            [], // initialCreditWhitelistSpaceIds
+            ethers.ZeroAddress, // paymentToken
+            0, // paymentTokenPricePerToken
+            0, // tokensForSale
+            0, // purchaseEligibilityMode
+            [], // initialPurchaseWhitelistSpaceIds
           );
         const receipt = await tx.wait();
         const tokenDeployedEvent = receipt?.logs
@@ -4353,10 +4392,20 @@ describe('Comprehensive Proposal Creation and Voting Tests with Delegation', fun
             false,
             true,
             0,
+            ethers.ZeroAddress, // priceCurrencyFeed (USD)
             false,
             false,
             [], // initialTransferWhitelist
             [], // initialReceiveWhitelist
+            [], // initialTransferWhitelistSpaceIds
+            [], // initialReceiveWhitelistSpaceIds
+            0, // defaultCreditLimit
+            [], // initialCreditWhitelistSpaceIds
+            ethers.ZeroAddress, // paymentToken
+            0, // paymentTokenPricePerToken
+            0, // tokensForSale
+            0, // purchaseEligibilityMode
+            [], // initialPurchaseWhitelistSpaceIds
           );
         const receipt = await tx.wait();
         const tokenDeployedEvent = receipt?.logs
@@ -4495,12 +4544,20 @@ describe('Comprehensive Proposal Creation and Voting Tests with Delegation', fun
             false,
             true,
             0,
+            ethers.ZeroAddress, // priceCurrencyFeed (USD)
             false,
             false,
             [], // initialTransferWhitelist
             [], // initialReceiveWhitelist
+            [], // initialTransferWhitelistSpaceIds
+            [], // initialReceiveWhitelistSpaceIds
             100, // 1% decay
             3600, // per hour
+            ethers.ZeroAddress, // paymentToken
+            0, // paymentTokenPricePerToken
+            0, // tokensForSale
+            0, // purchaseEligibilityMode
+            [], // initialPurchaseWhitelistSpaceIds
           );
         const receipt = await tx.wait();
         const tokenDeployedEvent = receipt?.logs
@@ -4618,12 +4675,20 @@ describe('Comprehensive Proposal Creation and Voting Tests with Delegation', fun
             false,
             true,
             0,
+            ethers.ZeroAddress, // priceCurrencyFeed (USD)
             false,
             false,
             [], // initialTransferWhitelist
             [], // initialReceiveWhitelist
+            [], // initialTransferWhitelistSpaceIds
+            [], // initialReceiveWhitelistSpaceIds
             1000, // 10% decay per interval
             3600,
+            ethers.ZeroAddress, // paymentToken
+            0, // paymentTokenPricePerToken
+            0, // tokensForSale
+            0, // purchaseEligibilityMode
+            [], // initialPurchaseWhitelistSpaceIds
           );
         const receipt = await tx.wait();
         const tokenDeployedEvent = receipt?.logs
@@ -4742,10 +4807,20 @@ describe('Comprehensive Proposal Creation and Voting Tests with Delegation', fun
             false,
             true,
             0,
+            ethers.ZeroAddress, // priceCurrencyFeed (USD)
             false,
             false,
-            [],
-            [],
+            [], // initialTransferWhitelist
+            [], // initialReceiveWhitelist
+            [], // initialTransferWhitelistSpaceIds
+            [], // initialReceiveWhitelistSpaceIds
+            0, // defaultCreditLimit
+            [], // initialCreditWhitelistSpaceIds
+            ethers.ZeroAddress, // paymentToken
+            0, // paymentTokenPricePerToken
+            0, // tokensForSale
+            0, // purchaseEligibilityMode
+            [], // initialPurchaseWhitelistSpaceIds
           );
         const receipt = await tx.wait();
         const tokenDeployedEvent = receipt?.logs
@@ -4906,10 +4981,20 @@ describe('Comprehensive Proposal Creation and Voting Tests with Delegation', fun
             false,
             true,
             0,
+            ethers.ZeroAddress, // priceCurrencyFeed (USD)
             false,
             false,
-            [],
-            [],
+            [], // initialTransferWhitelist
+            [], // initialReceiveWhitelist
+            [], // initialTransferWhitelistSpaceIds
+            [], // initialReceiveWhitelistSpaceIds
+            0, // defaultCreditLimit
+            [], // initialCreditWhitelistSpaceIds
+            ethers.ZeroAddress, // paymentToken
+            0, // paymentTokenPricePerToken
+            0, // tokensForSale
+            0, // purchaseEligibilityMode
+            [], // initialPurchaseWhitelistSpaceIds
           );
         const receipt = await tx.wait();
         const tokenDeployedEvent = receipt?.logs
@@ -5043,10 +5128,20 @@ describe('Comprehensive Proposal Creation and Voting Tests with Delegation', fun
             false,
             true,
             0,
+            ethers.ZeroAddress, // priceCurrencyFeed (USD)
             false,
             false,
-            [],
-            [],
+            [], // initialTransferWhitelist
+            [], // initialReceiveWhitelist
+            [], // initialTransferWhitelistSpaceIds
+            [], // initialReceiveWhitelistSpaceIds
+            0, // defaultCreditLimit
+            [], // initialCreditWhitelistSpaceIds
+            ethers.ZeroAddress, // paymentToken
+            0, // paymentTokenPricePerToken
+            0, // tokensForSale
+            0, // purchaseEligibilityMode
+            [], // initialPurchaseWhitelistSpaceIds
           );
         const receipt = await tx.wait();
         const tokenDeployedEvent = receipt?.logs
@@ -5173,10 +5268,20 @@ describe('Comprehensive Proposal Creation and Voting Tests with Delegation', fun
             false,
             true,
             0,
+            ethers.ZeroAddress, // priceCurrencyFeed (USD)
             false,
             false,
-            [],
-            [],
+            [], // initialTransferWhitelist
+            [], // initialReceiveWhitelist
+            [], // initialTransferWhitelistSpaceIds
+            [], // initialReceiveWhitelistSpaceIds
+            0, // defaultCreditLimit
+            [], // initialCreditWhitelistSpaceIds
+            ethers.ZeroAddress, // paymentToken
+            0, // paymentTokenPricePerToken
+            0, // tokensForSale
+            0, // purchaseEligibilityMode
+            [], // initialPurchaseWhitelistSpaceIds
           );
         const receipt = await tx.wait();
         const tokenDeployedEvent = receipt?.logs
@@ -5328,10 +5433,20 @@ describe('Comprehensive Proposal Creation and Voting Tests with Delegation', fun
             false,
             true,
             0,
+            ethers.ZeroAddress, // priceCurrencyFeed (USD)
             false,
             false,
-            [],
-            [],
+            [], // initialTransferWhitelist
+            [], // initialReceiveWhitelist
+            [], // initialTransferWhitelistSpaceIds
+            [], // initialReceiveWhitelistSpaceIds
+            0, // defaultCreditLimit
+            [], // initialCreditWhitelistSpaceIds
+            ethers.ZeroAddress, // paymentToken
+            0, // paymentTokenPricePerToken
+            0, // tokensForSale
+            0, // purchaseEligibilityMode
+            [], // initialPurchaseWhitelistSpaceIds
           );
         const receipt = await tx.wait();
         const tokenDeployedEvent = receipt?.logs
@@ -5395,9 +5510,11 @@ describe('Comprehensive Proposal Creation and Voting Tests with Delegation', fun
           .connect(executorSigner)
           .mint(members[0].address, ethers.parseEther('200'));
 
-        // Vote to exceed snapshot
+        // Vote to exceed snapshot. The vote must be contested (one NO, cast
+        // first): a unanimous-yes full participation now executes immediately,
+        // bypassing the minimum duration by design.
+        await daoProposals.connect(members[1]).vote(proposalId, false); // 100 NO
         await daoProposals.connect(owner).vote(proposalId, true); // 300 YES
-        await daoProposals.connect(members[0]).vote(proposalId, true); // 300 YES
 
         let proposalState = await daoProposals.getProposalCore(proposalId);
         console.log(
@@ -5633,10 +5750,20 @@ describe('Comprehensive Proposal Creation and Voting Tests with Delegation', fun
             false,
             true,
             0,
+            ethers.ZeroAddress, // priceCurrencyFeed (USD)
             false,
             false,
-            [],
-            [],
+            [], // initialTransferWhitelist
+            [], // initialReceiveWhitelist
+            [], // initialTransferWhitelistSpaceIds
+            [], // initialReceiveWhitelistSpaceIds
+            0, // defaultCreditLimit
+            [], // initialCreditWhitelistSpaceIds
+            ethers.ZeroAddress, // paymentToken
+            0, // paymentTokenPricePerToken
+            0, // tokensForSale
+            0, // purchaseEligibilityMode
+            [], // initialPurchaseWhitelistSpaceIds
           );
         const receipt = await tx.wait();
         const tokenDeployedEvent = receipt?.logs
@@ -5761,10 +5888,20 @@ describe('Comprehensive Proposal Creation and Voting Tests with Delegation', fun
             false,
             true,
             0,
+            ethers.ZeroAddress, // priceCurrencyFeed (USD)
             false,
             false,
-            [],
-            [],
+            [], // initialTransferWhitelist
+            [], // initialReceiveWhitelist
+            [], // initialTransferWhitelistSpaceIds
+            [], // initialReceiveWhitelistSpaceIds
+            0, // defaultCreditLimit
+            [], // initialCreditWhitelistSpaceIds
+            ethers.ZeroAddress, // paymentToken
+            0, // paymentTokenPricePerToken
+            0, // tokensForSale
+            0, // purchaseEligibilityMode
+            [], // initialPurchaseWhitelistSpaceIds
           );
         const receipt = await tx.wait();
         const tokenDeployedEvent = receipt?.logs


### PR DESCRIPTION
## Summary

- When **100% of a space's voting power has voted yes**, the proposal now executes immediately instead of waiting out the minimum proposal duration (default 72h for spaces with quorum < 20%). No remaining or dissenting voting power could change the outcome, so there is nothing to wait for.
- The change is deliberately scoped to **unanimous approval only**:
  - Contested full participation (any "no" votes) still waits out the minimum duration, preserving the window for voters to change their vote (`VoteChanged` flow).
  - Unanimous "no" still waits as well — rejection is never fast-tracked.
  - Spaces without a minimum duration (quorum >= 20%) keep their existing immediate quorum+unity execution behavior.
- `vote()` already calls `checkAndExecuteProposal` after every ballot, so the final voter's transaction triggers execution automatically — no keeper or cron needed.

## Implementation notes

- ~10-line change in `checkAndExecuteProposal` in `DAOProposalsImplementation.sol` (UUPS upgradeable — deployable as a proxy upgrade, no storage layout changes).
- `unanimousApproval` requires `yesVotes > 0`, so a zero-voting-power snapshot can never instantly execute via `triggerExecutionCheck`.
- Note: `totalVotingPowerAtSnapshot` is snapshotted at proposal creation, so this fast path is most relevant for 1-member-1-vote spaces; token-weighted (especially decay-token) spaces will rarely hit exactly 100% participation.

## Testing

New suite `test/ProposalUnanimousEarlyExecution.test.ts` (6 passing):
- Unanimous yes with full participation executes instantly on the final vote.
- Quorum+unity without full participation still waits.
- Contested full participation still waits, then resolves after the minimum duration.
- A dissenting voter flipping to yes (making it unanimous) triggers instant execution.
- Unanimous no never fast-tracks; rejects only after the minimum duration.
- Quorum >= 20% spaces keep existing immediate execution.

### ProposalVotingComprehensive suite repaired

The suite had 18 pre-existing failures on `main`; this PR also fixes them (**93 passing, 0 failing**):
- Updated `deployToken` / `deployOwnershipToken` / `deployDecayingToken` calls to the current factory signatures (`priceCurrencyFeed`, whitelist space IDs, credit, and payment/sale parameters).
- Updated revert-message assertions to the shortened contract messages (`!executor`, `!member`, `!transferable`).
- HyphaToken voting bypass test: second vote is now NO so quorum+unity don't execute the mock HyphaToken calldata, which reverts inside the Executor on the mainnet fork.
- "Min duration respected when votes exceed snapshot": the overshoot is now contested (NO cast first), since unanimous-yes full participation executes immediately by design in this PR.

## Deployment

Not deployed — contract change only, ready for review. Rolling out requires a UUPS proxy upgrade of `DAOProposalsImplementation` on Base.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Proposals can now execute immediately upon unanimous approval with full voter participation, bypassing the standard minimum duration requirement.
  * Execution timing dynamically adjusts based on voting unanimity and participation levels.

* **Tests**
  * Added comprehensive test coverage for unanimous voting scenarios and execution timing rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->