### PR TITLE
feat(tokens): add API to fetch token icon URL by address

### DIFF
--- a/apps/web/src/app/api/v1/tokens/[token]/image/route.ts
+++ b/apps/web/src/app/api/v1/tokens/[token]/image/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { findTokenByAddress } from '@hypha-platform/core/server';
+import { db } from '@hypha-platform/storage-postgres';
+
+const EVM_ADDRESS = /^0x[a-fA-F0-9]{40}$/i;
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ token: string }> },
+) {
+  const { token } = await params;
+
+  if (!token || !EVM_ADDRESS.test(token)) {
+    return NextResponse.json(
+      { error: 'Valid token address is required' },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const result = await findTokenByAddress(token, { db });
+    if (!result) {
+      return NextResponse.json({ error: 'Token not found' }, { status: 404 });
+    }
+    return NextResponse.json({ iconUrl: result.iconUrl ?? null });
+  } catch (error) {
+    console.error(`Failed to fetch token image for ${token}:`, error);
+    return NextResponse.json(
+      { error: 'Failed to fetch token image' },
+      { status: 500 },
+    );
+  }
+}

--- a/packages/core/src/assets/server/queries.ts
+++ b/packages/core/src/assets/server/queries.ts
@@ -75,3 +75,19 @@ export const findAllTokens = async (
 
   return results;
 };
+
+export const findTokenByAddress = async (address: string, { db }: DbConfig) => {
+  const [token] = await db
+    .select({
+      id: tokens.id,
+      name: tokens.name,
+      symbol: tokens.symbol,
+      address: tokens.address,
+      iconUrl: tokens.iconUrl,
+    })
+    .from(tokens)
+    .where(sql`lower(${tokens.address}) = lower(${address})`)
+    .limit(1);
+
+  return token ?? null;
+};

--- a/packages/storage-evm/scripts/base-mainnet-contracts-scripts/FETCH_TOKEN_SYMBOL_AND_NAME.md
+++ b/packages/storage-evm/scripts/base-mainnet-contracts-scripts/FETCH_TOKEN_SYMBOL_AND_NAME.md
@@ -1,0 +1,93 @@
+# Fetch Token Symbol and Name
+
+A beginner-friendly guide to `fetch-token-symbol-and-name.ts` — a small script that reads a
+token's name, symbol, and decimals directly from the blockchain.
+
+## What "fetching onchain data" means
+
+A smart contract (like an ERC20 token) lives at an **address** on a blockchain. It stores data and
+exposes **functions** you can call. Some functions only *read* data and cost no gas and require no
+wallet/private key — these are called `view` functions. `name()`, `symbol()`, and `decimals()` are
+exactly these kinds of read-only functions.
+
+To read them you need three things:
+
+1. **An RPC URL** — the "phone line" to a blockchain node. You send your request here and it
+   answers. (We use Base Mainnet in this repo.)
+2. **The contract address** — *which* token you want to ask.
+3. **The ABI** — a description of what functions exist and what they return, so the library knows
+   how to encode your question and decode the answer.
+
+## The three building blocks in the code
+
+```typescript
+// 1. The provider = your connection to the blockchain (read-only)
+const provider = new ethers.JsonRpcProvider(process.env.RPC_URL);
+
+// 2. The contract = address + ABI + provider, bundled so you can call its functions
+const token = new ethers.Contract(tokenAddress, tokenAbi, provider);
+
+// 3. Calling the view functions (they return Promises, so we await them)
+const [name, symbol, decimals] = await Promise.all([
+  token.name(),
+  token.symbol(),
+  token.decimals(),
+]);
+```
+
+`Promise.all` just runs the three reads at the same time instead of one after another — faster, same
+result.
+
+### What is the ABI here?
+
+The ABI in this script is a tiny JSON list describing only the three functions we use. Each entry
+says: the function takes no `inputs`, is `view` (read-only), and returns a `string` (for `name`/
+`symbol`) or a `uint8` (for `decimals`). You don't need the token's full ABI — only the parts you
+call.
+
+### Why convert `decimals`?
+
+Numbers from the chain come back as `BigInt`. `decimals` is small, so we turn it into a normal
+number with `Number(decimals)` for easy printing.
+
+## How to run it
+
+You need `RPC_URL` set in a `.env` file in `packages/storage-evm` (Base Mainnet RPC endpoint).
+
+```bash
+# Pass the token address with a flag
+npx tsx fetch-token-symbol-and-name.ts --token 0xYourTokenAddress
+
+# Or as a plain argument
+npx tsx fetch-token-symbol-and-name.ts 0xYourTokenAddress
+
+# Or via an environment variable
+TOKEN_ADDRESS=0xYourTokenAddress npx tsx fetch-token-symbol-and-name.ts
+
+# See all options
+npx tsx fetch-token-symbol-and-name.ts --help
+```
+
+Example output:
+
+```
+=== Token: Hypha Token (HYPHA) ===
+Address: 0xYourTokenAddress
+Name: Hypha Token
+Symbol: HYPHA
+Decimals: 18
+===============
+```
+
+## Common errors
+
+- **`Missing required environment variable: RPC_URL`** — add `RPC_URL` to your `.env`.
+- **`Invalid token address`** — the address is malformed (must be a valid `0x...` address).
+- **`could not decode result data`** — the address isn't an ERC20 token, or it doesn't implement
+  these functions.
+
+## Where to go next
+
+Once you understand reading `view` functions, the next steps are: reading functions that take
+arguments (e.g. `balanceOf(address)`), and *writing* to the chain (which needs a wallet, a private
+key, and costs gas). See the other scripts in this folder for those patterns.

--- a/packages/storage-evm/scripts/base-mainnet-contracts-scripts/fetch-token-symbol-and-name.ts
+++ b/packages/storage-evm/scripts/base-mainnet-contracts-scripts/fetch-token-symbol-and-name.ts
@@ -1,0 +1,135 @@
+import dotenv from 'dotenv';
+import { ethers } from 'ethers';
+
+dotenv.config();
+
+interface TokenMetadataInterface {
+  name: () => Promise<string>;
+  symbol: () => Promise<string>;
+  decimals: () => Promise<bigint>;
+}
+
+// Minimal ERC20 metadata ABI - only the read-only functions we need
+const tokenAbi = [
+  {
+    inputs: [],
+    name: 'name',
+    outputs: [{ internalType: 'string', name: '', type: 'string' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'symbol',
+    outputs: [{ internalType: 'string', name: '', type: 'string' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'decimals',
+    outputs: [{ internalType: 'uint8', name: '', type: 'uint8' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+];
+
+function parseArguments(): { tokenAddress?: string } {
+  const args = process.argv.slice(2);
+  const result: { tokenAddress?: string } = {};
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+
+    if ((arg === '--token' || arg === '--address') && i + 1 < args.length) {
+      result.tokenAddress = args[i + 1];
+      i++; // Skip the value
+    } else if (arg === '--help' || arg === '-h') {
+      console.log(`
+Usage: npx tsx fetch-token-symbol-and-name.ts [options]
+
+Reads the on-chain ERC20 metadata (name, symbol, decimals) for a token contract.
+
+Options:
+  --token, --address <address>   Token contract address to inspect
+  --help, -h                     Show this help message
+
+Environment variables:
+  RPC_URL          RPC endpoint (e.g. Base Mainnet)
+  TOKEN_ADDRESS    Default token address used when --token is omitted
+
+Examples:
+  npx tsx fetch-token-symbol-and-name.ts --token 0x1234...
+  TOKEN_ADDRESS=0x1234... npx tsx fetch-token-symbol-and-name.ts
+      `);
+      process.exit(0);
+    } else if (!arg.startsWith('--') && !result.tokenAddress) {
+      // Allow passing the address as a positional argument
+      result.tokenAddress = arg;
+    }
+  }
+
+  return result;
+}
+
+async function fetchTokenMetadata(
+  tokenAddress: string,
+  provider: ethers.JsonRpcProvider,
+): Promise<{ name: string; symbol: string; decimals: number }> {
+  const token = new ethers.Contract(
+    tokenAddress,
+    tokenAbi,
+    provider,
+  ) as ethers.Contract & TokenMetadataInterface;
+
+  // Read the metadata fields in parallel
+  const [name, symbol, decimals] = await Promise.all([
+    token.name(),
+    token.symbol(),
+    token.decimals(),
+  ]);
+
+  return { name, symbol, decimals: Number(decimals) };
+}
+
+async function main(): Promise<void> {
+  if (!process.env.RPC_URL) {
+    throw new Error('Missing required environment variable: RPC_URL');
+  }
+
+  const { tokenAddress } = parseArguments();
+  const targetAddress = tokenAddress || process.env.TOKEN_ADDRESS;
+
+  if (!targetAddress) {
+    throw new Error(
+      'No token address provided. Pass --token <address> or set TOKEN_ADDRESS in .env',
+    );
+  }
+
+  if (!ethers.isAddress(targetAddress)) {
+    throw new Error(`Invalid token address: ${targetAddress}`);
+  }
+
+  const provider = new ethers.JsonRpcProvider(process.env.RPC_URL);
+
+  console.log(`Fetching token metadata for: ${targetAddress}\n`);
+
+  const { name, symbol, decimals } = await fetchTokenMetadata(
+    targetAddress,
+    provider,
+  );
+
+  console.log(`=== Token: ${name} (${symbol}) ===`);
+  console.log('Address:', targetAddress);
+  console.log('Name:', name);
+  console.log('Symbol:', symbol);
+  console.log('Decimals:', decimals);
+  console.log('===============');
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error('Error:', error.message);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary
- Add `GET /api/v1/tokens/[token]/image` that resolves a token by its on-chain contract address and returns its stored icon URL as JSON: `{ "iconUrl": "https://..." }` (or `{ "iconUrl": null }` when none is set).
- Add a `findTokenByAddress` query in `packages/core/src/assets/server/queries.ts` (case-insensitive address match), auto-exported via `@hypha-platform/core/server`.

Images are stored as URLs in `tokens.icon_url` (UploadThing), so the endpoint just resolves and returns that string. No DB migration, no new env vars, no auth (consistent with the existing public `GET /api/v1/tokens` and `tokens/[token]/supply` routes).

### Behavior
- `GET /api/v1/tokens/0xABC.../image` -> `{ "iconUrl": "https://....png" }`
- Token found, no icon -> `{ "iconUrl": null }` (200)
- Invalid/missing address -> 400; unknown token -> 404; failure -> 500

> Note: this branch also carries 2 pre-existing unrelated commits (example token symbol/name script + docs).

## Test plan
- [ ] On the preview deploy, grab a real address: `curl -s "$BASE/api/v1/tokens" | jq '.[] | {symbol, address, iconUrl}'`
- [ ] `curl -s "$BASE/api/v1/tokens/<address>/image" | jq` returns the expected `iconUrl`
- [ ] Invalid address returns 400; unknown (valid-format) address returns 404

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New API endpoint to retrieve token icon and image data by token address with validation
  * Token lookup functionality enabling queries by address for enhanced data retrieval capabilities

* **Documentation**
  * Added user guide explaining how to fetch and display token metadata including name, symbol, and decimal information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->