### PR TITLE
fix(treasury): show full transfer history and fix 500 on busy profiles

### DIFF
--- a/apps/web/src/app/api/v1/people/[personSlug]/transactions/route.ts
+++ b/apps/web/src/app/api/v1/people/[personSlug]/transactions/route.ts
@@ -10,11 +10,10 @@ import {
   TokenType,
 } from '@hypha-platform/core/client';
 import {
-  findPersonByWeb3Address,
-  findSpaceByAddress,
+  findPeopleByWeb3Addresses,
+  findSpaceByAddresses,
 } from '@hypha-platform/core/server';
 import { findPersonBySlug, getDb } from '@hypha-platform/core/server';
-import { zeroAddress } from 'viem';
 import { hasEmojiOrLink, tryDecodeUriPart } from '@hypha-platform/ui-utils';
 import { ProfileRouteParams } from '@hypha-platform/epics';
 import { findAllTransfers } from '@hypha-platform/core/server';
@@ -28,7 +27,7 @@ import { findAllTransfers } from '@hypha-platform/core/server';
  * - toDate: timestamp of the end date from which to get the transfers. Optional
  * - fromBlock: the minimum block number from which to get the transfers. Optional
  * - toBlock: the maximum block number from which to get the transfers. Optional
- * - limit: the desired number of the result. Not greater than 50. Defaults to 10
+ * - limit: the desired number of the result. Not greater than 50. When omitted, all available transfers are returned
  */
 
 export async function GET(
@@ -105,60 +104,118 @@ export async function GET(
       address: token.address ?? undefined,
     }));
 
