### PR TITLE
fix(governance): always show delegated voting member when logged out

### DIFF
--- a/packages/epics/src/governance/hooks/use-person-by-web3-address.ts
+++ b/packages/epics/src/governance/hooks/use-person-by-web3-address.ts
@@ -19,12 +19,15 @@ export const usePersonByWeb3Address = (
     [address],
   );
 
+  // The endpoint is public, so we fetch regardless of auth state. This ensures
+  // person data (e.g. the delegated voting member) is shown even when the
+  // viewer is logged out. The JWT is forwarded only when it is available.
   const { data: person, isLoading } = useSWR(
-    jwt ? [endpoint, jwt] : null,
+    address ? [endpoint, jwt] : null,
     ([endpoint]) =>
       fetch(endpoint, {
         headers: {
-          Authorization: `Bearer ${jwt}`,
+          ...(jwt ? { Authorization: `Bearer ${jwt}` } : {}),
           'Content-Type': 'application/json',
         },
       }).then((res) => res.json()),


### PR DESCRIPTION
## Summary

- The "Delegated Voting Member" (and any person resolved from a web3 address) sometimes did not appear on the proposal view — specifically when the viewer was not logged in.
- Root cause: `usePersonByWeb3Address` gated its SWR fetch on a JWT being present (`jwt ? [endpoint, jwt] : null`). With no JWT, SWR never fetched and the person never resolved, leaving only the placeholder avatar.
- The underlying endpoint `GET /api/v1/people/by-web3-address/[address]` is **public** (no auth check), so the gate only suppressed display. This matches the sibling `useSpacesByWeb3IdsClient` hook, which already fetches without a JWT — that's why the governance space rendered but the delegated member did not.

## Changes

- `usePersonByWeb3Address` now fetches whenever an `address` is provided, regardless of auth state, and forwards the `Authorization: Bearer` header only when a JWT is available.

This affects all proposal display components that resolve a person from an address (delegate, mint/burn, membership exit, accept investment, transaction items, etc.), making them consistently render for logged-out viewers.

## Test plan

- [ ] Open a "Change Space Delegate" proposal while logged out — the Delegated Voting Member name + avatar now display.
- [ ] Verify the same while logged in (no regression).
- [ ] Spot-check other proposal types that show person names (mint/burn, membership exit) while logged out.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * User information and delegation data are now accessible to logged-out viewers without requiring authentication. Previously restricted to authenticated sessions, this expanded access improves data visibility and transparency across the platform for all users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->