-    const transfersWithEntityInfo = await Promise.all(
-      transfers.map(async (transfer) => {
-        const tokenMeta = await getTokenMeta(
-          transfer.token as `0x${string}`,
-          dbTokens,
-        );
-        const name = tokenMeta.name || 'Unnamed';
-        const symbol = tokenMeta.symbol || 'UNKNOWN';
-        if (hasEmojiOrLink(name) || hasEmojiOrLink(symbol)) {
-          return null;
-        }
-
-        const isIncoming = transfer.to.toUpperCase() === address.toUpperCase();
-        const counterpartyAddress = isIncoming ? transfer.from : transfer.to;
-        let person = null;
-        let space = null;
-        const tokenIcon = tokenMeta.icon;
-
-        person = await findPersonByWeb3Address(
-          { address: counterpartyAddress },
-          { db: getDb({ authToken }) },
-        );
-        if (!person) {
-          space = await findSpaceByAddress(
-            { address: counterpartyAddress },
-            { db: getDb({ authToken }) },
+    // Resolve token metadata once per unique token. Resolving it per transfer
+    // fires one on-chain multicall per transfer, which fails with rate-limit
+    // errors on profiles with long transfer histories. Tokens whose metadata
+    // can't be resolved (e.g. spam tokens without symbol/name) are skipped
+    // instead of failing the whole response.
+    const uniqueTokenAddresses = Array.from(
+      new Set(transfers.map((transfer) => transfer.token.toLowerCase())),
+    );
+    const tokenMetaByAddress = new Map<
+      string,
+      Awaited<ReturnType<typeof getTokenMeta>>
+    >();
+    await Promise.all(
+      uniqueTokenAddresses.map(async (tokenAddress) => {
+        try {
+          const meta = await getTokenMeta(
+            tokenAddress as `0x${string}`,
+            dbTokens,
+          );
+          tokenMetaByAddress.set(tokenAddress, meta);
+        } catch (error) {
+          console.warn(
+            `Skipping token with unresolvable metadata: ${tokenAddress}`,
+            error,
           );
         }
-
-        const memo =
-          memoMap.get(transfer.transaction_hash.toLowerCase()) || null;
-
-        return {
-          ...transfer,
-          memo,
-          person: person
-            ? {
-                name: person.name,
-                surname: person.surname,
-                avatarUrl: person.avatarUrl,
-              }
-            : undefined,
-          space: space
-            ? {
-                title: space.title,
-                avatarUrl: space.logoUrl,
-              }
-            : undefined,
-          tokenIcon,
-          direction: isIncoming ? 'incoming' : 'outgoing',
-          counterparty: isIncoming ? 'from' : 'to',
-        };
       }),
     );
+
+    // Batch-resolve counterparties: one DB query for people and one for
+    // spaces, instead of up to two queries per transfer.
+    const uniqueCounterparties = Array.from(
+      new Set(
+        transfers.map((transfer) => {
+          const isIncoming =
+            transfer.to.toUpperCase() === address.toUpperCase();
+          return (isIncoming ? transfer.from : transfer.to).toUpperCase();
+        }),
+      ),
+    );
+    const counterpartyPeople = await findPeopleByWeb3Addresses(
+      { addresses: uniqueCounterparties },
+      { db: getDb({ authToken }) },
+    );
+    const personByAddress = new Map(
+      counterpartyPeople
+        .filter((person) => person.address)
+        .map((person) => [(person.address as string).toUpperCase(), person]),
+    );
+    const unmatchedAddresses = uniqueCounterparties.filter(
+      (counterparty) => !personByAddress.has(counterparty),
+    );
+    const counterpartySpaces =
+      unmatchedAddresses.length > 0
+        ? (
+            await findSpaceByAddresses(
+              unmatchedAddresses,
+              {},
+              { db: getDb({ authToken }) },
+            )
+          ).data
+        : [];
+    const spaceByAddress = new Map(
+      counterpartySpaces
+        .filter((space) => space.address)
+        .map((space) => [(space.address as string).toUpperCase(), space]),
+    );
+
+    const transfersWithEntityInfo = transfers.map((transfer) => {
+      const tokenMeta = tokenMetaByAddress.get(transfer.token.toLowerCase());
+      if (!tokenMeta) {
+        return null;
+      }
+      const name = tokenMeta.name || 'Unnamed';
+      const symbol = tokenMeta.symbol || 'UNKNOWN';
+      if (hasEmojiOrLink(name) || hasEmojiOrLink(symbol)) {
+        return null;
+      }
+
+      const isIncoming = transfer.to.toUpperCase() === address.toUpperCase();
+      const counterpartyAddress = (
+        isIncoming ? transfer.from : transfer.to
+      ).toUpperCase();
+      const person = personByAddress.get(counterpartyAddress) ?? null;
+      const space = person
+        ? null
+        : spaceByAddress.get(counterpartyAddress) ?? null;
+      const tokenIcon = tokenMeta.icon;
+
+      const memo = memoMap.get(transfer.transaction_hash.toLowerCase()) || null;
+
+      return {
+        ...transfer,
+        memo,
+        person: person
+          ? {
+              name: person.name,
+              surname: person.surname,
+              avatarUrl: person.avatarUrl,
+            }
+          : undefined,
+        space: space
+          ? {
+              title: space.title,
+              avatarUrl: space.logoUrl,
+            }
+          : undefined,
+        tokenIcon,
+        direction: isIncoming ? 'incoming' : 'outgoing',
+        counterparty: isIncoming ? 'from' : 'to',
+      };
+    });
 
     const validTransfers = transfersWithEntityInfo.filter((t) => t !== null);
 

--- a/apps/web/src/app/api/v1/spaces/[spaceSlug]/transfers/route.ts
+++ b/apps/web/src/app/api/v1/spaces/[spaceSlug]/transfers/route.ts
@@ -9,9 +9,9 @@ import {
   findSpaceBySlug,
   getTransfersByAddress,
   getMintTransfersByTokens,
-  findSpaceByAddress,
+  findSpaceByAddresses,
   getTokenMeta,
-  findPersonByWeb3Address,
+  findPeopleByWeb3Addresses,
   findAllTokens,
   findAllTransfers,
   web3Client,
@@ -34,8 +34,8 @@ import { checkSpaceAccess } from '@web/utils/check-space-access';
  * @param fromBlock The minimum block number from which to get transfers.
  *        Optional
  * @param toBlock The maximum block number from which to get transfers. Optional
- * @param limit The desired number of the result. Not greater than 50. Defaults
- *        to 10
+ * @param limit The desired number of the result. Not greater than 50. When
+ *        omitted, all available transfers are returned
  */
 export async function GET(
   request: NextRequest,
@@ -135,8 +135,8 @@ export async function GET(
     const fromTime = fromDate?.getTime();
     const toTime = toDate?.getTime();
 
-    // Enforce the requested limit on the merged set; otherwise the response
-    // could contain up to `limit` address-based transfers plus all mints.
+    // Enforce the limit on the merged set only when the caller requested one;
+    // `slice(0, undefined)` keeps the full history.
     const allTransfers = [...transfers, ...mintTransfers]
       .filter(
         (transfer) =>
@@ -161,57 +161,114 @@ export async function GET(
       address: token.address ?? undefined,
     }));
 
-    const transfersWithEntityInfo = await Promise.all(
-      allTransfers.map(async (transfer) => {
-        const isIncoming =
-          transfer.to.toUpperCase() === spaceAddress.toUpperCase();
-        const direction = isIncoming ? 'incoming' : 'outgoing';
-        const counterparty = isIncoming ? 'from' : 'to';
-
-        const meta = await getTokenMeta(
-          transfer.token as `0x${string}`,
-          dbTokens,
-        );
-        const name = meta.name || 'Unnamed';
-        const symbol = meta.symbol || 'UNKNOWN';
-        if (hasEmojiOrLink(name) || hasEmojiOrLink(symbol)) {
-          return null;
+    // Resolve token metadata once per unique token. Resolving it per transfer
+    // fires one on-chain multicall per transfer, which fails with rate-limit
+    // errors on spaces with long transfer histories. Tokens whose metadata
+    // can't be resolved (e.g. spam tokens without symbol/name) are skipped
+    // instead of failing the whole response.
+    const uniqueTokenAddresses = Array.from(
+      new Set(allTransfers.map((transfer) => transfer.token.toLowerCase())),
+    );
+    const tokenMetaByAddress = new Map<
+      string,
+      Awaited<ReturnType<typeof getTokenMeta>>
+    >();
+    await Promise.all(
+      uniqueTokenAddresses.map(async (tokenAddress) => {
+        try {
+          const meta = await getTokenMeta(
+            tokenAddress as `0x${string}`,
+            dbTokens,
+          );
+          tokenMetaByAddress.set(tokenAddress, meta);
+        } catch (error) {
+          console.warn(
+            `Skipping token with unresolvable metadata: ${tokenAddress}`,
+            error,
+          );
         }
-
-        const counterpartyAddress = isIncoming ? transfer.from : transfer.to;
-        const person =
-          (await findPersonByWeb3Address(
-            { address: counterpartyAddress },
-            { db },
-          )) || undefined;
-        const space = person
-          ? undefined
-          : (await findSpaceByAddress(
-              { address: counterpartyAddress },
-              { db },
-            )) || undefined;
-
-        const memo =
-          memoMap.get(transfer.transaction_hash.toLowerCase()) || null;
-
-        return {
-          ...transfer,
-          memo,
-          tokenIcon: meta.icon,
-          person: person && {
-            name: person.name,
-            surname: person.surname,
-            avatarUrl: person.avatarUrl,
-          },
-          space: space && {
-            title: space.title,
-            avatarUrl: space.logoUrl,
-          },
-          direction,
-          counterparty,
-        };
       }),
     );
+
+    // Batch-resolve counterparties: one DB query for people and one for
+    // spaces, instead of up to two queries per transfer.
+    const uniqueCounterparties = Array.from(
+      new Set(
+        allTransfers.map((transfer) => {
+          const isIncoming =
+            transfer.to.toUpperCase() === spaceAddress.toUpperCase();
+          return (isIncoming ? transfer.from : transfer.to).toUpperCase();
+        }),
+      ),
+    );
+    const counterpartyPeople = await findPeopleByWeb3Addresses(
+      { addresses: uniqueCounterparties },
+      { db },
+    );
+    const personByAddress = new Map(
+      counterpartyPeople
+        .filter((person) => person.address)
+        .map((person) => [(person.address as string).toUpperCase(), person]),
+    );
+    const unmatchedAddresses = uniqueCounterparties.filter(
+      (counterparty) => !personByAddress.has(counterparty),
+    );
+    const counterpartySpaces =
+      unmatchedAddresses.length > 0
+        ? (await findSpaceByAddresses(unmatchedAddresses, {}, { db })).data
+        : [];
+    const spaceByAddress = new Map(
+      counterpartySpaces
+        .filter((counterpartySpace) => counterpartySpace.address)
+        .map((counterpartySpace) => [
+          (counterpartySpace.address as string).toUpperCase(),
+          counterpartySpace,
+        ]),
+    );
+
+    const transfersWithEntityInfo = allTransfers.map((transfer) => {
+      const isIncoming =
+        transfer.to.toUpperCase() === spaceAddress.toUpperCase();
+      const direction = isIncoming ? 'incoming' : 'outgoing';
+      const counterparty = isIncoming ? 'from' : 'to';
+
+      const meta = tokenMetaByAddress.get(transfer.token.toLowerCase());
+      if (!meta) {
+        return null;
+      }
+      const name = meta.name || 'Unnamed';
+      const symbol = meta.symbol || 'UNKNOWN';
+      if (hasEmojiOrLink(name) || hasEmojiOrLink(symbol)) {
+        return null;
+      }
+
+      const counterpartyAddress = (
+        isIncoming ? transfer.from : transfer.to
+      ).toUpperCase();
+      const person = personByAddress.get(counterpartyAddress);
+      const counterpartySpace = person
+        ? undefined
+        : spaceByAddress.get(counterpartyAddress);
+
+      const memo = memoMap.get(transfer.transaction_hash.toLowerCase()) || null;
+
+      return {
+        ...transfer,
+        memo,
+        tokenIcon: meta.icon,
+        person: person && {
+          name: person.name,
+          surname: person.surname,
+          avatarUrl: person.avatarUrl,
+        },
+        space: counterpartySpace && {
+          title: counterpartySpace.title,
+          avatarUrl: counterpartySpace.logoUrl,
+        },
+        direction,
+        counterparty,
+      };
+    });
 
     const validTransfers = transfersWithEntityInfo.filter((t) => t !== null);
 

--- a/packages/core/src/common/server/get-transfers-by-address.ts
+++ b/packages/core/src/common/server/get-transfers-by-address.ts
@@ -171,8 +171,9 @@ export async function getMintTransfersByTokens({
     // contain only the oldest mints and newly minted transfers would never
     // appear. Request newest-first so the page holds the most recent mints.
     order: SortingOrder.DESCENDING,
-    // Bound the result set so a token with many mint events can't trigger an
-    // unbounded fetch; callers pass their requested limit here.
+    // Bound the result set when the caller requested a limit. When undefined,
+    // Alchemy falls back to its page maximum (1000), matching the behavior of
+    // the address-based queries above.
     maxCount: limit,
   });
 

--- a/packages/core/src/people/server/queries.ts
+++ b/packages/core/src/people/server/queries.ts
@@ -171,7 +171,6 @@ export const findPeopleByWeb3Addresses = async (
   if (addresses.length === 0) return [];
 
   const upperAddresses = addresses.map((addr) => addr.toUpperCase());
-  console.debug('upperAddresses', upperAddresses);
   const dbPeople = await db
     .select()
     .from(people)

--- a/packages/core/src/transaction/validate.ts
+++ b/packages/core/src/transaction/validate.ts
@@ -26,5 +26,6 @@ export const schemaGetTransfersQuery = z.object({
   toDate: stringifiedDate.optional().catch(undefined),
   fromBlock: blockNumber.optional().catch(undefined),
   toBlock: blockNumber.optional().catch(undefined),
-  limit: z.coerce.number().int().min(1).max(50).catch(10),
+  // No default: when omitted, routes return the full transfer history.
+  limit: z.coerce.number().int().min(1).max(50).optional().catch(undefined),
 });


### PR DESCRIPTION
## Summary

- **Space treasury showed only the latest 10 transactions.** PR #2306 started enforcing the transfers `limit` query param, and its schema default of 10 capped the list (the treasury UI never sends a limit). `limit` is now optional with no default — omitting it returns the full history, explicit limits (max 50) still work.
- **Profile transactions returned 500 on profiles with long histories** (e.g. `cometogether` on production). The route enriched every transfer in parallel with its own on-chain multicall for token metadata plus up to two DB queries for the counterparty — thousands of simultaneous RPC/Neon calls for one page load. Additionally, a single token with unresolvable metadata (spam tokens) threw and failed the whole response.
- Both the profile transactions route and the space transfers route now resolve token metadata **once per unique token** (skipping unresolvable tokens with a warning instead of failing) and resolve counterparties with **two batched DB queries** (`findPeopleByWeb3Addresses` + `findSpaceByAddresses`) instead of up to two per transfer.

For a profile with 1000 transfers across 5 tokens and 200 unique counterparties: ~5 RPC calls + 2 DB queries instead of ~3000 calls.

## Notes

- Alchemy returns at most 1000 results per query without pagination, so "full history" is effectively the newest 1000 per query branch — same as the behavior before #2306. `pageKey` pagination can be added later if a space outgrows that.
- `findSpaceByAddresses` excludes archived spaces, so transfers whose counterparty is an archived space no longer display that space's title/avatar.
- Also removed a `console.debug` in `findPeopleByWeb3Addresses` that would log up to 1000 addresses per request.

## Test plan

- [ ] Open a space treasury with more than 10 transactions — all historical transfers are listed
- [ ] Open the `cometogether` profile — transactions load without a 500
- [ ] Verify transfer rows still show counterparty person/space names, avatars, token icons, and memos
- [ ] Verify an explicit `?limit=5` on `/api/v1/spaces/{slug}/transfers` returns 5 results

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized transaction and transfer API endpoints to reduce database and blockchain lookups, improving response speed.

* **API Changes**
  * Updated transaction limit parameter behavior to return full history when omitted instead of defaulting to 10 results.

* **Bug Fixes**
  * Improved robustness in token metadata resolution to prevent API failures when metadata for specific tokens cannot be retrieved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->