### PR TITLE
Add Hypha AI cost docs and Phase II tokenomics simulator

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -90,6 +90,18 @@ const nextConfig: NextConfig = {
       },
     ];
   },
+  rewrites: async () => {
+    return [
+      {
+        source: '/tokenomics1',
+        destination: '/tokenomics1/index.html',
+      },
+      {
+        source: '/tokenomics2',
+        destination: '/tokenomics2/index.html',
+      },
+    ];
+  },
 };
 
 const withVercelToolbar = createWithVercelToolbar();

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,7 +10,7 @@
     "lint": "next lint",
     "check-types": "tsc --noEmit",
     "postinstall": "if [ ! -f .env ] && [ -z \"$CI\" ]; then cp .env.template .env; fi",
-    "sync:tokenomics": "cp ../../docs/hypha-ai-cost/tokenomics-simulator.html public/tokenomics2/index.html"
+    "sync:tokenomics": "cp ../../docs/hypha-ai-cost/tokenomics-simulator-phase1.html public/tokenomics1/index.html && cp ../../docs/hypha-ai-cost/tokenomics-simulator.html public/tokenomics2/index.html"
   },
   "dependencies": {
     "@ai-sdk/react": "^3.0.107",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,7 +9,8 @@
     "start": "next start",
     "lint": "next lint",
     "check-types": "tsc --noEmit",
-    "postinstall": "if [ ! -f .env ] && [ -z \"$CI\" ]; then cp .env.template .env; fi"
+    "postinstall": "if [ ! -f .env ] && [ -z \"$CI\" ]; then cp .env.template .env; fi",
+    "sync:tokenomics": "cp ../../docs/hypha-ai-cost/tokenomics-simulator.html public/tokenomics2/index.html"
   },
   "dependencies": {
     "@ai-sdk/react": "^3.0.107",

--- a/apps/web/public/tokenomics1/index.html
+++ b/apps/web/public/tokenomics1/index.html
@@ -70,7 +70,7 @@ const HyphaTokenomicsCalculator = () => {
   const [tokensForSale, setTokensForSale] = useState(10000000);
   const [yieldMultiplier, setYieldMultiplier] = useState(30);
   const [saleMonths, setSaleMonths] = useState(12);
-  const [tokenPrice, setTokenPrice] = useState(0.25);
+  const [tokenPrice, setTokenPrice] = useState(0.20);
   const [totalSupply, setTotalSupply] = useState(555555555);
   const [existingLockedSupply, setExistingLockedSupply] = useState(111111111);
 
@@ -258,7 +258,7 @@ const HyphaTokenomicsCalculator = () => {
     setTokensForSale(10000000);
     setYieldMultiplier(30);
     setSaleMonths(12);
-    setTokenPrice(0.25);
+    setTokenPrice(0.20);
     setTotalSupply(555555555);
     setExistingLockedSupply(111111111);
     setNumberOfAOs(50);
@@ -279,6 +279,7 @@ const HyphaTokenomicsCalculator = () => {
   return (
     <div className="p-6 bg-gray-50 rounded-lg shadow-lg">
       <h1 className="text-2xl font-bold mb-1 text-center">HYPHA Tokenomics Simulator (Phase I)</h1>
+      <p className="text-sm text-gray-500 mb-6 text-center">Phase I uses a fixed reference token price; Phase II derives price from IEX dynamics.</p>
       <p className="text-sm text-gray-500 mb-6 text-center">With per-Space AI + Base L2 gas operating cost model — closed-source vs open-source LLMs.</p>
 
       <div className="mb-8 border border-indigo-200 bg-indigo-50 p-4 rounded-lg">

--- a/apps/web/public/tokenomics1/index.html
+++ b/apps/web/public/tokenomics1/index.html
@@ -75,7 +75,7 @@ const HyphaTokenomicsCalculator = () => {
   const [existingLockedSupply, setExistingLockedSupply] = useState(111111111);
 
   const [numberOfAOs, setNumberOfAOs] = useState(50);
-  const [paymentPerAO, setPaymentPerAO] = useState(22);
+  const [paymentPerAO, setPaymentPerAO] = useState(44);
   const [usdcFromInvestors, setUsdcFromInvestors] = useState(100000);
   const [aoGrowthRate, setAoGrowthRate] = useState(50);
 
@@ -262,7 +262,7 @@ const HyphaTokenomicsCalculator = () => {
     setTotalSupply(555555555);
     setExistingLockedSupply(111111111);
     setNumberOfAOs(50);
-    setPaymentPerAO(11);
+    setPaymentPerAO(44);
     setUsdcFromInvestors(100000);
     setAoGrowthRate(50);
     setMonthlyOverrides({});

--- a/apps/web/public/tokenomics1/index.html
+++ b/apps/web/public/tokenomics1/index.html
@@ -66,15 +66,12 @@ const GAS_MONTHLY_BY_PROFILE = { light: 0.06, typical: 0.37, heavy: 3.27 };
 const GAS_SETUP_ONE_TIME = 0.035;
 const perSpaceMonthlyGas = (profile) => GAS_MONTHLY_BY_PROFILE[profile] || GAS_MONTHLY_BY_PROFILE.typical;
 
-const PHASE0_ACTIVE_SPACES = 4373;
+// Phase I bootstraps from a near-zero seed to ~4,373 paying Spaces over 12 months.
+const PHASE_I_END_SPACES = 4373;
 const PHASE_I_MONTHS = 12;
-const PHASE_I_MONTHLY_GROWTH = 0.72;
-const phaseIHandoffSpaces = () => {
-  let n = PHASE0_ACTIVE_SPACES;
-  for (let m = 2; m <= PHASE_I_MONTHS; m++) n = Math.round(n * (1 + PHASE_I_MONTHLY_GROWTH / 100));
-  return n;
-};
-const PHASE_II_START_SPACES = phaseIHandoffSpaces();
+const PHASE_I_SEED_SPACES = 50;       // month 1 seed (~0 Spaces at month 0)
+const PHASE_I_MONTHLY_GROWTH = 50;    // %/mo → ~4,373 by month 12
+const PHASE_II_START_SPACES = PHASE_I_END_SPACES;
 
 const HyphaTokenomicsCalculator = () => {
   const [tokensForSale, setTokensForSale] = useState(10000000);
@@ -84,7 +81,7 @@ const HyphaTokenomicsCalculator = () => {
   const [totalSupply, setTotalSupply] = useState(555555555);
   const [existingLockedSupply, setExistingLockedSupply] = useState(111111111);
 
-  const [numberOfAOs, setNumberOfAOs] = useState(PHASE0_ACTIVE_SPACES);
+  const [numberOfAOs, setNumberOfAOs] = useState(PHASE_I_SEED_SPACES);
   const [paymentPerAO, setPaymentPerAO] = useState(44);
   const [usdcFromInvestors, setUsdcFromInvestors] = useState(100000);
   const [aoGrowthRate, setAoGrowthRate] = useState(PHASE_I_MONTHLY_GROWTH);
@@ -271,7 +268,7 @@ const HyphaTokenomicsCalculator = () => {
     setTokenPrice(0.20);
     setTotalSupply(555555555);
     setExistingLockedSupply(111111111);
-    setNumberOfAOs(PHASE0_ACTIVE_SPACES);
+    setNumberOfAOs(PHASE_I_SEED_SPACES);
     setPaymentPerAO(44);
     setUsdcFromInvestors(100000);
     setAoGrowthRate(PHASE_I_MONTHLY_GROWTH);
@@ -297,15 +294,15 @@ const HyphaTokenomicsCalculator = () => {
         <div className="grid grid-cols-1 md:grid-cols-3 gap-3 text-sm">
           <div className="bg-white p-3 rounded border border-slate-200">
             <div className="font-semibold text-slate-600">Phase 0 — Today</div>
-            <p className="text-xs text-gray-600 mt-1">~4,373 Spaces on Hypha. Tokenomics Phase I begins at month 0. Reference FDV ~$111M at $0.20.</p>
+            <p className="text-xs text-gray-600 mt-1">Pre-launch. Reference FDV ~$111M at $0.20 (111M locked supply).</p>
           </div>
           <div className="bg-indigo-600 text-white p-3 rounded border border-indigo-700">
-            <div className="font-semibold">Phase I — Month 0+ (this sim)</div>
-            <p className="text-xs text-indigo-100 mt-1">{PHASE0_ACTIVE_SPACES.toLocaleString()} Spaces at month 0 → ~{PHASE_II_START_SPACES.toLocaleString()} at month {PHASE_I_MONTHS} ({PHASE_I_MONTHLY_GROWTH}%/mo). Same rate continues in Phase II Low.</p>
+            <div className="font-semibold">Phase I — Year 1 (this sim)</div>
+            <p className="text-xs text-indigo-100 mt-1">Bootstrap: ~0 Spaces at month 0 → ~{PHASE_I_END_SPACES.toLocaleString()} by month {PHASE_I_MONTHS} ({PHASE_I_MONTHLY_GROWTH}%/mo from a {PHASE_I_SEED_SPACES}-Space seed). Phase II continues from here.</p>
           </div>
           <div className="bg-white p-3 rounded border border-slate-200">
-            <div className="font-semibold text-slate-700">Phase II — After Phase I</div>
-            <p className="text-xs text-gray-600 mt-1">$44/Space/mo, dynamic IEX pricing. <a href="/tokenomics2/" className="text-indigo-600 underline">Phase II simulator →</a></p>
+            <div className="font-semibold text-slate-700">Phase II — Years 2–5</div>
+            <p className="text-xs text-gray-600 mt-1">$44/Space/mo, dynamic IEX. Year-5 active: Low ~25k · Mid ~250k · High ~2M. <a href="/tokenomics2/" className="text-indigo-600 underline">Phase II →</a></p>
           </div>
         </div>
       </div>

--- a/apps/web/public/tokenomics1/index.html
+++ b/apps/web/public/tokenomics1/index.html
@@ -1,0 +1,717 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>HYPHA Tokenomics Simulator (Phase I)</title>
+<link rel="icon" href="https://hypha.earth/wp-content/uploads/2023/07/cropped-favicon-32x32.png" sizes="32x32" />
+<script type="importmap">
+{
+  "imports": {
+    "react": "https://esm.sh/react@18.3.1",
+    "react/jsx-runtime": "https://esm.sh/react@18.3.1/jsx-runtime",
+    "react/jsx-dev-runtime": "https://esm.sh/react@18.3.1/jsx-dev-runtime",
+    "react-dom": "https://esm.sh/react-dom@18.3.1",
+    "react-dom/client": "https://esm.sh/react-dom@18.3.1/client",
+    "recharts": "https://esm.sh/recharts@2.12.7?external=react,react-dom"
+  }
+}
+</script>
+<script src="https://cdn.tailwindcss.com"></script>
+<script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+<style> body { background:#f3f4f6; } </style>
+</head>
+<body>
+<div id="root" class="p-4"></div>
+<script type="text/babel" data-type="module" data-presets="react" data-presets-options='{"react":{"runtime":"classic"}}'>
+import React, { useState, useEffect } from 'react';
+import { createRoot } from 'react-dom/client';
+import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, AreaChart, Area } from 'recharts';
+
+const HyphaTokenomicsCalculator = () => {
+  const [tokensForSale, setTokensForSale] = useState(10000000);
+  const [yieldMultiplier, setYieldMultiplier] = useState(30);
+  const [saleMonths, setSaleMonths] = useState(12);
+  const [tokenPrice, setTokenPrice] = useState(0.25);
+  const [totalSupply, setTotalSupply] = useState(555555555);
+  const [existingLockedSupply, setExistingLockedSupply] = useState(111111111);
+
+  const [numberOfAOs, setNumberOfAOs] = useState(50);
+  const [paymentPerAO, setPaymentPerAO] = useState(11);
+  const [usdcFromInvestors, setUsdcFromInvestors] = useState(100000);
+  const [aoGrowthRate, setAoGrowthRate] = useState(50);
+
+  const [showMonthlyConfig, setShowMonthlyConfig] = useState(false);
+  const [monthlyOverrides, setMonthlyOverrides] = useState({});
+  const [selectedMonth, setSelectedMonth] = useState(1);
+
+  const [monthlyData, setMonthlyData] = useState([]);
+  const [cumulativeData, setCumulativeData] = useState([]);
+  const [fdv, setFdv] = useState(0);
+  const [marketCap, setMarketCap] = useState(0);
+  const [totalValue, setTotalValue] = useState(0);
+  const [totalYieldTokens, setTotalYieldTokens] = useState(0);
+  const [totalTokensSold, setTotalTokensSold] = useState(0);
+  const [yieldPerLockedToken, setYieldPerLockedToken] = useState(0);
+
+  useEffect(() => {
+    calculateTokenomics();
+  }, [
+    tokensForSale, yieldMultiplier, saleMonths, tokenPrice, totalSupply,
+    numberOfAOs, paymentPerAO, usdcFromInvestors, aoGrowthRate,
+    existingLockedSupply, monthlyOverrides
+  ]);
+
+  const getParamForMonth = (month, paramName, defaultValue) => {
+    if (monthlyOverrides[month-1] && monthlyOverrides[month-1][paramName] !== undefined) {
+      return monthlyOverrides[month-1][paramName];
+    }
+    return defaultValue;
+  };
+
+  const calculateTokenomics = () => {
+    const calculatedFdv = totalSupply * tokenPrice;
+    setFdv(calculatedFdv);
+
+    const calculatedMarketCap = existingLockedSupply * tokenPrice;
+    setMarketCap(calculatedMarketCap);
+
+    const monthlyTokenSales = [];
+    const cumulativeTokenSales = [];
+
+    let cumulativeSold = 0;
+    let cumulativeYield = 0;
+    let totalYield = 0;
+    let currentNumberOfAOs = numberOfAOs;
+    let totalUSDC = 0;
+    let calculatedTotalValue = 0;
+
+    for (let month = 1; month <= saleMonths; month++) {
+      const monthTokenPrice = tokenPrice;
+      const monthYieldMultiplier = getParamForMonth(month, 'yieldMultiplier', yieldMultiplier);
+
+      if (month > 1) {
+        if (monthlyOverrides[month-1] && monthlyOverrides[month-1]['numberOfAOs'] !== undefined) {
+          currentNumberOfAOs = monthlyOverrides[month-1]['numberOfAOs'];
+        } else {
+          const monthAoGrowthRate = getParamForMonth(month, 'aoGrowthRate', aoGrowthRate) / 100;
+          currentNumberOfAOs = Math.round(currentNumberOfAOs * (1 + monthAoGrowthRate));
+        }
+      } else {
+        currentNumberOfAOs = numberOfAOs;
+      }
+
+      const monthPaymentPerAO = getParamForMonth(month, 'paymentPerAO', paymentPerAO);
+      const monthInvestorUSDC = getParamForMonth(month, 'usdcFromInvestors', usdcFromInvestors);
+
+      const aoIncome = currentNumberOfAOs * monthPaymentPerAO;
+      const monthlyUSDC = aoIncome + monthInvestorUSDC;
+      totalUSDC += monthlyUSDC;
+
+      const tokensSold = monthlyUSDC / monthTokenPrice;
+      cumulativeSold += tokensSold;
+      calculatedTotalValue += monthlyUSDC;
+
+      const monthlyYield = (aoIncome * monthYieldMultiplier) / monthTokenPrice;
+      cumulativeYield += monthlyYield;
+      totalYield += monthlyYield;
+
+      monthlyTokenSales.push({
+        month,
+        tokensSold,
+        yield: monthlyYield,
+        yieldMultiplier: monthYieldMultiplier,
+        tokenPrice: monthTokenPrice,
+        numberOfAOs: currentNumberOfAOs,
+        aoIncome,
+        investorUSDC: monthInvestorUSDC,
+        totalMonthlyUSDC: monthlyUSDC,
+        totalUSDC,
+        aoPaymentYield: aoIncome * monthYieldMultiplier
+      });
+
+      cumulativeTokenSales.push({
+        month,
+        cumulativeSold,
+        cumulativeYield,
+        initialLockedSupply: existingLockedSupply,
+        totalEarningTokens: cumulativeSold + existingLockedSupply,
+        tokenPrice: monthTokenPrice,
+        fdv: totalSupply * monthTokenPrice,
+        totalUSDC
+      });
+    }
+
+    const totalLockedTokens = existingLockedSupply + cumulativeSold;
+    const calculatedYieldPerLockedToken = totalLockedTokens > 0 ? totalYield / totalLockedTokens : 0;
+
+    setMonthlyData(monthlyTokenSales);
+    setCumulativeData(cumulativeTokenSales);
+    setTotalYieldTokens(totalYield);
+    setTotalValue(calculatedTotalValue);
+    setTotalTokensSold(cumulativeSold);
+    setYieldPerLockedToken(calculatedYieldPerLockedToken);
+  };
+
+  const handleMonthlyOverride = (paramName, value) => {
+    const newOverrides = { ...monthlyOverrides };
+
+    if (!newOverrides[selectedMonth-1]) {
+      newOverrides[selectedMonth-1] = {};
+    }
+
+    newOverrides[selectedMonth-1][paramName] = value;
+    setMonthlyOverrides(newOverrides);
+  };
+
+  const removeMonthlyOverride = (month, paramName) => {
+    const newOverrides = { ...monthlyOverrides };
+
+    if (newOverrides[month-1] && newOverrides[month-1][paramName] !== undefined) {
+      delete newOverrides[month-1][paramName];
+
+      if (Object.keys(newOverrides[month-1]).length === 0) {
+        delete newOverrides[month-1];
+      }
+
+      setMonthlyOverrides(newOverrides);
+    }
+  };
+
+  const formatCurrency = (value) => {
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: 'USD',
+      minimumFractionDigits: value < 1 ? 3 : 0,
+      maximumFractionDigits: value < 1 ? 3 : 0,
+    }).format(value);
+  };
+
+  const formatNumber = (value) => {
+    return new Intl.NumberFormat('en-US').format(Math.round(value));
+  };
+
+  const resetParameters = () => {
+    setTokensForSale(10000000);
+    setYieldMultiplier(30);
+    setSaleMonths(12);
+    setTokenPrice(0.25);
+    setTotalSupply(555555555);
+    setExistingLockedSupply(111111111);
+    setNumberOfAOs(50);
+    setPaymentPerAO(11);
+    setUsdcFromInvestors(100000);
+    setAoGrowthRate(50);
+    setMonthlyOverrides({});
+  };
+
+  return (
+    <div className="p-6 bg-gray-50 rounded-lg shadow-lg">
+      <h1 className="text-2xl font-bold mb-6 text-center">HYPHA Tokenomics Simulator (Phase I)</h1>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
+        <div className="bg-white p-4 rounded-lg shadow">
+          <h2 className="text-lg font-semibold mb-4">Initial Parameters</h2>
+
+          <div className="mb-4">
+            <label className="block text-sm font-medium mb-1">Total Supply of HYPHA</label>
+            <div className="flex items-center">
+              <input
+                type="range"
+                min="100000000"
+                max="1000000000"
+                step="10000000"
+                value={totalSupply}
+                onChange={(e) => setTotalSupply(Number(e.target.value))}
+                className="w-full mr-3"
+              />
+              <input
+                type="text"
+                value={totalSupply.toLocaleString('en-US')}
+                onChange={(e) => setTotalSupply(Number(e.target.value.replace(/,/g, '')))}
+                className="w-32 p-1 border rounded text-right"
+                min="1"
+                step="1000000"
+              />
+            </div>
+          </div>
+
+          <div className="mb-4">
+            <label className="block text-sm font-medium mb-1">Existing Locked Tokens Allocation</label>
+            <div className="flex items-center">
+              <input
+                type="range"
+                min="0"
+                max="100000000"
+                step="1000000"
+                value={existingLockedSupply}
+                onChange={(e) => setExistingLockedSupply(Number(e.target.value))}
+                className="w-full mr-3"
+              />
+              <input
+                type="text"
+                value={existingLockedSupply.toLocaleString('en-US')}
+                onChange={(e) => setExistingLockedSupply(Number(e.target.value.replace(/,/g, '')))}
+                className="w-32 p-1 border rounded text-right"
+                min="0"
+                step="1000"
+              />
+            </div>
+          </div>
+
+          <div className="mb-4">
+            <label className="block text-sm font-medium mb-1">HYPHA Token Price (USD)</label>
+            <div className="flex items-center">
+              <input
+                type="range"
+                min="0.001"
+                max="0.5"
+                step="0.001"
+                value={tokenPrice}
+                onChange={(e) => setTokenPrice(Number(e.target.value))}
+                className="w-full mr-3"
+              />
+              <input
+                type="number"
+                value={tokenPrice}
+                onChange={(e) => setTokenPrice(Number(e.target.value))}
+                className="w-24 p-1 border rounded text-right"
+                min="0.0001"
+                step="0.001"
+              />
+            </div>
+          </div>
+
+          <div className="mb-4">
+            <label className="block text-sm font-medium mb-1">Sale Duration (Months)</label>
+            <div className="flex items-center">
+              <input
+                type="range"
+                min="1"
+                max="60"
+                step="1"
+                value={saleMonths}
+                onChange={(e) => setSaleMonths(Number(e.target.value))}
+                className="w-full mr-3"
+              />
+              <input
+                type="number"
+                value={saleMonths}
+                onChange={(e) => setSaleMonths(Number(e.target.value))}
+                className="w-16 p-1 border rounded text-right"
+                min="1"
+                max="60"
+              />
+            </div>
+          </div>
+        </div>
+
+        <div className="bg-white p-4 rounded-lg shadow">
+          <div className="flex justify-between items-center mb-4">
+            <h2 className="text-lg font-semibold">Monthly Parameters</h2>
+            <button
+              onClick={() => setShowMonthlyConfig(!showMonthlyConfig)}
+              className="px-3 py-1 bg-blue-500 text-white rounded hover:bg-blue-600 text-sm"
+            >
+              {showMonthlyConfig ? 'Hide' : 'Show'} Configuration
+            </button>
+          </div>
+
+          <div className="mb-4">
+            <label className="block text-sm font-medium mb-1">Initial Number of Spaces</label>
+            <div className="flex items-center">
+              <input
+                type="range"
+                min="0"
+                max="100"
+                step="1"
+                value={numberOfAOs}
+                onChange={(e) => setNumberOfAOs(Number(e.target.value))}
+                className="w-full mr-3"
+              />
+              <input
+                type="number"
+                value={numberOfAOs}
+                onChange={(e) => setNumberOfAOs(Number(e.target.value))}
+                className="w-16 p-1 border rounded text-right"
+                min="0"
+              />
+            </div>
+          </div>
+
+          <div className="mb-4">
+            <label className="block text-sm font-medium mb-1">Spaces Growth Rate (%)</label>
+            <div className="flex items-center">
+              <input
+                type="range"
+                min="0"
+                max="100"
+                step="1"
+                value={aoGrowthRate}
+                onChange={(e) => setAoGrowthRate(Number(e.target.value))}
+                className="w-full mr-3"
+              />
+              <input
+                type="number"
+                value={aoGrowthRate}
+                onChange={(e) => setAoGrowthRate(Number(e.target.value))}
+                className="w-16 p-1 border rounded text-right"
+                min="0"
+                max="100"
+              />
+              <span className="ml-1">%</span>
+            </div>
+            <p className="text-xs text-gray-500 mt-1">Monthly growth rate of Spaces (if not explicitly set per month)</p>
+          </div>
+
+          <div className="mb-4">
+            <label className="block text-sm font-medium mb-1">Space&apos;s contribution to Hypha Network (USDC)</label>
+            <div className="flex items-center">
+              <input
+                type="range"
+                min="0"
+                max="1000"
+                step="10"
+                value={paymentPerAO}
+                onChange={(e) => setPaymentPerAO(Number(e.target.value))}
+                className="w-full mr-3"
+              />
+              <input
+                type="number"
+                value={paymentPerAO}
+                onChange={(e) => setPaymentPerAO(Number(e.target.value))}
+                className="w-20 p-1 border rounded text-right"
+                min="0"
+                step="1"
+              />
+              <span className="ml-1">USDC</span>
+            </div>
+          </div>
+
+          <div className="mb-4">
+            <label className="block text-sm font-medium mb-1">Distribution Multiplier</label>
+            <div className="flex items-center">
+              <input
+                type="range"
+                min="0"
+                max="50"
+                step="0.1"
+                value={yieldMultiplier}
+                onChange={(e) => setYieldMultiplier(Number(e.target.value))}
+                className="w-full mr-3"
+              />
+              <input
+                type="number"
+                value={yieldMultiplier}
+                onChange={(e) => setYieldMultiplier(Number(e.target.value))}
+                className="w-16 p-1 border rounded text-right"
+                min="0"
+                step="0.1"
+              />
+            </div>
+            <p className="text-xs text-gray-500 mt-1">Tokens distributed = Spaces&apos; contributions to Hypha Network (HYPHA) × Distribution Multiplier</p>
+          </div>
+
+          <div className="mb-4">
+            <label className="block text-sm font-medium mb-1">Initial HYPHA purchases from investors (USDC)</label>
+            <div className="flex items-center">
+              <input
+                type="range"
+                min="0"
+                max="150000"
+                step="1000"
+                value={usdcFromInvestors}
+                onChange={(e) => setUsdcFromInvestors(Number(e.target.value))}
+                className="w-full mr-3"
+              />
+              <input
+                type="text"
+                value={usdcFromInvestors.toLocaleString('en-US')}
+                onChange={(e) => setUsdcFromInvestors(Number(e.target.value.replace(/,/g, '')))}
+                className="w-24 p-1 border rounded text-right"
+                min="0"
+                step="1000"
+              />
+              <span className="ml-1">USDC</span>
+            </div>
+            <p className="text-xs text-gray-500 mt-1">This value is used for all months unless customized per month.</p>
+          </div>
+
+          {showMonthlyConfig && (
+            <div className="border rounded p-4 mt-4">
+              <div className="mb-4">
+                <label className="block text-sm font-medium mb-1">Select Month</label>
+                <select
+                  value={selectedMonth}
+                  onChange={(e) => setSelectedMonth(Number(e.target.value))}
+                  className="w-full p-2 border rounded"
+                >
+                  {Array.from({ length: saleMonths }, (_, i) => (
+                    <option key={i+1} value={i+1}>
+                      Month {i+1} {monthlyOverrides[i] ? '(Custom)' : ''}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              <h3 className="font-semibold text-sm mb-2">Month {selectedMonth} Parameters</h3>
+
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+                <div>
+                  <label className="block text-xs font-medium mb-1">Distribution Multiplier</label>
+                  <div className="flex items-center">
+                    <input
+                      type="number"
+                      value={monthlyOverrides[selectedMonth-1]?.yieldMultiplier !== undefined
+                        ? monthlyOverrides[selectedMonth-1].yieldMultiplier
+                        : ''}
+                      onChange={(e) => handleMonthlyOverride('yieldMultiplier', Number(e.target.value))}
+                      placeholder={yieldMultiplier}
+                      className="w-full p-1 border rounded text-sm"
+                      min="0"
+                      step="0.1"
+                    />
+                    {monthlyOverrides[selectedMonth-1]?.yieldMultiplier !== undefined && (
+                      <button
+                        onClick={() => removeMonthlyOverride(selectedMonth, 'yieldMultiplier')}
+                        className="ml-1 text-red-500 text-lg"
+                        title="Reset to global value"
+                      >
+                        ×
+                      </button>
+                    )}
+                  </div>
+                </div>
+
+                <div>
+                  <label className="block text-xs font-medium mb-1">Payment per AO</label>
+                  <div className="flex items-center">
+                    <input
+                      type="number"
+                      value={monthlyOverrides[selectedMonth-1]?.paymentPerAO !== undefined
+                        ? monthlyOverrides[selectedMonth-1].paymentPerAO
+                        : ''}
+                      onChange={(e) => handleMonthlyOverride('paymentPerAO', Number(e.target.value))}
+                      placeholder={paymentPerAO}
+                      className="w-full p-1 border rounded text-sm"
+                      min="0"
+                      step="1"
+                    />
+                    {monthlyOverrides[selectedMonth-1]?.paymentPerAO !== undefined && (
+                      <button
+                        onClick={() => removeMonthlyOverride(selectedMonth, 'paymentPerAO')}
+                        className="ml-1 text-red-500 text-lg"
+                        title="Reset to global value"
+                      >
+                        ×
+                      </button>
+                    )}
+                  </div>
+                </div>
+
+                <div>
+                  <label className="block text-xs font-medium mb-1">Investor USDC</label>
+                  <div className="flex items-center">
+                    <input
+                      type="number"
+                      value={monthlyOverrides[selectedMonth-1]?.usdcFromInvestors !== undefined
+                        ? monthlyOverrides[selectedMonth-1].usdcFromInvestors
+                        : ''}
+                      onChange={(e) => handleMonthlyOverride('usdcFromInvestors', Number(e.target.value))}
+                      placeholder={usdcFromInvestors}
+                      className="w-full p-1 border rounded text-sm"
+                      min="0"
+                      step="1000"
+                    />
+                    {monthlyOverrides[selectedMonth-1]?.usdcFromInvestors !== undefined && (
+                      <button
+                        onClick={() => removeMonthlyOverride(selectedMonth, 'usdcFromInvestors')}
+                        className="ml-1 text-red-500 text-lg"
+                        title="Reset to global value"
+                      >
+                        ×
+                      </button>
+                    )}
+                  </div>
+                </div>
+
+                {selectedMonth > 1 && (
+                  <div>
+                    <label className="block text-xs font-medium mb-1">Spaces Growth Rate (%)</label>
+                    <div className="flex items-center">
+                      <input
+                        type="number"
+                        value={monthlyOverrides[selectedMonth-1]?.aoGrowthRate !== undefined
+                          ? monthlyOverrides[selectedMonth-1].aoGrowthRate
+                          : ''}
+                        onChange={(e) => handleMonthlyOverride('aoGrowthRate', Number(e.target.value))}
+                        placeholder={aoGrowthRate}
+                        className="w-full p-1 border rounded text-sm"
+                        min="0"
+                        max="100"
+                        step="1"
+                      />
+                      {monthlyOverrides[selectedMonth-1]?.aoGrowthRate !== undefined && (
+                        <button
+                          onClick={() => removeMonthlyOverride(selectedMonth, 'aoGrowthRate')}
+                          className="ml-1 text-red-500 text-lg"
+                          title="Reset to global value"
+                        >
+                          ×
+                        </button>
+                      )}
+                    </div>
+                  </div>
+                )}
+              </div>
+
+              <div className="mt-3 text-xs text-gray-500">
+                Empty fields use the global values. For Number of Spaces after month 1, the value is calculated based on growth rate if not explicitly set.
+              </div>
+            </div>
+          )}
+
+          {Object.keys(monthlyOverrides).length > 0 && (
+            <div className="mt-2 text-sm text-gray-500">
+              Customized months: {Object.keys(monthlyOverrides).map(m => Number(m) + 1).sort((a, b) => a - b).join(', ')}
+            </div>
+          )}
+
+          <button
+            onClick={resetParameters}
+            className="mt-4 px-4 py-2 bg-gray-200 rounded hover:bg-gray-300"
+          >
+            Reset All Parameters
+          </button>
+        </div>
+      </div>
+
+      <div className="bg-white p-4 rounded-lg shadow mb-8">
+        <h2 className="text-lg font-semibold mb-4">Key Metrics</h2>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-4">
+          <div className="p-4 bg-indigo-50 rounded-lg">
+            <div className="text-sm text-indigo-600">Current Valuation (Market Cap.)</div>
+            <div className="text-2xl font-bold">{formatCurrency(marketCap)}</div>
+          </div>
+
+          <div className="p-4 bg-blue-50 rounded-lg">
+            <div className="text-sm text-blue-600">Fully Diluted Valuation (FDV)</div>
+            <div className="text-2xl font-bold">{formatCurrency(fdv)}</div>
+          </div>
+
+          <div className="p-4 bg-green-50 rounded-lg">
+            <div className="text-sm text-green-600">Total Dollar Value Sold</div>
+            <div className="text-2xl font-bold">{formatCurrency(totalValue)}</div>
+          </div>
+
+          <div className="p-4 bg-purple-50 rounded-lg">
+            <div className="text-sm text-purple-600">Total Tokens Locked</div>
+            <div className="text-2xl font-bold">{formatNumber(totalTokensSold)}</div>
+          </div>
+
+          <div className="p-4 bg-amber-50 rounded-lg">
+            <div className="text-sm text-amber-600">Total Tokens Distributed</div>
+            <div className="text-2xl font-bold">{formatNumber(totalYieldTokens)}</div>
+            <div className="text-sm text-amber-600 mt-2">Reward per Locked Token</div>
+            <div className="text-xl font-bold">{yieldPerLockedToken.toFixed(4)}</div>
+            <div className="text-xs text-amber-600 mt-1">(Not including monthly compounding effects)</div>
+          </div>
+        </div>
+      </div>
+
+      <div className="bg-white p-4 rounded-lg shadow mb-8">
+        <h2 className="text-lg font-semibold mb-4">Token Distribution Over Time</h2>
+        <ResponsiveContainer width="100%" height={300}>
+          <AreaChart
+            data={cumulativeData}
+            margin={{ top: 5, right: 30, left: 60, bottom: 5 }}
+          >
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="month" label={{ value: 'Month', position: 'insideBottom', offset: -5 }} />
+            <YAxis
+              tickFormatter={(value) => new Intl.NumberFormat('en-US').format(value)}
+            />
+            <Tooltip
+              formatter={(value, name) => {
+                if (name === "cumulativeSold") {
+                  return [formatNumber(value), "Tokens Locked"];
+                } else if (name === "cumulativeYield") {
+                  return [formatNumber(value), "Tokens Distributed"];
+                } else if (name === "initialLockedSupply") {
+                  return [formatNumber(value), "Existing Locked Tokens Allocation"];
+                }
+                return [formatNumber(value), name];
+              }}
+            />
+            <Legend />
+            <Area type="monotone" dataKey="initialLockedSupply" name="Existing Locked Tokens Allocation" stackId="1" stroke="#ff8c00" fill="#ffcc80" />
+            <Area type="monotone" dataKey="cumulativeSold" name="Tokens Locked" stackId="1" stroke="#8884d8" fill="#8884d8" />
+            <Area type="monotone" dataKey="cumulativeYield" name="Tokens Distributed" stackId="2" stroke="#82ca9d" fill="#82ca9d" />
+          </AreaChart>
+        </ResponsiveContainer>
+      </div>
+
+      <div className="bg-white p-4 rounded-lg shadow mb-8">
+        <h2 className="text-lg font-semibold mb-4">Spaces Growth Over Time</h2>
+        <ResponsiveContainer width="100%" height={300}>
+          <LineChart
+            data={monthlyData}
+            margin={{ top: 5, right: 30, left: 40, bottom: 5 }}
+          >
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="month" label={{ value: 'Month', position: 'insideBottom', offset: -5 }} />
+            <YAxis
+              tickFormatter={(value) => new Intl.NumberFormat('en-US').format(value)}
+            />
+            <Tooltip formatter={(value) => [formatNumber(value)]} />
+            <Legend />
+            <Line type="monotone" dataKey="numberOfAOs" name="Number of Spaces" stroke="#8884d8" activeDot={{ r: 8 }} />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+
+      <div className="bg-white p-4 rounded-lg shadow">
+        <h2 className="text-lg font-semibold mb-4">Monthly Breakdown</h2>
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead>
+              <tr className="bg-gray-100">
+                <th className="px-4 py-3 text-center font-semibold text-gray-700">Month</th>
+                <th className="px-4 py-3 text-center font-semibold text-gray-700">USDC Income</th>
+                <th className="px-4 py-3 text-center font-semibold text-gray-700">Token Price</th>
+                <th className="px-4 py-3 text-center font-semibold text-gray-700">Tokens Locked</th>
+                <th className="px-4 py-3 text-center font-semibold text-gray-700">Tokens Distributed</th>
+                <th className="px-4 py-3 text-center font-semibold text-gray-700">Total Tokens Locked</th>
+                <th className="px-4 py-3 text-center font-semibold text-gray-700">Number of Spaces</th>
+                <th className="px-4 py-3 text-center font-semibold text-gray-700">Distribution Multiplier</th>
+              </tr>
+            </thead>
+            <tbody>
+              {monthlyData.map((month, index) => (
+                <tr key={index} className={index % 2 === 0 ? 'bg-white' : 'bg-gray-50'}>
+                  <td className="px-4 py-3 text-center font-medium">{month.month}</td>
+                  <td className="px-4 py-3 text-center">{formatCurrency(month.totalMonthlyUSDC)}</td>
+                  <td className="px-4 py-3 text-center">{formatCurrency(month.tokenPrice)}</td>
+                  <td className="px-4 py-3 text-center">{formatNumber(month.tokensSold)}</td>
+                  <td className="px-4 py-3 text-center">{formatNumber(month.yield)}</td>
+                  <td className="px-4 py-3 text-center">
+                    {formatNumber(cumulativeData[index].cumulativeSold + cumulativeData[index].cumulativeYield + existingLockedSupply)}
+                  </td>
+                  <td className="px-4 py-3 text-center">{formatNumber(month.numberOfAOs)}</td>
+                  <td className="px-4 py-3 text-center">{month.yieldMultiplier}x</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const root = createRoot(document.getElementById('root'));
+root.render(<HyphaTokenomicsCalculator />);
+</script>
+</body>
+</html>

--- a/apps/web/public/tokenomics1/index.html
+++ b/apps/web/public/tokenomics1/index.html
@@ -66,18 +66,28 @@ const GAS_MONTHLY_BY_PROFILE = { light: 0.06, typical: 0.37, heavy: 3.27 };
 const GAS_SETUP_ONE_TIME = 0.035;
 const perSpaceMonthlyGas = (profile) => GAS_MONTHLY_BY_PROFILE[profile] || GAS_MONTHLY_BY_PROFILE.typical;
 
+const PHASE0_ACTIVE_SPACES = 4373;
+const PHASE_I_MONTHS = 12;
+const PHASE_I_MONTHLY_GROWTH = 0.72;
+const phaseIHandoffSpaces = () => {
+  let n = PHASE0_ACTIVE_SPACES;
+  for (let m = 2; m <= PHASE_I_MONTHS; m++) n = Math.round(n * (1 + PHASE_I_MONTHLY_GROWTH / 100));
+  return n;
+};
+const PHASE_II_START_SPACES = phaseIHandoffSpaces();
+
 const HyphaTokenomicsCalculator = () => {
   const [tokensForSale, setTokensForSale] = useState(10000000);
   const [yieldMultiplier, setYieldMultiplier] = useState(30);
-  const [saleMonths, setSaleMonths] = useState(12);
+  const [saleMonths, setSaleMonths] = useState(PHASE_I_MONTHS);
   const [tokenPrice, setTokenPrice] = useState(0.20);
   const [totalSupply, setTotalSupply] = useState(555555555);
   const [existingLockedSupply, setExistingLockedSupply] = useState(111111111);
 
-  const [numberOfAOs, setNumberOfAOs] = useState(50);
+  const [numberOfAOs, setNumberOfAOs] = useState(PHASE0_ACTIVE_SPACES);
   const [paymentPerAO, setPaymentPerAO] = useState(44);
   const [usdcFromInvestors, setUsdcFromInvestors] = useState(100000);
-  const [aoGrowthRate, setAoGrowthRate] = useState(50);
+  const [aoGrowthRate, setAoGrowthRate] = useState(PHASE_I_MONTHLY_GROWTH);
 
   const [aiModelId, setAiModelId] = useState('kimi-or');
   const [aiProfile, setAiProfile] = useState('typical');
@@ -257,14 +267,14 @@ const HyphaTokenomicsCalculator = () => {
   const resetParameters = () => {
     setTokensForSale(10000000);
     setYieldMultiplier(30);
-    setSaleMonths(12);
+    setSaleMonths(PHASE_I_MONTHS);
     setTokenPrice(0.20);
     setTotalSupply(555555555);
     setExistingLockedSupply(111111111);
-    setNumberOfAOs(50);
+    setNumberOfAOs(PHASE0_ACTIVE_SPACES);
     setPaymentPerAO(44);
     setUsdcFromInvestors(100000);
-    setAoGrowthRate(50);
+    setAoGrowthRate(PHASE_I_MONTHLY_GROWTH);
     setMonthlyOverrides({});
     setAiModelId('kimi-or');
     setAiProfile('typical');
@@ -291,7 +301,7 @@ const HyphaTokenomicsCalculator = () => {
           </div>
           <div className="bg-indigo-600 text-white p-3 rounded border border-indigo-700">
             <div className="font-semibold">Phase I — Month 0+ (this sim)</div>
-            <p className="text-xs text-indigo-100 mt-1">Default: 50 Spaces → ~4,325 by month 12 at 50%/mo growth. Handoff to Phase II at ~4,373 paying Spaces.</p>
+            <p className="text-xs text-indigo-100 mt-1">{PHASE0_ACTIVE_SPACES.toLocaleString()} Spaces at month 0 → ~{PHASE_II_START_SPACES.toLocaleString()} at month {PHASE_I_MONTHS} ({PHASE_I_MONTHLY_GROWTH}%/mo). Same rate continues in Phase II Low.</p>
           </div>
           <div className="bg-white p-3 rounded border border-slate-200">
             <div className="font-semibold text-slate-700">Phase II — After Phase I</div>
@@ -828,6 +838,12 @@ const HyphaTokenomicsCalculator = () => {
 
           {lastMonth && (
             <>
+              <div className="p-4 bg-slate-50 rounded-lg border-l-4 border-slate-400">
+                <div className="text-sm text-slate-600">Phase II handoff (month {saleMonths})</div>
+                <div className="text-2xl font-bold text-slate-800">{formatNumber(lastMonth.numberOfAOs)} active Spaces</div>
+                <div className="text-xs text-slate-600 mt-1">Phase II sim starts here — <a href="/tokenomics2/" className="text-indigo-600 underline">open Phase II →</a></div>
+              </div>
+
               <div className="p-4 bg-green-50 rounded-lg border-l-4 border-green-400">
                 <div className="text-sm text-green-600">Run-rate ARR (month {saleMonths})</div>
                 <div className="text-2xl font-bold text-green-700">{formatCurrency(phase1RunRateArr)}</div>

--- a/apps/web/public/tokenomics1/index.html
+++ b/apps/web/public/tokenomics1/index.html
@@ -302,7 +302,7 @@ const HyphaTokenomicsCalculator = () => {
           </div>
           <div className="bg-white p-3 rounded border border-slate-200">
             <div className="font-semibold text-slate-700">Phase II — Years 2–5</div>
-            <p className="text-xs text-gray-600 mt-1">$44/Space/mo, dynamic IEX. Year-5 active: Low ~25k · Mid ~250k · High ~2M. <a href="/tokenomics2/" className="text-indigo-600 underline">Phase II →</a></p>
+            <p className="text-xs text-gray-600 mt-1">$44/Space/mo, dynamic IEX. Year-5 paying Spaces: Low ~250k · Mid ~1M · High ~10M. <a href="/tokenomics2/" className="text-indigo-600 underline">Phase II →</a></p>
           </div>
         </div>
       </div>

--- a/apps/web/public/tokenomics1/index.html
+++ b/apps/web/public/tokenomics1/index.html
@@ -275,12 +275,32 @@ const HyphaTokenomicsCalculator = () => {
   const perSpaceGas = perSpaceMonthlyGas(aiProfile);
   const baselinePerSpace = perSpaceMonthlyAICost(getModel('composer-fast'), aiProfile);
   const lastMonth = monthlyData.length > 0 ? monthlyData[monthlyData.length - 1] : null;
+  const phase1RunRateArr = lastMonth ? lastMonth.aoIncome * 12 : 0;
 
   return (
     <div className="p-6 bg-gray-50 rounded-lg shadow-lg">
       <h1 className="text-2xl font-bold mb-1 text-center">HYPHA Tokenomics Simulator (Phase I)</h1>
-      <p className="text-sm text-gray-500 mb-6 text-center">Phase I uses a fixed reference token price; Phase II derives price from IEX dynamics.</p>
-      <p className="text-sm text-gray-500 mb-6 text-center">With per-Space AI + Base L2 gas operating cost model — closed-source vs open-source LLMs.</p>
+      <p className="text-sm text-gray-500 mb-3 text-center">Fixed $0.20 reference price — token sale, locking &amp; yield distribution at Phase I month 0+.</p>
+
+      <div className="mb-6 border border-slate-200 bg-slate-50 p-4 rounded-lg">
+        <h2 className="text-xs font-semibold text-slate-600 uppercase tracking-wide mb-2 text-center">Roadmap: Phase 0 → Phase I → Phase II</h2>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-3 text-sm">
+          <div className="bg-white p-3 rounded border border-slate-200">
+            <div className="font-semibold text-slate-600">Phase 0 — Today</div>
+            <p className="text-xs text-gray-600 mt-1">~4,373 Spaces on Hypha. Tokenomics Phase I begins at month 0. Reference FDV ~$111M at $0.20.</p>
+          </div>
+          <div className="bg-indigo-600 text-white p-3 rounded border border-indigo-700">
+            <div className="font-semibold">Phase I — Month 0+ (this sim)</div>
+            <p className="text-xs text-indigo-100 mt-1">Default: 50 Spaces → ~4,325 by month 12 at 50%/mo growth. Handoff to Phase II at ~4,373 paying Spaces.</p>
+          </div>
+          <div className="bg-white p-3 rounded border border-slate-200">
+            <div className="font-semibold text-slate-700">Phase II — After Phase I</div>
+            <p className="text-xs text-gray-600 mt-1">$44/Space/mo, dynamic IEX pricing. <a href="/tokenomics2/" className="text-indigo-600 underline">Phase II simulator →</a></p>
+          </div>
+        </div>
+      </div>
+
+      <p className="text-sm text-gray-500 mb-6 text-center">Per-Space AI + Base L2 gas operating cost model — closed-source vs open-source LLMs.</p>
 
       <div className="mb-8 border border-indigo-200 bg-indigo-50 p-4 rounded-lg">
         <h2 className="text-lg font-semibold mb-1">AI &amp; On-Chain Operating Cost per Space</h2>
@@ -808,6 +828,14 @@ const HyphaTokenomicsCalculator = () => {
 
           {lastMonth && (
             <>
+              <div className="p-4 bg-green-50 rounded-lg border-l-4 border-green-400">
+                <div className="text-sm text-green-600">Run-rate ARR (month {saleMonths})</div>
+                <div className="text-2xl font-bold text-green-700">{formatCurrency(phase1RunRateArr)}</div>
+                <div className="text-xs text-green-600 mt-1">
+                  {formatNumber(lastMonth.numberOfAOs)} active Spaces × ${paymentPerAO} × 12
+                </div>
+              </div>
+
               <div className="p-4 bg-green-50 rounded-lg border-l-4 border-green-400">
                 <div className="text-sm text-green-600">Cumulated Space Contributions</div>
                 <div className="text-2xl font-bold text-green-700">

--- a/apps/web/public/tokenomics1/index.html
+++ b/apps/web/public/tokenomics1/index.html
@@ -28,6 +28,44 @@ import React, { useState, useEffect } from 'react';
 import { createRoot } from 'react-dom/client';
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, AreaChart, Area } from 'recharts';
 
+// ============================================================
+// AI Operating Cost model (from docs/hypha-ai-cost)
+// Typical Space workload = 4.66M input + 0.17M output tokens / month.
+// Per-space monthly $ = (in_M * inPrice + out_M * outPrice) * profileMult.
+// ============================================================
+const TYPICAL_INPUT_M = 4.66;
+const TYPICAL_OUTPUT_M = 0.17;
+const PROFILE_MULT = { light: 0.33, typical: 1, heavy: 2.73 };
+
+const AI_MODELS = {
+  closed: [
+    { id: 'composer-fast', name: 'Composer 2.5 Fast', input: 3.0, output: 15.0, note: 'IDE default reference / baseline' },
+    { id: 'composer-standard', name: 'Composer 2.5 Standard', input: 0.5, output: 2.5, note: 'Same model, lower throughput' },
+  ],
+  open: [
+    { id: 'kimi-list', name: 'Kimi K2.6 (list)', input: 0.95, output: 4.0, note: 'Leads open quality; Composer lineage' },
+    { id: 'kimi-or', name: 'Kimi K2.6 (OpenRouter low)', input: 0.68, output: 3.41, note: 'Cheapest Kimi host' },
+    { id: 'qwen', name: 'Qwen3.5-397B', input: 0.6, output: 3.6, note: 'Strong open frontier MoE' },
+    { id: 'llama', name: 'Llama 4 Maverick', input: 0.5, output: 2.15, note: '400B MoE (DeepInfra)' },
+    { id: 'deepseek-pro', name: 'DeepSeek V4-Pro', input: 0.44, output: 0.87, note: 'Flagship open reasoning/coding' },
+    { id: 'deepseek-flash', name: 'DeepSeek V4-Flash', input: 0.14, output: 0.28, note: 'Budget leader' },
+  ],
+};
+const ALL_MODELS = [...AI_MODELS.closed, ...AI_MODELS.open];
+const getModel = (id) => ALL_MODELS.find((m) => m.id === id) || ALL_MODELS[0];
+const perSpaceMonthlyAICost = (model, profile) =>
+  (TYPICAL_INPUT_M * model.input + TYPICAL_OUTPUT_M * model.output) * PROFILE_MULT[profile];
+const ONBOARDING_BASELINE = 0.56;
+const onboardingCost = (model) => ONBOARDING_BASELINE * (model.input / 3.0);
+
+// ============================================================
+// Base L2 gas cost model (from docs/hypha-ai-cost)
+// Active governance · 0.005 Gwei · ETH $1,748 · non-exec vote @ 150k gas
+// ============================================================
+const GAS_MONTHLY_BY_PROFILE = { light: 0.06, typical: 0.37, heavy: 3.27 };
+const GAS_SETUP_ONE_TIME = 0.035;
+const perSpaceMonthlyGas = (profile) => GAS_MONTHLY_BY_PROFILE[profile] || GAS_MONTHLY_BY_PROFILE.typical;
+
 const HyphaTokenomicsCalculator = () => {
   const [tokensForSale, setTokensForSale] = useState(10000000);
   const [yieldMultiplier, setYieldMultiplier] = useState(30);
@@ -37,9 +75,12 @@ const HyphaTokenomicsCalculator = () => {
   const [existingLockedSupply, setExistingLockedSupply] = useState(111111111);
 
   const [numberOfAOs, setNumberOfAOs] = useState(50);
-  const [paymentPerAO, setPaymentPerAO] = useState(11);
+  const [paymentPerAO, setPaymentPerAO] = useState(22);
   const [usdcFromInvestors, setUsdcFromInvestors] = useState(100000);
   const [aoGrowthRate, setAoGrowthRate] = useState(50);
+
+  const [aiModelId, setAiModelId] = useState('kimi-or');
+  const [aiProfile, setAiProfile] = useState('typical');
 
   const [showMonthlyConfig, setShowMonthlyConfig] = useState(false);
   const [monthlyOverrides, setMonthlyOverrides] = useState({});
@@ -53,13 +94,15 @@ const HyphaTokenomicsCalculator = () => {
   const [totalYieldTokens, setTotalYieldTokens] = useState(0);
   const [totalTokensSold, setTotalTokensSold] = useState(0);
   const [yieldPerLockedToken, setYieldPerLockedToken] = useState(0);
+  const [totalAICost, setTotalAICost] = useState(0);
+  const [totalGasCost, setTotalGasCost] = useState(0);
 
   useEffect(() => {
     calculateTokenomics();
   }, [
     tokensForSale, yieldMultiplier, saleMonths, tokenPrice, totalSupply,
     numberOfAOs, paymentPerAO, usdcFromInvestors, aoGrowthRate,
-    existingLockedSupply, monthlyOverrides
+    existingLockedSupply, monthlyOverrides, aiModelId, aiProfile
   ]);
 
   const getParamForMonth = (month, paramName, defaultValue) => {
@@ -86,6 +129,12 @@ const HyphaTokenomicsCalculator = () => {
     let totalUSDC = 0;
     let calculatedTotalValue = 0;
 
+    const aiModel = getModel(aiModelId);
+    const perSpaceAI = perSpaceMonthlyAICost(aiModel, aiProfile);
+    const perSpaceGas = perSpaceMonthlyGas(aiProfile);
+    let cumulativeAICost = 0;
+    let cumulativeGasCost = 0;
+
     for (let month = 1; month <= saleMonths; month++) {
       const monthTokenPrice = tokenPrice;
       const monthYieldMultiplier = getParamForMonth(month, 'yieldMultiplier', yieldMultiplier);
@@ -105,6 +154,12 @@ const HyphaTokenomicsCalculator = () => {
       const monthInvestorUSDC = getParamForMonth(month, 'usdcFromInvestors', usdcFromInvestors);
 
       const aoIncome = currentNumberOfAOs * monthPaymentPerAO;
+      const monthAICost = currentNumberOfAOs * perSpaceAI;
+      cumulativeAICost += monthAICost;
+      const monthGasCost = currentNumberOfAOs * perSpaceGas;
+      cumulativeGasCost += monthGasCost;
+      const netContribution = aoIncome - monthAICost;
+      const netAfterGas = netContribution - monthGasCost;
       const monthlyUSDC = aoIncome + monthInvestorUSDC;
       totalUSDC += monthlyUSDC;
 
@@ -127,7 +182,13 @@ const HyphaTokenomicsCalculator = () => {
         investorUSDC: monthInvestorUSDC,
         totalMonthlyUSDC: monthlyUSDC,
         totalUSDC,
-        aoPaymentYield: aoIncome * monthYieldMultiplier
+        aoPaymentYield: aoIncome * monthYieldMultiplier,
+        aiCost: monthAICost,
+        cumulativeAICost,
+        gasCost: monthGasCost,
+        cumulativeGasCost,
+        netContribution,
+        netAfterGas,
       });
 
       cumulativeTokenSales.push({
@@ -151,6 +212,8 @@ const HyphaTokenomicsCalculator = () => {
     setTotalValue(calculatedTotalValue);
     setTotalTokensSold(cumulativeSold);
     setYieldPerLockedToken(calculatedYieldPerLockedToken);
+    setTotalAICost(cumulativeAICost);
+    setTotalGasCost(cumulativeGasCost);
   };
 
   const handleMonthlyOverride = (paramName, value) => {
@@ -203,11 +266,129 @@ const HyphaTokenomicsCalculator = () => {
     setUsdcFromInvestors(100000);
     setAoGrowthRate(50);
     setMonthlyOverrides({});
+    setAiModelId('kimi-or');
+    setAiProfile('typical');
   };
+
+  const aiModel = getModel(aiModelId);
+  const perSpaceAI = perSpaceMonthlyAICost(aiModel, aiProfile);
+  const perSpaceGas = perSpaceMonthlyGas(aiProfile);
+  const baselinePerSpace = perSpaceMonthlyAICost(getModel('composer-fast'), aiProfile);
+  const lastMonth = monthlyData.length > 0 ? monthlyData[monthlyData.length - 1] : null;
 
   return (
     <div className="p-6 bg-gray-50 rounded-lg shadow-lg">
-      <h1 className="text-2xl font-bold mb-6 text-center">HYPHA Tokenomics Simulator (Phase I)</h1>
+      <h1 className="text-2xl font-bold mb-1 text-center">HYPHA Tokenomics Simulator (Phase I)</h1>
+      <p className="text-sm text-gray-500 mb-6 text-center">With per-Space AI + Base L2 gas operating cost model — closed-source vs open-source LLMs.</p>
+
+      <div className="mb-8 border border-indigo-200 bg-indigo-50 p-4 rounded-lg">
+        <h2 className="text-lg font-semibold mb-1">AI &amp; On-Chain Operating Cost per Space</h2>
+        <p className="text-xs text-gray-600 mb-3">
+          A Space&apos;s AI workload (full vision) is ~{TYPICAL_INPUT_M}M input + {TYPICAL_OUTPUT_M}M output tokens/month for a Typical space.
+          Pick the inference model and Space profile; the simulator bills every active Space each month for AI inference and Base L2 gas (active governance).
+        </p>
+
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <div>
+            <label className="block text-sm font-medium mb-1">Inference Model</label>
+            <select
+              value={aiModelId}
+              onChange={(e) => setAiModelId(e.target.value)}
+              className="w-full p-2 border rounded bg-white"
+            >
+              <optgroup label="Closed source">
+                {AI_MODELS.closed.map((m) => (
+                  <option key={m.id} value={m.id}>{m.name} — ${m.input}/${m.output} per 1M</option>
+                ))}
+              </optgroup>
+              <optgroup label="Open source">
+                {AI_MODELS.open.map((m) => (
+                  <option key={m.id} value={m.id}>{m.name} — ${m.input}/${m.output} per 1M</option>
+                ))}
+              </optgroup>
+            </select>
+            <p className="text-xs text-gray-500 mt-1">{aiModel.note}</p>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium mb-1">Space Profile</label>
+            <select
+              value={aiProfile}
+              onChange={(e) => setAiProfile(e.target.value)}
+              className="w-full p-2 border rounded bg-white"
+            >
+              <option value="light">Light (~5 members · 0.33×)</option>
+              <option value="typical">Typical (~15 members · 1×)</option>
+              <option value="heavy">Heavy (~50 members · 2.73×)</option>
+            </select>
+            <p className="text-xs text-gray-500 mt-1">Scales AI token volume and gas activity (proposals/votes).</p>
+          </div>
+
+          <div className="bg-white border rounded p-3">
+            <div className="text-xs text-gray-500">AI cost / Space / month</div>
+            <div className="text-2xl font-bold text-indigo-700">${perSpaceAI.toFixed(2)}</div>
+            <div className="text-xs text-gray-500 mt-1">
+              One-time onboarding ≈ ${onboardingCost(aiModel).toFixed(2)} / Space
+            </div>
+            <div className="text-xs text-gray-500">
+              vs Composer Fast: {(baselinePerSpace / perSpaceAI).toFixed(1)}× cheaper
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-4 border border-amber-200 bg-amber-50 rounded p-3">
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div>
+              <div className="text-xs text-gray-600 font-medium">Base L2 gas / Space / month ({aiProfile})</div>
+              <div className="text-2xl font-bold text-amber-700">${perSpaceGas.toFixed(2)}</div>
+              <div className="text-xs text-gray-500 mt-1">Active governance · 0.005 Gwei · ETH $1,748</div>
+            </div>
+            <div>
+              <div className="text-xs text-gray-600 font-medium">One-time setup / Space</div>
+              <div className="text-2xl font-bold text-amber-700">${GAS_SETUP_ONE_TIME.toFixed(3)}</div>
+              <div className="text-xs text-gray-500 mt-1">Create space + deploy-token proposal + deciding vote</div>
+            </div>
+            <div>
+              <div className="text-xs text-gray-600 font-medium">Combined ops / Space / month</div>
+              <div className="text-2xl font-bold text-gray-800">${(perSpaceAI + perSpaceGas).toFixed(2)}</div>
+              <div className="text-xs text-gray-500 mt-1">AI ${perSpaceAI.toFixed(2)} + gas ${perSpaceGas.toFixed(2)}</div>
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-4 overflow-x-auto">
+          <table className="min-w-full bg-white border text-sm">
+            <thead className="bg-gray-100">
+              <tr>
+                <th className="py-1 px-3 border text-left">Model</th>
+                <th className="py-1 px-3 border">Type</th>
+                <th className="py-1 px-3 border text-right">In $/1M</th>
+                <th className="py-1 px-3 border text-right">Out $/1M</th>
+                <th className="py-1 px-3 border text-right">$/Space/mo ({aiProfile})</th>
+                <th className="py-1 px-3 border text-right">vs Composer Fast</th>
+              </tr>
+            </thead>
+            <tbody>
+              {ALL_MODELS.map((m) => {
+                const cost = perSpaceMonthlyAICost(m, aiProfile);
+                const isOpen = AI_MODELS.open.some((o) => o.id === m.id);
+                return (
+                  <tr key={m.id} className={m.id === aiModelId ? 'bg-indigo-100 font-semibold' : ''}>
+                    <td className="py-1 px-3 border">{m.name}</td>
+                    <td className="py-1 px-3 border text-center">{isOpen ? 'Open' : 'Closed'}</td>
+                    <td className="py-1 px-3 border text-right">${m.input.toFixed(2)}</td>
+                    <td className="py-1 px-3 border text-right">${m.output.toFixed(2)}</td>
+                    <td className="py-1 px-3 border text-right">${cost.toFixed(2)}</td>
+                    <td className="py-1 px-3 border text-right">
+                      {m.id === 'composer-fast' ? '—' : `${(baselinePerSpace / cost).toFixed(1)}×`}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </div>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
         <div className="bg-white p-4 rounded-lg shadow">
@@ -370,7 +551,7 @@ const HyphaTokenomicsCalculator = () => {
               <input
                 type="range"
                 min="0"
-                max="1000"
+                max="130"
                 step="10"
                 value={paymentPerAO}
                 onChange={(e) => setPaymentPerAO(Number(e.target.value))}
@@ -382,6 +563,7 @@ const HyphaTokenomicsCalculator = () => {
                 onChange={(e) => setPaymentPerAO(Number(e.target.value))}
                 className="w-20 p-1 border rounded text-right"
                 min="0"
+                max="130"
                 step="1"
               />
               <span className="ml-1">USDC</span>
@@ -410,6 +592,7 @@ const HyphaTokenomicsCalculator = () => {
               />
             </div>
             <p className="text-xs text-gray-500 mt-1">Tokens distributed = Spaces&apos; contributions to Hypha Network (HYPHA) × Distribution Multiplier</p>
+            <p className="text-xs text-gray-500">AI cost (${perSpaceAI.toFixed(2)}/Space) is tracked separately from token sales.</p>
           </div>
 
           <div className="mb-4">
@@ -587,27 +770,31 @@ const HyphaTokenomicsCalculator = () => {
       </div>
 
       <div className="bg-white p-4 rounded-lg shadow mb-8">
-        <h2 className="text-lg font-semibold mb-4">Key Metrics</h2>
+        <h2 className="text-lg font-semibold mb-4">Key Metrics at Month {saleMonths}</h2>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-4">
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
           <div className="p-4 bg-indigo-50 rounded-lg">
             <div className="text-sm text-indigo-600">Current Valuation (Market Cap.)</div>
             <div className="text-2xl font-bold">{formatCurrency(marketCap)}</div>
+            <div className="text-xs text-indigo-600 mt-1">At month {saleMonths} token price</div>
           </div>
 
           <div className="p-4 bg-blue-50 rounded-lg">
             <div className="text-sm text-blue-600">Fully Diluted Valuation (FDV)</div>
             <div className="text-2xl font-bold">{formatCurrency(fdv)}</div>
+            <div className="text-xs text-blue-600 mt-1">At month {saleMonths} token price</div>
           </div>
 
           <div className="p-4 bg-green-50 rounded-lg">
             <div className="text-sm text-green-600">Total Dollar Value Sold</div>
             <div className="text-2xl font-bold">{formatCurrency(totalValue)}</div>
+            <div className="text-xs text-green-600 mt-1">Cumulative over {saleMonths} months</div>
           </div>
 
           <div className="p-4 bg-purple-50 rounded-lg">
             <div className="text-sm text-purple-600">Total Tokens Locked</div>
             <div className="text-2xl font-bold">{formatNumber(totalTokensSold)}</div>
+            <div className="text-xs text-purple-600 mt-1">Cumulative through month {saleMonths}</div>
           </div>
 
           <div className="p-4 bg-amber-50 rounded-lg">
@@ -615,8 +802,62 @@ const HyphaTokenomicsCalculator = () => {
             <div className="text-2xl font-bold">{formatNumber(totalYieldTokens)}</div>
             <div className="text-sm text-amber-600 mt-2">Reward per Locked Token</div>
             <div className="text-xl font-bold">{yieldPerLockedToken.toFixed(4)}</div>
-            <div className="text-xs text-amber-600 mt-1">(Not including monthly compounding effects)</div>
+            <div className="text-xs text-amber-600 mt-1">Cumulative through month {saleMonths}</div>
           </div>
+
+          {lastMonth && (
+            <>
+              <div className="p-4 bg-green-50 rounded-lg border-l-4 border-green-400">
+                <div className="text-sm text-green-600">Cumulated Space Contributions</div>
+                <div className="text-2xl font-bold text-green-700">
+                  {formatCurrency(monthlyData.reduce((s, m) => s + m.aoIncome, 0))}
+                </div>
+                <div className="text-xs text-green-600 mt-1">
+                  Month {saleMonths}: {formatCurrency(lastMonth.aoIncome)} from {formatNumber(lastMonth.numberOfAOs)} Spaces
+                </div>
+              </div>
+
+              <div className="p-4 bg-indigo-50 rounded-lg border-l-4 border-indigo-400">
+                <div className="text-sm text-indigo-600">Monthly AI Cost</div>
+                <div className="text-2xl font-bold text-indigo-700">{formatCurrency(lastMonth.aiCost)}</div>
+                <div className="text-xs text-indigo-600 mt-1">{aiModel.name} · ${perSpaceAI.toFixed(2)}/Space</div>
+              </div>
+
+              <div className="p-4 bg-indigo-50 rounded-lg border-l-4 border-indigo-400">
+                <div className="text-sm text-indigo-600">Cumulative AI Cost</div>
+                <div className="text-2xl font-bold text-indigo-700">{formatCurrency(totalAICost)}</div>
+                <div className="text-xs text-indigo-600 mt-1">Total inference spend over {saleMonths} months</div>
+              </div>
+
+              <div className="p-4 bg-indigo-50 rounded-lg border-l-4 border-indigo-400">
+                <div className="text-sm text-indigo-600">Net After AI (monthly)</div>
+                <div className={`text-2xl font-bold ${lastMonth.netContribution >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+                  {formatCurrency(lastMonth.netContribution)}
+                </div>
+                <div className="text-xs text-indigo-600 mt-1">Space contributions − AI cost (month {saleMonths})</div>
+              </div>
+
+              <div className="p-4 bg-amber-50 rounded-lg border-l-4 border-amber-400">
+                <div className="text-sm text-amber-700">Monthly Gas Cost</div>
+                <div className="text-2xl font-bold text-amber-800">{formatCurrency(lastMonth.gasCost)}</div>
+                <div className="text-xs text-amber-700 mt-1">${perSpaceGas.toFixed(2)}/Space · {aiProfile} profile</div>
+              </div>
+
+              <div className="p-4 bg-amber-50 rounded-lg border-l-4 border-amber-400">
+                <div className="text-sm text-amber-700">Cumulative Gas Cost</div>
+                <div className="text-2xl font-bold text-amber-800">{formatCurrency(totalGasCost)}</div>
+                <div className="text-xs text-amber-700 mt-1">Base L2 governance gas over {saleMonths} months</div>
+              </div>
+
+              <div className="p-4 bg-teal-50 rounded-lg border-l-4 border-teal-400">
+                <div className="text-sm text-teal-700">Net After AI + Gas (monthly)</div>
+                <div className={`text-2xl font-bold ${lastMonth.netAfterGas >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+                  {formatCurrency(lastMonth.netAfterGas)}
+                </div>
+                <div className="text-xs text-teal-700 mt-1">Contributions − AI − gas (month {saleMonths})</div>
+              </div>
+            </>
+          )}
         </div>
       </div>
 
@@ -671,6 +912,48 @@ const HyphaTokenomicsCalculator = () => {
         </ResponsiveContainer>
       </div>
 
+      <div className="bg-white p-4 rounded-lg shadow mb-8">
+        <h2 className="text-lg font-semibold mb-1">Space Contributions vs AI &amp; Gas Cost</h2>
+        <p className="text-xs text-gray-500 mb-4">
+          Space contributions = Spaces × ${paymentPerAO} USDC/Space. AI and gas costs scale with the same Space count × selected model/profile rates.
+        </p>
+        <ResponsiveContainer width="100%" height={300}>
+          <LineChart
+            data={monthlyData}
+            margin={{ top: 5, right: 30, left: 50, bottom: 5 }}
+          >
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="month" label={{ value: 'Month', position: 'insideBottom', offset: -5 }} />
+            <YAxis tickFormatter={(value) => formatCurrency(value)} width={70} />
+            <Tooltip formatter={(value, name) => [formatCurrency(value), name]} />
+            <Legend />
+            <Line type="monotone" dataKey="aoIncome" name="Space Contributions (USD)" stroke="#82ca9d" strokeWidth={2} />
+            <Line type="monotone" dataKey="aiCost" name="AI Cost (USD)" stroke="#6366f1" strokeWidth={2} />
+            <Line type="monotone" dataKey="gasCost" name="Gas Cost (USD)" stroke="#d97706" strokeWidth={2} />
+            <Line type="monotone" dataKey="netContribution" name="Net Contributions (USD)" stroke="#ff7300" strokeWidth={2} />
+            <Line type="monotone" dataKey="netAfterGas" name="Net After AI + Gas (USD)" stroke="#0d9488" strokeWidth={2} strokeDasharray="5 5" />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+
+      <div className="bg-white p-4 rounded-lg shadow mb-8">
+        <h2 className="text-lg font-semibold mb-4">Cumulative AI &amp; Gas Cost</h2>
+        <ResponsiveContainer width="100%" height={300}>
+          <LineChart
+            data={monthlyData}
+            margin={{ top: 5, right: 30, left: 50, bottom: 5 }}
+          >
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="month" label={{ value: 'Month', position: 'insideBottom', offset: -5 }} />
+            <YAxis tickFormatter={(value) => formatCurrency(value)} width={70} />
+            <Tooltip formatter={(value, name) => [formatCurrency(value), name]} />
+            <Legend />
+            <Line type="monotone" dataKey="cumulativeAICost" name="Cumulative AI Cost (USD)" stroke="#6366f1" strokeWidth={2} />
+            <Line type="monotone" dataKey="cumulativeGasCost" name="Cumulative Gas Cost (USD)" stroke="#d97706" strokeWidth={2} />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+
       <div className="bg-white p-4 rounded-lg shadow">
         <h2 className="text-lg font-semibold mb-4">Monthly Breakdown</h2>
         <div className="overflow-x-auto">
@@ -684,6 +967,13 @@ const HyphaTokenomicsCalculator = () => {
                 <th className="px-4 py-3 text-center font-semibold text-gray-700">Tokens Distributed</th>
                 <th className="px-4 py-3 text-center font-semibold text-gray-700">Total Tokens Locked</th>
                 <th className="px-4 py-3 text-center font-semibold text-gray-700">Number of Spaces</th>
+                <th className="px-4 py-3 text-center font-semibold text-gray-700">Space Contributions (USD)</th>
+                <th className="px-4 py-3 text-center font-semibold text-gray-700">AI Cost (USD)</th>
+                <th className="px-4 py-3 text-center font-semibold text-gray-700">Gas Cost (USD)</th>
+                <th className="px-4 py-3 text-center font-semibold text-gray-700">Net After AI (USD)</th>
+                <th className="px-4 py-3 text-center font-semibold text-gray-700">Net After AI + Gas (USD)</th>
+                <th className="px-4 py-3 text-center font-semibold text-gray-700">Cumulative AI Cost (USD)</th>
+                <th className="px-4 py-3 text-center font-semibold text-gray-700">Cumulative Gas Cost (USD)</th>
                 <th className="px-4 py-3 text-center font-semibold text-gray-700">Distribution Multiplier</th>
               </tr>
             </thead>
@@ -699,6 +989,17 @@ const HyphaTokenomicsCalculator = () => {
                     {formatNumber(cumulativeData[index].cumulativeSold + cumulativeData[index].cumulativeYield + existingLockedSupply)}
                   </td>
                   <td className="px-4 py-3 text-center">{formatNumber(month.numberOfAOs)}</td>
+                  <td className="px-4 py-3 text-center">{formatCurrency(month.aoIncome)}</td>
+                  <td className="px-4 py-3 text-center text-indigo-700">{formatCurrency(month.aiCost)}</td>
+                  <td className="px-4 py-3 text-center text-amber-700">{formatCurrency(month.gasCost)}</td>
+                  <td className={`px-4 py-3 text-center ${month.netContribution >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+                    {formatCurrency(month.netContribution)}
+                  </td>
+                  <td className={`px-4 py-3 text-center ${month.netAfterGas >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+                    {formatCurrency(month.netAfterGas)}
+                  </td>
+                  <td className="px-4 py-3 text-center text-indigo-700">{formatCurrency(month.cumulativeAICost)}</td>
+                  <td className="px-4 py-3 text-center text-amber-700">{formatCurrency(month.cumulativeGasCost)}</td>
                   <td className="px-4 py-3 text-center">{month.yieldMultiplier}x</td>
                 </tr>
               ))}

--- a/apps/web/public/tokenomics2/index.html
+++ b/apps/web/public/tokenomics2/index.html
@@ -73,18 +73,19 @@ const GROWTH_PRESETS = {
     subtitle: '~250k Spaces',
     defaults: {
       orgPayment: 44,
-      investorSelling: 10,
-      additionalPurchase: 10,
-      unlockRate: 5,
-      initialHypha: 3333333,
-      initialUsdc: 1000000,
+      iexAllocationPct: 8,
+      investorSelling: 5,
+      additionalPurchase: 5,
+      unlockRate: 4,
+      initialHypha: 20000000,
+      initialUsdc: 4000000,
       orgCount: 4373,
-      orgGrowthRate: 25,
+      orgGrowthRate: 9,
     },
+    // Target ~250k Spaces at month 48 (~9.0%/mo, months 2–48)
     build: () => {
-      const m = { 1: { orgGrowthRate: 25 } };
-      for (let i = 2; i <= 26; i++) m[i] = { orgGrowthRate: 0 };
-      for (let i = 27; i <= 48; i++) m[i] = { orgGrowthRate: 3 };
+      const m = {};
+      for (let i = 2; i <= 48; i++) m[i] = { orgGrowthRate: 9.0 };
       return m;
     },
   },
@@ -93,45 +94,40 @@ const GROWTH_PRESETS = {
     subtitle: '~1M Spaces',
     defaults: {
       orgPayment: 44,
-      investorSelling: 10,
-      additionalPurchase: 10,
-      unlockRate: 4,
-      initialHypha: 12000000,
-      initialUsdc: 750000,
+      iexAllocationPct: 10,
+      investorSelling: 5,
+      additionalPurchase: 5,
+      unlockRate: 3.5,
+      initialHypha: 40000000,
+      initialUsdc: 8000000,
       orgCount: 4373,
-      orgGrowthRate: 25,
+      orgGrowthRate: 12.26,
     },
-    build: () => ({
-      1: { orgGrowthRate: 25 }, 2: { orgGrowthRate: 1 }, 3: { orgGrowthRate: 2 }, 4: { orgGrowthRate: 2 },
-      5: { orgGrowthRate: 2 }, 6: { orgGrowthRate: 2 }, 7: { orgGrowthRate: 3 }, 8: { orgGrowthRate: 2 },
-      9: { orgGrowthRate: 3 }, 10: { orgGrowthRate: 27 }, 11: { orgGrowthRate: 15 }, 12: { orgGrowthRate: 14 },
-      13: { orgGrowthRate: 13 }, 14: { orgGrowthRate: 12 }, 15: { orgGrowthRate: 25 }, 16: { orgGrowthRate: 10 },
-      17: { orgGrowthRate: 3 }, 18: { orgGrowthRate: 8 }, 19: { orgGrowthRate: 7 }, 20: { orgGrowthRate: 2 },
-      21: { orgGrowthRate: 1 }, 22: { orgGrowthRate: 4 }, 23: { orgGrowthRate: 4 }, 24: { orgGrowthRate: 4 },
-      25: { orgGrowthRate: 4 }, 26: { orgGrowthRate: 4 }, 27: { orgGrowthRate: 3 }, 28: { orgGrowthRate: 3 },
-      29: { orgGrowthRate: 3 }, 30: { orgGrowthRate: 3 }, 31: { orgGrowthRate: 3 }, 32: { orgGrowthRate: 3 },
-      33: { orgGrowthRate: 3 }, 34: { orgGrowthRate: 3 }, 35: { orgGrowthRate: 3 }, 36: { orgGrowthRate: 3 },
-      37: { orgGrowthRate: 3 }, 38: { orgGrowthRate: 3 }, 39: { orgGrowthRate: 3 }, 40: { orgGrowthRate: 3 },
-      41: { orgGrowthRate: 3 }, 42: { orgGrowthRate: 3 }, 43: { orgGrowthRate: 3 }, 44: { orgGrowthRate: 3 },
-      45: { orgGrowthRate: 3 }, 46: { orgGrowthRate: 3 }, 47: { orgGrowthRate: 3 }, 48: { orgGrowthRate: 3 },
-    }),
+    // Target ~1M Spaces at month 48 (~12.26%/mo, months 2–48)
+    build: () => {
+      const m = {};
+      for (let i = 2; i <= 48; i++) m[i] = { orgGrowthRate: 12.26 };
+      return m;
+    },
   },
   high: {
     label: 'High',
     subtitle: '~10M Spaces',
     defaults: {
       orgPayment: 44,
-      investorSelling: 10,
-      additionalPurchase: 10,
-      unlockRate: 4,
-      initialHypha: 20000000,
-      initialUsdc: 1000000,
+      iexAllocationPct: 12,
+      investorSelling: 5,
+      additionalPurchase: 5,
+      unlockRate: 3,
+      initialHypha: 100000000,
+      initialUsdc: 25000000,
       orgCount: 4373,
-      orgGrowthRate: 25,
+      orgGrowthRate: 17.9,
     },
+    // Target ~10M Spaces at month 48 (~17.9%/mo, months 2–48)
     build: () => {
-      const m = { 1: { orgGrowthRate: 25 } };
-      for (let i = 2; i <= 48; i++) m[i] = { orgGrowthRate: 18 };
+      const m = {};
+      for (let i = 2; i <= 48; i++) m[i] = { orgGrowthRate: 17.9 };
       return m;
     },
   },
@@ -151,6 +147,7 @@ const TokenomicsSimulator = () => {
   const [additionalPurchase, setAdditionalPurchase] = useState(GROWTH_PRESETS.low.defaults.additionalPurchase);
   const [orgCount, setOrgCount] = useState(GROWTH_PRESETS.low.defaults.orgCount);
   const [orgPayment, setOrgPayment] = useState(GROWTH_PRESETS.low.defaults.orgPayment);
+  const [iexAllocationPct, setIexAllocationPct] = useState(GROWTH_PRESETS.low.defaults.iexAllocationPct);
   const [orgGrowthRate, setOrgGrowthRate] = useState(GROWTH_PRESETS.low.defaults.orgGrowthRate);
 
   // AI operating cost controls
@@ -169,7 +166,7 @@ const TokenomicsSimulator = () => {
     calculateTokenomics();
   }, [initialHypha, initialUsdc, months, unlockRate, stakingRate, sellRate,
       investorSelling, additionalPurchase, stakingRewards, rewardSplit, maxSupply,
-      orgCount, orgPayment, orgGrowthRate, monthlyParams, aiModelId, aiProfile]);
+      orgCount, orgPayment, iexAllocationPct, orgGrowthRate, monthlyParams, aiModelId, aiProfile]);
 
   const getMonthlyParameter = (paramName, month) => {
     if (monthlyParams[month] && monthlyParams[month][paramName] !== undefined) {
@@ -189,6 +186,7 @@ const TokenomicsSimulator = () => {
       case 'additionalPurchase': return additionalPurchase;
       case 'orgCount': return orgCount;
       case 'orgPayment': return orgPayment;
+      case 'iexAllocationPct': return iexAllocationPct;
       case 'orgGrowthRate': return orgGrowthRate;
       default: return 0;
     }
@@ -246,14 +244,16 @@ const TokenomicsSimulator = () => {
       }
 
       const monthOrgPayment = getMonthlyParameter('orgPayment', month);
-      const orgTotalPurchase = currentOrgCount * monthOrgPayment;
+      const grossContribution = currentOrgCount * monthOrgPayment;
+      const iexPct = getMonthlyParameter('iexAllocationPct', month) / 100;
+      const orgTotalPurchase = grossContribution * iexPct;
 
       // AI operating cost for this month (all active spaces)
       const monthAICost = currentOrgCount * perSpaceAI;
       cumulativeAICost += monthAICost;
       const monthGasCost = currentOrgCount * perSpaceGas;
       cumulativeGasCost += monthGasCost;
-      const netContribution = orgTotalPurchase - monthAICost;
+      const netContribution = grossContribution - monthAICost;
       const netAfterGas = netContribution - monthGasCost;
 
       const dexPrice = dexUsdc / dexHypha;
@@ -360,7 +360,8 @@ const TokenomicsSimulator = () => {
         dexHypha: Math.round(dexHypha), dexUsdc: Math.round(dexUsdc),
         tokenPrice: endOfMonthPrice.toFixed(6), deltaPrice: priceChange.toFixed(2),
         orgCount: currentOrgCount, cumulativeOrgCount,
-        orgUsdcPurchase: orgTotalPurchase,
+        orgUsdcPurchase: grossContribution,
+        iexUsdcPurchase: orgTotalPurchase,
         orgPurchasedTokens: Math.round(actualOrgPurchasedTokens),
         investorPurchasedTokens: Math.round(investorPurchasedTokens),
         totalPurchasedTokens: Math.round(totalPurchasedTokens),
@@ -387,7 +388,8 @@ const TokenomicsSimulator = () => {
         'Price (USDC)': parseFloat(endOfMonthPrice.toFixed(6)),
         'FDV (Million $)': Math.round(fdv / 1000000),
         'Space Purchases': Math.round(actualOrgPurchasedTokens),
-        'Space Contributions (USD)': Math.round(orgTotalPurchase),
+        'Space Contributions (USD)': Math.round(grossContribution),
+        'IEX Buy (USD)': Math.round(orgTotalPurchase),
         'AI Cost (USD)': Math.round(monthAICost),
         'Gas Cost (USD)': Math.round(monthGasCost),
         'Net Contributions (USD)': Math.round(netContribution),
@@ -404,6 +406,7 @@ const TokenomicsSimulator = () => {
   const applyScenarioDefaults = (scenario) => {
     const d = GROWTH_PRESETS[scenario].defaults;
     setOrgPayment(d.orgPayment);
+    setIexAllocationPct(d.iexAllocationPct);
     setInvestorSelling(d.investorSelling);
     setAdditionalPurchase(d.additionalPurchase);
     setUnlockRate(d.unlockRate);
@@ -662,7 +665,16 @@ const TokenomicsSimulator = () => {
               <input type="number" min="0" max="200" value={monthlyParams[selectedMonth]?.orgPayment ?? orgPayment} onChange={(e) => { const v = Number(e.target.value); selectedMonth === 1 ? setOrgPayment(v) : updateMonthlyParameter('orgPayment', v); }} className="w-20 p-1 border rounded text-right" />
               <span className="ml-1">USDC</span>
             </div>
-            <p className="text-xs text-gray-500 mt-1">AI (${perSpaceAI.toFixed(2)}/Space) and gas (${perSpaceGas.toFixed(2)}/Space) tracked separately from IEX purchases.</p>
+            <p className="text-xs text-gray-500 mt-1">Gross revenue per Space. AI (${perSpaceAI.toFixed(2)}/Space) and gas (${perSpaceGas.toFixed(2)}/Space) tracked separately; only a % routes to IEX.</p>
+          </div>
+          <div className="mb-4">
+            <label className="block text-sm font-medium mb-1">% routed to IEX (buy pressure)</label>
+            <div className="flex items-center">
+              <input type="range" min="0" max="30" step="1" value={monthlyParams[selectedMonth]?.iexAllocationPct ?? iexAllocationPct} onChange={(e) => { const v = Number(e.target.value); selectedMonth === 1 ? setIexAllocationPct(v) : updateMonthlyParameter('iexAllocationPct', v); }} className="w-full mr-3" />
+              <input type="number" min="0" max="30" value={monthlyParams[selectedMonth]?.iexAllocationPct ?? iexAllocationPct} onChange={(e) => { const v = Number(e.target.value); selectedMonth === 1 ? setIexAllocationPct(v) : updateMonthlyParameter('iexAllocationPct', v); }} className="w-16 p-1 border rounded text-right" />
+              <span className="ml-1">%</span>
+            </div>
+            <p className="text-xs text-gray-500 mt-1">Remainder = treasury / ops / rewards off-pool.</p>
           </div>
           <div className="mb-4">
             <label className="block text-sm font-medium mb-1">Additional Investor Purchases + buybacks (% of USDC on IEX)</label>
@@ -677,8 +689,8 @@ const TokenomicsSimulator = () => {
           <div className="mb-4">
             <label className="block text-sm font-medium mb-1">Investor Selling (% of HYPHA on IEX)</label>
             <div className="flex items-center">
-              <input type="range" min="10" max="30" step="0.5" value={monthlyParams[selectedMonth]?.investorSelling ?? investorSelling} onChange={(e) => { const v = Number(e.target.value); selectedMonth === 1 ? setInvestorSelling(v) : updateMonthlyParameter('investorSelling', v); }} className="w-full mr-3" />
-              <input type="number" min="10" max="30" step="0.5" value={monthlyParams[selectedMonth]?.investorSelling ?? investorSelling} onChange={(e) => { const v = Number(e.target.value); selectedMonth === 1 ? setInvestorSelling(v) : updateMonthlyParameter('investorSelling', v); }} className="w-16 p-1 border rounded text-right" />
+              <input type="range" min="0" max="30" step="0.5" value={monthlyParams[selectedMonth]?.investorSelling ?? investorSelling} onChange={(e) => { const v = Number(e.target.value); selectedMonth === 1 ? setInvestorSelling(v) : updateMonthlyParameter('investorSelling', v); }} className="w-full mr-3" />
+              <input type="number" min="0" max="30" step="0.5" value={monthlyParams[selectedMonth]?.investorSelling ?? investorSelling} onChange={(e) => { const v = Number(e.target.value); selectedMonth === 1 ? setInvestorSelling(v) : updateMonthlyParameter('investorSelling', v); }} className="w-16 p-1 border rounded text-right" />
               <span className="ml-1">%</span>
             </div>
           </div>
@@ -866,7 +878,7 @@ const TokenomicsSimulator = () => {
           <div className="h-80 bg-white p-4 rounded-lg shadow md:col-span-2">
             <h3 className="text-md font-medium mb-1">Space Contributions vs AI &amp; Gas Cost</h3>
             <p className="text-xs text-gray-500 mb-2">
-              Contributions = Spaces × ${orgPayment} USDC/Space. Flat stretches happen when per-month Space Growth Rate is 0% (default: months 2–26). AI and gas costs scale with the same Space count × selected model/profile rates.
+              Gross contributions = Spaces × ${orgPayment} USDC/Space. Only {iexAllocationPct}% routes to IEX each month; AI and gas costs scale with Space count × selected model/profile rates.
             </p>
             <ResponsiveContainer width="100%" height="85%">
               <LineChart data={chartData} margin={{ top: 5, right: 50, left: 50, bottom: 5 }}>

--- a/apps/web/public/tokenomics2/index.html
+++ b/apps/web/public/tokenomics2/index.html
@@ -66,11 +66,22 @@ const GAS_MONTHLY_BY_PROFILE = { light: 0.06, typical: 0.37, heavy: 3.27 };
 const GAS_SETUP_ONE_TIME = 0.035;
 const perSpaceMonthlyGas = (profile) => GAS_MONTHLY_BY_PROFILE[profile] || GAS_MONTHLY_BY_PROFILE.typical;
 
+// Phase 0 → Phase I → Phase II continuity (same network, one growth story)
+const PHASE0_ACTIVE_SPACES = 4373;
+const PHASE_I_MONTHS = 12;
+const PHASE_I_MONTHLY_GROWTH = 0.72; // continues into Phase II Low preset
+const phaseIHandoffSpaces = () => {
+  let n = PHASE0_ACTIVE_SPACES;
+  for (let m = 2; m <= PHASE_I_MONTHS; m++) n = Math.round(n * (1 + PHASE_I_MONTHLY_GROWTH / 100));
+  return n;
+};
+const PHASE_II_START_SPACES = phaseIHandoffSpaces(); // ~4,732 after 12 mo Phase I
+
 
 const GROWTH_PRESETS = {
   low: {
     label: 'Low',
-    subtitle: '~250k cumulative',
+    subtitle: '~270k cumulative',
     defaults: {
       orgPayment: 44,
       iexAllocationPct: 25,
@@ -79,10 +90,10 @@ const GROWTH_PRESETS = {
       unlockRate: 4,
       initialHypha: 5000000,
       initialUsdc: 1000000,
-      orgCount: 4373,
+      orgCount: PHASE_II_START_SPACES,
       orgGrowthRate: 0.72,
     },
-    // Target ~250k cumulative Space-months at month 48 (~0.72%/mo, months 2–48)
+    // ~270k cumulative Space-months at month 48 (0.72%/mo from Phase I handoff)
     build: () => {
       const m = {};
       for (let i = 2; i <= 48; i++) m[i] = { orgGrowthRate: 0.72 };
@@ -100,13 +111,13 @@ const GROWTH_PRESETS = {
       unlockRate: 3.5,
       initialHypha: 40000000,
       initialUsdc: 8000000,
-      orgCount: 4373,
-      orgGrowthRate: 5.63,
+      orgCount: PHASE_II_START_SPACES,
+      orgGrowthRate: 5.38,
     },
-    // Target ~1M cumulative Space-months at month 48 (~5.63%/mo, months 2–48)
+    // Target ~1M cumulative Space-months at month 48 (~5.38%/mo from handoff)
     build: () => {
       const m = {};
-      for (let i = 2; i <= 48; i++) m[i] = { orgGrowthRate: 5.63 };
+      for (let i = 2; i <= 48; i++) m[i] = { orgGrowthRate: 5.38 };
       return m;
     },
   },
@@ -121,13 +132,13 @@ const GROWTH_PRESETS = {
       unlockRate: 3,
       initialHypha: 100000000,
       initialUsdc: 25000000,
-      orgCount: 4373,
-      orgGrowthRate: 12.52,
+      orgCount: PHASE_II_START_SPACES,
+      orgGrowthRate: 12.29,
     },
-    // Target ~10M cumulative Space-months at month 48 (~12.52%/mo, months 2–48)
+    // Target ~10M cumulative Space-months at month 48 (~12.29%/mo from handoff)
     build: () => {
       const m = {};
-      for (let i = 2; i <= 48; i++) m[i] = { orgGrowthRate: 12.52 };
+      for (let i = 2; i <= 48; i++) m[i] = { orgGrowthRate: 12.29 };
       return m;
     },
   },
@@ -469,7 +480,7 @@ const TokenomicsSimulator = () => {
           </div>
           <div className="bg-indigo-600 text-white p-3 rounded border border-indigo-700">
             <div className="font-semibold">Phase II — After Phase I (this sim)</div>
-            <p className="text-xs text-indigo-100 mt-1">Starts ~4,373 paying Spaces × $44/mo. Month 1 = first month after handoff.</p>
+            <p className="text-xs text-indigo-100 mt-1">Starts ~{PHASE_II_START_SPACES.toLocaleString()} paying Spaces (Phase I handoff) × $44/mo. Month 1 = first month after Phase I.</p>
           </div>
         </div>
       </div>

--- a/apps/web/public/tokenomics2/index.html
+++ b/apps/web/public/tokenomics2/index.html
@@ -67,78 +67,72 @@ const GAS_SETUP_ONE_TIME = 0.035;
 const perSpaceMonthlyGas = (profile) => GAS_MONTHLY_BY_PROFILE[profile] || GAS_MONTHLY_BY_PROFILE.typical;
 
 // Phase 0 → Phase I → Phase II continuity (same network, one growth story)
-const PHASE0_ACTIVE_SPACES = 4373;
-const PHASE_I_MONTHS = 12;
-const PHASE_I_MONTHLY_GROWTH = 0.72; // continues into Phase II Low preset
-const phaseIHandoffSpaces = () => {
-  let n = PHASE0_ACTIVE_SPACES;
-  for (let m = 2; m <= PHASE_I_MONTHS; m++) n = Math.round(n * (1 + PHASE_I_MONTHLY_GROWTH / 100));
-  return n;
-};
-const PHASE_II_START_SPACES = phaseIHandoffSpaces(); // ~4,732 after 12 mo Phase I
+// Phase I bootstraps 0 → ~4,373 active Spaces over 12 months. Phase II starts there.
+const PHASE_I_END_SPACES = 4373;
+const PHASE_II_START_SPACES = PHASE_I_END_SPACES;
 
-
+// Year-5 (Phase II month 48) ACTIVE Space targets: Low ~25k, Mid ~250k, High ~2M
 const GROWTH_PRESETS = {
   low: {
     label: 'Low',
-    subtitle: '~270k cumulative',
+    subtitle: '~25k active (year 5)',
     defaults: {
       orgPayment: 44,
       iexAllocationPct: 25,
-      investorSelling: 5,
+      investorSelling: 3,
       additionalPurchase: 5,
       unlockRate: 4,
-      initialHypha: 5000000,
-      initialUsdc: 1000000,
+      initialHypha: 40000000,
+      initialUsdc: 8000000,
       orgCount: PHASE_II_START_SPACES,
-      orgGrowthRate: 0.72,
+      orgGrowthRate: 3.78,
     },
-    // ~270k cumulative Space-months at month 48 (0.72%/mo from Phase I handoff)
+    // ~25k active / ~570k cumulative Space-months at Phase II month 48 (~3.78%/mo)
     build: () => {
       const m = {};
-      for (let i = 2; i <= 48; i++) m[i] = { orgGrowthRate: 0.72 };
+      for (let i = 2; i <= 48; i++) m[i] = { orgGrowthRate: 3.78 };
       return m;
     },
   },
   mid: {
     label: 'Mid',
-    subtitle: '~1M cumulative',
+    subtitle: '~250k active (year 5)',
     defaults: {
       orgPayment: 44,
-      iexAllocationPct: 25,
+      iexAllocationPct: 19,
       investorSelling: 5,
       additionalPurchase: 8,
       unlockRate: 3.5,
-      initialHypha: 40000000,
-      initialUsdc: 8000000,
+      initialHypha: 80000000,
+      initialUsdc: 16000000,
       orgCount: PHASE_II_START_SPACES,
-      orgGrowthRate: 5.38,
+      orgGrowthRate: 8.99,
     },
-    // Target ~1M cumulative Space-months at month 48 (~5.38%/mo from handoff)
+    // ~250k active / ~3M cumulative Space-months at Phase II month 48 (~8.99%/mo)
     build: () => {
       const m = {};
-      for (let i = 2; i <= 48; i++) m[i] = { orgGrowthRate: 5.38 };
+      for (let i = 2; i <= 48; i++) m[i] = { orgGrowthRate: 8.99 };
       return m;
     },
   },
   high: {
     label: 'High',
-    subtitle: '~10M cumulative',
+    subtitle: '~2M active (year 5)',
     defaults: {
       orgPayment: 44,
       iexAllocationPct: 19,
       investorSelling: 3,
       additionalPurchase: 8,
       unlockRate: 3,
-      initialHypha: 100000000,
-      initialUsdc: 25000000,
+      initialHypha: 150000000,
+      initialUsdc: 30000000,
       orgCount: PHASE_II_START_SPACES,
-      orgGrowthRate: 12.29,
+      orgGrowthRate: 13.92,
     },
-    // Target ~10M cumulative Space-months at month 48 (~12.29%/mo from handoff)
+    // ~2M active / ~16M cumulative Space-months at Phase II month 48 (~13.92%/mo)
     build: () => {
       const m = {};
-      for (let i = 2; i <= 48; i++) m[i] = { orgGrowthRate: 12.29 };
+      for (let i = 2; i <= 48; i++) m[i] = { orgGrowthRate: 13.92 };
       return m;
     },
   },
@@ -472,15 +466,15 @@ const TokenomicsSimulator = () => {
         <div className="grid grid-cols-1 md:grid-cols-3 gap-3 text-sm">
           <div className="bg-white p-3 rounded border border-slate-200">
             <div className="font-semibold text-slate-600">Phase 0 — Today</div>
-            <p className="text-xs text-gray-600 mt-1">~4,373 Spaces live. Phase I at month 0. Reference FDV ~$111M at $0.20.</p>
+            <p className="text-xs text-gray-600 mt-1">Pre-launch. Reference FDV ~$111M at $0.20 (111M locked supply).</p>
           </div>
           <div className="bg-white p-3 rounded border border-slate-200">
-            <div className="font-semibold text-slate-700">Phase I — Month 0+</div>
-            <p className="text-xs text-gray-600 mt-1">Fixed $0.20 price, token sale &amp; locking. <a href="/tokenomics1/" className="text-indigo-600 underline">Phase I simulator →</a></p>
+            <div className="font-semibold text-slate-700">Phase I — Year 1 (months 0–12)</div>
+            <p className="text-xs text-gray-600 mt-1">Bootstrap 0 → ~4,373 paying Spaces, fixed $0.20. <a href="/tokenomics1/" className="text-indigo-600 underline">Phase I simulator →</a></p>
           </div>
           <div className="bg-indigo-600 text-white p-3 rounded border border-indigo-700">
-            <div className="font-semibold">Phase II — After Phase I (this sim)</div>
-            <p className="text-xs text-indigo-100 mt-1">Starts ~{PHASE_II_START_SPACES.toLocaleString()} paying Spaces (Phase I handoff) × $44/mo. Month 1 = first month after Phase I.</p>
+            <div className="font-semibold">Phase II — Years 2–5 (this sim)</div>
+            <p className="text-xs text-indigo-100 mt-1">Starts ~{PHASE_II_START_SPACES.toLocaleString()} paying Spaces × $44/mo. Month 1 = first month of year 2. Year 5 = month 48.</p>
           </div>
         </div>
       </div>
@@ -615,14 +609,14 @@ const TokenomicsSimulator = () => {
           <div className="mb-4">
             <label className="block text-sm font-medium mb-1">Initial HYPHA on IEX</label>
             <div className="flex items-center">
-              <input type="range" min="1000000" max="50000000" step="1000000" value={initialHypha} onChange={(e) => setInitialHypha(Number(e.target.value))} className="w-full mr-3" />
+              <input type="range" min="1000000" max="200000000" step="1000000" value={initialHypha} onChange={(e) => setInitialHypha(Number(e.target.value))} className="w-full mr-3" />
               <input type="text" value={formatNumber(initialHypha)} onChange={(e) => { const v = Number(e.target.value.replace(/,/g, '')); if (!isNaN(v)) setInitialHypha(v); }} className="w-24 p-1 border rounded text-right" />
             </div>
           </div>
           <div className="mb-4">
             <label className="block text-sm font-medium mb-1">Initial USDC on IEX</label>
             <div className="flex items-center">
-              <input type="range" min="100000" max="2000000" step="50000" value={initialUsdc} onChange={(e) => setInitialUsdc(Number(e.target.value))} className="w-full mr-3" />
+              <input type="range" min="100000" max="40000000" step="100000" value={initialUsdc} onChange={(e) => setInitialUsdc(Number(e.target.value))} className="w-full mr-3" />
               <input type="text" value={formatNumber(initialUsdc)} onChange={(e) => { const v = Number(e.target.value.replace(/,/g, '')); if (!isNaN(v)) setInitialUsdc(v); }} className="w-24 p-1 border rounded text-right" />
             </div>
           </div>

--- a/apps/web/public/tokenomics2/index.html
+++ b/apps/web/public/tokenomics2/index.html
@@ -58,6 +58,14 @@ const perSpaceMonthlyAICost = (model, profile) =>
 const ONBOARDING_BASELINE = 0.56; // Composer Fast one-time onboarding / space
 const onboardingCost = (model) => ONBOARDING_BASELINE * (model.input / 3.0); // scales with input price
 
+// ============================================================
+// Base L2 gas cost model (from docs/hypha-ai-cost)
+// Active governance · 0.005 Gwei · ETH $1,748 · non-exec vote @ 150k gas
+// ============================================================
+const GAS_MONTHLY_BY_PROFILE = { light: 0.06, typical: 0.37, heavy: 3.27 };
+const GAS_SETUP_ONE_TIME = 0.035;
+const perSpaceMonthlyGas = (profile) => GAS_MONTHLY_BY_PROFILE[profile] || GAS_MONTHLY_BY_PROFILE.typical;
+
 
 const GROWTH_PRESETS = {
   min: {
@@ -222,7 +230,9 @@ const TokenomicsSimulator = () => {
 
     const aiModel = getModel(aiModelId);
     const perSpaceAI = perSpaceMonthlyAICost(aiModel, aiProfile);
+    const perSpaceGas = perSpaceMonthlyGas(aiProfile);
     let cumulativeAICost = 0;
+    let cumulativeGasCost = 0;
 
     for (let month = 1; month <= months; month++) {
       const monthStakingRate = getMonthlyParameter('stakingRate', month) / 100;
@@ -250,7 +260,10 @@ const TokenomicsSimulator = () => {
       // AI operating cost for this month (all active spaces)
       const monthAICost = currentOrgCount * perSpaceAI;
       cumulativeAICost += monthAICost;
+      const monthGasCost = currentOrgCount * perSpaceGas;
+      cumulativeGasCost += monthGasCost;
       const netContribution = orgTotalPurchase - monthAICost;
+      const netAfterGas = netContribution - monthGasCost;
 
       const dexPrice = dexUsdc / dexHypha;
       const dexHyphaBefore = dexHypha;
@@ -363,7 +376,8 @@ const TokenomicsSimulator = () => {
         investorSellingUsdc: monthInvestorSelling, tokensSold,
         fdv: Math.round(fdv),
         aiCost: monthAICost, cumulativeAICost,
-        netContribution,
+        gasCost: monthGasCost, cumulativeGasCost,
+        netContribution, netAfterGas,
       });
 
       graphData.push({
@@ -384,8 +398,11 @@ const TokenomicsSimulator = () => {
         'Space Purchases': Math.round(actualOrgPurchasedTokens),
         'Space Contributions (USD)': Math.round(orgTotalPurchase),
         'AI Cost (USD)': Math.round(monthAICost),
+        'Gas Cost (USD)': Math.round(monthGasCost),
         'Net Contributions (USD)': Math.round(netContribution),
+        'Net After AI + Gas (USD)': Math.round(netAfterGas),
         'Cumulative AI Cost (USD)': Math.round(cumulativeAICost),
+        'Cumulative Gas Cost (USD)': Math.round(cumulativeGasCost),
       });
     }
 
@@ -426,6 +443,7 @@ const TokenomicsSimulator = () => {
 
   const aiModel = getModel(aiModelId);
   const perSpaceAI = perSpaceMonthlyAICost(aiModel, aiProfile);
+  const perSpaceGas = perSpaceMonthlyGas(aiProfile);
   const baselinePerSpace = perSpaceMonthlyAICost(getModel('composer-fast'), aiProfile);
 
 
@@ -434,14 +452,14 @@ const TokenomicsSimulator = () => {
       <div className="flex gap-6">
         <div className="flex-1 min-w-0">
       <h1 className="text-2xl font-bold mb-1">HYPHA Tokenomics Simulator (Phase II)</h1>
-      <p className="text-sm text-gray-500 mb-4">With per-Space AI operating cost model — closed-source vs open-source LLMs.</p>
+      <p className="text-sm text-gray-500 mb-4">With per-Space AI + Base L2 gas operating cost model — closed-source vs open-source LLMs.</p>
 
       {/* ============ AI OPERATING COST SECTION ============ */}
       <div className="mb-6 border border-indigo-200 bg-indigo-50 p-4 rounded-lg">
-        <h2 className="text-lg font-semibold mb-1">AI Operating Cost per Space</h2>
+        <h2 className="text-lg font-semibold mb-1">AI &amp; On-Chain Operating Cost per Space</h2>
         <p className="text-xs text-gray-600 mb-3">
           A Space's AI workload (full vision) is ~{TYPICAL_INPUT_M}M input + {TYPICAL_OUTPUT_M}M output tokens/month for a Typical space.
-          Pick the inference model and Space profile; the simulator bills every active Space each month.
+          Pick the inference model and Space profile; the simulator bills every active Space each month for AI inference and Base L2 gas (active governance).
         </p>
 
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
@@ -477,7 +495,7 @@ const TokenomicsSimulator = () => {
               <option value="typical">Typical (~15 members · 1×)</option>
               <option value="heavy">Heavy (~50 members · 2.73×)</option>
             </select>
-            <p className="text-xs text-gray-500 mt-1">Scales the per-Space token volume.</p>
+            <p className="text-xs text-gray-500 mt-1">Scales AI token volume and gas activity (proposals/votes).</p>
           </div>
 
           <div className="bg-white border rounded p-3">
@@ -488,6 +506,26 @@ const TokenomicsSimulator = () => {
             </div>
             <div className="text-xs text-gray-500">
               vs Composer Fast: {(baselinePerSpace / perSpaceAI).toFixed(1)}× cheaper
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-4 border border-amber-200 bg-amber-50 rounded p-3">
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div>
+              <div className="text-xs text-gray-600 font-medium">Base L2 gas / Space / month ({aiProfile})</div>
+              <div className="text-2xl font-bold text-amber-700">${perSpaceGas.toFixed(2)}</div>
+              <div className="text-xs text-gray-500 mt-1">Active governance · 0.005 Gwei · ETH $1,748</div>
+            </div>
+            <div>
+              <div className="text-xs text-gray-600 font-medium">One-time setup / Space</div>
+              <div className="text-2xl font-bold text-amber-700">${GAS_SETUP_ONE_TIME.toFixed(3)}</div>
+              <div className="text-xs text-gray-500 mt-1">Create space + deploy-token proposal + deciding vote</div>
+            </div>
+            <div>
+              <div className="text-xs text-gray-600 font-medium">Combined ops / Space / month</div>
+              <div className="text-2xl font-bold text-gray-800">${(perSpaceAI + perSpaceGas).toFixed(2)}</div>
+              <div className="text-xs text-gray-500 mt-1">AI ${perSpaceAI.toFixed(2)} + gas ${perSpaceGas.toFixed(2)}</div>
             </div>
           </div>
         </div>
@@ -633,7 +671,7 @@ const TokenomicsSimulator = () => {
               <input type="number" min="0" max="200" value={monthlyParams[selectedMonth]?.orgPayment ?? orgPayment} onChange={(e) => { const v = Number(e.target.value); selectedMonth === 1 ? setOrgPayment(v) : updateMonthlyParameter('orgPayment', v); }} className="w-20 p-1 border rounded text-right" />
               <span className="ml-1">USDC</span>
             </div>
-            <p className="text-xs text-gray-500 mt-1">AI cost (${perSpaceAI.toFixed(2)}/Space) is tracked separately from IEX purchases.</p>
+            <p className="text-xs text-gray-500 mt-1">AI (${perSpaceAI.toFixed(2)}/Space) and gas (${perSpaceGas.toFixed(2)}/Space) tracked separately from IEX purchases.</p>
           </div>
           <div className="mb-4">
             <label className="block text-sm font-medium mb-1">Additional Investor Purchases + buybacks (% of USDC on IEX)</label>
@@ -727,6 +765,22 @@ const TokenomicsSimulator = () => {
               </p>
               <p className="text-sm text-gray-500">Contributions − AI cost</p>
             </div>
+            <div className="bg-white p-4 rounded shadow border-l-4 border-amber-400">
+              <h3 className="text-sm font-medium text-gray-500">Monthly Gas Cost</h3>
+              <p className="text-2xl font-bold text-amber-800">${Math.round(results[results.length - 1].gasCost).toLocaleString()}</p>
+              <p className="text-sm text-gray-500">${perSpaceGas.toFixed(2)}/Space · {aiProfile} profile</p>
+            </div>
+            <div className="bg-white p-4 rounded shadow border-l-4 border-amber-400">
+              <h3 className="text-sm font-medium text-gray-500">Cumulative Gas Cost</h3>
+              <p className="text-2xl font-bold text-amber-800">${Math.round(results[results.length - 1].cumulativeGasCost).toLocaleString()}</p>
+            </div>
+            <div className="bg-white p-4 rounded shadow border-l-4 border-teal-400">
+              <h3 className="text-sm font-medium text-gray-500">Net After AI + Gas (monthly)</h3>
+              <p className={`text-2xl font-bold ${results[results.length - 1].netAfterGas >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+                ${Math.round(results[results.length - 1].netAfterGas).toLocaleString()}
+              </p>
+              <p className="text-sm text-gray-500">Contributions − AI − gas</p>
+            </div>
           </div>
         </div>
       )}
@@ -819,9 +873,9 @@ const TokenomicsSimulator = () => {
             </ResponsiveContainer>
           </div>
           <div className="h-80 bg-white p-4 rounded-lg shadow md:col-span-2">
-            <h3 className="text-md font-medium mb-1">Space Contributions vs AI Cost</h3>
+            <h3 className="text-md font-medium mb-1">Space Contributions vs AI &amp; Gas Cost</h3>
             <p className="text-xs text-gray-500 mb-2">
-              Contributions = Spaces × ${orgPayment} USDC/Space. Flat stretches happen when per-month Space Growth Rate is 0% (default: months 2–26). AI cost scales with the same Space count × selected model rate.
+              Contributions = Spaces × ${orgPayment} USDC/Space. Flat stretches happen when per-month Space Growth Rate is 0% (default: months 2–26). AI and gas costs scale with the same Space count × selected model/profile rates.
             </p>
             <ResponsiveContainer width="100%" height="85%">
               <LineChart data={chartData} margin={{ top: 5, right: 50, left: 50, bottom: 5 }}>
@@ -832,19 +886,23 @@ const TokenomicsSimulator = () => {
                 <Legend />
                 <Line type="monotone" dataKey="Space Contributions (USD)" stroke="#82ca9d" strokeWidth={2} />
                 <Line type="monotone" dataKey="AI Cost (USD)" stroke="#6366f1" strokeWidth={2} />
+                <Line type="monotone" dataKey="Gas Cost (USD)" stroke="#d97706" strokeWidth={2} />
                 <Line type="monotone" dataKey="Net Contributions (USD)" stroke="#ff7300" strokeWidth={2} />
+                <Line type="monotone" dataKey="Net After AI + Gas (USD)" stroke="#0d9488" strokeWidth={2} strokeDasharray="5 5" />
               </LineChart>
             </ResponsiveContainer>
           </div>
           <div className="h-80 bg-white p-4 rounded-lg shadow">
-            <h3 className="text-md font-medium mb-2">Cumulative AI Cost</h3>
+            <h3 className="text-md font-medium mb-2">Cumulative AI &amp; Gas Cost</h3>
             <ResponsiveContainer width="100%" height="90%">
               <LineChart data={chartData} margin={{ top: 5, right: 40, left: 40, bottom: 5 }}>
                 <CartesianGrid strokeDasharray="3 3" />
                 <XAxis dataKey="name" />
                 <YAxis tickFormatter={(v) => v.toLocaleString()} width={60} />
                 <Tooltip formatter={(v) => v.toLocaleString()} />
+                <Legend />
                 <Line type="monotone" dataKey="Cumulative AI Cost (USD)" stroke="#6366f1" strokeWidth={2} />
+                <Line type="monotone" dataKey="Cumulative Gas Cost (USD)" stroke="#d97706" strokeWidth={2} />
               </LineChart>
             </ResponsiveContainer>
           </div>
@@ -872,8 +930,11 @@ const TokenomicsSimulator = () => {
                 <th className="py-2 px-4 border text-right">IEX USDC</th>
                 <th className="py-2 px-4 border text-right">Space Contributions (USD)</th>
                 <th className="py-2 px-4 border text-right">AI Cost (USD)</th>
+                <th className="py-2 px-4 border text-right">Gas Cost (USD)</th>
                 <th className="py-2 px-4 border text-right">Net After AI (USD)</th>
+                <th className="py-2 px-4 border text-right">Net After AI + Gas (USD)</th>
                 <th className="py-2 px-4 border text-right">Cumulative AI Cost (USD)</th>
+                <th className="py-2 px-4 border text-right">Cumulative Gas Cost (USD)</th>
                 <th className="py-2 px-4 border text-right">Token Price</th>
                 <th className="py-2 px-4 border text-right">Price Change</th>
                 <th className="py-2 px-4 border text-right">FDV (USD)</th>
@@ -903,10 +964,15 @@ const TokenomicsSimulator = () => {
                   <td className="py-2 px-4 border text-right">{row.dexUsdc.toLocaleString()}</td>
                   <td className="py-2 px-4 border text-right">${Math.round(row.orgUsdcPurchase).toLocaleString()}</td>
                   <td className="py-2 px-4 border text-right text-indigo-700">${Math.round(row.aiCost).toLocaleString()}</td>
+                  <td className="py-2 px-4 border text-right text-amber-700">${Math.round(row.gasCost).toLocaleString()}</td>
                   <td className={`py-2 px-4 border text-right ${row.netContribution >= 0 ? 'text-green-600' : 'text-red-600'}`}>
                     ${Math.round(row.netContribution).toLocaleString()}
                   </td>
+                  <td className={`py-2 px-4 border text-right ${row.netAfterGas >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+                    ${Math.round(row.netAfterGas).toLocaleString()}
+                  </td>
                   <td className="py-2 px-4 border text-right text-indigo-700">${Math.round(row.cumulativeAICost).toLocaleString()}</td>
+                  <td className="py-2 px-4 border text-right text-amber-700">${Math.round(row.cumulativeGasCost).toLocaleString()}</td>
                   <td className="py-2 px-4 border text-right">${row.tokenPrice}</td>
                   <td className="py-2 px-4 border text-right">{row.deltaPrice}%</td>
                   <td className="py-2 px-4 border text-right">${row.fdv.toLocaleString()}</td>

--- a/apps/web/public/tokenomics2/index.html
+++ b/apps/web/public/tokenomics2/index.html
@@ -1,0 +1,962 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>HYPHA Tokenomics Simulator</title>
+<link rel="icon" href="https://hypha.earth/wp-content/uploads/2023/07/cropped-favicon-32x32.png" sizes="32x32" />
+<script type="importmap">
+{
+  "imports": {
+    "react": "https://esm.sh/react@18.3.1",
+    "react/jsx-runtime": "https://esm.sh/react@18.3.1/jsx-runtime",
+    "react/jsx-dev-runtime": "https://esm.sh/react@18.3.1/jsx-dev-runtime",
+    "react-dom": "https://esm.sh/react-dom@18.3.1",
+    "react-dom/client": "https://esm.sh/react-dom@18.3.1/client",
+    "recharts": "https://esm.sh/recharts@2.12.7?external=react,react-dom"
+  }
+}
+</script>
+<script src="https://cdn.tailwindcss.com"></script>
+<script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+<style> body { background:#f3f4f6; } </style>
+</head>
+<body>
+<div id="root" class="p-4"></div>
+<script type="text/babel" data-type="module" data-presets="react" data-presets-options='{"react":{"runtime":"classic"}}'>
+import React, { useState, useEffect } from 'react';
+import { createRoot } from 'react-dom/client';
+import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+
+// ============================================================
+// AI Operating Cost model (from docs/hypha-ai-cost)
+// Typical Space workload = 4.66M input + 0.17M output tokens / month.
+// Per-space monthly $ = (in_M * inPrice + out_M * outPrice) * profileMult.
+// ============================================================
+const TYPICAL_INPUT_M = 4.66;
+const TYPICAL_OUTPUT_M = 0.17;
+const PROFILE_MULT = { light: 0.33, typical: 1, heavy: 2.73 };
+
+const AI_MODELS = {
+  closed: [
+    { id: 'composer-fast', name: 'Composer 2.5 Fast', input: 3.0, output: 15.0, note: 'IDE default reference / baseline' },
+    { id: 'composer-standard', name: 'Composer 2.5 Standard', input: 0.5, output: 2.5, note: 'Same model, lower throughput' },
+  ],
+  open: [
+    { id: 'kimi-list', name: 'Kimi K2.6 (list)', input: 0.95, output: 4.0, note: 'Leads open quality; Composer lineage' },
+    { id: 'kimi-or', name: 'Kimi K2.6 (OpenRouter low)', input: 0.68, output: 3.41, note: 'Cheapest Kimi host' },
+    { id: 'qwen', name: 'Qwen3.5-397B', input: 0.6, output: 3.6, note: 'Strong open frontier MoE' },
+    { id: 'llama', name: 'Llama 4 Maverick', input: 0.5, output: 2.15, note: '400B MoE (DeepInfra)' },
+    { id: 'deepseek-pro', name: 'DeepSeek V4-Pro', input: 0.44, output: 0.87, note: 'Flagship open reasoning/coding' },
+    { id: 'deepseek-flash', name: 'DeepSeek V4-Flash', input: 0.14, output: 0.28, note: 'Budget leader' },
+  ],
+};
+const ALL_MODELS = [...AI_MODELS.closed, ...AI_MODELS.open];
+const getModel = (id) => ALL_MODELS.find((m) => m.id === id) || ALL_MODELS[0];
+const perSpaceMonthlyAICost = (model, profile) =>
+  (TYPICAL_INPUT_M * model.input + TYPICAL_OUTPUT_M * model.output) * PROFILE_MULT[profile];
+const ONBOARDING_BASELINE = 0.56; // Composer Fast one-time onboarding / space
+const onboardingCost = (model) => ONBOARDING_BASELINE * (model.input / 3.0); // scales with input price
+
+
+const GROWTH_PRESETS = {
+  min: {
+    label: 'Min',
+    subtitle: '~250k Spaces',
+    defaults: {
+      orgPayment: 22,
+      investorSelling: 13.5,
+      additionalPurchase: 7,
+      unlockRate: 5,
+      initialHypha: 3333333,
+      initialUsdc: 1000000,
+      orgCount: 4373,
+      orgGrowthRate: 25,
+    },
+    build: () => {
+      const m = { 1: { orgGrowthRate: 25 } };
+      for (let i = 2; i <= 26; i++) m[i] = { orgGrowthRate: 0 };
+      for (let i = 27; i <= 48; i++) m[i] = { orgGrowthRate: 3 };
+      return m;
+    },
+  },
+  medium: {
+    label: 'Medium',
+    subtitle: '~1M Spaces',
+    defaults: {
+      orgPayment: 22,
+      investorSelling: 26,
+      additionalPurchase: 11,
+      unlockRate: 4,
+      initialHypha: 12000000,
+      initialUsdc: 750000,
+      orgCount: 4373,
+      orgGrowthRate: 25,
+    },
+    build: () => ({
+      1: { orgGrowthRate: 25 }, 2: { orgGrowthRate: 1 }, 3: { orgGrowthRate: 2 }, 4: { orgGrowthRate: 2 },
+      5: { orgGrowthRate: 2 }, 6: { orgGrowthRate: 2 }, 7: { orgGrowthRate: 3 }, 8: { orgGrowthRate: 2 },
+      9: { orgGrowthRate: 3 }, 10: { orgGrowthRate: 27 }, 11: { orgGrowthRate: 15 }, 12: { orgGrowthRate: 14 },
+      13: { orgGrowthRate: 13 }, 14: { orgGrowthRate: 12 }, 15: { orgGrowthRate: 25 }, 16: { orgGrowthRate: 10 },
+      17: { orgGrowthRate: 3 }, 18: { orgGrowthRate: 8 }, 19: { orgGrowthRate: 7 }, 20: { orgGrowthRate: 2 },
+      21: { orgGrowthRate: 1 }, 22: { orgGrowthRate: 4 }, 23: { orgGrowthRate: 4 }, 24: { orgGrowthRate: 4 },
+      25: { orgGrowthRate: 4 }, 26: { orgGrowthRate: 4 }, 27: { orgGrowthRate: 3 }, 28: { orgGrowthRate: 3 },
+      29: { orgGrowthRate: 3 }, 30: { orgGrowthRate: 3 }, 31: { orgGrowthRate: 3 }, 32: { orgGrowthRate: 3 },
+      33: { orgGrowthRate: 3 }, 34: { orgGrowthRate: 3 }, 35: { orgGrowthRate: 3 }, 36: { orgGrowthRate: 3 },
+      37: { orgGrowthRate: 3 }, 38: { orgGrowthRate: 3 }, 39: { orgGrowthRate: 3 }, 40: { orgGrowthRate: 3 },
+      41: { orgGrowthRate: 3 }, 42: { orgGrowthRate: 3 }, 43: { orgGrowthRate: 3 }, 44: { orgGrowthRate: 3 },
+      45: { orgGrowthRate: 3 }, 46: { orgGrowthRate: 3 }, 47: { orgGrowthRate: 3 }, 48: { orgGrowthRate: 3 },
+    }),
+  },
+  max: {
+    label: 'Max',
+    subtitle: '~2M Spaces',
+    defaults: {
+      orgPayment: 22,
+      investorSelling: 14.5,
+      additionalPurchase: 3,
+      unlockRate: 4,
+      initialHypha: 20000000,
+      initialUsdc: 1000000,
+      orgCount: 4373,
+      orgGrowthRate: 25,
+    },
+    build: () => ({
+      1: { orgGrowthRate: 25 }, 2: { orgGrowthRate: 10 }, 3: { orgGrowthRate: 10 }, 4: { orgGrowthRate: 10 },
+      5: { orgGrowthRate: 10 }, 6: { orgGrowthRate: 10 }, 7: { orgGrowthRate: 10 }, 8: { orgGrowthRate: 10 },
+      9: { orgGrowthRate: 10 }, 10: { orgGrowthRate: 27 }, 11: { orgGrowthRate: 15 }, 12: { orgGrowthRate: 14 },
+      13: { orgGrowthRate: 13 }, 14: { orgGrowthRate: 12 }, 15: { orgGrowthRate: 25 }, 16: { orgGrowthRate: 23 },
+      17: { orgGrowthRate: 3 }, 18: { orgGrowthRate: 8 }, 19: { orgGrowthRate: 7 }, 20: { orgGrowthRate: 2 },
+      21: { orgGrowthRate: 1 }, 22: { orgGrowthRate: 4 }, 23: { orgGrowthRate: 4 }, 24: { orgGrowthRate: 4 },
+      25: { orgGrowthRate: 4 }, 26: { orgGrowthRate: 4 }, 27: { orgGrowthRate: 3 }, 28: { orgGrowthRate: 3 },
+      29: { orgGrowthRate: 3 }, 30: { orgGrowthRate: 3 }, 31: { orgGrowthRate: 3 }, 32: { orgGrowthRate: 3 },
+      33: { orgGrowthRate: 3 }, 34: { orgGrowthRate: 3 }, 35: { orgGrowthRate: 3 }, 36: { orgGrowthRate: 3 },
+      37: { orgGrowthRate: 3 }, 38: { orgGrowthRate: 3 }, 39: { orgGrowthRate: 3 }, 40: { orgGrowthRate: 3 },
+      41: { orgGrowthRate: 3 }, 42: { orgGrowthRate: 3 }, 43: { orgGrowthRate: 3 }, 44: { orgGrowthRate: 3 },
+      45: { orgGrowthRate: 3 }, 46: { orgGrowthRate: 3 }, 47: { orgGrowthRate: 3 }, 48: { orgGrowthRate: 3 },
+    }),
+  },
+};
+
+const TokenomicsSimulator = () => {
+  const [maxSupply, setMaxSupply] = useState(555555555);
+  const [initialHypha, setInitialHypha] = useState(GROWTH_PRESETS.min.defaults.initialHypha);
+  const [initialUsdc, setInitialUsdc] = useState(GROWTH_PRESETS.min.defaults.initialUsdc);
+  const [months, setMonths] = useState(48);
+  const [unlockRate, setUnlockRate] = useState(GROWTH_PRESETS.min.defaults.unlockRate);
+  const [stakingRewards, setStakingRewards] = useState(30);
+  const [rewardSplit, setRewardSplit] = useState(50);
+  const [stakingRate, setStakingRate] = useState(75);
+  const [sellRate, setSellRate] = useState(30);
+  const [investorSelling, setInvestorSelling] = useState(GROWTH_PRESETS.min.defaults.investorSelling);
+  const [additionalPurchase, setAdditionalPurchase] = useState(GROWTH_PRESETS.min.defaults.additionalPurchase);
+  const [orgCount, setOrgCount] = useState(GROWTH_PRESETS.min.defaults.orgCount);
+  const [orgPayment, setOrgPayment] = useState(GROWTH_PRESETS.min.defaults.orgPayment);
+  const [orgGrowthRate, setOrgGrowthRate] = useState(GROWTH_PRESETS.min.defaults.orgGrowthRate);
+
+  // AI operating cost controls
+  const [aiModelId, setAiModelId] = useState('kimi-or');
+  const [aiProfile, setAiProfile] = useState('typical');
+  const [growthScenario, setGrowthScenario] = useState('min');
+
+  const [selectedMonth, setSelectedMonth] = useState(1);
+  const [monthlyParams, setMonthlyParams] = useState(GROWTH_PRESETS.min.build());
+  const [showMonthlyConfig, setShowMonthlyConfig] = useState(false);
+
+  const [results, setResults] = useState([]);
+  const [chartData, setChartData] = useState([]);
+
+  useEffect(() => {
+    calculateTokenomics();
+  }, [initialHypha, initialUsdc, months, unlockRate, stakingRate, sellRate,
+      investorSelling, additionalPurchase, stakingRewards, rewardSplit, maxSupply,
+      orgCount, orgPayment, orgGrowthRate, monthlyParams, aiModelId, aiProfile]);
+
+  const getMonthlyParameter = (paramName, month) => {
+    if (monthlyParams[month] && monthlyParams[month][paramName] !== undefined) {
+      return monthlyParams[month][paramName];
+    }
+    for (let prevMonth = month - 1; prevMonth >= 1; prevMonth--) {
+      if (monthlyParams[prevMonth] && monthlyParams[prevMonth][paramName] !== undefined) {
+        return monthlyParams[prevMonth][paramName];
+      }
+    }
+    switch (paramName) {
+      case 'unlockRate': return unlockRate;
+      case 'rewardSplit': return rewardSplit;
+      case 'stakingRate': return stakingRate;
+      case 'sellRate': return sellRate;
+      case 'investorSelling': return investorSelling;
+      case 'additionalPurchase': return additionalPurchase;
+      case 'orgCount': return orgCount;
+      case 'orgPayment': return orgPayment;
+      case 'orgGrowthRate': return orgGrowthRate;
+      default: return 0;
+    }
+  };
+
+  const updateMonthlyParameter = (paramName, value) => {
+    setMonthlyParams((prev) => {
+      const newParams = { ...prev };
+      if (!newParams[selectedMonth]) newParams[selectedMonth] = {};
+      newParams[selectedMonth][paramName] = value;
+      return newParams;
+    });
+  };
+
+  const formatNumber = (number) => number.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+
+
+  const calculateTokenomics = () => {
+    let dexHypha = initialHypha;
+    let dexUsdc = initialUsdc;
+    let circulatingSupply = 0;
+    let cumulativeIssued = 0;
+    let prevPrice = dexUsdc / dexHypha;
+    let cumulativeOrgCountTracker = 0;
+    const feeRate = 0.003;
+    const tokenResults = [];
+    const graphData = [];
+    let currentOrgCount = getMonthlyParameter('orgCount', 1);
+    let cumulativeStaked = 0;
+
+    const aiModel = getModel(aiModelId);
+    const perSpaceAI = perSpaceMonthlyAICost(aiModel, aiProfile);
+    let cumulativeAICost = 0;
+
+    for (let month = 1; month <= months; month++) {
+      const monthStakingRate = getMonthlyParameter('stakingRate', month) / 100;
+      const monthSellRate = getMonthlyParameter('sellRate', month) / 100;
+      const monthInvestorSelling = getMonthlyParameter('investorSelling', month);
+      const monthPurchase = getMonthlyParameter('additionalPurchase', month);
+
+      const minUnlockRate = 0.02;
+      const actualUnlockRate = minUnlockRate + (monthStakingRate * (unlockRate - minUnlockRate));
+
+      if (month > 1) {
+        if (monthlyParams[month] && monthlyParams[month].orgCount !== undefined) {
+          currentOrgCount = monthlyParams[month].orgCount;
+        } else {
+          const monthOrgGrowthRate = getMonthlyParameter('orgGrowthRate', month) / 100;
+          currentOrgCount = Math.round(currentOrgCount * (1 + monthOrgGrowthRate));
+        }
+      } else {
+        currentOrgCount = getMonthlyParameter('orgCount', month);
+      }
+
+      const monthOrgPayment = getMonthlyParameter('orgPayment', month);
+      const orgTotalPurchase = currentOrgCount * monthOrgPayment;
+
+      // AI operating cost for this month (all active spaces)
+      const monthAICost = currentOrgCount * perSpaceAI;
+      cumulativeAICost += monthAICost;
+      const netContribution = orgTotalPurchase - monthAICost;
+
+      const dexPrice = dexUsdc / dexHypha;
+      const dexHyphaBefore = dexHypha;
+
+      let actualOrgPurchasedTokens = 0;
+      if (orgTotalPurchase > 0) {
+        const k = dexHypha * dexUsdc;
+        const usdcWithFee = orgTotalPurchase * (1 - feeRate);
+        const newDexUsdc = dexUsdc + usdcWithFee;
+        const newDexHypha = k / newDexUsdc;
+        const hyphaReceived = dexHypha - newDexHypha;
+        if (hyphaReceived > 0) {
+          const limitedHyphaReceived = Math.min(hyphaReceived, dexHypha * 0.25);
+          const limitedNewDexHypha = dexHypha - limitedHyphaReceived;
+          const limitedNewDexUsdc = k / limitedNewDexHypha;
+          dexHypha = limitedNewDexHypha;
+          dexUsdc = limitedNewDexUsdc;
+          actualOrgPurchasedTokens = limitedHyphaReceived;
+        }
+      }
+
+      cumulativeOrgCountTracker += currentOrgCount;
+      const cumulativeOrgCount = cumulativeOrgCountTracker;
+
+      const distributionMultiplier = getMonthlyParameter('unlockRate', month);
+      const safeStakingRate = Math.min(monthStakingRate, 0.9);
+      const stakingRateModifier = 1 / (1 - safeStakingRate);
+      let totalIssuance = Math.round(actualOrgPurchasedTokens * stakingRateModifier * distributionMultiplier);
+      const maxMonthlyIssuance = 10000000;
+      totalIssuance = Math.min(totalIssuance, maxMonthlyIssuance);
+      if (cumulativeIssued + totalIssuance > maxSupply) {
+        totalIssuance = Math.max(0, maxSupply - cumulativeIssued);
+      }
+      cumulativeIssued += totalIssuance;
+      circulatingSupply = cumulativeIssued;
+
+      const monthlyStakedAmount = circulatingSupply * monthStakingRate;
+      cumulativeStaked = monthlyStakedAmount;
+
+      const initialStakingAllocation = Math.round(totalIssuance * (rewardSplit / 100));
+      const initialUnlockAllocation = totalIssuance - initialStakingAllocation;
+      const monthlyRewardsRate = stakingRewards / 1200;
+      const requiredForStakingRewards = Math.round(monthlyStakedAmount * monthlyRewardsRate);
+
+      let stakingRewardsAmount, unlockRewards;
+      if (requiredForStakingRewards <= initialStakingAllocation) {
+        stakingRewardsAmount = requiredForStakingRewards;
+        unlockRewards = totalIssuance - stakingRewardsAmount;
+      } else {
+        stakingRewardsAmount = initialStakingAllocation;
+        unlockRewards = initialUnlockAllocation;
+      }
+
+      const actualMonthlyRewardsRate = monthlyStakedAmount > 0 ? (stakingRewardsAmount / monthlyStakedAmount) * 100 : 0;
+      const actualRewards = actualMonthlyRewardsRate * 12;
+
+      let investorPurchasedTokens = 0;
+      if (monthPurchase > 0) {
+        const actualPurchaseAmount = (dexUsdc * monthPurchase) / 100;
+        if (actualPurchaseAmount > 0) {
+          const k = dexHypha * dexUsdc;
+          const usdcWithFee = actualPurchaseAmount * (1 - feeRate);
+          const newDexUsdc = dexUsdc + usdcWithFee;
+          const newDexHypha = k / newDexUsdc;
+          const hyphaReceived = dexHypha - newDexHypha;
+          if (hyphaReceived > 0 && hyphaReceived < dexHypha * 0.5) {
+            dexHypha = newDexHypha;
+            dexUsdc = newDexUsdc;
+            investorPurchasedTokens = hyphaReceived;
+            circulatingSupply += investorPurchasedTokens;
+          }
+        }
+      }
+
+      let tokensSold = 0;
+      if (monthInvestorSelling > 0 && dexHypha > 0 && dexUsdc > 0) {
+        const tokensToSell = Math.round((dexHypha * monthInvestorSelling) / 100);
+        if (tokensToSell > 0) {
+          const k = dexHypha * dexUsdc;
+          const newDexHypha = dexHypha + tokensToSell;
+          const newDexUsdc = k / newDexHypha;
+          const usdcReceived = dexUsdc - newDexUsdc;
+          dexHypha = newDexHypha;
+          dexUsdc = newDexUsdc;
+          tokensSold = tokensToSell;
+        }
+      }
+
+      const totalPurchasedTokens = actualOrgPurchasedTokens + investorPurchasedTokens;
+      const endOfMonthPrice = dexUsdc / dexHypha;
+      const priceChange = prevPrice > 0 ? ((endOfMonthPrice / prevPrice) - 1) * 100 : 0;
+      prevPrice = endOfMonthPrice;
+      const fdv = endOfMonthPrice * maxSupply;
+
+      tokenResults.push({
+        month, totalIssuance, cumulativeIssuance: cumulativeIssued,
+        stakingRewards: stakingRewardsAmount, unlockRewards,
+        stakingRewardsPercentage: totalIssuance > 0 ? Math.round((stakingRewardsAmount / totalIssuance) * 100) : 0,
+        actualRewards: actualRewards.toFixed(2),
+        circulatingSupply: Math.round(circulatingSupply),
+        stakedAmount: Math.round(cumulativeStaked),
+        dexHyphaBefore: Math.round(dexHyphaBefore),
+        dexHypha: Math.round(dexHypha), dexUsdc: Math.round(dexUsdc),
+        tokenPrice: endOfMonthPrice.toFixed(6), deltaPrice: priceChange.toFixed(2),
+        orgCount: currentOrgCount, cumulativeOrgCount,
+        orgUsdcPurchase: orgTotalPurchase,
+        orgPurchasedTokens: Math.round(actualOrgPurchasedTokens),
+        investorPurchasedTokens: Math.round(investorPurchasedTokens),
+        totalPurchasedTokens: Math.round(totalPurchasedTokens),
+        investorSellingUsdc: monthInvestorSelling, tokensSold,
+        fdv: Math.round(fdv),
+        aiCost: monthAICost, cumulativeAICost,
+        netContribution,
+      });
+
+      graphData.push({
+        name: `Month ${month}`,
+        'Circulating Supply': Math.round(circulatingSupply),
+        'Total Unlocked': cumulativeIssued,
+        'IEX HYPHA': Math.round(dexHypha),
+        'IEX USDC': Math.round(dexUsdc),
+        'Monthly Issuance': totalIssuance,
+        'Staking Rewards': stakingRewardsAmount,
+        'Unlock Rewards': unlockRewards,
+        'Investor Selling (% of HYPHA)': monthInvestorSelling,
+        'Total Tokens Sold': tokensSold,
+        'Number of Spaces': currentOrgCount,
+        'Cumulative Spaces': cumulativeOrgCount,
+        'Price (USDC)': parseFloat(endOfMonthPrice.toFixed(6)),
+        'FDV (Million $)': Math.round(fdv / 1000000),
+        'Space Purchases': Math.round(actualOrgPurchasedTokens),
+        'Space Contributions (USD)': Math.round(orgTotalPurchase),
+        'AI Cost (USD)': Math.round(monthAICost),
+        'Net Contributions (USD)': Math.round(netContribution),
+        'Cumulative AI Cost (USD)': Math.round(cumulativeAICost),
+      });
+    }
+
+    setResults(tokenResults);
+    setChartData(graphData);
+  };
+
+  const applyScenarioDefaults = (scenario) => {
+    const d = GROWTH_PRESETS[scenario].defaults;
+    setOrgPayment(d.orgPayment);
+    setInvestorSelling(d.investorSelling);
+    setAdditionalPurchase(d.additionalPurchase);
+    setUnlockRate(d.unlockRate);
+    setInitialHypha(d.initialHypha);
+    setInitialUsdc(d.initialUsdc);
+    setOrgCount(d.orgCount);
+    setOrgGrowthRate(d.orgGrowthRate);
+  };
+
+  const applyGrowthScenario = (scenario) => {
+    setGrowthScenario(scenario);
+    setMonthlyParams(GROWTH_PRESETS[scenario].build());
+    applyScenarioDefaults(scenario);
+  };
+
+  const resetParameters = () => {
+    setMaxSupply(555555555);
+    setMonths(48);
+    setStakingRewards(30);
+    setRewardSplit(50);
+    setStakingRate(75);
+    setSellRate(30);
+    setAiModelId('kimi-or');
+    setAiProfile('typical');
+    setMonthlyParams(GROWTH_PRESETS[growthScenario].build());
+    applyScenarioDefaults(growthScenario);
+  };
+
+  const aiModel = getModel(aiModelId);
+  const perSpaceAI = perSpaceMonthlyAICost(aiModel, aiProfile);
+  const baselinePerSpace = perSpaceMonthlyAICost(getModel('composer-fast'), aiProfile);
+
+
+  return (
+    <div className="p-4 max-w-7xl mx-auto bg-white rounded-xl shadow-md">
+      <div className="flex gap-6">
+        <div className="flex-1 min-w-0">
+      <h1 className="text-2xl font-bold mb-1">HYPHA Tokenomics Simulator (Phase II)</h1>
+      <p className="text-sm text-gray-500 mb-4">With per-Space AI operating cost model — closed-source vs open-source LLMs.</p>
+
+      {/* ============ AI OPERATING COST SECTION ============ */}
+      <div className="mb-6 border border-indigo-200 bg-indigo-50 p-4 rounded-lg">
+        <h2 className="text-lg font-semibold mb-1">AI Operating Cost per Space</h2>
+        <p className="text-xs text-gray-600 mb-3">
+          A Space's AI workload (full vision) is ~{TYPICAL_INPUT_M}M input + {TYPICAL_OUTPUT_M}M output tokens/month for a Typical space.
+          Pick the inference model and Space profile; the simulator bills every active Space each month.
+        </p>
+
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <div>
+            <label className="block text-sm font-medium mb-1">Inference Model</label>
+            <select
+              value={aiModelId}
+              onChange={(e) => setAiModelId(e.target.value)}
+              className="w-full p-2 border rounded bg-white"
+            >
+              <optgroup label="Closed source">
+                {AI_MODELS.closed.map((m) => (
+                  <option key={m.id} value={m.id}>{m.name} — ${m.input}/${m.output} per 1M</option>
+                ))}
+              </optgroup>
+              <optgroup label="Open source">
+                {AI_MODELS.open.map((m) => (
+                  <option key={m.id} value={m.id}>{m.name} — ${m.input}/${m.output} per 1M</option>
+                ))}
+              </optgroup>
+            </select>
+            <p className="text-xs text-gray-500 mt-1">{aiModel.note}</p>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium mb-1">Space Profile</label>
+            <select
+              value={aiProfile}
+              onChange={(e) => setAiProfile(e.target.value)}
+              className="w-full p-2 border rounded bg-white"
+            >
+              <option value="light">Light (~5 members · 0.33×)</option>
+              <option value="typical">Typical (~15 members · 1×)</option>
+              <option value="heavy">Heavy (~50 members · 2.73×)</option>
+            </select>
+            <p className="text-xs text-gray-500 mt-1">Scales the per-Space token volume.</p>
+          </div>
+
+          <div className="bg-white border rounded p-3">
+            <div className="text-xs text-gray-500">AI cost / Space / month</div>
+            <div className="text-2xl font-bold text-indigo-700">${perSpaceAI.toFixed(2)}</div>
+            <div className="text-xs text-gray-500 mt-1">
+              One-time onboarding ≈ ${onboardingCost(aiModel).toFixed(2)} / Space
+            </div>
+            <div className="text-xs text-gray-500">
+              vs Composer Fast: {(baselinePerSpace / perSpaceAI).toFixed(1)}× cheaper
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-4 overflow-x-auto">
+          <table className="min-w-full bg-white border text-sm">
+            <thead className="bg-gray-100">
+              <tr>
+                <th className="py-1 px-3 border text-left">Model</th>
+                <th className="py-1 px-3 border">Type</th>
+                <th className="py-1 px-3 border text-right">In $/1M</th>
+                <th className="py-1 px-3 border text-right">Out $/1M</th>
+                <th className="py-1 px-3 border text-right">$/Space/mo ({aiProfile})</th>
+                <th className="py-1 px-3 border text-right">vs Composer Fast</th>
+              </tr>
+            </thead>
+            <tbody>
+              {ALL_MODELS.map((m) => {
+                const cost = perSpaceMonthlyAICost(m, aiProfile);
+                const isOpen = AI_MODELS.open.some((o) => o.id === m.id);
+                return (
+                  <tr key={m.id} className={m.id === aiModelId ? 'bg-indigo-100 font-semibold' : ''}>
+                    <td className="py-1 px-3 border">{m.name}</td>
+                    <td className="py-1 px-3 border text-center">{isOpen ? 'Open' : 'Closed'}</td>
+                    <td className="py-1 px-3 border text-right">${m.input.toFixed(2)}</td>
+                    <td className="py-1 px-3 border text-right">${m.output.toFixed(2)}</td>
+                    <td className="py-1 px-3 border text-right">${cost.toFixed(2)}</td>
+                    <td className="py-1 px-3 border text-right">
+                      {m.id === 'composer-fast' ? '—' : `${(baselinePerSpace / cost).toFixed(1)}×`}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
+        <div className="bg-gray-50 p-4 rounded-lg">
+          <h2 className="text-lg font-semibold mb-3">Initial Parameters</h2>
+          <div className="mb-4">
+            <label className="block text-sm font-medium mb-1">Total Supply of HYPHA</label>
+            <div className="flex items-center">
+              <input type="range" min="100000000" max="1000000000" step="10000000" value={maxSupply} onChange={(e) => setMaxSupply(Number(e.target.value))} className="w-full mr-3" />
+              <input type="text" value={formatNumber(maxSupply)} onChange={(e) => { const v = Number(e.target.value.replace(/,/g, '')); if (!isNaN(v)) setMaxSupply(v); }} className="w-32 p-1 border rounded text-right" />
+            </div>
+          </div>
+          <div className="mb-4">
+            <label className="block text-sm font-medium mb-1">Initial HYPHA on IEX</label>
+            <div className="flex items-center">
+              <input type="range" min="1000000" max="50000000" step="1000000" value={initialHypha} onChange={(e) => setInitialHypha(Number(e.target.value))} className="w-full mr-3" />
+              <input type="text" value={formatNumber(initialHypha)} onChange={(e) => { const v = Number(e.target.value.replace(/,/g, '')); if (!isNaN(v)) setInitialHypha(v); }} className="w-24 p-1 border rounded text-right" />
+            </div>
+          </div>
+          <div className="mb-4">
+            <label className="block text-sm font-medium mb-1">Initial USDC on IEX</label>
+            <div className="flex items-center">
+              <input type="range" min="100000" max="2000000" step="50000" value={initialUsdc} onChange={(e) => setInitialUsdc(Number(e.target.value))} className="w-full mr-3" />
+              <input type="text" value={formatNumber(initialUsdc)} onChange={(e) => { const v = Number(e.target.value.replace(/,/g, '')); if (!isNaN(v)) setInitialUsdc(v); }} className="w-24 p-1 border rounded text-right" />
+            </div>
+          </div>
+          <div className="mb-4">
+            <label className="block text-sm font-medium mb-1">Simulation Months</label>
+            <div className="flex items-center">
+              <input type="range" min="6" max="60" step="1" value={months} onChange={(e) => setMonths(Number(e.target.value))} className="w-full mr-3" />
+              <input type="number" value={months} onChange={(e) => setMonths(Number(e.target.value))} className="w-16 p-1 border rounded text-right" />
+            </div>
+          </div>
+        </div>
+
+        <div className="bg-gray-50 p-4 rounded-lg">
+          <h2 className="text-lg font-semibold mb-3">Monthly Parameters</h2>
+          <div className="mb-4 bg-blue-50 p-3 rounded-lg">
+            <div className="flex justify-between items-center mb-2">
+              <h3 className="text-md font-medium">Per-Month Configuration</h3>
+              <button onClick={() => setShowMonthlyConfig(!showMonthlyConfig)} className="px-2 py-1 bg-blue-100 rounded hover:bg-blue-200 text-sm">{showMonthlyConfig ? 'Hide Details' : 'Show Details'}</button>
+            </div>
+            {showMonthlyConfig && (
+              <div className="mb-3">
+                <div className="flex items-center mb-3">
+                  <label className="block text-sm font-medium mr-2">Select Month:</label>
+                  <select value={selectedMonth} onChange={(e) => setSelectedMonth(Number(e.target.value))} className="p-1 border rounded">
+                    {Array.from({length: months}, (_, i) => i + 1).map(month => (<option key={month} value={month}>Month {month}</option>))}
+                  </select>
+                </div>
+              </div>
+            )}
+          </div>
+
+          <h3 className="text-md font-medium mb-2">Issuance Distribution</h3>
+          <div className="mb-4">
+            <label className="block text-sm font-medium mb-1">Staking Rate (%)</label>
+            <div className="flex items-center">
+              <input type="range" min="0" max="90" step="1" value={monthlyParams[selectedMonth]?.stakingRate ?? stakingRate} onChange={(e) => { const v = Number(e.target.value); selectedMonth === 1 ? setStakingRate(v) : updateMonthlyParameter('stakingRate', v); }} className="w-full mr-3" />
+              <input type="number" min="0" max="90" value={monthlyParams[selectedMonth]?.stakingRate ?? stakingRate} onChange={(e) => { const v = Number(e.target.value); selectedMonth === 1 ? setStakingRate(v) : updateMonthlyParameter('stakingRate', v); }} className="w-16 p-1 border rounded text-right" />
+              <span className="ml-1">%</span>
+            </div>
+          </div>
+          <div className="mb-4">
+            <label className="block text-sm font-medium mb-1">Distribution Multiplier</label>
+            <div className="flex items-center">
+              <input type="range" min="0.1" max="10" step="0.1" value={monthlyParams[selectedMonth]?.unlockRate ?? unlockRate} onChange={(e) => { const v = Number(e.target.value); selectedMonth === 1 ? setUnlockRate(v) : updateMonthlyParameter('unlockRate', v); }} className="w-full mr-3" />
+              <input type="number" min="0.1" max="10" step="0.1" value={monthlyParams[selectedMonth]?.unlockRate ?? unlockRate} onChange={(e) => { const v = Number(e.target.value); selectedMonth === 1 ? setUnlockRate(v) : updateMonthlyParameter('unlockRate', v); }} className="w-16 p-1 border rounded text-right" />
+            </div>
+          </div>
+          <div className="mb-4">
+            <label className="block text-sm font-medium mb-1">Max. Staking Rewards (Yearly)</label>
+            <div className="flex items-center">
+              <input type="range" min="5" max="30" step="1" value={monthlyParams[selectedMonth]?.stakingRewards ?? stakingRewards} onChange={(e) => { const v = Number(e.target.value); selectedMonth === 1 ? setStakingRewards(v) : updateMonthlyParameter('stakingRewards', v); }} className="w-full mr-3" />
+              <input type="number" value={monthlyParams[selectedMonth]?.stakingRewards ?? stakingRewards} onChange={(e) => { const v = Number(e.target.value); selectedMonth === 1 ? setStakingRewards(v) : updateMonthlyParameter('stakingRewards', v); }} className="w-16 p-1 border rounded text-right" />
+              <span className="ml-1">%</span>
+            </div>
+          </div>
+          <div className="mb-4">
+            <label className="block text-sm font-medium mb-1">Issuance Split (% to Staking)</label>
+            <div className="flex items-center">
+              <input type="range" min="10" max="90" step="5" value={monthlyParams[selectedMonth]?.rewardSplit ?? rewardSplit} onChange={(e) => { const v = Number(e.target.value); selectedMonth === 1 ? setRewardSplit(v) : updateMonthlyParameter('rewardSplit', v); }} className="w-full mr-3" />
+              <input type="number" value={monthlyParams[selectedMonth]?.rewardSplit ?? rewardSplit} onChange={(e) => { const v = Number(e.target.value); selectedMonth === 1 ? setRewardSplit(v) : updateMonthlyParameter('rewardSplit', v); }} className="w-16 p-1 border rounded text-right" />
+              <span className="ml-1">%</span>
+            </div>
+          </div>
+
+          <h3 className="text-md font-medium mb-2 mt-4">Buying Pressure on IEX</h3>
+          <div className="mb-4">
+            <label className="block text-sm font-medium mb-1">Number of Spaces</label>
+            <div className="flex items-center">
+              <input type="range" min="0" max="5000" step="10" value={monthlyParams[selectedMonth]?.orgCount ?? orgCount} onChange={(e) => { const v = Number(e.target.value); selectedMonth === 1 ? setOrgCount(v) : updateMonthlyParameter('orgCount', v); }} className="w-full mr-3" />
+              <input type="number" min="0" value={monthlyParams[selectedMonth]?.orgCount ?? orgCount} onChange={(e) => { const v = Number(e.target.value); selectedMonth === 1 ? setOrgCount(v) : updateMonthlyParameter('orgCount', v); }} className="w-16 p-1 border rounded text-right" />
+            </div>
+          </div>
+          <div className="mb-4">
+            <label className="block text-sm font-medium mb-1">Space Growth Rate (%)</label>
+            <div className="flex items-center">
+              <input type="range" min="0" max="50" step="1" value={monthlyParams[selectedMonth]?.orgGrowthRate ?? orgGrowthRate} onChange={(e) => { const v = Number(e.target.value); selectedMonth === 1 ? setOrgGrowthRate(v) : updateMonthlyParameter('orgGrowthRate', v); }} className="w-full mr-3" />
+              <input type="number" min="0" max="50" value={monthlyParams[selectedMonth]?.orgGrowthRate ?? orgGrowthRate} onChange={(e) => { const v = Number(e.target.value); selectedMonth === 1 ? setOrgGrowthRate(v) : updateMonthlyParameter('orgGrowthRate', v); }} className="w-16 p-1 border rounded text-right" />
+              <span className="ml-1">%</span>
+            </div>
+          </div>
+          <div className="mb-4">
+            <label className="block text-sm font-medium mb-1">USDC Contribution per Space (monthly)</label>
+            <div className="flex items-center">
+              <input type="range" min="0" max="200" step="1" value={monthlyParams[selectedMonth]?.orgPayment ?? orgPayment} onChange={(e) => { const v = Number(e.target.value); selectedMonth === 1 ? setOrgPayment(v) : updateMonthlyParameter('orgPayment', v); }} className="w-full mr-3" />
+              <input type="number" min="0" max="200" value={monthlyParams[selectedMonth]?.orgPayment ?? orgPayment} onChange={(e) => { const v = Number(e.target.value); selectedMonth === 1 ? setOrgPayment(v) : updateMonthlyParameter('orgPayment', v); }} className="w-20 p-1 border rounded text-right" />
+              <span className="ml-1">USDC</span>
+            </div>
+            <p className="text-xs text-gray-500 mt-1">AI cost (${perSpaceAI.toFixed(2)}/Space) is tracked separately from IEX purchases.</p>
+          </div>
+          <div className="mb-4">
+            <label className="block text-sm font-medium mb-1">Additional Investor Purchases + buybacks (% of USDC on IEX)</label>
+            <div className="flex items-center">
+              <input type="range" min="0" max="50" step="1" value={monthlyParams[selectedMonth]?.additionalPurchase ?? additionalPurchase} onChange={(e) => { const v = Number(e.target.value); selectedMonth === 1 ? setAdditionalPurchase(v) : updateMonthlyParameter('additionalPurchase', v); }} className="w-full mr-3" />
+              <input type="number" min="0" max="50" value={monthlyParams[selectedMonth]?.additionalPurchase ?? additionalPurchase} onChange={(e) => { const v = Number(e.target.value); selectedMonth === 1 ? setAdditionalPurchase(v) : updateMonthlyParameter('additionalPurchase', v); }} className="w-16 p-1 border rounded text-right" />
+              <span className="ml-1">%</span>
+            </div>
+          </div>
+
+          <h3 className="text-md font-medium mb-2 mt-4">Selling Pressure on IEX</h3>
+          <div className="mb-4">
+            <label className="block text-sm font-medium mb-1">Investor Selling (% of HYPHA on IEX)</label>
+            <div className="flex items-center">
+              <input type="range" min="10" max="30" step="0.5" value={monthlyParams[selectedMonth]?.investorSelling ?? investorSelling} onChange={(e) => { const v = Number(e.target.value); selectedMonth === 1 ? setInvestorSelling(v) : updateMonthlyParameter('investorSelling', v); }} className="w-full mr-3" />
+              <input type="number" min="10" max="30" step="0.5" value={monthlyParams[selectedMonth]?.investorSelling ?? investorSelling} onChange={(e) => { const v = Number(e.target.value); selectedMonth === 1 ? setInvestorSelling(v) : updateMonthlyParameter('investorSelling', v); }} className="w-16 p-1 border rounded text-right" />
+              <span className="ml-1">%</span>
+            </div>
+          </div>
+          <button onClick={resetParameters} className="mt-2 px-4 py-2 bg-gray-200 rounded hover:bg-gray-300">Reset All Parameters</button>
+        </div>
+      </div>
+
+      {results.length > 0 && (
+        <div className="mt-4 mb-6 bg-blue-50 p-6 rounded-lg shadow">
+          <h2 className="text-xl font-bold mb-4">Key Metrics at Month {months}</h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+            <div className="bg-white p-4 rounded shadow">
+              <h3 className="text-sm font-medium text-gray-500">Spaces</h3>
+              <p className="text-2xl font-bold">{results[results.length - 1].cumulativeOrgCount.toLocaleString()}</p>
+              <p className="text-sm text-gray-500">Current Month: {results[results.length - 1].orgCount.toLocaleString()}</p>
+            </div>
+            <div className="bg-white p-4 rounded shadow">
+              <h3 className="text-sm font-medium text-gray-500">Token Price</h3>
+              <p className="text-2xl font-bold">${results[results.length - 1].tokenPrice}</p>
+              <p className="text-sm text-gray-500">Last Month Change: {results[results.length - 1].deltaPrice}%</p>
+            </div>
+            <div className="bg-white p-4 rounded shadow">
+              <h3 className="text-sm font-medium text-gray-500">Circulating Supply</h3>
+              <p className="text-2xl font-bold">{results[results.length - 1].circulatingSupply.toLocaleString()}</p>
+              <p className="text-sm text-gray-500">
+                Staked: {results[results.length - 1].stakedAmount.toLocaleString()} ({results[results.length - 1].circulatingSupply > 0 ? (results[results.length - 1].stakedAmount / results[results.length - 1].circulatingSupply * 100).toFixed(1) : 0}%)
+              </p>
+            </div>
+            <div className="bg-white p-4 rounded shadow">
+              <h3 className="text-sm font-medium text-gray-500">IEX HYPHA Balance</h3>
+              <p className="text-2xl font-bold">{results[results.length - 1].dexHypha.toLocaleString()}</p>
+            </div>
+            <div className="bg-white p-4 rounded shadow">
+              <h3 className="text-sm font-medium text-gray-500">IEX USDC Balance</h3>
+              <p className="text-2xl font-bold">${results[results.length - 1].dexUsdc.toLocaleString()}</p>
+            </div>
+            <div className="bg-white p-4 rounded shadow">
+              <h3 className="text-sm font-medium text-gray-500">Cumulated Space Contributions</h3>
+              <p className="text-2xl font-bold">${results.reduce((s, r) => s + r.orgUsdcPurchase, 0).toLocaleString()}</p>
+            </div>
+            <div className="bg-white p-4 rounded shadow">
+              <h3 className="text-sm font-medium text-gray-500">Tokens Purchased by Spaces</h3>
+              <p className="text-2xl font-bold">{results.reduce((s, r) => s + r.orgPurchasedTokens, 0).toLocaleString()}</p>
+            </div>
+            <div className="bg-white p-4 rounded shadow">
+              <h3 className="text-sm font-medium text-gray-500">Tokens Purchased by Investors</h3>
+              <p className="text-2xl font-bold">{results.reduce((s, r) => s + r.investorPurchasedTokens, 0).toLocaleString()}</p>
+            </div>
+            <div className="bg-white p-4 rounded shadow">
+              <h3 className="text-sm font-medium text-gray-500">Total Issuance</h3>
+              <p className="text-2xl font-bold">{results[results.length - 1].cumulativeIssuance.toLocaleString()}</p>
+              <p className="text-sm text-gray-500">{(results[results.length - 1].cumulativeIssuance / maxSupply * 100).toFixed(1)}% of Max Supply</p>
+            </div>
+            <div className="bg-white p-4 rounded shadow">
+              <h3 className="text-sm font-medium text-gray-500">Average Rewards</h3>
+              <p className="text-2xl font-bold">{(results.reduce((s, r) => s + parseFloat(r.actualRewards), 0) / results.length).toFixed(2)}%</p>
+            </div>
+            <div className="bg-white p-4 rounded shadow">
+              <h3 className="text-sm font-medium text-gray-500">FDV (Full Diluted Value)</h3>
+              <p className="text-2xl font-bold">${results[results.length - 1].fdv.toLocaleString()}</p>
+            </div>
+            <div className="bg-white p-4 rounded shadow border-l-4 border-indigo-400">
+              <h3 className="text-sm font-medium text-gray-500">Monthly AI Cost</h3>
+              <p className="text-2xl font-bold text-indigo-700">${Math.round(results[results.length - 1].aiCost).toLocaleString()}</p>
+              <p className="text-sm text-gray-500">{aiModel.name} · ${perSpaceAI.toFixed(2)}/Space</p>
+            </div>
+            <div className="bg-white p-4 rounded shadow border-l-4 border-indigo-400">
+              <h3 className="text-sm font-medium text-gray-500">Cumulative AI Cost</h3>
+              <p className="text-2xl font-bold text-indigo-700">${Math.round(results[results.length - 1].cumulativeAICost).toLocaleString()}</p>
+            </div>
+            <div className="bg-white p-4 rounded shadow border-l-4 border-indigo-400">
+              <h3 className="text-sm font-medium text-gray-500">Net After AI (monthly)</h3>
+              <p className={`text-2xl font-bold ${results[results.length - 1].netContribution >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+                ${Math.round(results[results.length - 1].netContribution).toLocaleString()}
+              </p>
+              <p className="text-sm text-gray-500">Contributions − AI cost</p>
+            </div>
+          </div>
+        </div>
+      )}
+
+      <div className="mb-6">
+        <h2 className="text-lg font-semibold mb-3">Simulation Results</h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
+          <div className="h-80 bg-white p-4 rounded-lg shadow">
+            <h3 className="text-md font-medium mb-2">Reward Distribution</h3>
+            <ResponsiveContainer width="100%" height="90%">
+              <LineChart data={chartData} margin={{ top: 5, right: 50, left: 50, bottom: 5 }}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="name" />
+                <YAxis tickFormatter={(v) => v.toLocaleString()} width={60} />
+                <Tooltip formatter={(v) => v.toLocaleString()} />
+                <Legend />
+                <Line type="monotone" dataKey="Staking Rewards" stroke="#8884d8" strokeWidth={2} />
+                <Line type="monotone" dataKey="Unlock Rewards" stroke="#82ca9d" strokeWidth={2} />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+          <div className="h-80 bg-white p-4 rounded-lg shadow">
+            <h3 className="text-md font-medium mb-2">Circulating Supply &amp; Total Unlocked</h3>
+            <ResponsiveContainer width="100%" height="90%">
+              <LineChart data={chartData} margin={{ top: 5, right: 40, left: 40, bottom: 5 }}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="name" />
+                <YAxis tickFormatter={(v) => v.toLocaleString()} width={60} />
+                <Tooltip formatter={(v) => v.toLocaleString()} />
+                <Legend />
+                <Line type="monotone" dataKey="Circulating Supply" stroke="#8884d8" activeDot={{ r: 8 }} />
+                <Line type="monotone" dataKey="Total Unlocked" stroke="#82ca9d" strokeWidth={2} />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+          <div className="h-80 bg-white p-4 rounded-lg shadow">
+            <h3 className="text-md font-medium mb-2">IEX HYPHA Balance &amp; Space Purchases</h3>
+            <ResponsiveContainer width="100%" height="90%">
+              <LineChart data={chartData} margin={{ top: 5, right: 50, left: 50, bottom: 5 }}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="name" />
+                <YAxis tickFormatter={(v) => v.toLocaleString()} />
+                <Tooltip formatter={(v) => v.toLocaleString()} />
+                <Legend />
+                <Line type="monotone" dataKey="IEX HYPHA" stroke="#82ca9d" strokeWidth={2} activeDot={{ r: 8 }} />
+                <Line type="monotone" dataKey="Space Purchases" stroke="#8884d8" strokeWidth={1.5} dot={{ r: 4 }} />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+          <div className="h-80 bg-white p-4 rounded-lg shadow">
+            <h3 className="text-md font-medium mb-2">IEX USDC</h3>
+            <ResponsiveContainer width="100%" height="90%">
+              <LineChart data={chartData} margin={{ top: 5, right: 40, left: 40, bottom: 5 }}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="name" />
+                <YAxis tickFormatter={(v) => v.toLocaleString()} />
+                <Tooltip formatter={(v) => v.toLocaleString()} />
+                <Line type="monotone" dataKey="IEX USDC" stroke="#8884d8" />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+          <div className="h-80 bg-white p-4 rounded-lg shadow">
+            <h3 className="text-md font-medium mb-2">Space Growth</h3>
+            <ResponsiveContainer width="100%" height="90%">
+              <LineChart data={chartData} margin={{ top: 5, right: 30, left: 30, bottom: 5 }}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="name" />
+                <YAxis yAxisId="left" tickFormatter={(v) => v.toLocaleString()} width={60} />
+                <YAxis yAxisId="right" orientation="right" tickFormatter={(v) => v.toLocaleString()} width={60} />
+                <Tooltip formatter={(v) => v.toLocaleString()} />
+                <Legend />
+                <Line yAxisId="left" type="monotone" dataKey="Number of Spaces" stroke="#8884d8" strokeWidth={2} />
+                <Line yAxisId="right" type="monotone" dataKey="Cumulative Spaces" stroke="#82ca9d" strokeWidth={2} />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+          <div className="h-80 bg-white p-4 rounded-lg shadow">
+            <h3 className="text-md font-medium mb-2">Token Price &amp; FDV</h3>
+            <ResponsiveContainer width="100%" height="90%">
+              <LineChart data={chartData} margin={{ top: 5, right: 30, left: 30, bottom: 5 }}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="name" />
+                <YAxis yAxisId="left" tickFormatter={(v) => v.toLocaleString()} width={60} />
+                <YAxis yAxisId="right" orientation="right" tickFormatter={(v) => v.toLocaleString()} width={60} />
+                <Tooltip formatter={(v) => v.toLocaleString()} />
+                <Legend />
+                <Line yAxisId="left" type="monotone" dataKey="Price (USDC)" stroke="#ff7300" />
+                <Line yAxisId="right" type="monotone" dataKey="FDV (Million $)" stroke="#0088FE" />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+          <div className="h-80 bg-white p-4 rounded-lg shadow md:col-span-2">
+            <h3 className="text-md font-medium mb-1">Space Contributions vs AI Cost</h3>
+            <p className="text-xs text-gray-500 mb-2">
+              Contributions = Spaces × ${orgPayment} USDC/Space. Flat stretches happen when per-month Space Growth Rate is 0% (default: months 2–26). AI cost scales with the same Space count × selected model rate.
+            </p>
+            <ResponsiveContainer width="100%" height="85%">
+              <LineChart data={chartData} margin={{ top: 5, right: 50, left: 50, bottom: 5 }}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="name" />
+                <YAxis tickFormatter={(v) => v.toLocaleString()} width={60} />
+                <Tooltip formatter={(v) => v.toLocaleString()} />
+                <Legend />
+                <Line type="monotone" dataKey="Space Contributions (USD)" stroke="#82ca9d" strokeWidth={2} />
+                <Line type="monotone" dataKey="AI Cost (USD)" stroke="#6366f1" strokeWidth={2} />
+                <Line type="monotone" dataKey="Net Contributions (USD)" stroke="#ff7300" strokeWidth={2} />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+          <div className="h-80 bg-white p-4 rounded-lg shadow">
+            <h3 className="text-md font-medium mb-2">Cumulative AI Cost</h3>
+            <ResponsiveContainer width="100%" height="90%">
+              <LineChart data={chartData} margin={{ top: 5, right: 40, left: 40, bottom: 5 }}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="name" />
+                <YAxis tickFormatter={(v) => v.toLocaleString()} width={60} />
+                <Tooltip formatter={(v) => v.toLocaleString()} />
+                <Line type="monotone" dataKey="Cumulative AI Cost (USD)" stroke="#6366f1" strokeWidth={2} />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+        </div>
+
+        <div className="overflow-x-auto">
+          <table className="min-w-full bg-white border text-sm">
+            <thead className="bg-gray-100">
+              <tr>
+                <th className="py-2 px-4 border">Month</th>
+                <th className="py-2 px-4 border text-right">Total Issuance (monthly)</th>
+                <th className="py-2 px-4 border text-right">Total Unlocked (cumulative)</th>
+                <th className="py-2 px-4 border text-right">Staking Rewards</th>
+                <th className="py-2 px-4 border text-right">Unlock Rewards</th>
+                <th className="py-2 px-4 border text-right">Actual Rewards</th>
+                <th className="py-2 px-4 border text-right">Spaces (monthly)</th>
+                <th className="py-2 px-4 border text-right">Spaces (cumulative)</th>
+                <th className="py-2 px-4 border text-right">Staked Tokens (cumulative)</th>
+                <th className="py-2 px-4 border text-right">Circulating Supply</th>
+                <th className="py-2 px-4 border text-right">IEX HYPHA Before</th>
+                <th className="py-2 px-4 border text-right">Space HYPHA Purchased</th>
+                <th className="py-2 px-4 border text-right">Investor HYPHA Purchased</th>
+                <th className="py-2 px-4 border text-right">Tokens Sold on IEX</th>
+                <th className="py-2 px-4 border text-right">IEX HYPHA After</th>
+                <th className="py-2 px-4 border text-right">IEX USDC</th>
+                <th className="py-2 px-4 border text-right">Space Contributions (USD)</th>
+                <th className="py-2 px-4 border text-right">AI Cost (USD)</th>
+                <th className="py-2 px-4 border text-right">Net After AI (USD)</th>
+                <th className="py-2 px-4 border text-right">Cumulative AI Cost (USD)</th>
+                <th className="py-2 px-4 border text-right">Token Price</th>
+                <th className="py-2 px-4 border text-right">Price Change</th>
+                <th className="py-2 px-4 border text-right">FDV (USD)</th>
+              </tr>
+            </thead>
+            <tbody>
+              {results.map((row) => (
+                <tr key={row.month}>
+                  <td className="py-2 px-4 border text-center">{row.month}</td>
+                  <td className="py-2 px-4 border text-right">{row.totalIssuance.toLocaleString()}</td>
+                  <td className="py-2 px-4 border text-right">{row.cumulativeIssuance.toLocaleString()}</td>
+                  <td className="py-2 px-4 border text-right">
+                    {row.stakingRewards.toLocaleString()}
+                    <span className="text-xs text-gray-500 ml-1">({row.stakingRewardsPercentage}%)</span>
+                  </td>
+                  <td className="py-2 px-4 border text-right">{row.unlockRewards.toLocaleString()}</td>
+                  <td className="py-2 px-4 border text-right">{row.actualRewards}%</td>
+                  <td className="py-2 px-4 border text-right">{row.orgCount.toLocaleString()}</td>
+                  <td className="py-2 px-4 border text-right">{row.cumulativeOrgCount.toLocaleString()}</td>
+                  <td className="py-2 px-4 border text-right">{row.stakedAmount.toLocaleString()}</td>
+                  <td className="py-2 px-4 border text-right">{row.circulatingSupply.toLocaleString()}</td>
+                  <td className="py-2 px-4 border text-right">{row.dexHyphaBefore.toLocaleString()}</td>
+                  <td className="py-2 px-4 border text-right">{row.orgPurchasedTokens.toLocaleString()}</td>
+                  <td className="py-2 px-4 border text-right">{row.investorPurchasedTokens.toLocaleString()}</td>
+                  <td className="py-2 px-4 border text-right">{row.tokensSold.toLocaleString()}</td>
+                  <td className="py-2 px-4 border text-right">{row.dexHypha.toLocaleString()}</td>
+                  <td className="py-2 px-4 border text-right">{row.dexUsdc.toLocaleString()}</td>
+                  <td className="py-2 px-4 border text-right">${Math.round(row.orgUsdcPurchase).toLocaleString()}</td>
+                  <td className="py-2 px-4 border text-right text-indigo-700">${Math.round(row.aiCost).toLocaleString()}</td>
+                  <td className={`py-2 px-4 border text-right ${row.netContribution >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+                    ${Math.round(row.netContribution).toLocaleString()}
+                  </td>
+                  <td className="py-2 px-4 border text-right text-indigo-700">${Math.round(row.cumulativeAICost).toLocaleString()}</td>
+                  <td className="py-2 px-4 border text-right">${row.tokenPrice}</td>
+                  <td className="py-2 px-4 border text-right">{row.deltaPrice}%</td>
+                  <td className="py-2 px-4 border text-right">${row.fdv.toLocaleString()}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+        </div>
+
+        <div className="w-48 flex-shrink-0">
+          <div className="sticky top-4 border border-gray-200 rounded-lg overflow-hidden shadow-sm">
+            <div className="bg-gray-100 px-3 py-2 text-xs font-semibold text-gray-600 uppercase tracking-wide">
+              Growth Scenario
+            </div>
+            {Object.entries(GROWTH_PRESETS).map(([key, preset]) => (
+              <button
+                key={key}
+                type="button"
+                onClick={() => applyGrowthScenario(key)}
+                className={`w-full text-left px-3 py-3 border-t border-gray-200 transition-colors ${
+                  growthScenario === key
+                    ? 'bg-indigo-600 text-white'
+                    : 'bg-white hover:bg-indigo-50 text-gray-800'
+                }`}
+              >
+                <div className="font-semibold text-sm">{preset.label}</div>
+                <div className={`text-xs mt-0.5 ${growthScenario === key ? 'text-indigo-100' : 'text-gray-500'}`}>
+                  {preset.subtitle}
+                </div>
+                {results.length > 0 && growthScenario === key && (
+                  <div className="text-xs mt-1 text-indigo-100">
+                    {results[results.length - 1].orgCount.toLocaleString()} Spaces · FDV ${(results[results.length - 1].fdv / 1e6).toFixed(0)}M
+                  </div>
+                )}
+              </button>
+            ))}
+            <p className="px-3 py-2 text-xs text-gray-500 bg-gray-50 border-t border-gray-200">
+              Sets per-month Space Growth Rate presets. Override individual months via Per-Month Configuration.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const root = createRoot(document.getElementById('root'));
+root.render(<TokenomicsSimulator />);
+</script>
+</body>
+</html>

--- a/apps/web/public/tokenomics2/index.html
+++ b/apps/web/public/tokenomics2/index.html
@@ -70,64 +70,64 @@ const perSpaceMonthlyGas = (profile) => GAS_MONTHLY_BY_PROFILE[profile] || GAS_M
 const GROWTH_PRESETS = {
   low: {
     label: 'Low',
-    subtitle: '~250k Spaces',
+    subtitle: '~250k cumulative',
     defaults: {
       orgPayment: 44,
-      iexAllocationPct: 8,
+      iexAllocationPct: 25,
       investorSelling: 5,
       additionalPurchase: 5,
       unlockRate: 4,
-      initialHypha: 20000000,
-      initialUsdc: 4000000,
+      initialHypha: 5000000,
+      initialUsdc: 1000000,
       orgCount: 4373,
-      orgGrowthRate: 9,
+      orgGrowthRate: 0.72,
     },
-    // Target ~250k Spaces at month 48 (~9.0%/mo, months 2–48)
+    // Target ~250k cumulative Space-months at month 48 (~0.72%/mo, months 2–48)
     build: () => {
       const m = {};
-      for (let i = 2; i <= 48; i++) m[i] = { orgGrowthRate: 9.0 };
+      for (let i = 2; i <= 48; i++) m[i] = { orgGrowthRate: 0.72 };
       return m;
     },
   },
   mid: {
     label: 'Mid',
-    subtitle: '~1M Spaces',
+    subtitle: '~1M cumulative',
     defaults: {
       orgPayment: 44,
-      iexAllocationPct: 10,
+      iexAllocationPct: 25,
       investorSelling: 5,
-      additionalPurchase: 5,
+      additionalPurchase: 8,
       unlockRate: 3.5,
       initialHypha: 40000000,
       initialUsdc: 8000000,
       orgCount: 4373,
-      orgGrowthRate: 12.26,
+      orgGrowthRate: 5.63,
     },
-    // Target ~1M Spaces at month 48 (~12.26%/mo, months 2–48)
+    // Target ~1M cumulative Space-months at month 48 (~5.63%/mo, months 2–48)
     build: () => {
       const m = {};
-      for (let i = 2; i <= 48; i++) m[i] = { orgGrowthRate: 12.26 };
+      for (let i = 2; i <= 48; i++) m[i] = { orgGrowthRate: 5.63 };
       return m;
     },
   },
   high: {
     label: 'High',
-    subtitle: '~10M Spaces',
+    subtitle: '~10M cumulative',
     defaults: {
       orgPayment: 44,
-      iexAllocationPct: 12,
-      investorSelling: 5,
-      additionalPurchase: 5,
+      iexAllocationPct: 19,
+      investorSelling: 3,
+      additionalPurchase: 8,
       unlockRate: 3,
       initialHypha: 100000000,
       initialUsdc: 25000000,
       orgCount: 4373,
-      orgGrowthRate: 17.9,
+      orgGrowthRate: 12.52,
     },
-    // Target ~10M Spaces at month 48 (~17.9%/mo, months 2–48)
+    // Target ~10M cumulative Space-months at month 48 (~12.52%/mo, months 2–48)
     build: () => {
       const m = {};
-      for (let i = 2; i <= 48; i++) m[i] = { orgGrowthRate: 17.9 };
+      for (let i = 2; i <= 48; i++) m[i] = { orgGrowthRate: 12.52 };
       return m;
     },
   },
@@ -222,6 +222,7 @@ const TokenomicsSimulator = () => {
     const perSpaceGas = perSpaceMonthlyGas(aiProfile);
     let cumulativeAICost = 0;
     let cumulativeGasCost = 0;
+    let cumulativeGrossRevenue = 0;
 
     for (let month = 1; month <= months; month++) {
       const monthStakingRate = getMonthlyParameter('stakingRate', month) / 100;
@@ -278,6 +279,8 @@ const TokenomicsSimulator = () => {
 
       cumulativeOrgCountTracker += currentOrgCount;
       const cumulativeOrgCount = cumulativeOrgCountTracker;
+      cumulativeGrossRevenue += grossContribution;
+      const runRateArr = currentOrgCount * monthOrgPayment * 12;
 
       const distributionMultiplier = getMonthlyParameter('unlockRate', month);
       const safeStakingRate = Math.min(monthStakingRate, 0.9);
@@ -367,6 +370,9 @@ const TokenomicsSimulator = () => {
         totalPurchasedTokens: Math.round(totalPurchasedTokens),
         investorSellingUsdc: monthInvestorSelling, tokensSold,
         fdv: Math.round(fdv),
+        runRateArr: Math.round(runRateArr),
+        fdvArr: runRateArr > 0 ? +(fdv / runRateArr).toFixed(1) : null,
+        cumulativeGrossRevenue: Math.round(cumulativeGrossRevenue),
         aiCost: monthAICost, cumulativeAICost,
         gasCost: monthGasCost, cumulativeGasCost,
         netContribution, netAfterGas,
@@ -439,6 +445,8 @@ const TokenomicsSimulator = () => {
   const perSpaceAI = perSpaceMonthlyAICost(aiModel, aiProfile);
   const perSpaceGas = perSpaceMonthlyGas(aiProfile);
   const baselinePerSpace = perSpaceMonthlyAICost(getModel('composer-fast'), aiProfile);
+  const lastResult = results.length > 0 ? results[results.length - 1] : null;
+  const offPoolPct = 100 - (monthlyParams[selectedMonth]?.iexAllocationPct ?? iexAllocationPct);
 
 
   return (
@@ -446,7 +454,33 @@ const TokenomicsSimulator = () => {
       <div className="flex gap-6">
         <div className="flex-1 min-w-0">
       <h1 className="text-2xl font-bold mb-1">HYPHA Tokenomics Simulator (Phase II)</h1>
-      <p className="text-sm text-gray-500 mb-4">With per-Space AI + Base L2 gas operating cost model — closed-source vs open-source LLMs.</p>
+      <p className="text-sm text-gray-500 mb-3">Dynamic IEX pricing after Phase I handoff — per-Space AI + Base L2 gas operating cost model.</p>
+
+      <div className="mb-4 border border-slate-200 bg-slate-50 p-4 rounded-lg">
+        <h2 className="text-xs font-semibold text-slate-600 uppercase tracking-wide mb-2">Roadmap: Phase 0 → Phase I → Phase II</h2>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-3 text-sm">
+          <div className="bg-white p-3 rounded border border-slate-200">
+            <div className="font-semibold text-slate-600">Phase 0 — Today</div>
+            <p className="text-xs text-gray-600 mt-1">~4,373 Spaces live. Phase I at month 0. Reference FDV ~$111M at $0.20.</p>
+          </div>
+          <div className="bg-white p-3 rounded border border-slate-200">
+            <div className="font-semibold text-slate-700">Phase I — Month 0+</div>
+            <p className="text-xs text-gray-600 mt-1">Fixed $0.20 price, token sale &amp; locking. <a href="/tokenomics1/" className="text-indigo-600 underline">Phase I simulator →</a></p>
+          </div>
+          <div className="bg-indigo-600 text-white p-3 rounded border border-indigo-700">
+            <div className="font-semibold">Phase II — After Phase I (this sim)</div>
+            <p className="text-xs text-indigo-100 mt-1">Starts ~4,373 paying Spaces × $44/mo. Month 1 = first month after handoff.</p>
+          </div>
+        </div>
+      </div>
+
+      <div className="mb-4 border border-teal-200 bg-teal-50 p-3 rounded-lg text-sm">
+        <span className="font-semibold text-teal-800">Revenue split:</span>{' '}
+        <span className="text-teal-900">{iexAllocationPct}% → IEX buy pressure</span>
+        <span className="text-teal-700"> · </span>
+        <span className="text-teal-900">{offPoolPct}% → AI (~${perSpaceAI.toFixed(2)}/Space), gas, ops, rewards, treasury</span>
+        <span className="text-xs text-teal-700 block mt-1">Only active Spaces in each month pay $44. Cumulative totals are Space-months over the horizon, not concurrent payers.</span>
+      </div>
 
       {/* ============ AI OPERATING COST SECTION ============ */}
       <div className="mb-6 border border-indigo-200 bg-indigo-50 p-4 rounded-lg">
@@ -665,16 +699,16 @@ const TokenomicsSimulator = () => {
               <input type="number" min="0" max="200" value={monthlyParams[selectedMonth]?.orgPayment ?? orgPayment} onChange={(e) => { const v = Number(e.target.value); selectedMonth === 1 ? setOrgPayment(v) : updateMonthlyParameter('orgPayment', v); }} className="w-20 p-1 border rounded text-right" />
               <span className="ml-1">USDC</span>
             </div>
-            <p className="text-xs text-gray-500 mt-1">Gross revenue per Space. AI (${perSpaceAI.toFixed(2)}/Space) and gas (${perSpaceGas.toFixed(2)}/Space) tracked separately; only a % routes to IEX.</p>
+            <p className="text-xs text-gray-500 mt-1">Gross revenue per Space. Default AI ~${perSpaceAI.toFixed(2)}/Space (open-weight); Composer reference ~${baselinePerSpace.toFixed(2)}/Space. Only {iexAllocationPct}% routes to IEX; {offPoolPct}% off-pool.</p>
           </div>
           <div className="mb-4">
             <label className="block text-sm font-medium mb-1">% routed to IEX (buy pressure)</label>
             <div className="flex items-center">
-              <input type="range" min="0" max="30" step="1" value={monthlyParams[selectedMonth]?.iexAllocationPct ?? iexAllocationPct} onChange={(e) => { const v = Number(e.target.value); selectedMonth === 1 ? setIexAllocationPct(v) : updateMonthlyParameter('iexAllocationPct', v); }} className="w-full mr-3" />
-              <input type="number" min="0" max="30" value={monthlyParams[selectedMonth]?.iexAllocationPct ?? iexAllocationPct} onChange={(e) => { const v = Number(e.target.value); selectedMonth === 1 ? setIexAllocationPct(v) : updateMonthlyParameter('iexAllocationPct', v); }} className="w-16 p-1 border rounded text-right" />
+              <input type="range" min="0" max="50" step="1" value={monthlyParams[selectedMonth]?.iexAllocationPct ?? iexAllocationPct} onChange={(e) => { const v = Number(e.target.value); selectedMonth === 1 ? setIexAllocationPct(v) : updateMonthlyParameter('iexAllocationPct', v); }} className="w-full mr-3" />
+              <input type="number" min="0" max="50" value={monthlyParams[selectedMonth]?.iexAllocationPct ?? iexAllocationPct} onChange={(e) => { const v = Number(e.target.value); selectedMonth === 1 ? setIexAllocationPct(v) : updateMonthlyParameter('iexAllocationPct', v); }} className="w-16 p-1 border rounded text-right" />
               <span className="ml-1">%</span>
             </div>
-            <p className="text-xs text-gray-500 mt-1">Remainder = treasury / ops / rewards off-pool.</p>
+            <p className="text-xs text-gray-500 mt-1">Remainder ({offPoolPct}%) = AI, gas, treasury / ops / off-pool rewards.</p>
           </div>
           <div className="mb-4">
             <label className="block text-sm font-medium mb-1">Additional Investor Purchases + buybacks (% of USDC on IEX)</label>
@@ -703,9 +737,19 @@ const TokenomicsSimulator = () => {
           <h2 className="text-xl font-bold mb-4">Key Metrics at Month {months}</h2>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
             <div className="bg-white p-4 rounded shadow">
-              <h3 className="text-sm font-medium text-gray-500">Spaces</h3>
+              <h3 className="text-sm font-medium text-gray-500">Cumulative Spaces</h3>
               <p className="text-2xl font-bold">{results[results.length - 1].cumulativeOrgCount.toLocaleString()}</p>
-              <p className="text-sm text-gray-500">Current Month: {results[results.length - 1].orgCount.toLocaleString()}</p>
+              <p className="text-sm text-gray-500">Active (month {months}): {results[results.length - 1].orgCount.toLocaleString()}</p>
+            </div>
+            <div className="bg-white p-4 rounded shadow border-l-4 border-green-500">
+              <h3 className="text-sm font-medium text-gray-500">Run-rate ARR (month {months})</h3>
+              <p className="text-2xl font-bold text-green-700">${lastResult ? lastResult.runRateArr.toLocaleString() : 0}</p>
+              <p className="text-sm text-gray-500">{lastResult ? lastResult.orgCount.toLocaleString() : 0} active Spaces × ${orgPayment} × 12</p>
+            </div>
+            <div className="bg-white p-4 rounded shadow border-l-4 border-green-500">
+              <h3 className="text-sm font-medium text-gray-500">4-year gross billed</h3>
+              <p className="text-2xl font-bold text-green-700">${lastResult ? lastResult.cumulativeGrossRevenue.toLocaleString() : 0}</p>
+              <p className="text-sm text-gray-500">Sum of all monthly Space contributions</p>
             </div>
             <div className="bg-white p-4 rounded shadow">
               <h3 className="text-sm font-medium text-gray-500">Token Price</h3>
@@ -728,10 +772,6 @@ const TokenomicsSimulator = () => {
               <p className="text-2xl font-bold">${results[results.length - 1].dexUsdc.toLocaleString()}</p>
             </div>
             <div className="bg-white p-4 rounded shadow">
-              <h3 className="text-sm font-medium text-gray-500">Cumulated Space Contributions</h3>
-              <p className="text-2xl font-bold">${results.reduce((s, r) => s + r.orgUsdcPurchase, 0).toLocaleString()}</p>
-            </div>
-            <div className="bg-white p-4 rounded shadow">
               <h3 className="text-sm font-medium text-gray-500">Tokens Purchased by Spaces</h3>
               <p className="text-2xl font-bold">{results.reduce((s, r) => s + r.orgPurchasedTokens, 0).toLocaleString()}</p>
             </div>
@@ -751,6 +791,9 @@ const TokenomicsSimulator = () => {
             <div className="bg-white p-4 rounded shadow">
               <h3 className="text-sm font-medium text-gray-500">FDV (Full Diluted Value)</h3>
               <p className="text-2xl font-bold">${results[results.length - 1].fdv.toLocaleString()}</p>
+              {lastResult && lastResult.fdvArr != null && (
+                <p className="text-sm text-gray-500">FDV / ARR: {lastResult.fdvArr}× (ramp narrative at Low/Mid)</p>
+              )}
             </div>
             <div className="bg-white p-4 rounded shadow border-l-4 border-indigo-400">
               <h3 className="text-sm font-medium text-gray-500">Monthly AI Cost</h3>
@@ -1009,13 +1052,13 @@ const TokenomicsSimulator = () => {
                 </div>
                 {results.length > 0 && growthScenario === key && (
                   <div className="text-xs mt-1 text-indigo-100">
-                    {results[results.length - 1].orgCount.toLocaleString()} Spaces · FDV ${(results[results.length - 1].fdv / 1e6).toFixed(0)}M
+                    {results[results.length - 1].orgCount.toLocaleString()} paying · FDV ${(results[results.length - 1].fdv / 1e6).toFixed(0)}M
                   </div>
                 )}
               </button>
             ))}
             <p className="px-3 py-2 text-xs text-gray-500 bg-gray-50 border-t border-gray-200">
-              Sets per-month Space Growth Rate presets. Override individual months via Per-Month Configuration.
+              Targets cumulative Space-months (sum of active Spaces each month) at month 48. Override growth per month via Per-Month Configuration.
             </p>
           </div>
         </div>

--- a/apps/web/public/tokenomics2/index.html
+++ b/apps/web/public/tokenomics2/index.html
@@ -68,13 +68,13 @@ const perSpaceMonthlyGas = (profile) => GAS_MONTHLY_BY_PROFILE[profile] || GAS_M
 
 
 const GROWTH_PRESETS = {
-  min: {
-    label: 'Min',
+  low: {
+    label: 'Low',
     subtitle: '~250k Spaces',
     defaults: {
-      orgPayment: 22,
-      investorSelling: 13.5,
-      additionalPurchase: 7,
+      orgPayment: 44,
+      investorSelling: 10,
+      additionalPurchase: 10,
       unlockRate: 5,
       initialHypha: 3333333,
       initialUsdc: 1000000,
@@ -88,13 +88,13 @@ const GROWTH_PRESETS = {
       return m;
     },
   },
-  medium: {
-    label: 'Medium',
+  mid: {
+    label: 'Mid',
     subtitle: '~1M Spaces',
     defaults: {
-      orgPayment: 22,
-      investorSelling: 26,
-      additionalPurchase: 11,
+      orgPayment: 44,
+      investorSelling: 10,
+      additionalPurchase: 10,
       unlockRate: 4,
       initialHypha: 12000000,
       initialUsdc: 750000,
@@ -116,59 +116,50 @@ const GROWTH_PRESETS = {
       45: { orgGrowthRate: 3 }, 46: { orgGrowthRate: 3 }, 47: { orgGrowthRate: 3 }, 48: { orgGrowthRate: 3 },
     }),
   },
-  max: {
-    label: 'Max',
-    subtitle: '~2M Spaces',
+  high: {
+    label: 'High',
+    subtitle: '~10M Spaces',
     defaults: {
-      orgPayment: 22,
-      investorSelling: 14.5,
-      additionalPurchase: 3,
+      orgPayment: 44,
+      investorSelling: 10,
+      additionalPurchase: 10,
       unlockRate: 4,
       initialHypha: 20000000,
       initialUsdc: 1000000,
       orgCount: 4373,
       orgGrowthRate: 25,
     },
-    build: () => ({
-      1: { orgGrowthRate: 25 }, 2: { orgGrowthRate: 10 }, 3: { orgGrowthRate: 10 }, 4: { orgGrowthRate: 10 },
-      5: { orgGrowthRate: 10 }, 6: { orgGrowthRate: 10 }, 7: { orgGrowthRate: 10 }, 8: { orgGrowthRate: 10 },
-      9: { orgGrowthRate: 10 }, 10: { orgGrowthRate: 27 }, 11: { orgGrowthRate: 15 }, 12: { orgGrowthRate: 14 },
-      13: { orgGrowthRate: 13 }, 14: { orgGrowthRate: 12 }, 15: { orgGrowthRate: 25 }, 16: { orgGrowthRate: 23 },
-      17: { orgGrowthRate: 3 }, 18: { orgGrowthRate: 8 }, 19: { orgGrowthRate: 7 }, 20: { orgGrowthRate: 2 },
-      21: { orgGrowthRate: 1 }, 22: { orgGrowthRate: 4 }, 23: { orgGrowthRate: 4 }, 24: { orgGrowthRate: 4 },
-      25: { orgGrowthRate: 4 }, 26: { orgGrowthRate: 4 }, 27: { orgGrowthRate: 3 }, 28: { orgGrowthRate: 3 },
-      29: { orgGrowthRate: 3 }, 30: { orgGrowthRate: 3 }, 31: { orgGrowthRate: 3 }, 32: { orgGrowthRate: 3 },
-      33: { orgGrowthRate: 3 }, 34: { orgGrowthRate: 3 }, 35: { orgGrowthRate: 3 }, 36: { orgGrowthRate: 3 },
-      37: { orgGrowthRate: 3 }, 38: { orgGrowthRate: 3 }, 39: { orgGrowthRate: 3 }, 40: { orgGrowthRate: 3 },
-      41: { orgGrowthRate: 3 }, 42: { orgGrowthRate: 3 }, 43: { orgGrowthRate: 3 }, 44: { orgGrowthRate: 3 },
-      45: { orgGrowthRate: 3 }, 46: { orgGrowthRate: 3 }, 47: { orgGrowthRate: 3 }, 48: { orgGrowthRate: 3 },
-    }),
+    build: () => {
+      const m = { 1: { orgGrowthRate: 25 } };
+      for (let i = 2; i <= 48; i++) m[i] = { orgGrowthRate: 18 };
+      return m;
+    },
   },
 };
 
 const TokenomicsSimulator = () => {
   const [maxSupply, setMaxSupply] = useState(555555555);
-  const [initialHypha, setInitialHypha] = useState(GROWTH_PRESETS.min.defaults.initialHypha);
-  const [initialUsdc, setInitialUsdc] = useState(GROWTH_PRESETS.min.defaults.initialUsdc);
+  const [initialHypha, setInitialHypha] = useState(GROWTH_PRESETS.low.defaults.initialHypha);
+  const [initialUsdc, setInitialUsdc] = useState(GROWTH_PRESETS.low.defaults.initialUsdc);
   const [months, setMonths] = useState(48);
-  const [unlockRate, setUnlockRate] = useState(GROWTH_PRESETS.min.defaults.unlockRate);
+  const [unlockRate, setUnlockRate] = useState(GROWTH_PRESETS.low.defaults.unlockRate);
   const [stakingRewards, setStakingRewards] = useState(30);
   const [rewardSplit, setRewardSplit] = useState(50);
   const [stakingRate, setStakingRate] = useState(75);
   const [sellRate, setSellRate] = useState(30);
-  const [investorSelling, setInvestorSelling] = useState(GROWTH_PRESETS.min.defaults.investorSelling);
-  const [additionalPurchase, setAdditionalPurchase] = useState(GROWTH_PRESETS.min.defaults.additionalPurchase);
-  const [orgCount, setOrgCount] = useState(GROWTH_PRESETS.min.defaults.orgCount);
-  const [orgPayment, setOrgPayment] = useState(GROWTH_PRESETS.min.defaults.orgPayment);
-  const [orgGrowthRate, setOrgGrowthRate] = useState(GROWTH_PRESETS.min.defaults.orgGrowthRate);
+  const [investorSelling, setInvestorSelling] = useState(GROWTH_PRESETS.low.defaults.investorSelling);
+  const [additionalPurchase, setAdditionalPurchase] = useState(GROWTH_PRESETS.low.defaults.additionalPurchase);
+  const [orgCount, setOrgCount] = useState(GROWTH_PRESETS.low.defaults.orgCount);
+  const [orgPayment, setOrgPayment] = useState(GROWTH_PRESETS.low.defaults.orgPayment);
+  const [orgGrowthRate, setOrgGrowthRate] = useState(GROWTH_PRESETS.low.defaults.orgGrowthRate);
 
   // AI operating cost controls
   const [aiModelId, setAiModelId] = useState('kimi-or');
   const [aiProfile, setAiProfile] = useState('typical');
-  const [growthScenario, setGrowthScenario] = useState('min');
+  const [growthScenario, setGrowthScenario] = useState('low');
 
   const [selectedMonth, setSelectedMonth] = useState(1);
-  const [monthlyParams, setMonthlyParams] = useState(GROWTH_PRESETS.min.build());
+  const [monthlyParams, setMonthlyParams] = useState(GROWTH_PRESETS.low.build());
   const [showMonthlyConfig, setShowMonthlyConfig] = useState(false);
 
   const [results, setResults] = useState([]);

--- a/apps/web/public/tokenomics2/index.html
+++ b/apps/web/public/tokenomics2/index.html
@@ -67,72 +67,74 @@ const GAS_SETUP_ONE_TIME = 0.035;
 const perSpaceMonthlyGas = (profile) => GAS_MONTHLY_BY_PROFILE[profile] || GAS_MONTHLY_BY_PROFILE.typical;
 
 // Phase 0 → Phase I → Phase II continuity (same network, one growth story)
-// Phase I bootstraps 0 → ~4,373 active Spaces over 12 months. Phase II starts there.
+// Phase I bootstraps 0 → ~4,373 paying Spaces over 12 months. Phase II starts there.
 const PHASE_I_END_SPACES = 4373;
 const PHASE_II_START_SPACES = PHASE_I_END_SPACES;
 
-// Year-5 (Phase II month 48) ACTIVE Space targets: Low ~25k, Mid ~250k, High ~2M
+// One series only: every Space pays $44/mo (no free tier). The Space count grows from the
+// ~4,373 Phase I handoff to the year-5 (Phase II month 48) target and drives all revenue.
+// Year-5 cumulative Space targets: Low ~250k, Mid ~1M, High ~10M.
 const GROWTH_PRESETS = {
   low: {
     label: 'Low',
-    subtitle: '~25k active (year 5)',
+    subtitle: '~250k paying Spaces (yr 5)',
     defaults: {
       orgPayment: 44,
-      iexAllocationPct: 25,
-      investorSelling: 3,
+      iexAllocationPct: 22,
+      investorSelling: 5,
       additionalPurchase: 5,
       unlockRate: 4,
-      initialHypha: 40000000,
-      initialUsdc: 8000000,
-      orgCount: PHASE_II_START_SPACES,
-      orgGrowthRate: 3.78,
-    },
-    // ~25k active / ~570k cumulative Space-months at Phase II month 48 (~3.78%/mo)
-    build: () => {
-      const m = {};
-      for (let i = 2; i <= 48; i++) m[i] = { orgGrowthRate: 3.78 };
-      return m;
-    },
-  },
-  mid: {
-    label: 'Mid',
-    subtitle: '~250k active (year 5)',
-    defaults: {
-      orgPayment: 44,
-      iexAllocationPct: 19,
-      investorSelling: 5,
-      additionalPurchase: 8,
-      unlockRate: 3.5,
-      initialHypha: 80000000,
-      initialUsdc: 16000000,
+      initialHypha: 29000000,
+      initialUsdc: 5800000,
       orgCount: PHASE_II_START_SPACES,
       orgGrowthRate: 8.99,
     },
-    // ~250k active / ~3M cumulative Space-months at Phase II month 48 (~8.99%/mo)
+    // 4,373 → ~250k paying Spaces at month 48 (~8.99%/mo)
     build: () => {
       const m = {};
       for (let i = 2; i <= 48; i++) m[i] = { orgGrowthRate: 8.99 };
       return m;
     },
   },
-  high: {
-    label: 'High',
-    subtitle: '~2M active (year 5)',
+  mid: {
+    label: 'Mid',
+    subtitle: '~1M paying Spaces (yr 5)',
     defaults: {
       orgPayment: 44,
-      iexAllocationPct: 19,
-      investorSelling: 3,
-      additionalPurchase: 8,
-      unlockRate: 3,
-      initialHypha: 150000000,
-      initialUsdc: 30000000,
+      iexAllocationPct: 20,
+      investorSelling: 6,
+      additionalPurchase: 6,
+      unlockRate: 3.5,
+      initialHypha: 41000000,
+      initialUsdc: 8200000,
       orgCount: PHASE_II_START_SPACES,
-      orgGrowthRate: 13.92,
+      orgGrowthRate: 12.25,
     },
-    // ~2M active / ~16M cumulative Space-months at Phase II month 48 (~13.92%/mo)
+    // 4,373 → ~1M paying Spaces at month 48 (~12.25%/mo)
     build: () => {
       const m = {};
-      for (let i = 2; i <= 48; i++) m[i] = { orgGrowthRate: 13.92 };
+      for (let i = 2; i <= 48; i++) m[i] = { orgGrowthRate: 12.25 };
+      return m;
+    },
+  },
+  high: {
+    label: 'High',
+    subtitle: '~10M paying Spaces (yr 5)',
+    defaults: {
+      orgPayment: 44,
+      iexAllocationPct: 18,
+      investorSelling: 7,
+      additionalPurchase: 7,
+      unlockRate: 3,
+      initialHypha: 111000000,
+      initialUsdc: 22200000,
+      orgCount: PHASE_II_START_SPACES,
+      orgGrowthRate: 17.89,
+    },
+    // 4,373 → ~10M paying Spaces at month 48 (~17.89%/mo)
+    build: () => {
+      const m = {};
+      for (let i = 2; i <= 48; i++) m[i] = { orgGrowthRate: 17.89 };
       return m;
     },
   },
@@ -215,7 +217,6 @@ const TokenomicsSimulator = () => {
     let circulatingSupply = 0;
     let cumulativeIssued = 0;
     let prevPrice = dexUsdc / dexHypha;
-    let cumulativeOrgCountTracker = 0;
     const feeRate = 0.003;
     const tokenResults = [];
     const graphData = [];
@@ -282,8 +283,9 @@ const TokenomicsSimulator = () => {
         }
       }
 
-      cumulativeOrgCountTracker += currentOrgCount;
-      const cumulativeOrgCount = cumulativeOrgCountTracker;
+      // Every Space pays — no free tier and no churn — so the running Space count
+      // is itself the cumulative Space total. Both metrics track the same series.
+      const cumulativeOrgCount = currentOrgCount;
       cumulativeGrossRevenue += grossContribution;
       const runRateArr = currentOrgCount * monthOrgPayment * 12;
 
@@ -474,17 +476,9 @@ const TokenomicsSimulator = () => {
           </div>
           <div className="bg-indigo-600 text-white p-3 rounded border border-indigo-700">
             <div className="font-semibold">Phase II — Years 2–5 (this sim)</div>
-            <p className="text-xs text-indigo-100 mt-1">Starts ~{PHASE_II_START_SPACES.toLocaleString()} paying Spaces × $44/mo. Month 1 = first month of year 2. Year 5 = month 48.</p>
+            <p className="text-xs text-indigo-100 mt-1">Starts ~{PHASE_II_START_SPACES.toLocaleString()} paying Spaces × $44/mo. Year-5 paying Spaces: Low ~250k · Mid ~1M · High ~10M.</p>
           </div>
         </div>
-      </div>
-
-      <div className="mb-4 border border-teal-200 bg-teal-50 p-3 rounded-lg text-sm">
-        <span className="font-semibold text-teal-800">Revenue split:</span>{' '}
-        <span className="text-teal-900">{iexAllocationPct}% → IEX buy pressure</span>
-        <span className="text-teal-700"> · </span>
-        <span className="text-teal-900">{offPoolPct}% → AI (~${perSpaceAI.toFixed(2)}/Space), gas, ops, rewards, treasury</span>
-        <span className="text-xs text-teal-700 block mt-1">Only active Spaces in each month pay $44. Cumulative totals are Space-months over the horizon, not concurrent payers.</span>
       </div>
 
       {/* ============ AI OPERATING COST SECTION ============ */}
@@ -744,7 +738,7 @@ const TokenomicsSimulator = () => {
             <div className="bg-white p-4 rounded shadow">
               <h3 className="text-sm font-medium text-gray-500">Cumulative Spaces</h3>
               <p className="text-2xl font-bold">{results[results.length - 1].cumulativeOrgCount.toLocaleString()}</p>
-              <p className="text-sm text-gray-500">Active (month {months}): {results[results.length - 1].orgCount.toLocaleString()}</p>
+              <p className="text-sm text-gray-500">All paying · $44/mo (month {months})</p>
             </div>
             <div className="bg-white p-4 rounded shadow border-l-4 border-green-500">
               <h3 className="text-sm font-medium text-gray-500">Run-rate ARR (month {months})</h3>
@@ -894,17 +888,15 @@ const TokenomicsSimulator = () => {
             </ResponsiveContainer>
           </div>
           <div className="h-80 bg-white p-4 rounded-lg shadow">
-            <h3 className="text-md font-medium mb-2">Space Growth</h3>
+            <h3 className="text-md font-medium mb-2">Space Growth (all paying)</h3>
             <ResponsiveContainer width="100%" height="90%">
               <LineChart data={chartData} margin={{ top: 5, right: 30, left: 30, bottom: 5 }}>
                 <CartesianGrid strokeDasharray="3 3" />
                 <XAxis dataKey="name" />
-                <YAxis yAxisId="left" tickFormatter={(v) => v.toLocaleString()} width={60} />
-                <YAxis yAxisId="right" orientation="right" tickFormatter={(v) => v.toLocaleString()} width={60} />
+                <YAxis tickFormatter={(v) => v.toLocaleString()} width={60} />
                 <Tooltip formatter={(v) => v.toLocaleString()} />
                 <Legend />
-                <Line yAxisId="left" type="monotone" dataKey="Number of Spaces" stroke="#8884d8" strokeWidth={2} />
-                <Line yAxisId="right" type="monotone" dataKey="Cumulative Spaces" stroke="#82ca9d" strokeWidth={2} />
+                <Line type="monotone" dataKey="Cumulative Spaces" stroke="#82ca9d" strokeWidth={2} />
               </LineChart>
             </ResponsiveContainer>
           </div>
@@ -970,7 +962,7 @@ const TokenomicsSimulator = () => {
                 <th className="py-2 px-4 border text-right">Unlock Rewards</th>
                 <th className="py-2 px-4 border text-right">Actual Rewards</th>
                 <th className="py-2 px-4 border text-right">Spaces (monthly)</th>
-                <th className="py-2 px-4 border text-right">Spaces (cumulative)</th>
+                <th className="py-2 px-4 border text-right">Cumulative Spaces</th>
                 <th className="py-2 px-4 border text-right">Staked Tokens (cumulative)</th>
                 <th className="py-2 px-4 border text-right">Circulating Supply</th>
                 <th className="py-2 px-4 border text-right">IEX HYPHA Before</th>
@@ -1055,15 +1047,10 @@ const TokenomicsSimulator = () => {
                 <div className={`text-xs mt-0.5 ${growthScenario === key ? 'text-indigo-100' : 'text-gray-500'}`}>
                   {preset.subtitle}
                 </div>
-                {results.length > 0 && growthScenario === key && (
-                  <div className="text-xs mt-1 text-indigo-100">
-                    {results[results.length - 1].orgCount.toLocaleString()} paying · FDV ${(results[results.length - 1].fdv / 1e6).toFixed(0)}M
-                  </div>
-                )}
               </button>
             ))}
             <p className="px-3 py-2 text-xs text-gray-500 bg-gray-50 border-t border-gray-200">
-              Targets cumulative Space-months (sum of active Spaces each month) at month 48. Override growth per month via Per-Month Configuration.
+              Targets total paying Spaces at year 5 (month 48). Every Space pays $44/mo; override Space growth per month via Per-Month Configuration.
             </p>
           </div>
         </div>

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -119,6 +119,6 @@ export function middleware(request: NextRequest) {
 
 export const config = {
   matcher: [
-    '/((?!api|signin|placeholder|icon|onesignal|tokenomics2|.well-known|_next/static|_next/image|favicon.ico).*)',
+    '/((?!api|signin|placeholder|icon|onesignal|tokenomics1|tokenomics2|.well-known|_next/static|_next/image|favicon.ico).*)',
   ],
 };

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -119,6 +119,6 @@ export function middleware(request: NextRequest) {
 
 export const config = {
   matcher: [
-    '/((?!api|signin|placeholder|icon|onesignal|.well-known|_next/static|_next/image|favicon.ico).*)',
+    '/((?!api|signin|placeholder|icon|onesignal|tokenomics2|.well-known|_next/static|_next/image|favicon.ico).*)',
   ],
 };

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,6 +1,11 @@
 {
   "redirects": [
     {
+      "source": "/tokenomics1",
+      "destination": "/tokenomics1/",
+      "permanent": true
+    },
+    {
       "source": "/tokenomics2",
       "destination": "/tokenomics2/",
       "permanent": true

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,0 +1,9 @@
+{
+  "redirects": [
+    {
+      "source": "/tokenomics2",
+      "destination": "/tokenomics2/",
+      "permanent": true
+    }
+  ]
+}

--- a/docs/hypha-ai-cost/README-investor-pitch.md
+++ b/docs/hypha-ai-cost/README-investor-pitch.md
@@ -1,0 +1,166 @@
+# HYPHA Tokenomics — Investor Pitch Guide
+
+> **Who this is for:** Hypha team members talking to investors.  
+> **Goal:** Explain our token model in plain language in 5–10 minutes.  
+> **Live tools:** [Phase I simulator](https://app.hypha.earth/tokenomics1/) · [Phase II simulator](https://app.hypha.earth/tokenomics2/)
+
+---
+
+## The roadmap: Phase 0 → Phase I → Phase II
+
+| Phase | When | What happens | Key numbers |
+|---|---|---|---|
+| **Phase 0** | **Today** | ~4,373 Spaces live on Hypha. Tokenomics Phase I has not started (month 0). | Reference FDV ~**$111M** at **$0.20** (111M locked supply) |
+| **Phase I** | **Month 0+** | Fixed **$0.20** token price. Token sale, locking, and yield distribution over ~12 months. | Default sim: 50 → ~**4,325** active Spaces by month 12 |
+| **Phase II** | **After Phase I** | **$44/Space/mo** gross revenue. **Dynamic IEX price** from usage + liquidity. 48-month growth scenarios. | Starts ~**4,373** paying Spaces; scenarios to year 4 below |
+
+**Pitch order:** Phase 0 (where we are) → Phase I sim (bootstrap) → Phase II sim (scale scenarios).
+
+---
+
+## The one-sentence pitch
+
+**Hypha is a network of autonomous organizations (“Spaces”) that pay recurring revenue into the protocol; HYPHA captures value as the network scales, with token economics tied to real usage—not speculation alone.**
+
+---
+
+## Start here: what is a “Space”?
+
+A **Space** is one organization on Hypha (a DAO, community, or team). Think of it like one customer account on a SaaS platform.
+
+**~4,373 Spaces are active today (Phase 0).** Phase II scenarios model what happens over the **four years after Phase I**, using cumulative adoption milestones of **250k, 1M, or 10M Space-months**.
+
+**Critical distinction — who is paying each month:**
+
+- **Cumulative Space-months (250k / 1M / 10M)** = sum of active Spaces counted **each month** over 48 months (adoption milestone).
+- **Active Spaces at year 4** = organizations **paying that month** (~6k / ~58k / ~1.1M).
+- **ARR** = active Spaces at month 48 × **$44 × 12** (run-rate, not cumulative).
+
+Only **active Spaces in a given month** pay that month’s $44. Cumulative totals are **not** “1M organizations paying at once.”
+
+---
+
+## Where the money comes from
+
+Each **active** Space contributes **$44 USDC per month** in gross revenue to the Hypha network (Phase II onward).
+
+That number is the anchor for all three scenarios. Operating costs (AI inference and blockchain gas) are modeled separately and are **much smaller** than $44 per Space at typical usage on open-weight inference (~$4/Space/mo AI in the sim default; up to ~$17 on Composer-class stack).
+
+**Revenue allocation (Phase II):**
+
+| Share | Use |
+|---:|---|
+| **25%** (Low/Mid) or **19%** (High) | IEX buy pressure — supports HYPHA on the exchange |
+| **75% / 81%** | AI inference, gas, operations, off-pool rewards, treasury |
+
+**Month-48 run-rate ARR (who is paying in the final month):**
+
+| Active Spaces (month 48) | Paying monthly | Annual revenue (ARR) |
+|---:|---:|---:|
+| ~6,000 | ~$270k/mo | **~$3M** |
+| ~58,000 | ~$2.5M/mo | **~$30M** |
+| ~1,100,000 | ~$49M/mo | **~$590M** |
+
+**Total gross billed over 4 years** (all months): Low ~$11M · Mid ~$44M · High ~$440M (cumulative Space-months × $44).
+
+Lead with: *“At year four, ~6k to ~1.1M Spaces pay each month — that’s the $3M to $590M run-rate. Cumulative adoption tells us how we got there.”*
+
+---
+
+## What HYPHA token does
+
+HYPHA is the network token. In the model:
+
+1. **Spaces pay in USDC** → a fixed share supports the token via the **IEX** (the protocol’s exchange pool).
+2. **The rest runs the platform** — AI, gas, ops, rewards, treasury (see 75% above).
+3. **Token holders** participate through staking, rewards, and network growth.
+
+**Say it simply:** *“Usage drives USDC into the network; ~20–25% supports HYPHA on the exchange; the rest runs the platform.”*
+
+---
+
+## Three scenarios (Low / Mid / High) — Phase II
+
+Use the **Phase II simulator** sidebar. Each is a four-year story **after Phase I handoff**.
+
+| Scenario | Cumulative (4yr) | **Active & paying (M48)** | ARR (M48) | FDV (indicative) | Token price |
+|---|---:|---:|---:|---:|---:|
+| **Low** | ~250k | **~6k** | ~$3M | **~$1.5B** | **~$2.75** |
+| **Mid** | ~1M | **~58k** | ~$30M | **~$4B** | **~$7** |
+| **High** | ~10M | **~1.1M** | ~$590M | **~$31B** | **~$57** |
+
+FDV is **fully diluted** (555M HYPHA). Low/Mid FDV reflects **network optionality + Phase I anchor** while run-rate ARR is still ramping — not a strict 12-month revenue multiple. High is closer to large-network comps but still optimistic (~50× run-rate ARR).
+
+**Important framing:** Scenario models, not forecasts.
+
+---
+
+## How to walk an investor through the simulators
+
+### Option A — Full story (~8 min)
+
+1. **Phase 0:** ~4,373 Spaces today, ~$111M reference FDV at $0.20.
+2. Open [tokenomics1](https://app.hypha.earth/tokenomics1/) — Phase I fixed price, growth to ~4,325 Spaces by month 12.
+3. Open [tokenomics2](https://app.hypha.earth/tokenomics2/) — handoff at ~4,373 Spaces, **$44/Space**, dynamic IEX.
+4. Click **Low** → **Cumulative Spaces** (~250k), **Active (month 48)** (~6k paying), **ARR**, **FDV/ARR**, **FDV**.
+5. Click **Mid**, then **High**.
+
+### Option B — Quick demo (Phase II only, ~5 min)
+
+1. Open [tokenomics2](https://app.hypha.earth/tokenomics2/)
+2. **$44/Space** · **25% to IEX** · **75% off-pool**
+3. Show **Active (month 48)** before citing cumulative totals
+4. Show **FDV/ARR** — explain Low/Mid are ramp narratives
+
+---
+
+## Answers to common investor questions
+
+**“Is $44 per Space realistic?”**  
+Working assumption for protocol value capture (AI + governance + treasury). Stress-test in the simulator.
+
+**“Why doesn’t 100% of revenue buy the token?”**  
+**19–25%** to IEX is deliberate value accrual; **75–81%** funds AI (~$4/Space on open models), gas, ops, and treasury.
+
+**“What does 250k Spaces mean if only ~6k pay at year 4?”**  
+**250k = cumulative Space-months** over four years. **~6k pay each month** in year 4 → **~$3M ARR**. Always state **active payers + ARR** when citing scenario labels.
+
+**“How does Phase I connect to Phase II?”**  
+Phase I bootstraps at fixed **$0.20** (~$111M FDV). Phase II starts ~4,373 paying Spaces; price emerges from IEX. Low scenario FDV (~$1.5B) is ~14× Phase I reference — reflects network growth narrative, not 6k × revenue alone.
+
+**“How does this compare to other tokens?”**  
+High scenario: large-network band (Maker, Uniswap). Low/Mid: early-stage / ramp comps (Bittensor, Helium) — not Maker 10–15× on year-4 ARR alone.
+
+**“Is this financial advice?”**  
+No. Internal planning tool. Past comps don’t guarantee future pricing.
+
+---
+
+## Suggested 60-second script
+
+> “We’re at **Phase 0** — **~4,400 Spaces** on Hypha, **~$111M** reference valuation. **Phase I** launches tokenomics at fixed **$0.20**. **Phase II** adds **$44/month per Space** and dynamic exchange pricing.  
+>  
+> Over four years after handoff, cumulative adoption could reach **250k to 10M Space-months** — meaning **~6k to ~1.1M Spaces paying each month** at year four, **$3M to $590M run-rate ARR**. **~25%** of gross supports HYPHA on IEX; the rest runs the platform. Models imply **~$1.5B to ~$31B fully diluted** depending on scenario.  
+>  
+> Click through both simulators and stress-test the assumptions.”
+
+---
+
+## Cheat sheet
+
+| | Low | Mid | High |
+|---|---:|---:|---:|
+| **Cumulative Space-months** | ~250k | ~1M | ~10M |
+| **Active & paying (M48)** | **~6k** | **~58k** | **~1.1M** |
+| **ARR (M48 run-rate)** | ~$3M | ~$30M | ~$590M |
+| **4yr total gross billed** | ~$11M | ~$44M | ~$440M |
+| **FDV (indicative)** | ~$1.5B | ~$4B | ~$31B |
+| **IEX routing** | 25% | 25% | 19% |
+
+---
+
+## Where to go deeper
+
+- **Technical cost model (AI + gas per Space):** [README.md](./README.md)
+- **Scenario parameters and comps:** [README.md — Tokenomics simulator assumptions](./README.md#tokenomics-simulator-scenario-assumptions-phase-ii)
+

--- a/docs/hypha-ai-cost/README-investor-pitch.md
+++ b/docs/hypha-ai-cost/README-investor-pitch.md
@@ -8,13 +8,13 @@
 
 ## The roadmap: Phase 0 → Phase I → Phase II
 
-| Phase | When | What happens | Key numbers |
+| Phase | When | What happens | Active Spaces |
 |---|---|---|---|
-| **Phase 0** | **Today** | ~4,373 Spaces live on Hypha. Tokenomics Phase I has not started (month 0). | Reference FDV ~**$111M** at **$0.20** (111M locked supply) |
-| **Phase I** | **Month 0+** | Fixed **$0.20** token price. Token sale, locking, and yield over **12 months**. Same network as today — **not** a separate 50-Space bootstrap. | **4,373 → ~4,732** active Spaces at 0.72%/mo |
-| **Phase II** | **After Phase I** | **$44/Space/mo** gross. Dynamic IEX pricing. **48 months** at Phase I handoff (~4,732 Spaces). | Low → **~6,600** paying at year 5 (month 60 total) |
+| **Phase 0** | **Today** | Pre-launch. Tokenomics not started. | Reference FDV ~**$111M** at **$0.20** |
+| **Phase I** | **Year 1 (months 0–12)** | Bootstrap the network, fixed **$0.20** price, token sale + locking. | **~0 → ~4,373** |
+| **Phase II** | **Years 2–5 (48 months)** | **$44/Space/mo** gross revenue, dynamic IEX pricing. Starts at ~4,373. | Year 5: Low **~25k** · Mid **~250k** · High **~2M** |
 
-**Pitch order:** Phase 0 (where we are) → Phase I sim (bootstrap) → Phase II sim (scale scenarios).
+**Pitch order:** Phase 0 (where we are) → Phase I sim (bootstrap to 4,373) → Phase II sim (scale scenarios).
 
 ---
 
@@ -28,43 +28,42 @@
 
 A **Space** is one organization on Hypha (a DAO, community, or team). Think of it like one customer account on a SaaS platform.
 
-**~4,373 Spaces are active today (Phase 0).** Phase I starts from that same network. Phase II scenarios run **48 months from the Phase I handoff (~4,732 Spaces)**, using cumulative adoption milestones of **~270k, 1M, or 10M Space-months** (Phase II only).
+**Phase I bootstraps the network from ~0 to ~4,373 paying Spaces in year 1.** Phase II then runs **48 months (years 2–5)** from that ~4,373 base, with year-5 active targets of **~25k / ~250k / ~2M** (Low / Mid / High).
 
-**Critical distinction — who is paying each month:**
+**Two numbers to keep straight:**
 
-- **Cumulative Space-months (~270k / 1M / 10M in Phase II)** = sum of active Spaces counted **each month** over 48 Phase II months.
-- **Active Spaces at Phase II month 48 (year 5 total)** = organizations **paying that month** (~6.6k / ~56k / ~1.1M).
-- **Full Low journey (Phase I + II):** **4,373 → ~6,676** paying at month 60 at 0.72%/mo throughout.
-- **ARR** = active Spaces at that month × **$44 × 12** (run-rate, not cumulative).
+- **Active Spaces at year 5 (Phase II month 48)** = organizations **paying that month**: **~25k / ~250k / ~2M**.
+- **Cumulative Space-months (Phase II)** = sum of active Spaces counted each month over 48 months: **~570k / ~3M / ~16M**.
+- **ARR** = active Spaces at year 5 × **$44 × 12**: **~$13M / ~$132M / ~$1.06B**.
 
-Only **active Spaces in a given month** pay that month’s $44. Cumulative totals are **not** “1M organizations paying at once.”
+Only **active Spaces in a given month** pay that month’s $44.
 
 ---
 
 ## Where the money comes from
 
-Each **active** Space contributes **$44 USDC per month** in gross revenue to the Hypha network (Phase II onward).
+Each **active** Space contributes **$44 USDC per month** in gross revenue (Phase II onward).
 
-That number is the anchor for all three scenarios. Operating costs (AI inference and blockchain gas) are modeled separately and are **much smaller** than $44 per Space at typical usage on open-weight inference (~$4/Space/mo AI in the sim default; up to ~$17 on Composer-class stack).
+That number anchors all three scenarios. Operating costs (AI inference and blockchain gas) are modeled separately and are **much smaller** than $44 per Space at typical usage on open-weight inference (~$4/Space/mo AI in the sim default; up to ~$17 on Composer-class stack).
 
 **Revenue allocation (Phase II):**
 
 | Share | Use |
 |---:|---|
-| **25%** (Low/Mid) or **19%** (High) | IEX buy pressure — supports HYPHA on the exchange |
-| **75% / 81%** | AI inference, gas, operations, off-pool rewards, treasury |
+| **19–25%** (by scenario) | IEX buy pressure — supports HYPHA on the exchange |
+| **75–81%** | AI inference, gas, operations, off-pool rewards, treasury |
 
-**Phase II month-48 run-rate ARR (who is paying in the final month):**
+**Year-5 run-rate ARR (who is paying in month 48):**
 
-| Active Spaces (Phase II M48) | Paying monthly | Annual revenue (ARR) |
+| Active Spaces (year 5) | Paying monthly | Annual revenue (ARR) |
 |---:|---:|---:|
-| ~6,600 | ~$290k/mo | **~$3.5M** |
-| ~56,000 | ~$2.4M/mo | **~$29M** |
-| ~1,100,000 | ~$48M/mo | **~$580M** |
+| ~25,000 | ~$1.1M/mo | **~$13M** |
+| ~250,000 | ~$11M/mo | **~$132M** |
+| ~2,000,000 | ~$88M/mo | **~$1.06B** |
 
-**Phase II gross billed over 4 years:** Low ~$12M · Mid ~$44M · High ~$440M (cumulative Space-months × $44).
+**Phase II gross billed over 4 years:** Low ~$25M · Mid ~$131M · High ~$719M (cumulative Space-months × $44).
 
-Lead with: *“Phase I handoff is ~4,732 Spaces. At Phase II year 4, ~6.6k to ~1.1M pay each month depending on scenario.”*
+Lead with: *“Phase I builds to ~4,373 paying Spaces. By year 5, that grows to ~25k / ~250k / ~2M depending on scenario.”*
 
 ---
 
@@ -73,7 +72,7 @@ Lead with: *“Phase I handoff is ~4,732 Spaces. At Phase II year 4, ~6.6k to ~1
 HYPHA is the network token. In the model:
 
 1. **Spaces pay in USDC** → a fixed share supports the token via the **IEX** (the protocol’s exchange pool).
-2. **The rest runs the platform** — AI, gas, ops, rewards, treasury (see 75% above).
+2. **The rest runs the platform** — AI, gas, ops, rewards, treasury (75–81%).
 3. **Token holders** participate through staking, rewards, and network growth.
 
 **Say it simply:** *“Usage drives USDC into the network; ~20–25% supports HYPHA on the exchange; the rest runs the platform.”*
@@ -82,15 +81,15 @@ HYPHA is the network token. In the model:
 
 ## Three scenarios (Low / Mid / High) — Phase II
 
-Use the **Phase II simulator** sidebar. Each is a four-year story **after Phase I handoff**.
+Use the **Phase II simulator** sidebar. Each is a four-year story from the ~4,373 Phase I handoff.
 
-| Scenario | Cumulative Phase II (4yr) | **Active & paying (M48)** | ARR (M48) | FDV (indicative) | Token price |
-|---|---:|---:|---:|---:|---:|
-| **Low** | ~270k | **~6.6k** | ~$3.5M | **~$1.5B** | **~$2.75** |
-| **Mid** | ~1M | **~56k** | ~$29M | **~$4B** | **~$7** |
-| **High** | ~10M | **~1.1M** | ~$580M | **~$31B** | **~$57** |
+| Scenario | Year-5 active (paying) | Cumulative Space-months | ARR (year 5) | FDV (indicative) | FDV/ARR | Token price |
+|---|---:|---:|---:|---:|---:|---:|
+| **Low** | **~25k** | ~570k | ~$13M | **~$1.5B** | ~115× | **~$2.65** |
+| **Mid** | **~250k** | ~3M | ~$132M | **~$4B** | ~30× | **~$7.30** |
+| **High** | **~2M** | ~16M | ~$1.06B | **~$31B** | ~29× | **~$56** |
 
-FDV is **fully diluted** (555M HYPHA). Low/Mid FDV reflects **network optionality + Phase I anchor** while run-rate ARR is still ramping — not a strict 12-month revenue multiple. High is closer to large-network comps but still optimistic (~50× run-rate ARR).
+FDV is **fully diluted** (555M HYPHA). Mid/High land at ~30× run-rate ARR — in range of growth-stage network comps. Low is higher (~115×) because year-5 ARR is still ramping; frame it as **early-network optionality**, not a revenue multiple.
 
 **Important framing:** Scenario models, not forecasts.
 
@@ -100,18 +99,18 @@ FDV is **fully diluted** (555M HYPHA). Low/Mid FDV reflects **network optionalit
 
 ### Option A — Full story (~8 min)
 
-1. **Phase 0:** ~4,373 Spaces today, ~$111M reference FDV at $0.20.
-2. Open [tokenomics1](https://app.hypha.earth/tokenomics1/) — Phase I: **4,373 → ~4,732** at 0.72%/mo, fixed $0.20.
-3. Open [tokenomics2](https://app.hypha.earth/tokenomics2/) — starts **~4,732** handoff, **$44/Space**, dynamic IEX.
-4. Click **Low** → cumulative ~270k, **~6.6k paying** at M48, ARR, FDV/ARR, FDV.
-5. Click **Mid**, then **High**.
+1. **Phase 0:** pre-launch, ~$111M reference FDV at $0.20.
+2. Open [tokenomics1](https://app.hypha.earth/tokenomics1/) — Phase I: **~0 → ~4,373** Spaces over 12 months, fixed $0.20.
+3. Open [tokenomics2](https://app.hypha.earth/tokenomics2/) — starts **~4,373**, **$44/Space**, dynamic IEX.
+4. Click **Low** → **~25k paying** at year 5, ARR ~$13M, FDV/ARR, FDV ~$1.5B.
+5. Click **Mid** (~250k, ~$4B), then **High** (~2M, ~$31B).
 
 ### Option B — Quick demo (Phase II only, ~5 min)
 
 1. Open [tokenomics2](https://app.hypha.earth/tokenomics2/)
-2. **$44/Space** · **25% to IEX** · **75% off-pool**
-3. Show **Active (month 48)** before citing cumulative totals
-4. Show **FDV/ARR** — explain Low/Mid are ramp narratives
+2. **$44/Space** · **~25% to IEX** · **~75% off-pool**
+3. Show **active Spaces at year 5** before citing cumulative totals
+4. Show **FDV/ARR** — Mid/High ~30×; Low is a ramp narrative
 
 ---
 
@@ -123,14 +122,14 @@ Working assumption for protocol value capture (AI + governance + treasury). Stre
 **“Why doesn’t 100% of revenue buy the token?”**  
 **19–25%** to IEX is deliberate value accrual; **75–81%** funds AI (~$4/Space on open models), gas, ops, and treasury.
 
-**“What does ~270k cumulative mean if only ~6.6k pay at year 5?”**  
-Cumulative = Space-months over Phase II. **~6.6k pay each month** in Low at Phase II month 48. Full journey from Phase 0: **4,373 → ~6,676** at 0.72%/mo over 5 years.
-
 **“How does Phase I connect to Phase II?”**  
-Phase I starts at today’s **4,373 Spaces**, fixed **$0.20** (~$111M FDV), grows to **~4,732** at 0.72%/mo. Phase II continues from that handoff at **$44/Space**; price emerges from IEX.
+Phase I bootstraps from ~0 to **~4,373 paying Spaces** in year 1 at fixed **$0.20** (~$111M FDV). Phase II continues from that ~4,373 base at **$44/Space**; price emerges from the IEX.
+
+**“What does ~570k cumulative mean if ~25k pay at year 5?”**  
+Cumulative = Space-months summed across all 48 Phase II months. **~25k pay in the final month** (Low). The cumulative figure is an adoption-intensity metric, not concurrent payers.
 
 **“How does this compare to other tokens?”**  
-High scenario: large-network band (Maker, Uniswap). Low/Mid: early-stage / ramp comps (Bittensor, Helium) — not Maker 10–15× on year-4 ARR alone.
+Mid/High sit at ~30× run-rate ARR — comparable to growth-stage networks (Maker, Uniswap, Bittensor at various points). Low is early-stage optionality (revenue still ramping).
 
 **“Is this financial advice?”**  
 No. Internal planning tool. Past comps don’t guarantee future pricing.
@@ -139,9 +138,9 @@ No. Internal planning tool. Past comps don’t guarantee future pricing.
 
 ## Suggested 60-second script
 
-> “We’re at **Phase 0** — **~4,400 Spaces**, **~$111M** reference valuation. **Phase I** starts at **4,373 Spaces**, fixed **$0.20**, growing to **~4,732** in year one. **Phase II** adds **$44/month per Space** from that handoff.  
+> “We’re at **Phase 0** — pre-launch, **~$111M** reference valuation. **Phase I** bootstraps the network from zero to **~4,373 paying Spaces** in year one at fixed **$0.20**. **Phase II** adds **$44/month per Space** with dynamic exchange pricing.  
 >  
-> Over **four Phase II years**, cumulative adoption reaches **~270k to 10M Space-months** — **~6.6k to ~1.1M paying each month** at year five, **~$3.5M to ~$580M run-rate ARR**. **~25%** to IEX. Models imply **~$1.5B to ~$31B fully diluted**.  
+> Over **four Phase II years**, active Spaces grow to **~25k, ~250k, or ~2M** by year five — **~$13M to ~$1.06B run-rate ARR**. **~20–25%** of gross supports HYPHA on the IEX; the rest runs the platform. Models imply **~$1.5B to ~$31B fully diluted**, roughly **30× revenue** at Mid/High.  
 >  
 > Click through both simulators and stress-test the assumptions.”
 
@@ -151,13 +150,13 @@ No. Internal planning tool. Past comps don’t guarantee future pricing.
 
 | | Low | Mid | High |
 |---|---:|---:|---:|
-| **Phase II cumulative Space-months** | ~270k | ~1M | ~10M |
-| **Active & paying (Phase II M48)** | **~6.6k** | **~56k** | **~1.1M** |
-| **5yr journey (Phase 0→II, Low)** | **4,373 → ~6,676** | — | — |
-| **ARR (Phase II M48)** | ~$3.5M | ~$29M | ~$580M |
-| **Phase II gross billed (4yr)** | ~$12M | ~$44M | ~$440M |
+| **Year-5 active (paying)** | **~25k** | **~250k** | **~2M** |
+| **Cumulative Space-months** | ~570k | ~3M | ~16M |
+| **ARR (year 5)** | ~$13M | ~$132M | ~$1.06B |
+| **Phase II gross billed (4yr)** | ~$25M | ~$131M | ~$719M |
 | **FDV (indicative)** | ~$1.5B | ~$4B | ~$31B |
-| **IEX routing** | 25% | 25% | 19% |
+| **FDV / ARR** | ~115× | ~30× | ~29× |
+| **IEX routing** | 25% | 19% | 19% |
 
 ---
 
@@ -165,4 +164,3 @@ No. Internal planning tool. Past comps don’t guarantee future pricing.
 
 - **Technical cost model (AI + gas per Space):** [README.md](./README.md)
 - **Scenario parameters and comps:** [README.md — Tokenomics simulator assumptions](./README.md#tokenomics-simulator-scenario-assumptions-phase-ii)
-

--- a/docs/hypha-ai-cost/README-investor-pitch.md
+++ b/docs/hypha-ai-cost/README-investor-pitch.md
@@ -12,7 +12,7 @@
 |---|---|---|---|
 | **Phase 0** | **Today** | Pre-launch. Tokenomics not started. | Reference FDV ~**$111M** at **$0.20** |
 | **Phase I** | **Year 1 (months 0–12)** | Bootstrap the network, fixed **$0.20** price, token sale + locking. | **~0 → ~4,373** |
-| **Phase II** | **Years 2–5 (48 months)** | **$44/Space/mo** gross revenue, dynamic IEX pricing. Starts at ~4,373. | Year 5 paying: Low **~15k** · Mid **~50k** · High **~500k** |
+| **Phase II** | **Years 2–5 (48 months)** | **$44/Space/mo** gross revenue, dynamic IEX pricing. Starts at ~4,373. | Year 5 paying: Low **~250k** · Mid **~1M** · High **~10M** |
 
 **Pitch order:** Phase 0 (where we are) → Phase I sim (bootstrap to 4,373) → Phase II sim (scale scenarios).
 
@@ -28,15 +28,12 @@
 
 A **Space** is one organization on Hypha (a DAO, community, or team). Think of it like one customer account on a SaaS platform.
 
-**Phase I bootstraps the network from ~0 to ~4,373 paying Spaces in year 1.** Phase II then runs **48 months (years 2–5)** from that ~4,373 base, with year-5 paying targets of **~15k / ~50k / ~500k** (Low / Mid / High).
+**Phase I bootstraps the network from ~0 to ~4,373 paying Spaces in year 1.** Phase II then runs **48 months (years 2–5)** from that ~4,373 base, with year-5 paying targets of **~250k / ~1M / ~10M** (Low / Mid / High).
 
-**Two numbers to keep straight:**
+**The number to keep straight:**
 
-- **Active (paying) Spaces at year 5 (Phase II month 48)** = organizations **paying that month**: **~15k / ~50k / ~500k**.
-- **Cumulative Spaces created (Phase II)** = total Spaces ever spun up — the full funnel, free + paid: **~250k / ~1M / ~10M**. Paying Spaces are the **~5–6%** that pay at year 5.
-- **ARR** = active Spaces at year 5 × **$44 × 12**: **~$7.9M / ~$26M / ~$264M**.
-
-Only **active (paying) Spaces in a given month** pay that month’s $44 and drive revenue.
+- **Paying Spaces at year 5 (Phase II month 48)** = organizations on the network, **every one paying** $44/mo: **~250k / ~1M / ~10M**. There is **no free tier** — cumulative Spaces and paying Spaces are the same number.
+- **ARR** = paying Spaces at year 5 × **$44 × 12**: **~$132M / ~$528M / ~$5.28B**.
 
 ---
 
@@ -50,20 +47,20 @@ That number anchors all three scenarios. Operating costs (AI inference and block
 
 | Share | Use |
 |---:|---|
-| **19–25%** (by scenario) | IEX buy pressure — supports HYPHA on the exchange |
-| **75–81%** | AI inference, gas, operations, off-pool rewards, treasury |
+| **18–22%** (by scenario) | IEX buy pressure — supports HYPHA on the exchange |
+| **78–82%** | AI inference, gas, operations, off-pool rewards, treasury |
 
 **Year-5 run-rate ARR (who is paying in month 48):**
 
-| Active (paying) Spaces (year 5) | Paying monthly | Annual revenue (ARR) |
+| Paying Spaces (year 5) | Paying monthly | Annual revenue (ARR) |
 |---:|---:|---:|
-| ~15,000 | ~$0.7M/mo | **~$7.9M** |
-| ~50,000 | ~$2.2M/mo | **~$26M** |
-| ~500,000 | ~$22M/mo | **~$264M** |
+| ~250,000 | ~$11M/mo | **~$132M** |
+| ~1,000,000 | ~$44M/mo | **~$528M** |
+| ~10,000,000 | ~$440M/mo | **~$5.28B** |
 
-**Phase II gross billed over 4 years:** Low ~$18M · Mid ~$40M · High ~$228M (sum of active Spaces × $44 each month).
+**Phase II gross billed over 4 years:** Low ~$0.13B · Mid ~$0.40B · High ~$2.9B (sum of Spaces × $44 each month).
 
-Lead with: *“Phase I builds to ~4,373 paying Spaces. By year 5, paying Spaces grow to ~15k / ~50k / ~500k depending on scenario — out of ~250k / ~1M / ~10M created.”*
+Lead with: *“Phase I builds to ~4,373 paying Spaces. By year 5, paying Spaces grow to ~250k / ~1M / ~10M depending on scenario — every Space paying $44/mo.”*
 
 ---
 
@@ -83,13 +80,13 @@ HYPHA is the network token. In the model:
 
 Use the **Phase II simulator** sidebar. Each is a four-year story from the ~4,373 Phase I handoff.
 
-| Scenario | Year-5 active (paying) | Cumulative created | ARR (year 5) | FDV (indicative) | FDV/ARR | Token price |
-|---|---:|---:|---:|---:|---:|---:|
-| **Low** | **~15k** | ~250k | ~$7.9M | **~$0.4B** | ~51× | **~$0.72** |
-| **Mid** | **~50k** | ~1M | ~$26M | **~$1.0B** | ~38× | **~$1.82** |
-| **High** | **~500k** | ~10M | ~$264M | **~$8.1B** | ~31× | **~$14.50** |
+| Scenario | Year-5 paying Spaces | ARR (year 5) | FDV (indicative) | FDV/ARR | Token price |
+|---|---:|---:|---:|---:|---:|
+| **Low** | **~250k** | ~$132M | **~$3.9B** | ~30× | **~$7.07** |
+| **Mid** | **~1M** | ~$528M | **~$12.8B** | ~24× | **~$23.04** |
+| **High** | **~10M** | ~$5.28B | **~$66B** | ~13× | **~$119** |
 
-FDV is **fully diluted** (555M HYPHA). High lands near ~30× run-rate ARR — in range of growth-stage network comps. Low/Mid carry higher multiples because year-5 ARR is still ramping; frame them as **early-network optionality**, not a mature revenue multiple.
+FDV is **fully diluted** (555M HYPHA). Low lands near ~30× run-rate ARR — in range of growth-stage network comps. Multiples **compress as the network matures** (toward ~13× at High mega-scale), reflecting a larger, more proven revenue base.
 
 **Important framing:** Scenario models, not forecasts.
 
@@ -102,15 +99,15 @@ FDV is **fully diluted** (555M HYPHA). High lands near ~30× run-rate ARR — in
 1. **Phase 0:** pre-launch, ~$111M reference FDV at $0.20.
 2. Open [tokenomics1](https://app.hypha.earth/tokenomics1/) — Phase I: **~0 → ~4,373** Spaces over 12 months, fixed $0.20.
 3. Open [tokenomics2](https://app.hypha.earth/tokenomics2/) — starts **~4,373**, **$44/Space**, dynamic IEX.
-4. Click **Low** → **~15k paying** at year 5 (~250k created), ARR ~$7.9M, FDV/ARR, FDV ~$0.4B.
-5. Click **Mid** (~50k paying / ~1M created, ~$1.0B), then **High** (~500k / ~10M, ~$8.1B).
+4. Click **Low** → **~250k paying** at year 5, ARR ~$132M, FDV/ARR, FDV ~$3.9B.
+5. Click **Mid** (~1M paying, ~$12.8B), then **High** (~10M, ~$66B).
 
 ### Option B — Quick demo (Phase II only, ~5 min)
 
 1. Open [tokenomics2](https://app.hypha.earth/tokenomics2/)
 2. **$44/Space** · **~25% to IEX** · **~75% off-pool**
 3. Show **active Spaces at year 5** before citing cumulative totals
-4. Show **FDV/ARR** — High ~30×; Low/Mid (~38–51×) are a ramp narrative
+4. Show **FDV/ARR** — Low ~30×, compressing toward ~13× at High as revenue matures
 
 ---
 
@@ -125,11 +122,11 @@ Working assumption for protocol value capture (AI + governance + treasury). Stre
 **“How does Phase I connect to Phase II?”**  
 Phase I bootstraps from ~0 to **~4,373 paying Spaces** in year 1 at fixed **$0.20** (~$111M FDV). Phase II continues from that ~4,373 base at **$44/Space**; price emerges from the IEX.
 
-**“What does ~250k cumulative mean if ~15k pay at year 5?”**  
-Cumulative = total Spaces ever created over Phase II — the full funnel, free + paid. **~15k pay in the final month** (Low), i.e. ~6% of created Spaces. The cumulative figure is an adoption/funnel metric; only paying Spaces generate revenue.
+**“Is every Space really paying?”**  
+Yes — the model assumes **no free tier**. The cumulative Space count and the paying Space count are the same number: ~250k / ~1M / ~10M at year 5, each paying $44/mo.
 
 **“How does this compare to other tokens?”**  
-High sits near ~30× run-rate ARR — comparable to growth-stage networks (Maker, Uniswap, Bittensor at various points). Low/Mid carry higher multiples (~38–51×) as early-stage optionality (revenue still ramping).
+Low sits near ~30× run-rate ARR — comparable to growth-stage networks (Maker, Uniswap, Bittensor at various points). Multiples compress toward ~13× at High mega-scale, reflecting a larger, more proven revenue base.
 
 **“Is this financial advice?”**  
 No. Internal planning tool. Past comps don’t guarantee future pricing.
@@ -140,7 +137,7 @@ No. Internal planning tool. Past comps don’t guarantee future pricing.
 
 > “We’re at **Phase 0** — pre-launch, **~$111M** reference valuation. **Phase I** bootstraps the network from zero to **~4,373 paying Spaces** in year one at fixed **$0.20**. **Phase II** adds **$44/month per Space** with dynamic exchange pricing.  
 >  
-> Over **four Phase II years**, paying Spaces grow to **~15k, ~50k, or ~500k** by year five (out of ~250k–10M created) — **~$7.9M to ~$264M run-rate ARR**. **~20–25%** of gross supports HYPHA on the IEX; the rest runs the platform. Models imply **~$0.4B to ~$8.1B fully diluted**, roughly **30× revenue** at High.  
+> Over **four Phase II years**, paying Spaces grow to **~250k, ~1M, or ~10M** by year five — every Space paying $44/mo, **~$132M to ~$5.28B run-rate ARR**. **~18–22%** of gross supports HYPHA on the IEX; the rest runs the platform. Models imply **~$3.9B to ~$66B fully diluted**, roughly **30×** revenue at Low compressing toward **~13×** at High.  
 >  
 > Click through both simulators and stress-test the assumptions.”
 
@@ -150,14 +147,12 @@ No. Internal planning tool. Past comps don’t guarantee future pricing.
 
 | | Low | Mid | High |
 |---|---:|---:|---:|
-| **Year-5 active (paying)** | **~15k** | **~50k** | **~500k** |
-| **Cumulative created** | ~250k | ~1M | ~10M |
-| **Paying rate (yr 5)** | ~6% | ~5% | ~5% |
-| **ARR (year 5)** | ~$7.9M | ~$26M | ~$264M |
-| **Phase II gross billed (4yr)** | ~$18M | ~$40M | ~$228M |
-| **FDV (indicative)** | ~$0.4B | ~$1.0B | ~$8.1B |
-| **FDV / ARR** | ~51× | ~38× | ~31× |
-| **IEX routing** | 25% | 22% | 19% |
+| **Year-5 paying Spaces** | **~250k** | **~1M** | **~10M** |
+| **ARR (year 5)** | ~$132M | ~$528M | ~$5.28B |
+| **Phase II gross billed (4yr)** | ~$0.13B | ~$0.40B | ~$2.9B |
+| **FDV (indicative)** | ~$3.9B | ~$12.8B | ~$66B |
+| **FDV / ARR** | ~30× | ~24× | ~13× |
+| **IEX routing** | 22% | 20% | 18% |
 
 ---
 

--- a/docs/hypha-ai-cost/README-investor-pitch.md
+++ b/docs/hypha-ai-cost/README-investor-pitch.md
@@ -11,8 +11,8 @@
 | Phase | When | What happens | Key numbers |
 |---|---|---|---|
 | **Phase 0** | **Today** | ~4,373 Spaces live on Hypha. Tokenomics Phase I has not started (month 0). | Reference FDV ~**$111M** at **$0.20** (111M locked supply) |
-| **Phase I** | **Month 0+** | Fixed **$0.20** token price. Token sale, locking, and yield distribution over ~12 months. | Default sim: 50 → ~**4,325** active Spaces by month 12 |
-| **Phase II** | **After Phase I** | **$44/Space/mo** gross revenue. **Dynamic IEX price** from usage + liquidity. 48-month growth scenarios. | Starts ~**4,373** paying Spaces; scenarios to year 4 below |
+| **Phase I** | **Month 0+** | Fixed **$0.20** token price. Token sale, locking, and yield over **12 months**. Same network as today — **not** a separate 50-Space bootstrap. | **4,373 → ~4,732** active Spaces at 0.72%/mo |
+| **Phase II** | **After Phase I** | **$44/Space/mo** gross. Dynamic IEX pricing. **48 months** at Phase I handoff (~4,732 Spaces). | Low → **~6,600** paying at year 5 (month 60 total) |
 
 **Pitch order:** Phase 0 (where we are) → Phase I sim (bootstrap) → Phase II sim (scale scenarios).
 
@@ -28,13 +28,14 @@
 
 A **Space** is one organization on Hypha (a DAO, community, or team). Think of it like one customer account on a SaaS platform.
 
-**~4,373 Spaces are active today (Phase 0).** Phase II scenarios model what happens over the **four years after Phase I**, using cumulative adoption milestones of **250k, 1M, or 10M Space-months**.
+**~4,373 Spaces are active today (Phase 0).** Phase I starts from that same network. Phase II scenarios run **48 months from the Phase I handoff (~4,732 Spaces)**, using cumulative adoption milestones of **~270k, 1M, or 10M Space-months** (Phase II only).
 
 **Critical distinction — who is paying each month:**
 
-- **Cumulative Space-months (250k / 1M / 10M)** = sum of active Spaces counted **each month** over 48 months (adoption milestone).
-- **Active Spaces at year 4** = organizations **paying that month** (~6k / ~58k / ~1.1M).
-- **ARR** = active Spaces at month 48 × **$44 × 12** (run-rate, not cumulative).
+- **Cumulative Space-months (~270k / 1M / 10M in Phase II)** = sum of active Spaces counted **each month** over 48 Phase II months.
+- **Active Spaces at Phase II month 48 (year 5 total)** = organizations **paying that month** (~6.6k / ~56k / ~1.1M).
+- **Full Low journey (Phase I + II):** **4,373 → ~6,676** paying at month 60 at 0.72%/mo throughout.
+- **ARR** = active Spaces at that month × **$44 × 12** (run-rate, not cumulative).
 
 Only **active Spaces in a given month** pay that month’s $44. Cumulative totals are **not** “1M organizations paying at once.”
 
@@ -53,17 +54,17 @@ That number is the anchor for all three scenarios. Operating costs (AI inference
 | **25%** (Low/Mid) or **19%** (High) | IEX buy pressure — supports HYPHA on the exchange |
 | **75% / 81%** | AI inference, gas, operations, off-pool rewards, treasury |
 
-**Month-48 run-rate ARR (who is paying in the final month):**
+**Phase II month-48 run-rate ARR (who is paying in the final month):**
 
-| Active Spaces (month 48) | Paying monthly | Annual revenue (ARR) |
+| Active Spaces (Phase II M48) | Paying monthly | Annual revenue (ARR) |
 |---:|---:|---:|
-| ~6,000 | ~$270k/mo | **~$3M** |
-| ~58,000 | ~$2.5M/mo | **~$30M** |
-| ~1,100,000 | ~$49M/mo | **~$590M** |
+| ~6,600 | ~$290k/mo | **~$3.5M** |
+| ~56,000 | ~$2.4M/mo | **~$29M** |
+| ~1,100,000 | ~$48M/mo | **~$580M** |
 
-**Total gross billed over 4 years** (all months): Low ~$11M · Mid ~$44M · High ~$440M (cumulative Space-months × $44).
+**Phase II gross billed over 4 years:** Low ~$12M · Mid ~$44M · High ~$440M (cumulative Space-months × $44).
 
-Lead with: *“At year four, ~6k to ~1.1M Spaces pay each month — that’s the $3M to $590M run-rate. Cumulative adoption tells us how we got there.”*
+Lead with: *“Phase I handoff is ~4,732 Spaces. At Phase II year 4, ~6.6k to ~1.1M pay each month depending on scenario.”*
 
 ---
 
@@ -83,11 +84,11 @@ HYPHA is the network token. In the model:
 
 Use the **Phase II simulator** sidebar. Each is a four-year story **after Phase I handoff**.
 
-| Scenario | Cumulative (4yr) | **Active & paying (M48)** | ARR (M48) | FDV (indicative) | Token price |
+| Scenario | Cumulative Phase II (4yr) | **Active & paying (M48)** | ARR (M48) | FDV (indicative) | Token price |
 |---|---:|---:|---:|---:|---:|
-| **Low** | ~250k | **~6k** | ~$3M | **~$1.5B** | **~$2.75** |
-| **Mid** | ~1M | **~58k** | ~$30M | **~$4B** | **~$7** |
-| **High** | ~10M | **~1.1M** | ~$590M | **~$31B** | **~$57** |
+| **Low** | ~270k | **~6.6k** | ~$3.5M | **~$1.5B** | **~$2.75** |
+| **Mid** | ~1M | **~56k** | ~$29M | **~$4B** | **~$7** |
+| **High** | ~10M | **~1.1M** | ~$580M | **~$31B** | **~$57** |
 
 FDV is **fully diluted** (555M HYPHA). Low/Mid FDV reflects **network optionality + Phase I anchor** while run-rate ARR is still ramping — not a strict 12-month revenue multiple. High is closer to large-network comps but still optimistic (~50× run-rate ARR).
 
@@ -100,9 +101,9 @@ FDV is **fully diluted** (555M HYPHA). Low/Mid FDV reflects **network optionalit
 ### Option A — Full story (~8 min)
 
 1. **Phase 0:** ~4,373 Spaces today, ~$111M reference FDV at $0.20.
-2. Open [tokenomics1](https://app.hypha.earth/tokenomics1/) — Phase I fixed price, growth to ~4,325 Spaces by month 12.
-3. Open [tokenomics2](https://app.hypha.earth/tokenomics2/) — handoff at ~4,373 Spaces, **$44/Space**, dynamic IEX.
-4. Click **Low** → **Cumulative Spaces** (~250k), **Active (month 48)** (~6k paying), **ARR**, **FDV/ARR**, **FDV**.
+2. Open [tokenomics1](https://app.hypha.earth/tokenomics1/) — Phase I: **4,373 → ~4,732** at 0.72%/mo, fixed $0.20.
+3. Open [tokenomics2](https://app.hypha.earth/tokenomics2/) — starts **~4,732** handoff, **$44/Space**, dynamic IEX.
+4. Click **Low** → cumulative ~270k, **~6.6k paying** at M48, ARR, FDV/ARR, FDV.
 5. Click **Mid**, then **High**.
 
 ### Option B — Quick demo (Phase II only, ~5 min)
@@ -122,11 +123,11 @@ Working assumption for protocol value capture (AI + governance + treasury). Stre
 **“Why doesn’t 100% of revenue buy the token?”**  
 **19–25%** to IEX is deliberate value accrual; **75–81%** funds AI (~$4/Space on open models), gas, ops, and treasury.
 
-**“What does 250k Spaces mean if only ~6k pay at year 4?”**  
-**250k = cumulative Space-months** over four years. **~6k pay each month** in year 4 → **~$3M ARR**. Always state **active payers + ARR** when citing scenario labels.
+**“What does ~270k cumulative mean if only ~6.6k pay at year 5?”**  
+Cumulative = Space-months over Phase II. **~6.6k pay each month** in Low at Phase II month 48. Full journey from Phase 0: **4,373 → ~6,676** at 0.72%/mo over 5 years.
 
 **“How does Phase I connect to Phase II?”**  
-Phase I bootstraps at fixed **$0.20** (~$111M FDV). Phase II starts ~4,373 paying Spaces; price emerges from IEX. Low scenario FDV (~$1.5B) is ~14× Phase I reference — reflects network growth narrative, not 6k × revenue alone.
+Phase I starts at today’s **4,373 Spaces**, fixed **$0.20** (~$111M FDV), grows to **~4,732** at 0.72%/mo. Phase II continues from that handoff at **$44/Space**; price emerges from IEX.
 
 **“How does this compare to other tokens?”**  
 High scenario: large-network band (Maker, Uniswap). Low/Mid: early-stage / ramp comps (Bittensor, Helium) — not Maker 10–15× on year-4 ARR alone.
@@ -138,9 +139,9 @@ No. Internal planning tool. Past comps don’t guarantee future pricing.
 
 ## Suggested 60-second script
 
-> “We’re at **Phase 0** — **~4,400 Spaces** on Hypha, **~$111M** reference valuation. **Phase I** launches tokenomics at fixed **$0.20**. **Phase II** adds **$44/month per Space** and dynamic exchange pricing.  
+> “We’re at **Phase 0** — **~4,400 Spaces**, **~$111M** reference valuation. **Phase I** starts at **4,373 Spaces**, fixed **$0.20**, growing to **~4,732** in year one. **Phase II** adds **$44/month per Space** from that handoff.  
 >  
-> Over four years after handoff, cumulative adoption could reach **250k to 10M Space-months** — meaning **~6k to ~1.1M Spaces paying each month** at year four, **$3M to $590M run-rate ARR**. **~25%** of gross supports HYPHA on IEX; the rest runs the platform. Models imply **~$1.5B to ~$31B fully diluted** depending on scenario.  
+> Over **four Phase II years**, cumulative adoption reaches **~270k to 10M Space-months** — **~6.6k to ~1.1M paying each month** at year five, **~$3.5M to ~$580M run-rate ARR**. **~25%** to IEX. Models imply **~$1.5B to ~$31B fully diluted**.  
 >  
 > Click through both simulators and stress-test the assumptions.”
 
@@ -150,10 +151,11 @@ No. Internal planning tool. Past comps don’t guarantee future pricing.
 
 | | Low | Mid | High |
 |---|---:|---:|---:|
-| **Cumulative Space-months** | ~250k | ~1M | ~10M |
-| **Active & paying (M48)** | **~6k** | **~58k** | **~1.1M** |
-| **ARR (M48 run-rate)** | ~$3M | ~$30M | ~$590M |
-| **4yr total gross billed** | ~$11M | ~$44M | ~$440M |
+| **Phase II cumulative Space-months** | ~270k | ~1M | ~10M |
+| **Active & paying (Phase II M48)** | **~6.6k** | **~56k** | **~1.1M** |
+| **5yr journey (Phase 0→II, Low)** | **4,373 → ~6,676** | — | — |
+| **ARR (Phase II M48)** | ~$3.5M | ~$29M | ~$580M |
+| **Phase II gross billed (4yr)** | ~$12M | ~$44M | ~$440M |
 | **FDV (indicative)** | ~$1.5B | ~$4B | ~$31B |
 | **IEX routing** | 25% | 25% | 19% |
 

--- a/docs/hypha-ai-cost/README-investor-pitch.md
+++ b/docs/hypha-ai-cost/README-investor-pitch.md
@@ -12,7 +12,7 @@
 |---|---|---|---|
 | **Phase 0** | **Today** | Pre-launch. Tokenomics not started. | Reference FDV ~**$111M** at **$0.20** |
 | **Phase I** | **Year 1 (months 0–12)** | Bootstrap the network, fixed **$0.20** price, token sale + locking. | **~0 → ~4,373** |
-| **Phase II** | **Years 2–5 (48 months)** | **$44/Space/mo** gross revenue, dynamic IEX pricing. Starts at ~4,373. | Year 5: Low **~25k** · Mid **~250k** · High **~2M** |
+| **Phase II** | **Years 2–5 (48 months)** | **$44/Space/mo** gross revenue, dynamic IEX pricing. Starts at ~4,373. | Year 5 paying: Low **~15k** · Mid **~50k** · High **~500k** |
 
 **Pitch order:** Phase 0 (where we are) → Phase I sim (bootstrap to 4,373) → Phase II sim (scale scenarios).
 
@@ -28,15 +28,15 @@
 
 A **Space** is one organization on Hypha (a DAO, community, or team). Think of it like one customer account on a SaaS platform.
 
-**Phase I bootstraps the network from ~0 to ~4,373 paying Spaces in year 1.** Phase II then runs **48 months (years 2–5)** from that ~4,373 base, with year-5 active targets of **~25k / ~250k / ~2M** (Low / Mid / High).
+**Phase I bootstraps the network from ~0 to ~4,373 paying Spaces in year 1.** Phase II then runs **48 months (years 2–5)** from that ~4,373 base, with year-5 paying targets of **~15k / ~50k / ~500k** (Low / Mid / High).
 
 **Two numbers to keep straight:**
 
-- **Active Spaces at year 5 (Phase II month 48)** = organizations **paying that month**: **~25k / ~250k / ~2M**.
-- **Cumulative Space-months (Phase II)** = sum of active Spaces counted each month over 48 months: **~570k / ~3M / ~16M**.
-- **ARR** = active Spaces at year 5 × **$44 × 12**: **~$13M / ~$132M / ~$1.06B**.
+- **Active (paying) Spaces at year 5 (Phase II month 48)** = organizations **paying that month**: **~15k / ~50k / ~500k**.
+- **Cumulative Spaces created (Phase II)** = total Spaces ever spun up — the full funnel, free + paid: **~250k / ~1M / ~10M**. Paying Spaces are the **~5–6%** that pay at year 5.
+- **ARR** = active Spaces at year 5 × **$44 × 12**: **~$7.9M / ~$26M / ~$264M**.
 
-Only **active Spaces in a given month** pay that month’s $44.
+Only **active (paying) Spaces in a given month** pay that month’s $44 and drive revenue.
 
 ---
 
@@ -55,15 +55,15 @@ That number anchors all three scenarios. Operating costs (AI inference and block
 
 **Year-5 run-rate ARR (who is paying in month 48):**
 
-| Active Spaces (year 5) | Paying monthly | Annual revenue (ARR) |
+| Active (paying) Spaces (year 5) | Paying monthly | Annual revenue (ARR) |
 |---:|---:|---:|
-| ~25,000 | ~$1.1M/mo | **~$13M** |
-| ~250,000 | ~$11M/mo | **~$132M** |
-| ~2,000,000 | ~$88M/mo | **~$1.06B** |
+| ~15,000 | ~$0.7M/mo | **~$7.9M** |
+| ~50,000 | ~$2.2M/mo | **~$26M** |
+| ~500,000 | ~$22M/mo | **~$264M** |
 
-**Phase II gross billed over 4 years:** Low ~$25M · Mid ~$131M · High ~$719M (cumulative Space-months × $44).
+**Phase II gross billed over 4 years:** Low ~$18M · Mid ~$40M · High ~$228M (sum of active Spaces × $44 each month).
 
-Lead with: *“Phase I builds to ~4,373 paying Spaces. By year 5, that grows to ~25k / ~250k / ~2M depending on scenario.”*
+Lead with: *“Phase I builds to ~4,373 paying Spaces. By year 5, paying Spaces grow to ~15k / ~50k / ~500k depending on scenario — out of ~250k / ~1M / ~10M created.”*
 
 ---
 
@@ -83,13 +83,13 @@ HYPHA is the network token. In the model:
 
 Use the **Phase II simulator** sidebar. Each is a four-year story from the ~4,373 Phase I handoff.
 
-| Scenario | Year-5 active (paying) | Cumulative Space-months | ARR (year 5) | FDV (indicative) | FDV/ARR | Token price |
+| Scenario | Year-5 active (paying) | Cumulative created | ARR (year 5) | FDV (indicative) | FDV/ARR | Token price |
 |---|---:|---:|---:|---:|---:|---:|
-| **Low** | **~25k** | ~570k | ~$13M | **~$1.5B** | ~115× | **~$2.65** |
-| **Mid** | **~250k** | ~3M | ~$132M | **~$4B** | ~30× | **~$7.30** |
-| **High** | **~2M** | ~16M | ~$1.06B | **~$31B** | ~29× | **~$56** |
+| **Low** | **~15k** | ~250k | ~$7.9M | **~$0.4B** | ~51× | **~$0.72** |
+| **Mid** | **~50k** | ~1M | ~$26M | **~$1.0B** | ~38× | **~$1.82** |
+| **High** | **~500k** | ~10M | ~$264M | **~$8.1B** | ~31× | **~$14.50** |
 
-FDV is **fully diluted** (555M HYPHA). Mid/High land at ~30× run-rate ARR — in range of growth-stage network comps. Low is higher (~115×) because year-5 ARR is still ramping; frame it as **early-network optionality**, not a revenue multiple.
+FDV is **fully diluted** (555M HYPHA). High lands near ~30× run-rate ARR — in range of growth-stage network comps. Low/Mid carry higher multiples because year-5 ARR is still ramping; frame them as **early-network optionality**, not a mature revenue multiple.
 
 **Important framing:** Scenario models, not forecasts.
 
@@ -102,15 +102,15 @@ FDV is **fully diluted** (555M HYPHA). Mid/High land at ~30× run-rate ARR — i
 1. **Phase 0:** pre-launch, ~$111M reference FDV at $0.20.
 2. Open [tokenomics1](https://app.hypha.earth/tokenomics1/) — Phase I: **~0 → ~4,373** Spaces over 12 months, fixed $0.20.
 3. Open [tokenomics2](https://app.hypha.earth/tokenomics2/) — starts **~4,373**, **$44/Space**, dynamic IEX.
-4. Click **Low** → **~25k paying** at year 5, ARR ~$13M, FDV/ARR, FDV ~$1.5B.
-5. Click **Mid** (~250k, ~$4B), then **High** (~2M, ~$31B).
+4. Click **Low** → **~15k paying** at year 5 (~250k created), ARR ~$7.9M, FDV/ARR, FDV ~$0.4B.
+5. Click **Mid** (~50k paying / ~1M created, ~$1.0B), then **High** (~500k / ~10M, ~$8.1B).
 
 ### Option B — Quick demo (Phase II only, ~5 min)
 
 1. Open [tokenomics2](https://app.hypha.earth/tokenomics2/)
 2. **$44/Space** · **~25% to IEX** · **~75% off-pool**
 3. Show **active Spaces at year 5** before citing cumulative totals
-4. Show **FDV/ARR** — Mid/High ~30×; Low is a ramp narrative
+4. Show **FDV/ARR** — High ~30×; Low/Mid (~38–51×) are a ramp narrative
 
 ---
 
@@ -125,11 +125,11 @@ Working assumption for protocol value capture (AI + governance + treasury). Stre
 **“How does Phase I connect to Phase II?”**  
 Phase I bootstraps from ~0 to **~4,373 paying Spaces** in year 1 at fixed **$0.20** (~$111M FDV). Phase II continues from that ~4,373 base at **$44/Space**; price emerges from the IEX.
 
-**“What does ~570k cumulative mean if ~25k pay at year 5?”**  
-Cumulative = Space-months summed across all 48 Phase II months. **~25k pay in the final month** (Low). The cumulative figure is an adoption-intensity metric, not concurrent payers.
+**“What does ~250k cumulative mean if ~15k pay at year 5?”**  
+Cumulative = total Spaces ever created over Phase II — the full funnel, free + paid. **~15k pay in the final month** (Low), i.e. ~6% of created Spaces. The cumulative figure is an adoption/funnel metric; only paying Spaces generate revenue.
 
 **“How does this compare to other tokens?”**  
-Mid/High sit at ~30× run-rate ARR — comparable to growth-stage networks (Maker, Uniswap, Bittensor at various points). Low is early-stage optionality (revenue still ramping).
+High sits near ~30× run-rate ARR — comparable to growth-stage networks (Maker, Uniswap, Bittensor at various points). Low/Mid carry higher multiples (~38–51×) as early-stage optionality (revenue still ramping).
 
 **“Is this financial advice?”**  
 No. Internal planning tool. Past comps don’t guarantee future pricing.
@@ -140,7 +140,7 @@ No. Internal planning tool. Past comps don’t guarantee future pricing.
 
 > “We’re at **Phase 0** — pre-launch, **~$111M** reference valuation. **Phase I** bootstraps the network from zero to **~4,373 paying Spaces** in year one at fixed **$0.20**. **Phase II** adds **$44/month per Space** with dynamic exchange pricing.  
 >  
-> Over **four Phase II years**, active Spaces grow to **~25k, ~250k, or ~2M** by year five — **~$13M to ~$1.06B run-rate ARR**. **~20–25%** of gross supports HYPHA on the IEX; the rest runs the platform. Models imply **~$1.5B to ~$31B fully diluted**, roughly **30× revenue** at Mid/High.  
+> Over **four Phase II years**, paying Spaces grow to **~15k, ~50k, or ~500k** by year five (out of ~250k–10M created) — **~$7.9M to ~$264M run-rate ARR**. **~20–25%** of gross supports HYPHA on the IEX; the rest runs the platform. Models imply **~$0.4B to ~$8.1B fully diluted**, roughly **30× revenue** at High.  
 >  
 > Click through both simulators and stress-test the assumptions.”
 
@@ -150,13 +150,14 @@ No. Internal planning tool. Past comps don’t guarantee future pricing.
 
 | | Low | Mid | High |
 |---|---:|---:|---:|
-| **Year-5 active (paying)** | **~25k** | **~250k** | **~2M** |
-| **Cumulative Space-months** | ~570k | ~3M | ~16M |
-| **ARR (year 5)** | ~$13M | ~$132M | ~$1.06B |
-| **Phase II gross billed (4yr)** | ~$25M | ~$131M | ~$719M |
-| **FDV (indicative)** | ~$1.5B | ~$4B | ~$31B |
-| **FDV / ARR** | ~115× | ~30× | ~29× |
-| **IEX routing** | 25% | 19% | 19% |
+| **Year-5 active (paying)** | **~15k** | **~50k** | **~500k** |
+| **Cumulative created** | ~250k | ~1M | ~10M |
+| **Paying rate (yr 5)** | ~6% | ~5% | ~5% |
+| **ARR (year 5)** | ~$7.9M | ~$26M | ~$264M |
+| **Phase II gross billed (4yr)** | ~$18M | ~$40M | ~$228M |
+| **FDV (indicative)** | ~$0.4B | ~$1.0B | ~$8.1B |
+| **FDV / ARR** | ~51× | ~38× | ~31× |
+| **IEX routing** | 25% | 22% | 19% |
 
 ---
 

--- a/docs/hypha-ai-cost/README.md
+++ b/docs/hypha-ai-cost/README.md
@@ -195,34 +195,27 @@ Every proposal has exactly **1 deciding vote** and typically **many more non-exe
 | Proposal creation (token mint) | Recurring | Verified | 378,389 | $0.0033 | `0xab9a53ae…` · typical agreement proposal |
 | USDC transfer (ERC-20) | Recurring | Verified | 62,135 | $0.0005 | `0x80e51f14…` |
 | Member join | Recurring | **Estimated** | 100,000 | $0.0009 | tx failed in analysis run |
-| Non-executing vote | Recurring | **Not measured** | — | — | no successful mainnet receipt in repo |
+| Non-executing vote | Recurring | **Assumed 150k** | 150,000 | $0.0013 | not yet verified on mainnet |
 
 **Verified one-time setup** (create + deploy-token proposal + deciding deploy vote): **4,036,728 gas → $0.035**.
 
 **Verified recurring proposal** (mint-scale agreement): 378,389 create + 446,949 deciding vote = **825,338 gas → $0.0072** per proposal, before non-executing member votes.
 
-### Two vote types — most votes do not execute
-
-- **Non-executing vote:** a member casts yes/no while the proposal is still open. Records voting power but **does not run the agreement** on-chain.
-- **Deciding vote:** the vote that reaches quorum/unity and **auto-executes** the proposal via the Executor (447k gas verified for a mint-scale agreement — execution bundled in this tx).
-
-Every proposal has exactly **1 deciding vote** and typically **many more non-executing votes**. The monthly model reflects this ratio explicitly.
-
 ### Recurring gas by Space size
 
-Assumes **active governance** with high member participation. Per proposal: 1× verified create + 1× verified deciding vote (includes execution) + **(N−1) non-executing votes** where N = members voting. Non-executing vote gas is **not measured**; the range uses 80k–200k gas each (unverified sensitivity band).
+Assumes **active governance** with high member participation. Per proposal: 1× verified create + 1× verified deciding vote (includes execution) + **(N−1) non-executing votes at 150k gas each** ($0.0013/vote).
 
-| Profile | Proposals/mo | Deciding votes | Non-exec votes | Ratio | Treasury/mo | Verified floor | Range (incl. non-exec) |
+| Profile | Proposals/mo | Deciding votes | Non-exec votes | Ratio | Treasury/mo | Verified portion | Monthly total |
 |---|--:|--:|--:|--:|--:|--:|--:|
-| Light (~5) | 5 | 5 | 20 | 4:1 | 3 | $0.036 | $0.05–0.07 |
-| **Typical (~15)** | **15** | **15** | **195** | **13:1** | **12** | **$0.12** | **$0.25–0.46** |
-| Heavy (~50) | 50 | 50 | 2,200 | 44:1 | 50 | $0.39 | $2.0–4.3 |
+| Light (~5) | 5 | 5 | 20 | 4:1 | 3 | $0.038 | $0.06 |
+| **Typical (~15)** | **15** | **15** | **195** | **13:1** | **12** | **$0.12** | **$0.37** |
+| Heavy (~50) | 50 | 50 | 2,200 | 44:1 | 50 | $0.39 | $3.27 |
 
-**Vote participation:** Typical ≈ 14 of 15 members vote per proposal (1 deciding + 13 non-exec). Light ≈ 5 of 5 (4:1). Heavy ≈ 45 of 50 (44:1). At these ratios, **non-executing votes dominate total gas** in the sensitivity range — there are far more of them, even though each one is cheaper than a deciding vote.
+**Vote participation:** Typical ≈ 14 of 15 members vote per proposal (1 deciding + 13 non-exec). Monthly total = verified portion + (non-exec votes × 150k gas). Non-executing votes contribute ~69% of Typical monthly gas ($0.26 of $0.37).
 
 ### Gas vs AI
 
-Even with active governance, a Typical space pays **$0.25–0.46/month** on-chain vs **$16.52/month** for AI (Composer 2.5 Fast) — roughly **36–65× less**. Only at Heavy scale with maximum assumptions does gas approach a few dollars/month.
+With active governance, a Typical space pays **$0.37/month** on-chain vs **$16.52/month** for AI (Composer 2.5 Fast) — roughly **45× less**. Only Heavy scale (~$3.27/mo) approaches meaningful on-chain spend.
 
 **Caveats:** L2 execution gas only; Base adds a small L1 data fee per tx. Gas scales linearly with gas price. Re-run `gas-cost-analysis.ts` on Base to capture a non-executing vote and a successful join.
 

--- a/docs/hypha-ai-cost/README.md
+++ b/docs/hypha-ai-cost/README.md
@@ -198,19 +198,19 @@ In Hypha, a passing proposal **auto-executes on the deciding vote** — there is
 
 ### Recurring gas by Space size
 
-Each proposal = 1× verified create (378,389) + 1× verified deciding vote (446,949) + treasury transfers (62,135 each). Non-executing member votes are **not measured**; the range adds an unverified sensitivity band of 80k–200k gas per vote.
+Assumes **active governance** — more proposals and broader member participation than a quiet space. Each proposal = 1× verified create (378,389) + 1× verified deciding vote (446,949) + treasury transfers (62,135 each). Non-executing member votes are **not measured**; the range adds an unverified sensitivity band of 80k–200k gas per vote.
 
 | Profile | Proposals/mo | Votes/mo | Non-exec votes | Treasury/mo | Verified floor | Range (incl. unmeasured votes) |
 |---|--:|--:|--:|--:|--:|--:|
-| Light (~5) | 2 | 6 | 4 | 1 | $0.015 | $0.015–0.022 |
-| **Typical (~15)** | **6** | **54** | **48** | **5** | **$0.046** | **$0.05–0.13** |
-| Heavy (~50) | 20 | 600 | 580 | 20 | $0.15 | $0.56–1.17 |
+| Light (~5) | 5 | 30 | 25 | 3 | $0.036 | $0.05–0.08 |
+| **Typical (~15)** | **15** | **180** | **165** | **12** | **$0.11** | **$0.23–0.40** |
+| Heavy (~50) | 50 | 2,000 | 1,950 | 50 | $0.39 | $1.75–3.80 |
 
-The verified floor counts only measured operations. The upper bound assumes non-executing votes at 200k gas each — still unverified for Hypha. A Heavy space running a token-deploy proposal in a given month adds ~$0.023 (verified) on top.
+**Activity assumptions:** Typical ≈ 1 proposal every 2 days, ~12 member votes per proposal. Light ≈ 1/week with ~6 votes each. Heavy ≈ 1–2/day across a 50-member ecosystem with ~40 votes per proposal. Verified floor counts only measured operations; upper bound assumes non-executing votes at 200k gas each — still unverified.
 
 ### Gas vs AI
 
-Even at the upper bound, a Typical space pays **$0.05–0.13/month** on-chain vs **$16.52/month** for AI (Composer 2.5 Fast) — roughly **130–360× less**. The verified floor alone ($0.046/mo) is **~360× smaller** than AI.
+Even with active governance, a Typical space pays **$0.23–0.40/month** on-chain vs **$16.52/month** for AI (Composer 2.5 Fast) — roughly **40–150× less**. Only at Heavy scale with maximum unverified vote assumptions does gas approach a few dollars/month.
 
 **Caveats:** L2 execution gas only; Base adds a small L1 data fee per tx. Gas scales linearly with gas price. Re-run `gas-cost-analysis.ts` on Base to capture a non-executing vote and a successful join.
 

--- a/docs/hypha-ai-cost/README.md
+++ b/docs/hypha-ai-cost/README.md
@@ -238,30 +238,57 @@ With active governance, a Typical space pays **$0.37/month** on-chain vs **$16.5
 
 Interactive simulators: [`tokenomics-simulator.html`](tokenomics-simulator.html) (Phase II) and [`tokenomics-simulator-phase1.html`](tokenomics-simulator-phase1.html) (Phase I). Deployed at `/tokenomics2` and `/tokenomics1` on the web app.
 
+**Investor-facing summary:** [README-investor-pitch.md](./README-investor-pitch.md)
+
+### Roadmap: Phase 0 → Phase I → Phase II
+
+| Phase | When | Simulator | Key state |
+|---|---|---|---|
+| **Phase 0** | Today | — | ~4,373 Spaces on Hypha. Phase I at month 0. Reference FDV ~$111M at $0.20 (111M locked supply). |
+| **Phase I** | Month 0+ | Phase I (`/tokenomics1`) | Fixed $0.20 price. Token sale, locking, yield. Default: 50 Spaces → ~4,325 by month 12 at 50%/mo growth. |
+| **Phase II** | After Phase I | Phase II (`/tokenomics2`) | ~4,373 paying Spaces at handoff. $44/Space/mo gross. Dynamic IEX price. 48-month Low/Mid/High scenarios. |
+
+Phase II month 1 starts from **4,373 active Spaces** — aligned with Phase I end-state and current network size.
+
 ### Fixed inputs
 
 | Parameter | Value |
 |---|---|
-| Gross revenue per Space | **$44 USDC / month** (unchanged across scenarios) |
-| Simulation horizon | 48 months |
+| Gross revenue per Space (Phase II) | **$44 USDC / month** |
+| Simulation horizon (Phase II) | 48 months |
 | Total HYPHA supply | 555,555,555 |
 | Phase I reference price | **$0.20** (fixed; ~$111M FDV) |
 
+### Revenue allocation (Phase II)
+
+| Share | Destination |
+|---:|---|
+| **19–25%** (by scenario) | IEX buy pressure |
+| **75–81%** | AI inference, gas, operations, off-pool rewards, treasury |
+
+Simulator default AI cost uses **open-weight inference (~$4/Space/mo typical)**; Composer Fast reference is **~$16.50/Space/mo** — see [TL;DR](#tldr) above.
+
 ### Growth scenarios
 
-Each preset targets an active Space count at month 48. Growth applies from month 2 onward (starting from 4,373 Spaces).
+Each preset targets **cumulative Space-months** at month 48 — the sum of active Spaces recorded each month over the 48-month horizon (not the active count in month 48 alone). Growth applies from month 2 onward (starting from 4,373 active Spaces).
 
-| Scenario | Target Spaces | Monthly growth (M2–M48) | IEX routing % |
-|---|---:|---:|---:|
-| **Low** | ~250k | 9.0% | 8% |
-| **Mid** | ~1M | 12.26% | 10% |
-| **High** | ~10M | 17.9% | 12% |
+| Scenario | Cumulative Space-months (M48) | Active Spaces (M48) | Monthly growth (M2–M48) | IEX routing % |
+|---|---:|---:|---:|---:|
+| **Low** | ~250k | ~6k | 0.72% | 25% |
+| **Mid** | ~1M | ~58k | 5.63% | 25% |
+| **High** | ~10M | ~1.1M | 12.52% | 19% |
 
-Only the **IEX routing %** of gross Space contributions enters the on-chain AMM buy path; the remainder models treasury / ops / off-pool rewards. Investor buy/sell pressure on IEX defaults to **5% each** (pool-relative, not dollar-matched).
+**ARR** uses **active Spaces in month 48** × $44 × 12. Low ~$3M · Mid ~$30M · High ~$590M.
+
+**4-year total gross billed** ≈ cumulative Space-months × $44: Low ~$11M · Mid ~$44M · High ~$440M.
+
+Only the **IEX routing %** of gross Space contributions enters the on-chain AMM buy path. Investor buy/sell pressure on IEX defaults to **5–8% buy** and **3–5% sell** (pool-relative, not dollar-matched).
+
+**Key metrics to show investors:** cumulative Space-months · **active payers (M48)** · run-rate ARR · FDV · **FDV/ARR** (Low/Mid are ramp narratives, not revenue multiples alone).
 
 ### Target valuation bands (Month 48, judgment + comps)
 
-Gross ARR at target scale: Low ~$132M · Mid ~$528M · High ~$5.3B.
+Gross ARR at month 48 (active run-rate): Low ~$3M · Mid ~$30M · High ~$590M. FDV targets reflect network-value narrative at cumulative adoption scale, not a strict revenue multiple on month-48 ARR alone (especially Low/Mid where run-rate revenue is still ramping).
 
 | Comp | Rough FDV | Revenue / fees | Implied multiple |
 |---|---:|---:|---:|
@@ -270,15 +297,15 @@ Gross ARR at target scale: Low ~$132M · Mid ~$528M · High ~$5.3B.
 | Helium (peak) | ~$1.2B | low on-chain revenue | growth narrative |
 | Bittensor | ~$3–4B | early / low | high narrative multiple |
 
-**Target FDV / FDV-to-ARR** after calibration (sim-verified):
+**Target FDV / FDV-to-ARR** after calibration (sim-verified; cumulative scenario framing):
 
 | Scenario | Target FDV | FDV/ARR | Token price (indicative) |
 |---|---:|---:|---:|
-| Low | $1.0–1.5B | ~8–11× | ~$2–3 |
-| Mid | $4–8B | ~8–15× | ~$7–14 |
-| High | $25–45B | ~5–9× | ~$45–$80 |
+| Low | ~$1.5B | narrative / early ramp | ~$2.75 |
+| Mid | ~$4B | narrative / ramp | ~$7 |
+| High | ~$31B | ~50× (scale + comps) | ~$57 |
 
-IEX seed liquidity scales with scenario (`initialHypha` / `initialUsdc` anchor starting price at $0.20–$0.25). Parameters were tuned so emergent IEX price × max supply lands in these bands — not by fixing an end-state price directly.
+IEX seed liquidity scales with scenario (`initialHypha` / `initialUsdc` anchor starting price at $0.20). Low uses a thinner seed pool (5M HYPHA / $1M USDC) so modest monthly buy flow still supports a credible early-network FDV. Parameters were tuned so emergent IEX price × max supply lands in these bands — not by fixing an end-state price directly.
 
 ---
 

--- a/docs/hypha-ai-cost/README.md
+++ b/docs/hypha-ai-cost/README.md
@@ -246,7 +246,7 @@ Interactive simulators: [`tokenomics-simulator.html`](tokenomics-simulator.html)
 |---|---|---|---|
 | **Phase 0** | Today | — | Pre-launch. Reference FDV ~$111M at $0.20 (111M locked supply). |
 | **Phase I** | Year 1 (months 0–12) | Phase I (`/tokenomics1`) | Fixed $0.20. **Bootstrap ~0 → ~4,373** paying Spaces (50-Space seed at 50%/mo). |
-| **Phase II** | Years 2–5 (48 months) | Phase II (`/tokenomics2`) | Starts **~4,373** paying Spaces. $44/Space/mo. Year-5 active: Low ~25k · Mid ~250k · High ~2M. |
+| **Phase II** | Years 2–5 (48 months) | Phase II (`/tokenomics2`) | Starts **~4,373** paying Spaces. $44/Space/mo. Year-5 paying / created: Low ~15k/250k · Mid ~50k/1M · High ~500k/10M. |
 
 Phase II month 1 = first month after Phase I (~4,373 active Spaces). Year 5 = Phase II month 48.
 
@@ -270,25 +270,28 @@ Simulator default AI cost uses **open-weight inference (~$4/Space/mo typical)**;
 
 ### Growth scenarios
 
-Each preset targets **active (paying) Spaces at year 5 (Phase II month 48)**, starting from the ~4,373 Phase I handoff. Growth applies from month 2 onward.
+Each preset tracks **two series**, both starting from the ~4,373 Phase I handoff and growing from month 2 onward:
 
-| Scenario | Year-5 active Spaces | Cumulative Space-months | Monthly growth (M2–M48) | IEX routing % |
-|---|---:|---:|---:|---:|
-| **Low** | ~25k | ~570k | 3.78% | 25% |
-| **Mid** | ~250k | ~3M | 8.99% | 19% |
-| **High** | ~2M | ~16M | 13.92% | 19% |
+- **Active (paying) Spaces** — pay $44/mo and drive all revenue (growth rate `active`).
+- **Cumulative Spaces created** — the full funnel (free + paid; growth rate `created`). Active payers are the **~5–6%** of created Spaces that pay at year 5.
 
-**ARR** uses **active Spaces at year 5** × $44 × 12. Low ~$13M · Mid ~$132M · High ~$1.06B.
+| Scenario | Year-5 active (paying) | Year-5 created (cumulative) | Paying rate | Active growth / mo | Created growth / mo | IEX routing % |
+|---|---:|---:|---:|---:|---:|---:|
+| **Low** | ~15k | ~250k | ~6% | 2.66% | 8.99% | 25% |
+| **Mid** | ~50k | ~1M | ~5% | 5.32% | 12.25% | 22% |
+| **High** | ~500k | ~10M | ~5% | 10.61% | 17.89% | 19% |
 
-**Phase II gross billed** ≈ cumulative × $44: Low ~$25M · Mid ~$131M · High ~$719M.
+**ARR** uses **active (paying) Spaces at year 5** × $44 × 12: Low ~$7.9M · Mid ~$26M · High ~$264M.
 
-Only the **IEX routing %** of gross Space contributions enters the on-chain AMM buy path. Investor buy/sell pressure on IEX defaults to **5–8% buy** and **3–5% sell** (pool-relative, not dollar-matched).
+**Phase II gross billed** (sum of active Spaces × $44 across 48 months): Low ~$18M · Mid ~$40M · High ~$228M.
 
-**Key metrics to show investors:** **active payers at year 5** · run-rate ARR · FDV · **FDV/ARR** · cumulative Space-months.
+Only the **IEX routing %** of gross Space contributions enters the on-chain AMM buy path. Investor buy/sell pressure on IEX defaults to **4–8% buy** and **4–5% sell** (pool-relative, not dollar-matched).
+
+**Key metrics to show investors:** **active payers at year 5** · cumulative created · run-rate ARR · FDV · **FDV/ARR**.
 
 ### Target valuation bands (year 5, judgment + comps)
 
-Run-rate ARR at year 5: Low ~$13M · Mid ~$132M · High ~$1.06B. Mid/High FDV lands near ~30× ARR (growth-stage comps); Low is higher (~115×) as an early-network optionality case while revenue ramps.
+Run-rate ARR at year 5: Low ~$7.9M · Mid ~$26M · High ~$264M. FDV multiples descend as the network matures — High lands near ~30× ARR (growth-stage comps); Low/Mid carry higher multiples as early-network optionality while revenue ramps.
 
 | Comp | Rough FDV | Revenue / fees | Implied multiple |
 |---|---:|---:|---:|
@@ -301,11 +304,11 @@ Run-rate ARR at year 5: Low ~$13M · Mid ~$132M · High ~$1.06B. Mid/High FDV la
 
 | Scenario | Target FDV | FDV/ARR | Token price (indicative) |
 |---|---:|---:|---:|
-| Low | ~$1.5B | ~115× (early ramp) | ~$2.65 |
-| Mid | ~$4B | ~30× | ~$7.30 |
-| High | ~$31B | ~29× | ~$56 |
+| Low | ~$0.4B | ~51× (early ramp) | ~$0.72 |
+| Mid | ~$1.0B | ~38× | ~$1.82 |
+| High | ~$8.1B | ~31× | ~$14.50 |
 
-IEX seed liquidity scales with scenario (`initialHypha` / `initialUsdc` anchor starting price at $0.20): Low 40M HYPHA / $8M USDC, Mid 80M / $16M, High 150M / $30M. Parameters were tuned so emergent IEX price × max supply lands in these bands — not by fixing an end-state price directly.
+IEX seed liquidity scales with scenario (`initialHypha` / `initialUsdc` anchor starting price at $0.20): Low 25M HYPHA / $5M USDC, Mid 35M / $7M, High 63M / $12.6M. Parameters were tuned so emergent IEX price × max supply lands in these bands — not by fixing an end-state price directly.
 
 ---
 

--- a/docs/hypha-ai-cost/README.md
+++ b/docs/hypha-ai-cost/README.md
@@ -72,6 +72,14 @@ Token sizes are read from `packages/chat-server`:
 
 Cost per task = `input_tokens × $3/1M + output_tokens × $15/1M`.
 
+**Hosting is already included.** All rates in this report are **managed / hosted
+inference** (per-token) — the provider runs the model on their GPUs and bills per
+token (Cursor for Composer; OpenRouter / DeepSeek / DeepInfra for the open models).
+There is no separate GPU/infra line to add. Self-hosting the open weights is a
+different, fixed-cost model (e.g. one H100 ≈ $1,400+/month) that is **more** expensive
+at per-Space volumes and only becomes economic when many Spaces share GPUs — so it is
+intentionally out of scope for a per-Space estimate.
+
 ---
 
 ## Per-feature breakdown — Typical Space (Composer 2.5 Fast, full vision)

--- a/docs/hypha-ai-cost/README.md
+++ b/docs/hypha-ai-cost/README.md
@@ -1,0 +1,191 @@
+# Hypha AI — Estimated AI Cost per Space
+
+> Cost model for running Hypha AI features against an LLM, expressed as **average
+> spend per Space**. Headline numbers use **Cursor Composer 2.5 Fast**; a dedicated
+> section estimates the same workload on the **most capable open-source models**.
+>
+> _Last updated: June 2026. Token volumes are grounded in the current
+> `packages/chat-server` implementation; pricing is sourced from public rate cards
+> (see [Sources](#sources))._
+
+---
+
+## TL;DR
+
+| Space profile | Members | AI cost / month (full vision) | Live-today only | AI tasks / month |
+|---|---|--:|--:|--:|
+| Light | ~5 | **$5.48** | $2.45 | 112 |
+| **Typical** | **~15** | **$16.52** | **$10.13** | **319** |
+| Heavy | ~50 | **$45.06** | $31.26 | 840 |
+
+- **One-time onboarding** (per Space, ~12-turn guided setup): **~$0.56**.
+- The **typical active Space costs ≈ $16.50/month (≈ $198/year)** on Composer 2.5 Fast.
+- Swapping the model out for a **top open-source model cuts this 3×–24×** — see
+  [Open-source model pricing](#open-source-model-pricing). The cheapest credible
+  option (DeepSeek V4-Flash) lands the typical Space at **~$0.70/month**.
+
+---
+
+## What "scope" means
+
+Only the **chat copilot** makes model calls in the build today. The **Signal
+Orchestrator, discussion summaries, and call summaries are heuristic** (template/
+word-overlap scoring — **zero LLM tokens**). They cost nothing until their Phase 3
+AI versions ship.
+
+- **Live today** — bills only the copilot (Q&A, advisory, memory deep-dive, signal
+  authoring, web search, discovery).
+- **Full AI vision** — bills *every* AI-augmented surface to the model, including the
+  background features that are heuristic today. This is the cost **ceiling**.
+
+---
+
+## Pricing basis — Composer 2.5 Fast
+
+| Tier | Input $/1M | Output $/1M | Notes |
+|---|--:|--:|---|
+| **Composer 2.5 Fast** | **$3.00** | **$15.00** | IDE default; high throughput. **Headline number.** |
+| Composer 2.5 Standard | $0.50 | $2.50 | Same model & intelligence, lower throughput (6× cheaper). |
+
+Composer runs **inside Cursor only** — there is no public API or third-party gateway.
+For a platform like Hypha (which calls models server-side via OpenRouter), Composer
+is therefore a **reference price point**, not a directly deployable backend. It is the
+basis the estimate was requested against.
+
+---
+
+## Methodology & assumptions
+
+Token sizes are read from `packages/chat-server`:
+
+- **In-space system prompt ≈ 5.6k tokens**, re-sent on every step.
+- **Tool loop capped at 6 steps** (`stepCountIs(6)`); full conversation history is
+  re-sent each step (no truncation).
+- **No `max_tokens` cap** is configured → output sizes below are conservative
+  per-reply estimates.
+- **Org-memory asset reads capped at 48k chars** (~12k tokens) per `fetch_org_memory_asset`;
+  PDFs/images push deep-dive turns to the high end.
+- **Orchestrator** capped at 3 auto-signals/day/space with cooldowns; discussion
+  refresh modeled at ~4 runs/day.
+- Task volumes for "Typical" assume ~15 members with a handful of AI-active users.
+  Light ≈ 0.33× and Heavy ≈ 2.73× the typical volume (costs scale ~linearly).
+
+Cost per task = `input_tokens × $3/1M + output_tokens × $15/1M`.
+
+---
+
+## Per-feature breakdown — Typical Space (Composer 2.5 Fast, full vision)
+
+| Feature | Surface | Status | Tasks/mo | In tok | Out tok | Cost/task | Monthly |
+|---|---|---|--:|--:|--:|--:|--:|
+| Discussion summary (background refresh) | Space Memory | Heuristic today | 120 | 12k | 400 | $0.042 | **$5.04** |
+| Advisory (multi-tool reads) | Copilot | Live | 40 | 28k | 900 | $0.098 | **$3.90** |
+| Q&A & navigation | Copilot | Live | 80 | 9k | 400 | $0.033 | **$2.64** |
+| Memory deep-dive (read file/PDF) | Space Memory | Live | 12 | 45k | 1.2k | $0.153 | **$1.84** |
+| Signal Orchestrator (auto signal) | Signals | Heuristic today | 30 | 10k | 600 | $0.039 | **$1.17** |
+| Signal authoring (member, gated) | Signals | Live | 8 | 30k | 1k | $0.105 | **$0.84** |
+| Web search assist | Copilot | Live | 15 | 12k | 500 | $0.044 | **$0.65** |
+| Network discovery (search spaces) | Discovery | Live | 8 | 9k | 400 | $0.033 | **$0.26** |
+| Call transcript summary (per call) | Space Memory | Heuristic today | 6 | 8k | 400 | $0.030 | **$0.18** |
+| **Total** | | | **319** | | | | **$16.52** |
+
+**Where the money goes:** background **Space Memory summaries (~31%)** and **copilot
+advisory reads (~24%)** dominate. The most expensive *per-task* feature is the
+**memory deep-dive** ($0.15/task) because reading a document loads ~12k tokens into
+context.
+
+Monthly volume drives total tokens of **≈ 4.66M input + 0.17M output** for the
+typical Space — input-heavy, which matters a lot for model selection below.
+
+---
+
+## Cost across Space sizes (full AI vision, Composer 2.5 Fast)
+
+| Profile | Monthly | Annualized | AI tasks/mo |
+|---|--:|--:|--:|
+| Light (~5 members) | $5.48 | $65.76 | 112 |
+| Typical (~15 members) | $16.52 | $198.24 | 319 |
+| Heavy (~50 members) | $45.06 | $540.72 | 840 |
+
+---
+
+## Open-source model pricing
+
+The same workload on the **most capable open-source (open-weight) models** of 2026.
+This is highly relevant: **Composer 2.5 is itself post-trained from Moonshot's Kimi
+K2.5**, so running the open Kimi line directly is the closest like-for-like swap — and
+costs a fraction of Composer Fast's interactive premium.
+
+### Representative rates (per 1M tokens)
+
+| Model | Open weights | Input $/1M | Output $/1M | Why it's here |
+|---|---|--:|--:|---|
+| **Kimi K2.6** (Moonshot) | Yes | $0.95 | $4.00 | Leads open-source quality rankings; agentic; same lineage as Composer. (OpenRouter as low as $0.68 / $3.41.) |
+| **DeepSeek V4-Pro** | Yes (MIT) | $0.44 | $0.87 | Flagship open reasoning/coding model; first-party API. |
+| **Qwen3.5-397B** (Alibaba) | Yes | $0.60 | $3.60 | Strong open frontier MoE. |
+| **Llama 4 Maverick** (Meta) | Yes | $0.50 | $2.15 | 400B MoE; DeepInfra-hosted rate. |
+| **DeepSeek V4-Flash** | Yes (MIT) | $0.14 | $0.28 | Budget leader; near-frontier at a fraction of the cost. |
+| _Composer 2.5 Fast (baseline)_ | No | $3.00 | $15.00 | _Reference._ |
+
+### Estimated cost — Typical Space (full AI vision)
+
+Applying each model's rate to the typical Space's **4.66M input + 0.17M output
+tokens/month**:
+
+| Model | Monthly / Space | Annualized | One-time onboarding | vs Composer Fast |
+|---|--:|--:|--:|--:|
+| Composer 2.5 Fast _(baseline)_ | $16.52 | $198.24 | $0.56 | — |
+| Composer 2.5 Standard | $2.75 | $33.05 | $0.09 | **6.0× cheaper** |
+| Kimi K2.6 (list) | $5.11 | $61.26 | $0.17 | **3.2× cheaper** |
+| Kimi K2.6 (OpenRouter low) | $3.75 | $44.96 | $0.13 | **4.4× cheaper** |
+| Qwen3.5-397B | $3.41 | $40.87 | $0.12 | **4.8× cheaper** |
+| Llama 4 Maverick | $2.69 | $32.33 | $0.09 | **6.1× cheaper** |
+| DeepSeek V4-Pro | $2.17 | $26.10 | $0.07 | **7.6× cheaper** |
+| **DeepSeek V4-Flash** | **$0.70** | **$8.40** | **$0.02** | **23.6× cheaper** |
+
+> Scale to other profiles by multiplying: **Light ≈ 0.33×**, **Heavy ≈ 2.73×** the
+> monthly figure above. E.g. a Heavy Space on Kimi K2.6 ≈ $13.9/month; on DeepSeek
+> V4-Flash ≈ $1.9/month.
+
+### Takeaways
+
+- **The workload is input-heavy** (≈ 96% of tokens are input — large system prompt +
+  re-sent history + tool results). Output price barely moves the total, so models with
+  **cheap input** (DeepSeek) win disproportionately.
+- **Kimi K2.6** is the natural "same quality, own the stack" choice given Composer's
+  Kimi lineage, at **~3× lower** cost than Composer Fast.
+- **DeepSeek V4-Flash** makes the AI layer **almost free per Space** (~$0.70/mo), a
+  strong default for background features (orchestrator, summaries) where latency and
+  peak reasoning matter least.
+- A **tiered routing** strategy — premium model for interactive copilot, DeepSeek
+  Flash / Composer Standard for background jobs — likely lands a typical Space at
+  **$1–3/month** with no perceptible quality loss on the heuristic-replacing features.
+
+---
+
+## Levers to reduce cost (any model)
+
+1. **Trim the system prompt / cache it.** It's ~5.6k tokens re-sent every step. Prompt
+   caching (60–80% cheaper on cached reads on most open hosts) attacks the single
+   biggest line item.
+2. **Truncate conversation history** instead of re-sending the full transcript per step.
+3. **Route background work to a cheap/standard tier** — orchestrator and summaries
+   don't need interactive latency or frontier reasoning.
+4. **Set a `max_tokens` cap** to bound output (currently uncapped).
+5. **Cap memory deep-dive context** below 48k chars for routine summarization.
+
+---
+
+## Sources
+
+- Composer 2.5 pricing: Cursor (Fast $3/$15, Standard $0.50/$2.50; Composer is
+  post-trained from Kimi K2.5).
+- Open-source rates: OpenRouter, DeepSeek first-party, and public LLM price
+  comparators (June 2026). Open-weight rates vary by host — verify on the live
+  provider dashboard before committing.
+- Token volumes & feature inventory: `packages/chat-server` (system prompt, 6-step
+  tool loop), `packages/core/src/coherence/server/signal-orchestrator.ts`,
+  `packages/core/src/governance/server/call-artifacts.ts`.
+
+> An interactive version of this model (toggle Space profile and scope) is also
+> available as a Cursor canvas: `hypha-ai-cost-per-space.canvas.tsx`.

--- a/docs/hypha-ai-cost/README.md
+++ b/docs/hypha-ai-cost/README.md
@@ -245,10 +245,10 @@ Interactive simulators: [`tokenomics-simulator.html`](tokenomics-simulator.html)
 | Phase | When | Simulator | Key state |
 |---|---|---|---|
 | **Phase 0** | Today | — | ~4,373 Spaces on Hypha. Phase I at month 0. Reference FDV ~$111M at $0.20 (111M locked supply). |
-| **Phase I** | Month 0+ | Phase I (`/tokenomics1`) | Fixed $0.20 price. Token sale, locking, yield. Default: 50 Spaces → ~4,325 by month 12 at 50%/mo growth. |
-| **Phase II** | After Phase I | Phase II (`/tokenomics2`) | ~4,373 paying Spaces at handoff. $44/Space/mo gross. Dynamic IEX price. 48-month Low/Mid/High scenarios. |
+| **Phase I** | Month 0+ | Phase I (`/tokenomics1`) | Fixed $0.20 price. Starts **4,373 Spaces** (Phase 0 network). **0.72%/mo** → **~4,732** at month 12 handoff. |
+| **Phase II** | After Phase I | Phase II (`/tokenomics2`) | Starts **~4,732** paying Spaces. $44/Space/mo. 48-month Low/Mid/High scenarios. |
 
-Phase II month 1 starts from **4,373 active Spaces** — aligned with Phase I end-state and current network size.
+Phase II month 1 = **Phase I handoff** (~4,732 active Spaces at 0.72%/mo continuity). Low scenario uses the same **0.72%/mo** rate throughout Phase I and Phase II.
 
 ### Fixed inputs
 
@@ -270,17 +270,19 @@ Simulator default AI cost uses **open-weight inference (~$4/Space/mo typical)**;
 
 ### Growth scenarios
 
-Each preset targets **cumulative Space-months** at month 48 — the sum of active Spaces recorded each month over the 48-month horizon (not the active count in month 48 alone). Growth applies from month 2 onward (starting from 4,373 active Spaces).
+Each preset targets **cumulative Space-months** at Phase II month 48. Growth applies from month 2 onward, starting from the **Phase I handoff (~4,732 active Spaces)**.
 
 | Scenario | Cumulative Space-months (M48) | Active Spaces (M48) | Monthly growth (M2–M48) | IEX routing % |
 |---|---:|---:|---:|---:|
-| **Low** | ~250k | ~6k | 0.72% | 25% |
-| **Mid** | ~1M | ~58k | 5.63% | 25% |
-| **High** | ~10M | ~1.1M | 12.52% | 19% |
+| **Low** | ~270k | ~6.6k | 0.72% | 25% |
+| **Mid** | ~1M | ~56k | 5.38% | 25% |
+| **High** | ~10M | ~1.1M | 12.29% | 19% |
 
-**ARR** uses **active Spaces in month 48** × $44 × 12. Low ~$3M · Mid ~$30M · High ~$590M.
+**ARR** uses **active Spaces in month 48** × $44 × 12. Low ~$3.5M · Mid ~$29M · High ~$580M.
 
-**4-year total gross billed** ≈ cumulative Space-months × $44: Low ~$11M · Mid ~$44M · High ~$440M.
+**5-year Low journey (Phase I + II at 0.72%/mo):** 4,373 → ~6,676 active; ~325k total Space-months.
+
+**Phase II gross billed** ≈ cumulative × $44: Low ~$12M · Mid ~$44M · High ~$440M.
 
 Only the **IEX routing %** of gross Space contributions enters the on-chain AMM buy path. Investor buy/sell pressure on IEX defaults to **5–8% buy** and **3–5% sell** (pool-relative, not dollar-matched).
 
@@ -288,7 +290,7 @@ Only the **IEX routing %** of gross Space contributions enters the on-chain AMM 
 
 ### Target valuation bands (Month 48, judgment + comps)
 
-Gross ARR at month 48 (active run-rate): Low ~$3M · Mid ~$30M · High ~$590M. FDV targets reflect network-value narrative at cumulative adoption scale, not a strict revenue multiple on month-48 ARR alone (especially Low/Mid where run-rate revenue is still ramping).
+Gross ARR at Phase II month 48: Low ~$3.5M · Mid ~$29M · High ~$580M. FDV targets reflect network-value narrative at cumulative adoption scale, not a strict revenue multiple on month-48 ARR alone (especially Low/Mid where run-rate revenue is still ramping).
 
 | Comp | Rough FDV | Revenue / fees | Implied multiple |
 |---|---:|---:|---:|

--- a/docs/hypha-ai-cost/README.md
+++ b/docs/hypha-ai-cost/README.md
@@ -175,9 +175,14 @@ tokens/month**:
 
 Governance, treasury and membership settle on **Base**. Gas units below are from **verified Base mainnet receipts** in `packages/storage-evm/scripts/base-mainnet-contracts-scripts/gas-cost-analysis-results.json` (Aug 2025), re-priced at **0.005 Gwei** and **ETH $1,748** (June 2026). Unmeasured operations are labeled and excluded from verified totals.
 
-### Execution is bundled into the deciding vote
+### Two vote types — most votes do not execute
 
-In Hypha, a passing proposal **auto-executes on the deciding vote** — there is no separate execution transaction. Measured vote gas **includes agreement execution** (447k for a mint-scale agreement; 2.5M when the vote also deploys a token). Do not add a separate "execution" line on top of vote gas.
+In Hypha, a passing proposal **auto-executes on the deciding vote** — there is no separate execution transaction.
+
+- **Non-executing vote:** a member casts yes/no while the proposal is still open. Records voting power but **does not run the agreement** on-chain.
+- **Deciding vote:** the vote that reaches quorum/unity and **auto-executes** the proposal via the Executor (447k gas verified for a mint-scale agreement — execution bundled in this tx; 2.5M when the vote also deploys a token).
+
+Every proposal has exactly **1 deciding vote** and typically **many more non-executing votes**. Do not add a separate "execution" line on top of deciding-vote gas.
 
 ### Verified measurements
 
@@ -196,21 +201,28 @@ In Hypha, a passing proposal **auto-executes on the deciding vote** — there is
 
 **Verified recurring proposal** (mint-scale agreement): 378,389 create + 446,949 deciding vote = **825,338 gas → $0.0072** per proposal, before non-executing member votes.
 
+### Two vote types — most votes do not execute
+
+- **Non-executing vote:** a member casts yes/no while the proposal is still open. Records voting power but **does not run the agreement** on-chain.
+- **Deciding vote:** the vote that reaches quorum/unity and **auto-executes** the proposal via the Executor (447k gas verified for a mint-scale agreement — execution bundled in this tx).
+
+Every proposal has exactly **1 deciding vote** and typically **many more non-executing votes**. The monthly model reflects this ratio explicitly.
+
 ### Recurring gas by Space size
 
-Assumes **active governance** — more proposals and broader member participation than a quiet space. Each proposal = 1× verified create (378,389) + 1× verified deciding vote (446,949) + treasury transfers (62,135 each). Non-executing member votes are **not measured**; the range adds an unverified sensitivity band of 80k–200k gas per vote.
+Assumes **active governance** with high member participation. Per proposal: 1× verified create + 1× verified deciding vote (includes execution) + **(N−1) non-executing votes** where N = members voting. Non-executing vote gas is **not measured**; the range uses 80k–200k gas each (unverified sensitivity band).
 
-| Profile | Proposals/mo | Votes/mo | Non-exec votes | Treasury/mo | Verified floor | Range (incl. unmeasured votes) |
-|---|--:|--:|--:|--:|--:|--:|
-| Light (~5) | 5 | 30 | 25 | 3 | $0.036 | $0.05–0.08 |
-| **Typical (~15)** | **15** | **180** | **165** | **12** | **$0.11** | **$0.23–0.40** |
-| Heavy (~50) | 50 | 2,000 | 1,950 | 50 | $0.39 | $1.75–3.80 |
+| Profile | Proposals/mo | Deciding votes | Non-exec votes | Ratio | Treasury/mo | Verified floor | Range (incl. non-exec) |
+|---|--:|--:|--:|--:|--:|--:|--:|
+| Light (~5) | 5 | 5 | 20 | 4:1 | 3 | $0.036 | $0.05–0.07 |
+| **Typical (~15)** | **15** | **15** | **195** | **13:1** | **12** | **$0.12** | **$0.25–0.46** |
+| Heavy (~50) | 50 | 50 | 2,200 | 44:1 | 50 | $0.39 | $2.0–4.3 |
 
-**Activity assumptions:** Typical ≈ 1 proposal every 2 days, ~12 member votes per proposal. Light ≈ 1/week with ~6 votes each. Heavy ≈ 1–2/day across a 50-member ecosystem with ~40 votes per proposal. Verified floor counts only measured operations; upper bound assumes non-executing votes at 200k gas each — still unverified.
+**Vote participation:** Typical ≈ 14 of 15 members vote per proposal (1 deciding + 13 non-exec). Light ≈ 5 of 5 (4:1). Heavy ≈ 45 of 50 (44:1). At these ratios, **non-executing votes dominate total gas** in the sensitivity range — there are far more of them, even though each one is cheaper than a deciding vote.
 
 ### Gas vs AI
 
-Even with active governance, a Typical space pays **$0.23–0.40/month** on-chain vs **$16.52/month** for AI (Composer 2.5 Fast) — roughly **40–150× less**. Only at Heavy scale with maximum unverified vote assumptions does gas approach a few dollars/month.
+Even with active governance, a Typical space pays **$0.25–0.46/month** on-chain vs **$16.52/month** for AI (Composer 2.5 Fast) — roughly **36–65× less**. Only at Heavy scale with maximum assumptions does gas approach a few dollars/month.
 
 **Caveats:** L2 execution gas only; Base adds a small L1 data fee per tx. Gas scales linearly with gas price. Re-run `gas-cost-analysis.ts` on Base to capture a non-executing vote and a successful join.
 

--- a/docs/hypha-ai-cost/README.md
+++ b/docs/hypha-ai-cost/README.md
@@ -234,6 +234,54 @@ With active governance, a Typical space pays **$0.37/month** on-chain vs **$16.5
 
 ---
 
+## Tokenomics simulator scenario assumptions (Phase II)
+
+Interactive simulators: [`tokenomics-simulator.html`](tokenomics-simulator.html) (Phase II) and [`tokenomics-simulator-phase1.html`](tokenomics-simulator-phase1.html) (Phase I). Deployed at `/tokenomics2` and `/tokenomics1` on the web app.
+
+### Fixed inputs
+
+| Parameter | Value |
+|---|---|
+| Gross revenue per Space | **$44 USDC / month** (unchanged across scenarios) |
+| Simulation horizon | 48 months |
+| Total HYPHA supply | 555,555,555 |
+| Phase I reference price | **$0.20** (fixed; ~$111M FDV) |
+
+### Growth scenarios
+
+Each preset targets an active Space count at month 48. Growth applies from month 2 onward (starting from 4,373 Spaces).
+
+| Scenario | Target Spaces | Monthly growth (M2–M48) | IEX routing % |
+|---|---:|---:|---:|
+| **Low** | ~250k | 9.0% | 8% |
+| **Mid** | ~1M | 12.26% | 10% |
+| **High** | ~10M | 17.9% | 12% |
+
+Only the **IEX routing %** of gross Space contributions enters the on-chain AMM buy path; the remainder models treasury / ops / off-pool rewards. Investor buy/sell pressure on IEX defaults to **5% each** (pool-relative, not dollar-matched).
+
+### Target valuation bands (Month 48, judgment + comps)
+
+Gross ARR at target scale: Low ~$132M · Mid ~$528M · High ~$5.3B.
+
+| Comp | Rough FDV | Revenue / fees | Implied multiple |
+|---|---:|---:|---:|
+| MakerDAO | ~$1–2B | ~$100–200M/yr | ~10–15× |
+| Uniswap | ~$5–15B | ~$500M–1B/yr | ~10–20× |
+| Helium (peak) | ~$1.2B | low on-chain revenue | growth narrative |
+| Bittensor | ~$3–4B | early / low | high narrative multiple |
+
+**Target FDV / FDV-to-ARR** after calibration (sim-verified):
+
+| Scenario | Target FDV | FDV/ARR | Token price (indicative) |
+|---|---:|---:|---:|
+| Low | $1.0–1.5B | ~8–11× | ~$2–3 |
+| Mid | $4–8B | ~8–15× | ~$7–14 |
+| High | $25–45B | ~5–9× | ~$45–$80 |
+
+IEX seed liquidity scales with scenario (`initialHypha` / `initialUsdc` anchor starting price at $0.20–$0.25). Parameters were tuned so emergent IEX price × max supply lands in these bands — not by fixing an end-state price directly.
+
+---
+
 ## Sources
 
 - Composer 2.5 pricing: Cursor (Fast $3/$15, Standard $0.50/$2.50; Composer is

--- a/docs/hypha-ai-cost/README.md
+++ b/docs/hypha-ai-cost/README.md
@@ -246,7 +246,7 @@ Interactive simulators: [`tokenomics-simulator.html`](tokenomics-simulator.html)
 |---|---|---|---|
 | **Phase 0** | Today | — | Pre-launch. Reference FDV ~$111M at $0.20 (111M locked supply). |
 | **Phase I** | Year 1 (months 0–12) | Phase I (`/tokenomics1`) | Fixed $0.20. **Bootstrap ~0 → ~4,373** paying Spaces (50-Space seed at 50%/mo). |
-| **Phase II** | Years 2–5 (48 months) | Phase II (`/tokenomics2`) | Starts **~4,373** paying Spaces. $44/Space/mo. Year-5 paying / created: Low ~15k/250k · Mid ~50k/1M · High ~500k/10M. |
+| **Phase II** | Years 2–5 (48 months) | Phase II (`/tokenomics2`) | Starts **~4,373** paying Spaces. $44/Space/mo. Year-5 paying Spaces: Low ~250k · Mid ~1M · High ~10M. |
 
 Phase II month 1 = first month after Phase I (~4,373 active Spaces). Year 5 = Phase II month 48.
 
@@ -263,35 +263,32 @@ Phase II month 1 = first month after Phase I (~4,373 active Spaces). Year 5 = Ph
 
 | Share | Destination |
 |---:|---|
-| **19–25%** (by scenario) | IEX buy pressure |
-| **75–81%** | AI inference, gas, operations, off-pool rewards, treasury |
+| **18–22%** (by scenario) | IEX buy pressure |
+| **78–82%** | AI inference, gas, operations, off-pool rewards, treasury |
 
 Simulator default AI cost uses **open-weight inference (~$4/Space/mo typical)**; Composer Fast reference is **~$16.50/Space/mo** — see [TL;DR](#tldr) above.
 
 ### Growth scenarios
 
-Each preset tracks **two series**, both starting from the ~4,373 Phase I handoff and growing from month 2 onward:
+**Every Space pays $44/mo — no free tier.** Each preset is a single Space-count series starting from the ~4,373 Phase I handoff and growing from month 2 onward to the year-5 (month 48) target. The whole count drives revenue.
 
-- **Active (paying) Spaces** — pay $44/mo and drive all revenue (growth rate `active`).
-- **Cumulative Spaces created** — the full funnel (free + paid; growth rate `created`). Active payers are the **~5–6%** of created Spaces that pay at year 5.
+| Scenario | Year-5 paying Spaces | Space growth / mo | IEX routing % |
+|---|---:|---:|---:|
+| **Low** | ~250k | 8.99% | 22% |
+| **Mid** | ~1M | 12.25% | 20% |
+| **High** | ~10M | 17.89% | 18% |
 
-| Scenario | Year-5 active (paying) | Year-5 created (cumulative) | Paying rate | Active growth / mo | Created growth / mo | IEX routing % |
-|---|---:|---:|---:|---:|---:|---:|
-| **Low** | ~15k | ~250k | ~6% | 2.66% | 8.99% | 25% |
-| **Mid** | ~50k | ~1M | ~5% | 5.32% | 12.25% | 22% |
-| **High** | ~500k | ~10M | ~5% | 10.61% | 17.89% | 19% |
+**ARR** uses **paying Spaces at year 5** × $44 × 12: Low ~$132M · Mid ~$528M · High ~$5.28B.
 
-**ARR** uses **active (paying) Spaces at year 5** × $44 × 12: Low ~$7.9M · Mid ~$26M · High ~$264M.
+**Phase II gross billed** (sum of Spaces × $44 across 48 months): Low ~$0.13B · Mid ~$0.40B · High ~$2.9B.
 
-**Phase II gross billed** (sum of active Spaces × $44 across 48 months): Low ~$18M · Mid ~$40M · High ~$228M.
+Only the **IEX routing %** of gross Space contributions enters the on-chain AMM buy path. Investor buy/sell pressure on IEX defaults to **5–7% buy** and **5–7% sell** (pool-relative, not dollar-matched).
 
-Only the **IEX routing %** of gross Space contributions enters the on-chain AMM buy path. Investor buy/sell pressure on IEX defaults to **4–8% buy** and **4–5% sell** (pool-relative, not dollar-matched).
-
-**Key metrics to show investors:** **active payers at year 5** · cumulative created · run-rate ARR · FDV · **FDV/ARR**.
+**Key metrics to show investors:** **paying Spaces at year 5** · run-rate ARR · FDV · **FDV/ARR**.
 
 ### Target valuation bands (year 5, judgment + comps)
 
-Run-rate ARR at year 5: Low ~$7.9M · Mid ~$26M · High ~$264M. FDV multiples descend as the network matures — High lands near ~30× ARR (growth-stage comps); Low/Mid carry higher multiples as early-network optionality while revenue ramps.
+Run-rate ARR at year 5: Low ~$132M · Mid ~$528M · High ~$5.28B. FDV multiples descend as the network matures — Low ~30× (growth-stage comps), compressing toward ~13× at High mega-scale.
 
 | Comp | Rough FDV | Revenue / fees | Implied multiple |
 |---|---:|---:|---:|
@@ -304,11 +301,11 @@ Run-rate ARR at year 5: Low ~$7.9M · Mid ~$26M · High ~$264M. FDV multiples de
 
 | Scenario | Target FDV | FDV/ARR | Token price (indicative) |
 |---|---:|---:|---:|
-| Low | ~$0.4B | ~51× (early ramp) | ~$0.72 |
-| Mid | ~$1.0B | ~38× | ~$1.82 |
-| High | ~$8.1B | ~31× | ~$14.50 |
+| Low | ~$3.9B | ~30× | ~$7.07 |
+| Mid | ~$12.8B | ~24× | ~$23.04 |
+| High | ~$66B | ~13× | ~$119 |
 
-IEX seed liquidity scales with scenario (`initialHypha` / `initialUsdc` anchor starting price at $0.20): Low 25M HYPHA / $5M USDC, Mid 35M / $7M, High 63M / $12.6M. Parameters were tuned so emergent IEX price × max supply lands in these bands — not by fixing an end-state price directly.
+IEX seed liquidity scales with scenario (`initialHypha` / `initialUsdc` anchor starting price at $0.20): Low 29M HYPHA / $5.8M USDC, Mid 41M / $8.2M, High 111M / $22.2M. Parameters were tuned so emergent IEX price × max supply lands in these bands — not by fixing an end-state price directly.
 
 ---
 

--- a/docs/hypha-ai-cost/README.md
+++ b/docs/hypha-ai-cost/README.md
@@ -244,11 +244,11 @@ Interactive simulators: [`tokenomics-simulator.html`](tokenomics-simulator.html)
 
 | Phase | When | Simulator | Key state |
 |---|---|---|---|
-| **Phase 0** | Today | — | ~4,373 Spaces on Hypha. Phase I at month 0. Reference FDV ~$111M at $0.20 (111M locked supply). |
-| **Phase I** | Month 0+ | Phase I (`/tokenomics1`) | Fixed $0.20 price. Starts **4,373 Spaces** (Phase 0 network). **0.72%/mo** → **~4,732** at month 12 handoff. |
-| **Phase II** | After Phase I | Phase II (`/tokenomics2`) | Starts **~4,732** paying Spaces. $44/Space/mo. 48-month Low/Mid/High scenarios. |
+| **Phase 0** | Today | — | Pre-launch. Reference FDV ~$111M at $0.20 (111M locked supply). |
+| **Phase I** | Year 1 (months 0–12) | Phase I (`/tokenomics1`) | Fixed $0.20. **Bootstrap ~0 → ~4,373** paying Spaces (50-Space seed at 50%/mo). |
+| **Phase II** | Years 2–5 (48 months) | Phase II (`/tokenomics2`) | Starts **~4,373** paying Spaces. $44/Space/mo. Year-5 active: Low ~25k · Mid ~250k · High ~2M. |
 
-Phase II month 1 = **Phase I handoff** (~4,732 active Spaces at 0.72%/mo continuity). Low scenario uses the same **0.72%/mo** rate throughout Phase I and Phase II.
+Phase II month 1 = first month after Phase I (~4,373 active Spaces). Year 5 = Phase II month 48.
 
 ### Fixed inputs
 
@@ -270,27 +270,25 @@ Simulator default AI cost uses **open-weight inference (~$4/Space/mo typical)**;
 
 ### Growth scenarios
 
-Each preset targets **cumulative Space-months** at Phase II month 48. Growth applies from month 2 onward, starting from the **Phase I handoff (~4,732 active Spaces)**.
+Each preset targets **active (paying) Spaces at year 5 (Phase II month 48)**, starting from the ~4,373 Phase I handoff. Growth applies from month 2 onward.
 
-| Scenario | Cumulative Space-months (M48) | Active Spaces (M48) | Monthly growth (M2–M48) | IEX routing % |
+| Scenario | Year-5 active Spaces | Cumulative Space-months | Monthly growth (M2–M48) | IEX routing % |
 |---|---:|---:|---:|---:|
-| **Low** | ~270k | ~6.6k | 0.72% | 25% |
-| **Mid** | ~1M | ~56k | 5.38% | 25% |
-| **High** | ~10M | ~1.1M | 12.29% | 19% |
+| **Low** | ~25k | ~570k | 3.78% | 25% |
+| **Mid** | ~250k | ~3M | 8.99% | 19% |
+| **High** | ~2M | ~16M | 13.92% | 19% |
 
-**ARR** uses **active Spaces in month 48** × $44 × 12. Low ~$3.5M · Mid ~$29M · High ~$580M.
+**ARR** uses **active Spaces at year 5** × $44 × 12. Low ~$13M · Mid ~$132M · High ~$1.06B.
 
-**5-year Low journey (Phase I + II at 0.72%/mo):** 4,373 → ~6,676 active; ~325k total Space-months.
-
-**Phase II gross billed** ≈ cumulative × $44: Low ~$12M · Mid ~$44M · High ~$440M.
+**Phase II gross billed** ≈ cumulative × $44: Low ~$25M · Mid ~$131M · High ~$719M.
 
 Only the **IEX routing %** of gross Space contributions enters the on-chain AMM buy path. Investor buy/sell pressure on IEX defaults to **5–8% buy** and **3–5% sell** (pool-relative, not dollar-matched).
 
-**Key metrics to show investors:** cumulative Space-months · **active payers (M48)** · run-rate ARR · FDV · **FDV/ARR** (Low/Mid are ramp narratives, not revenue multiples alone).
+**Key metrics to show investors:** **active payers at year 5** · run-rate ARR · FDV · **FDV/ARR** · cumulative Space-months.
 
-### Target valuation bands (Month 48, judgment + comps)
+### Target valuation bands (year 5, judgment + comps)
 
-Gross ARR at Phase II month 48: Low ~$3.5M · Mid ~$29M · High ~$580M. FDV targets reflect network-value narrative at cumulative adoption scale, not a strict revenue multiple on month-48 ARR alone (especially Low/Mid where run-rate revenue is still ramping).
+Run-rate ARR at year 5: Low ~$13M · Mid ~$132M · High ~$1.06B. Mid/High FDV lands near ~30× ARR (growth-stage comps); Low is higher (~115×) as an early-network optionality case while revenue ramps.
 
 | Comp | Rough FDV | Revenue / fees | Implied multiple |
 |---|---:|---:|---:|
@@ -299,15 +297,15 @@ Gross ARR at Phase II month 48: Low ~$3.5M · Mid ~$29M · High ~$580M. FDV targ
 | Helium (peak) | ~$1.2B | low on-chain revenue | growth narrative |
 | Bittensor | ~$3–4B | early / low | high narrative multiple |
 
-**Target FDV / FDV-to-ARR** after calibration (sim-verified; cumulative scenario framing):
+**Target FDV / FDV-to-ARR** after calibration (sim-verified):
 
 | Scenario | Target FDV | FDV/ARR | Token price (indicative) |
 |---|---:|---:|---:|
-| Low | ~$1.5B | narrative / early ramp | ~$2.75 |
-| Mid | ~$4B | narrative / ramp | ~$7 |
-| High | ~$31B | ~50× (scale + comps) | ~$57 |
+| Low | ~$1.5B | ~115× (early ramp) | ~$2.65 |
+| Mid | ~$4B | ~30× | ~$7.30 |
+| High | ~$31B | ~29× | ~$56 |
 
-IEX seed liquidity scales with scenario (`initialHypha` / `initialUsdc` anchor starting price at $0.20). Low uses a thinner seed pool (5M HYPHA / $1M USDC) so modest monthly buy flow still supports a credible early-network FDV. Parameters were tuned so emergent IEX price × max supply lands in these bands — not by fixing an end-state price directly.
+IEX seed liquidity scales with scenario (`initialHypha` / `initialUsdc` anchor starting price at $0.20): Low 40M HYPHA / $8M USDC, Mid 80M / $16M, High 150M / $30M. Parameters were tuned so emergent IEX price × max supply lands in these bands — not by fixing an end-state price directly.
 
 ---
 

--- a/docs/hypha-ai-cost/README.md
+++ b/docs/hypha-ai-cost/README.md
@@ -171,6 +171,51 @@ tokens/month**:
 
 ---
 
+## On-chain (gas) cost per Space — Base
+
+Governance, treasury and membership settle on **Base**. Gas units below are from **verified Base mainnet receipts** in `packages/storage-evm/scripts/base-mainnet-contracts-scripts/gas-cost-analysis-results.json` (Aug 2025), re-priced at **0.005 Gwei** and **ETH $1,748** (June 2026). Unmeasured operations are labeled and excluded from verified totals.
+
+### Execution is bundled into the deciding vote
+
+In Hypha, a passing proposal **auto-executes on the deciding vote** — there is no separate execution transaction. Measured vote gas **includes agreement execution** (447k for a mint-scale agreement; 2.5M when the vote also deploys a token). Do not add a separate "execution" line on top of vote gas.
+
+### Verified measurements
+
+| Operation | When | Status | Gas units | Cost (USD) | Tx / note |
+|---|---|---|--:|--:|---|
+| Vote + auto-execute (token deploy) | Setup | Verified | 2,549,025 | $0.0223 | `0x1f7ed7f4…` |
+| Space creation | Setup | Verified | 960,285 | $0.0084 | `0xb6b98a19…` |
+| Proposal creation (token deploy) | Setup | Verified | 527,418 | $0.0046 | `0x64e3d917…` |
+| Vote + auto-execute (token mint) | Recurring | Verified | 446,949 | $0.0039 | `0x3f0d5487…` · deciding vote incl. execution |
+| Proposal creation (token mint) | Recurring | Verified | 378,389 | $0.0033 | `0xab9a53ae…` · typical agreement proposal |
+| USDC transfer (ERC-20) | Recurring | Verified | 62,135 | $0.0005 | `0x80e51f14…` |
+| Member join | Recurring | **Estimated** | 100,000 | $0.0009 | tx failed in analysis run |
+| Non-executing vote | Recurring | **Not measured** | — | — | no successful mainnet receipt in repo |
+
+**Verified one-time setup** (create + deploy-token proposal + deciding deploy vote): **4,036,728 gas → $0.035**.
+
+**Verified recurring proposal** (mint-scale agreement): 378,389 create + 446,949 deciding vote = **825,338 gas → $0.0072** per proposal, before non-executing member votes.
+
+### Recurring gas by Space size
+
+Each proposal = 1× verified create (378,389) + 1× verified deciding vote (446,949) + treasury transfers (62,135 each). Non-executing member votes are **not measured**; the range adds an unverified sensitivity band of 80k–200k gas per vote.
+
+| Profile | Proposals/mo | Votes/mo | Non-exec votes | Treasury/mo | Verified floor | Range (incl. unmeasured votes) |
+|---|--:|--:|--:|--:|--:|--:|
+| Light (~5) | 2 | 6 | 4 | 1 | $0.015 | $0.015–0.022 |
+| **Typical (~15)** | **6** | **54** | **48** | **5** | **$0.046** | **$0.05–0.13** |
+| Heavy (~50) | 20 | 600 | 580 | 20 | $0.15 | $0.56–1.17 |
+
+The verified floor counts only measured operations. The upper bound assumes non-executing votes at 200k gas each — still unverified for Hypha. A Heavy space running a token-deploy proposal in a given month adds ~$0.023 (verified) on top.
+
+### Gas vs AI
+
+Even at the upper bound, a Typical space pays **$0.05–0.13/month** on-chain vs **$16.52/month** for AI (Composer 2.5 Fast) — roughly **130–360× less**. The verified floor alone ($0.046/mo) is **~360× smaller** than AI.
+
+**Caveats:** L2 execution gas only; Base adds a small L1 data fee per tx. Gas scales linearly with gas price. Re-run `gas-cost-analysis.ts` on Base to capture a non-executing vote and a successful join.
+
+---
+
 ## Levers to reduce cost (any model)
 
 1. **Trim the system prompt / cache it.** It's ~5.6k tokens re-sent every step. Prompt
@@ -194,6 +239,8 @@ tokens/month**:
 - Token volumes & feature inventory: `packages/chat-server` (system prompt, 6-step
   tool loop), `packages/core/src/coherence/server/signal-orchestrator.ts`,
   `packages/core/src/governance/server/call-artifacts.ts`.
+- Gas measurements: `packages/storage-evm/scripts/base-mainnet-contracts-scripts/gas-cost-analysis-results.json`
+  (Base mainnet, Aug 2025).
 
 > An interactive version of this model (toggle Space profile and scope) is also
 > available as a Cursor canvas: `hypha-ai-cost-per-space.canvas.tsx`.

--- a/docs/hypha-ai-cost/hypha-ai-cost-per-space.html
+++ b/docs/hypha-ai-cost/hypha-ai-cost-per-space.html
@@ -148,6 +148,10 @@
 
   <h2>Open-source model pricing</h2>
   <p>The same workload on the most capable open-weight models of 2026. Highly relevant here: <strong>Composer 2.5 is itself post-trained from Moonshot's Kimi K2.5</strong>, so running the open Kimi line directly is the closest like-for-like swap — at a fraction of Composer Fast's interactive premium.</p>
+  <div class="callout">
+    <div class="t">Hosting is already included</div>
+    <p>All rates here are managed / hosted inference (per-token) — the provider runs the model on their GPUs and bills per token (Cursor for Composer; OpenRouter / DeepSeek / DeepInfra for the open models). There is no separate GPU/infra cost to add. Self-hosting the open weights is a different fixed-cost model (e.g. one H100 ≈ $1,400+/month) that is more expensive at per-Space volumes and only pays off when many Spaces share GPUs — so it is out of scope for a per-Space estimate.</p>
+  </div>
 
   <h3>Representative rates (per 1M tokens)</h3>
   <div class="frame">

--- a/docs/hypha-ai-cost/hypha-ai-cost-per-space.html
+++ b/docs/hypha-ai-cost/hypha-ai-cost-per-space.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Hypha AI — Estimated AI Cost per Space</title>
+<title>Hypha — AI &amp; On-chain Cost per Space</title>
 <style>
   :root {
     --bg: #0f1115;
@@ -196,6 +196,63 @@
   </ul>
 
   <hr />
+
+  <h2>On-chain (gas) cost per Space — Base</h2>
+  <p>Governance, treasury and membership actions settle on the <strong>Base</strong> L2. These figures take the <strong>real gas amounts measured on Base mainnet</strong> (from the repo's <code>gas-cost-analysis</code> script) and re-price them at the current network conditions below. At these prices, on-chain activity is effectively free.</p>
+  <div class="pill-row">
+    <span class="tag">Gas price: 0.005 Gwei</span>
+    <span class="tag">ETH: $1,748</span>
+    <span class="tag">Cost per gas unit: ~$0.0000000087</span>
+    <span class="tag">Source: Base mainnet receipts</span>
+  </div>
+
+  <div class="stats" style="margin-top:18px">
+    <div class="stat"><div class="v accent">$0.12</div><div class="l">Gas / month · Typical space</div></div>
+    <div class="stat"><div class="v">$1.45</div><div class="l">Gas / year · Typical space</div></div>
+    <div class="stat"><div class="v warn">$0.035</div><div class="l">One-time setup (create + token)</div></div>
+    <div class="stat"><div class="v">~140×</div><div class="l">AI cost vs gas (Composer Fast)</div></div>
+  </div>
+
+  <h3>Cost per on-chain operation (at 0.005 Gwei)</h3>
+  <p>Gas units are actual on-chain measurements. In Hypha, a passing proposal auto-executes on the deciding vote, so execution gas can be bundled into that vote.</p>
+  <div class="frame">
+    <table>
+      <thead><tr><th>Operation</th><th>When</th><th class="n">Gas units</th><th class="n">Cost (USD)</th></tr></thead>
+      <tbody>
+        <tr><td>Token deploy — vote + auto-execute</td><td>Setup (one-time)</td><td class="n">2,549,025</td><td class="n">$0.0223</td></tr>
+        <tr><td>Space creation</td><td>Setup (one-time)</td><td class="n">960,285</td><td class="n">$0.0084</td></tr>
+        <tr><td>Token deployment proposal</td><td>Setup (one-time)</td><td class="n">527,418</td><td class="n">$0.0046</td></tr>
+        <tr><td>Proposal creation</td><td>Recurring</td><td class="n">~400,000</td><td class="n">$0.0035</td></tr>
+        <tr><td>Proposal execution (agreement)</td><td>Recurring</td><td class="n">~450,000</td><td class="n">$0.0039</td></tr>
+        <tr><td>Vote cast</td><td>Recurring</td><td class="n">~150,000</td><td class="n">$0.0013</td></tr>
+        <tr><td>Member join</td><td>Recurring</td><td class="n">~100,000</td><td class="n">$0.0009</td></tr>
+        <tr><td>Treasury transfer (ERC-20 / USDC)</td><td>Recurring</td><td class="n">62,135</td><td class="n">$0.0005</td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <h3>Recurring gas cost by Space size</h3>
+  <p>Monthly on-chain activity assumed per profile (proposals × votes dominate). Setup is one-time and excluded from the monthly figure.</p>
+  <div class="frame">
+    <table>
+      <thead><tr>
+        <th>Profile</th><th class="n">Proposals/mo</th><th class="n">Votes/mo</th>
+        <th class="n">Treasury txns/mo</th><th class="n">Gas/mo</th><th class="n">Monthly</th><th class="n">Annual</th>
+      </tr></thead>
+      <tbody>
+        <tr><td>Light (~5 members)</td><td class="n">2</td><td class="n">6</td><td class="n">1</td><td class="n">2.8M</td><td class="n"><div class="bar-cell"><span class="bar alt" style="width:4px"></span><span class="barlabel">$0.024</span></div></td><td class="n">$0.29</td></tr>
+        <tr><td><strong>Typical (~15 members)</strong></td><td class="n">6</td><td class="n">54</td><td class="n">5</td><td class="n">13.8M</td><td class="n"><div class="bar-cell"><span class="bar alt" style="width:20px"></span><span class="barlabel"><strong>$0.12</strong></span></div></td><td class="n">$1.45</td></tr>
+        <tr><td>Heavy (~50 members)</td><td class="n">20</td><td class="n">600</td><td class="n">20</td><td class="n">109M</td><td class="n"><div class="bar-cell"><span class="bar alt" style="width:160px"></span><span class="barlabel">$0.96</span></div></td><td class="n">$11.46</td></tr>
+      </tbody>
+    </table>
+  </div>
+  <p class="sub">For the Typical space, member votes are ~59% of monthly gas (54 votes × ~150k), proposal execution ~20%, proposal creation ~17%.</p>
+
+  <div class="callout">
+    <div class="t">Gas is negligible vs AI at these prices</div>
+    <p>A Typical space's on-chain cost is <strong>~$0.12/month</strong> — roughly <strong>140× smaller</strong> than the Composer 2.5 Fast AI estimate ($16.52), and still a fraction of even the cheapest open-source AI option (~$0.70). The AI layer, not the blockchain, is the cost driver.</p>
+  </div>
+  <p class="sub"><strong>Caveats.</strong> Figures are L2 execution gas at the stated 0.005 Gwei; Base also adds a small L1 data fee per transaction (typically sub-cent under current blob-fee conditions) not captured by a single L2 gas price. Gas scales linearly with gas price — a 10× spike to 0.05 Gwei makes a Typical space ~$1.20/month, still negligible. Who pays (member wallets vs. a platform paymaster) is a separate question; this is the aggregate on-chain cost of a Space's activity regardless of payer.</p>
 
   <div class="grid2">
     <div>

--- a/docs/hypha-ai-cost/hypha-ai-cost-per-space.html
+++ b/docs/hypha-ai-cost/hypha-ai-cost-per-space.html
@@ -212,14 +212,14 @@
     <div class="t">Two vote types — most votes do not execute</div>
     <p><strong>Non-executing vote:</strong> a member casts yes/no while the proposal is still open. It records voting power but <strong>does not run the agreement</strong> on-chain.<br />
     <strong>Deciding vote:</strong> the vote that reaches quorum/unity and <strong>auto-executes</strong> the proposal via the Executor (447k gas verified for a mint-scale agreement — execution bundled in this tx).<br />
-    Every proposal has exactly <strong>1 deciding vote</strong> and typically <strong>many more non-executing votes</strong> before it. The monthly model reflects this: e.g. Typical = 15 deciding vs 165 non-executing (<strong>11:1</strong>).</p>
+    Every proposal has exactly <strong>1 deciding vote</strong> and typically <strong>many more non-executing votes</strong> before it. The monthly model reflects this: e.g. Typical = 15 deciding vs 195 non-executing (<strong>13:1</strong>). Non-executing votes are modeled at <strong>150k gas each</strong> ($0.0013/vote at 0.005 Gwei) — not yet verified on mainnet.</p>
   </div>
 
   <div class="stats" style="margin-top:18px">
-    <div class="stat"><div class="v accent">$0.25–0.46</div><div class="l">Gas / month · Typical space (range)</div></div>
-    <div class="stat"><div class="v">$0.12</div><div class="l">Verified floor · Typical space</div></div>
+    <div class="stat"><div class="v accent">$0.37</div><div class="l">Gas / month · Typical space</div></div>
+    <div class="stat"><div class="v">$0.12</div><div class="l">Verified-only portion · Typical</div></div>
     <div class="stat"><div class="v warn">$0.035</div><div class="l">One-time setup (verified)</div></div>
-    <div class="stat"><div class="v">36–65×</div><div class="l">AI cost vs gas (Composer Fast)</div></div>
+    <div class="stat"><div class="v">~45×</div><div class="l">AI cost vs gas (Composer Fast)</div></div>
   </div>
 
   <h3>Verified on-chain measurements (0.005 Gwei · ETH $1,748)</h3>
@@ -234,32 +234,32 @@
         <tr><td>Proposal creation (token mint)</td><td>Recurring</td><td><span class="tag verified">verified</span></td><td class="n">378,389</td><td class="n">$0.0033</td><td><code>0xab9a53ae…</code> · typical agreement proposal</td></tr>
         <tr><td>USDC transfer (ERC-20)</td><td>Recurring</td><td><span class="tag verified">verified</span></td><td class="n">62,135</td><td class="n">$0.0005</td><td><code>0x80e51f14…</code></td></tr>
         <tr><td>Member join</td><td>Recurring</td><td><span class="tag est">estimated</span></td><td class="n">100,000</td><td class="n">$0.0009</td><td>tx failed in analysis run; not verified</td></tr>
-        <tr><td>Non-executing vote</td><td>Recurring</td><td><span class="tag est">not measured</span></td><td class="n">—</td><td class="n">—</td><td>no successful mainnet receipt in repo</td></tr>
+        <tr><td>Non-executing vote</td><td>Recurring</td><td><span class="tag est">assumed 150k</span></td><td class="n">150,000</td><td class="n">$0.0013</td><td>not yet verified on mainnet</td></tr>
       </tbody>
     </table>
   </div>
   <p class="sub"><strong>Verified one-time setup</strong> (create space + deploy-token proposal + deciding vote that deploys token): 4,036,728 gas → <strong>$0.035</strong>. <strong>Verified recurring proposal</strong> (mint-scale agreement): 378,389 create + 446,949 deciding vote = 825,338 gas → <strong>$0.0072</strong> per proposal, before any non-executing member votes.</p>
 
   <h3>Recurring gas by Space size</h3>
-  <p>Assumes <strong>active governance</strong> with high member participation. Per proposal: 1× verified create + 1× verified deciding vote (includes execution) + <strong>(N−1) non-executing votes</strong> where N = members voting. Non-executing vote gas is <strong>not measured</strong>; the range uses 80k–200k gas each (unverified sensitivity band).</p>
+  <p>Assumes <strong>active governance</strong> with high member participation. Per proposal: 1× verified create + 1× verified deciding vote (includes execution) + <strong>(N−1) non-executing votes at 150k gas each</strong> ($0.0013/vote).</p>
   <div class="frame">
     <table>
       <thead><tr>
         <th>Profile</th><th class="n">Proposals/mo</th><th class="n">Deciding votes</th><th class="n">Non-exec votes</th><th class="n">Ratio</th>
-        <th class="n">Treasury/mo</th><th class="n">Verified floor</th><th class="n">Range (incl. non-exec)</th>
+        <th class="n">Treasury/mo</th><th class="n">Verified portion</th><th class="n">Monthly total</th>
       </tr></thead>
       <tbody>
-        <tr><td>Light (~5 members)</td><td class="n">5</td><td class="n">5</td><td class="n">20</td><td class="n">4:1</td><td class="n">3</td><td class="n">$0.036</td><td class="n">$0.05–0.07</td></tr>
-        <tr><td><strong>Typical (~15 members)</strong></td><td class="n">15</td><td class="n">15</td><td class="n">195</td><td class="n">13:1</td><td class="n">12</td><td class="n">$0.12</td><td class="n"><strong>$0.25–0.46</strong></td></tr>
-        <tr><td>Heavy (~50 members)</td><td class="n">50</td><td class="n">50</td><td class="n">2,200</td><td class="n">44:1</td><td class="n">50</td><td class="n">$0.39</td><td class="n">$2.0–4.3</td></tr>
+        <tr><td>Light (~5 members)</td><td class="n">5</td><td class="n">5</td><td class="n">20</td><td class="n">4:1</td><td class="n">3</td><td class="n">$0.038</td><td class="n">$0.06</td></tr>
+        <tr><td><strong>Typical (~15 members)</strong></td><td class="n">15</td><td class="n">15</td><td class="n">195</td><td class="n">13:1</td><td class="n">12</td><td class="n">$0.12</td><td class="n"><strong>$0.37</strong></td></tr>
+        <tr><td>Heavy (~50 members)</td><td class="n">50</td><td class="n">50</td><td class="n">2,200</td><td class="n">44:1</td><td class="n">50</td><td class="n">$0.39</td><td class="n">$3.27</td></tr>
       </tbody>
     </table>
   </div>
-  <p class="sub">Vote participation: Typical ≈ 14 of 15 members vote per proposal (1 deciding + 13 non-exec). Light ≈ 5 of 5 members (4:1). Heavy ≈ 45 of 50 members (44:1). At these ratios, <strong>non-executing votes dominate total gas</strong> in the sensitivity range — even though each one is cheaper than a deciding vote, there are far more of them.</p>
+  <p class="sub">Vote participation: Typical ≈ 14 of 15 members vote per proposal (1 deciding + 13 non-exec). Monthly total = verified portion + (non-exec votes × 150k gas). Non-executing votes contribute ~69% of Typical monthly gas ($0.26 of $0.37).</p>
 
   <div class="callout">
     <div class="t">Gas remains negligible vs AI</div>
-    <p>Even with active governance, a Typical space pays <strong>$0.25–0.46/month</strong> on-chain vs <strong>$16.52/month</strong> for AI (Composer 2.5 Fast) — roughly <strong>36–65× less</strong>. Non-executing votes (13× more numerous than deciding votes) drive most of the gas range. Only at Heavy scale with maximum assumptions does gas approach a few dollars/month.</p>
+    <p>With active governance, a Typical space pays <strong>$0.37/month</strong> on-chain vs <strong>$16.52/month</strong> for AI (Composer 2.5 Fast) — roughly <strong>45× less</strong>. Non-executing votes at 150k gas each are the largest line item. Only Heavy scale (~$3.27/mo) approaches meaningful on-chain spend — still well below AI.</p>
   </div>
   <p class="sub"><strong>Caveats.</strong> L2 execution gas only at 0.005 Gwei; Base adds a small L1 data fee per tx (typically sub-cent). Gas scales linearly with gas price. Who pays (member wallets vs. paymaster) is separate from the aggregate cost shown here. Re-run <code>gas-cost-analysis.ts</code> on Base to capture a non-executing vote and a successful join.</p>
 

--- a/docs/hypha-ai-cost/hypha-ai-cost-per-space.html
+++ b/docs/hypha-ai-cost/hypha-ai-cost-per-space.html
@@ -214,10 +214,10 @@
   </div>
 
   <div class="stats" style="margin-top:18px">
-    <div class="stat"><div class="v accent">$0.05–0.13</div><div class="l">Gas / month · Typical space (range)</div></div>
-    <div class="stat"><div class="v">$0.046</div><div class="l">Verified floor · Typical space</div></div>
+    <div class="stat"><div class="v accent">$0.23–0.40</div><div class="l">Gas / month · Typical space (range)</div></div>
+    <div class="stat"><div class="v">$0.11</div><div class="l">Verified floor · Typical space</div></div>
     <div class="stat"><div class="v warn">$0.035</div><div class="l">One-time setup (verified)</div></div>
-    <div class="stat"><div class="v">130–360×</div><div class="l">AI cost vs gas (Composer Fast)</div></div>
+    <div class="stat"><div class="v">40–150×</div><div class="l">AI cost vs gas (Composer Fast)</div></div>
   </div>
 
   <h3>Verified on-chain measurements (0.005 Gwei · ETH $1,748)</h3>
@@ -239,7 +239,7 @@
   <p class="sub"><strong>Verified one-time setup</strong> (create space + deploy-token proposal + deciding vote that deploys token): 4,036,728 gas → <strong>$0.035</strong>. <strong>Verified recurring proposal</strong> (mint-scale agreement): 378,389 create + 446,949 deciding vote = 825,338 gas → <strong>$0.0072</strong> per proposal, before any non-executing member votes.</p>
 
   <h3>Recurring gas by Space size</h3>
-  <p>Monthly model: each proposal = 1× verified create (378,389) + 1× verified deciding vote (446,949) + treasury transfers (62,135 each). Non-executing member votes are <strong>not measured</strong>; the range adds a sensitivity band of 80k–200k gas per vote (industry-typical DAO range, unverified for Hypha).</p>
+  <p>Assumes <strong>active governance</strong>: more proposals and broader member participation than a quiet space. Each proposal = 1× verified create (378,389) + 1× verified deciding vote (446,949) + treasury transfers (62,135 each). Non-executing member votes are <strong>not measured</strong>; the range adds a sensitivity band of 80k–200k gas per vote (industry-typical DAO range, unverified for Hypha).</p>
   <div class="frame">
     <table>
       <thead><tr>
@@ -247,17 +247,17 @@
         <th class="n">Treasury/mo</th><th class="n">Verified floor</th><th class="n">Range (incl. unmeasured votes)</th>
       </tr></thead>
       <tbody>
-        <tr><td>Light (~5 members)</td><td class="n">2</td><td class="n">6</td><td class="n">4</td><td class="n">1</td><td class="n">$0.015</td><td class="n">$0.015–0.022</td></tr>
-        <tr><td><strong>Typical (~15 members)</strong></td><td class="n">6</td><td class="n">54</td><td class="n">48</td><td class="n">5</td><td class="n">$0.046</td><td class="n"><strong>$0.05–0.13</strong></td></tr>
-        <tr><td>Heavy (~50 members)</td><td class="n">20</td><td class="n">600</td><td class="n">580</td><td class="n">20</td><td class="n">$0.15</td><td class="n">$0.56–1.17</td></tr>
+        <tr><td>Light (~5 members)</td><td class="n">5</td><td class="n">30</td><td class="n">25</td><td class="n">3</td><td class="n">$0.036</td><td class="n">$0.05–0.08</td></tr>
+        <tr><td><strong>Typical (~15 members)</strong></td><td class="n">15</td><td class="n">180</td><td class="n">165</td><td class="n">12</td><td class="n">$0.11</td><td class="n"><strong>$0.23–0.40</strong></td></tr>
+        <tr><td>Heavy (~50 members)</td><td class="n">50</td><td class="n">2,000</td><td class="n">1,950</td><td class="n">50</td><td class="n">$0.39</td><td class="n">$1.75–3.80</td></tr>
       </tbody>
     </table>
   </div>
-  <p class="sub">Verified floor counts only measured operations. The upper bound assumes non-executing votes at 200k gas each — still unverified. A Heavy space with a token-deploy proposal in a given month would add ~$0.023 (verified deploy vote) on top of these figures.</p>
+  <p class="sub">Activity assumptions: Typical ≈ 1 proposal every 2 days, ~12 member votes per proposal on average. Light ≈ 1/week with ~6 votes each. Heavy ≈ 1–2/day across a 50-member ecosystem with ~40 votes per proposal. Verified floor counts only measured operations; upper bound assumes non-executing votes at 200k gas each — still unverified.</p>
 
   <div class="callout">
     <div class="t">Gas remains negligible vs AI</div>
-    <p>Even at the upper bound, a Typical space pays <strong>$0.05–0.13/month</strong> on-chain vs <strong>$16.52/month</strong> for AI (Composer 2.5 Fast) — roughly <strong>130–360× less</strong>. The verified floor alone ($0.046/mo) is <strong>~360× smaller</strong> than AI. Gas is not the cost driver.</p>
+    <p>Even with active governance, a Typical space pays <strong>$0.23–0.40/month</strong> on-chain vs <strong>$16.52/month</strong> for AI (Composer 2.5 Fast) — roughly <strong>40–150× less</strong>. Only at Heavy scale with maximum unverified vote assumptions does gas approach a few dollars/month — still well below AI for most Spaces.</p>
   </div>
   <p class="sub"><strong>Caveats.</strong> L2 execution gas only at 0.005 Gwei; Base adds a small L1 data fee per tx (typically sub-cent). Gas scales linearly with gas price. Who pays (member wallets vs. paymaster) is separate from the aggregate cost shown here. Re-run <code>gas-cost-analysis.ts</code> on Base to capture a non-executing vote and a successful join.</p>
 

--- a/docs/hypha-ai-cost/hypha-ai-cost-per-space.html
+++ b/docs/hypha-ai-cost/hypha-ai-cost-per-space.html
@@ -209,15 +209,17 @@
   </div>
 
   <div class="callout">
-    <div class="t">Execution is bundled into the deciding vote</div>
-    <p>In Hypha, a passing proposal <strong>auto-executes on the deciding vote</strong> — there is no separate execution transaction. Measured vote gas therefore <strong>includes agreement execution</strong> (447k for a mint-scale agreement; 2.5M when the vote also deploys a token). Do not add a separate "execution" line on top of vote gas.</p>
+    <div class="t">Two vote types — most votes do not execute</div>
+    <p><strong>Non-executing vote:</strong> a member casts yes/no while the proposal is still open. It records voting power but <strong>does not run the agreement</strong> on-chain.<br />
+    <strong>Deciding vote:</strong> the vote that reaches quorum/unity and <strong>auto-executes</strong> the proposal via the Executor (447k gas verified for a mint-scale agreement — execution bundled in this tx).<br />
+    Every proposal has exactly <strong>1 deciding vote</strong> and typically <strong>many more non-executing votes</strong> before it. The monthly model reflects this: e.g. Typical = 15 deciding vs 165 non-executing (<strong>11:1</strong>).</p>
   </div>
 
   <div class="stats" style="margin-top:18px">
-    <div class="stat"><div class="v accent">$0.23–0.40</div><div class="l">Gas / month · Typical space (range)</div></div>
-    <div class="stat"><div class="v">$0.11</div><div class="l">Verified floor · Typical space</div></div>
+    <div class="stat"><div class="v accent">$0.25–0.46</div><div class="l">Gas / month · Typical space (range)</div></div>
+    <div class="stat"><div class="v">$0.12</div><div class="l">Verified floor · Typical space</div></div>
     <div class="stat"><div class="v warn">$0.035</div><div class="l">One-time setup (verified)</div></div>
-    <div class="stat"><div class="v">40–150×</div><div class="l">AI cost vs gas (Composer Fast)</div></div>
+    <div class="stat"><div class="v">36–65×</div><div class="l">AI cost vs gas (Composer Fast)</div></div>
   </div>
 
   <h3>Verified on-chain measurements (0.005 Gwei · ETH $1,748)</h3>
@@ -239,25 +241,25 @@
   <p class="sub"><strong>Verified one-time setup</strong> (create space + deploy-token proposal + deciding vote that deploys token): 4,036,728 gas → <strong>$0.035</strong>. <strong>Verified recurring proposal</strong> (mint-scale agreement): 378,389 create + 446,949 deciding vote = 825,338 gas → <strong>$0.0072</strong> per proposal, before any non-executing member votes.</p>
 
   <h3>Recurring gas by Space size</h3>
-  <p>Assumes <strong>active governance</strong>: more proposals and broader member participation than a quiet space. Each proposal = 1× verified create (378,389) + 1× verified deciding vote (446,949) + treasury transfers (62,135 each). Non-executing member votes are <strong>not measured</strong>; the range adds a sensitivity band of 80k–200k gas per vote (industry-typical DAO range, unverified for Hypha).</p>
+  <p>Assumes <strong>active governance</strong> with high member participation. Per proposal: 1× verified create + 1× verified deciding vote (includes execution) + <strong>(N−1) non-executing votes</strong> where N = members voting. Non-executing vote gas is <strong>not measured</strong>; the range uses 80k–200k gas each (unverified sensitivity band).</p>
   <div class="frame">
     <table>
       <thead><tr>
-        <th>Profile</th><th class="n">Proposals/mo</th><th class="n">Votes/mo</th><th class="n">Non-exec votes</th>
-        <th class="n">Treasury/mo</th><th class="n">Verified floor</th><th class="n">Range (incl. unmeasured votes)</th>
+        <th>Profile</th><th class="n">Proposals/mo</th><th class="n">Deciding votes</th><th class="n">Non-exec votes</th><th class="n">Ratio</th>
+        <th class="n">Treasury/mo</th><th class="n">Verified floor</th><th class="n">Range (incl. non-exec)</th>
       </tr></thead>
       <tbody>
-        <tr><td>Light (~5 members)</td><td class="n">5</td><td class="n">30</td><td class="n">25</td><td class="n">3</td><td class="n">$0.036</td><td class="n">$0.05–0.08</td></tr>
-        <tr><td><strong>Typical (~15 members)</strong></td><td class="n">15</td><td class="n">180</td><td class="n">165</td><td class="n">12</td><td class="n">$0.11</td><td class="n"><strong>$0.23–0.40</strong></td></tr>
-        <tr><td>Heavy (~50 members)</td><td class="n">50</td><td class="n">2,000</td><td class="n">1,950</td><td class="n">50</td><td class="n">$0.39</td><td class="n">$1.75–3.80</td></tr>
+        <tr><td>Light (~5 members)</td><td class="n">5</td><td class="n">5</td><td class="n">20</td><td class="n">4:1</td><td class="n">3</td><td class="n">$0.036</td><td class="n">$0.05–0.07</td></tr>
+        <tr><td><strong>Typical (~15 members)</strong></td><td class="n">15</td><td class="n">15</td><td class="n">195</td><td class="n">13:1</td><td class="n">12</td><td class="n">$0.12</td><td class="n"><strong>$0.25–0.46</strong></td></tr>
+        <tr><td>Heavy (~50 members)</td><td class="n">50</td><td class="n">50</td><td class="n">2,200</td><td class="n">44:1</td><td class="n">50</td><td class="n">$0.39</td><td class="n">$2.0–4.3</td></tr>
       </tbody>
     </table>
   </div>
-  <p class="sub">Activity assumptions: Typical ≈ 1 proposal every 2 days, ~12 member votes per proposal on average. Light ≈ 1/week with ~6 votes each. Heavy ≈ 1–2/day across a 50-member ecosystem with ~40 votes per proposal. Verified floor counts only measured operations; upper bound assumes non-executing votes at 200k gas each — still unverified.</p>
+  <p class="sub">Vote participation: Typical ≈ 14 of 15 members vote per proposal (1 deciding + 13 non-exec). Light ≈ 5 of 5 members (4:1). Heavy ≈ 45 of 50 members (44:1). At these ratios, <strong>non-executing votes dominate total gas</strong> in the sensitivity range — even though each one is cheaper than a deciding vote, there are far more of them.</p>
 
   <div class="callout">
     <div class="t">Gas remains negligible vs AI</div>
-    <p>Even with active governance, a Typical space pays <strong>$0.23–0.40/month</strong> on-chain vs <strong>$16.52/month</strong> for AI (Composer 2.5 Fast) — roughly <strong>40–150× less</strong>. Only at Heavy scale with maximum unverified vote assumptions does gas approach a few dollars/month — still well below AI for most Spaces.</p>
+    <p>Even with active governance, a Typical space pays <strong>$0.25–0.46/month</strong> on-chain vs <strong>$16.52/month</strong> for AI (Composer 2.5 Fast) — roughly <strong>36–65× less</strong>. Non-executing votes (13× more numerous than deciding votes) drive most of the gas range. Only at Heavy scale with maximum assumptions does gas approach a few dollars/month.</p>
   </div>
   <p class="sub"><strong>Caveats.</strong> L2 execution gas only at 0.005 Gwei; Base adds a small L1 data fee per tx (typically sub-cent). Gas scales linearly with gas price. Who pays (member wallets vs. paymaster) is separate from the aggregate cost shown here. Re-run <code>gas-cost-analysis.ts</code> on Base to capture a non-executing vote and a successful join.</p>
 

--- a/docs/hypha-ai-cost/hypha-ai-cost-per-space.html
+++ b/docs/hypha-ai-cost/hypha-ai-cost-per-space.html
@@ -61,6 +61,8 @@
   .tag { display: inline-block; font-size: 11px; padding: 2px 8px; border-radius: 999px; border: 1px solid var(--stroke); color: var(--text-2); }
   .tag.live { color: var(--good); border-color: var(--good-soft); background: var(--good-soft); }
   .tag.heur { color: var(--warn); border-color: #3a2f17; background: #251d0f; }
+  .tag.verified { color: var(--good); border-color: var(--good-soft); background: var(--good-soft); }
+  .tag.est { color: var(--warn); border-color: #3a2f17; background: #251d0f; }
 
   .callout { background: var(--accent-soft); border: 1px solid #284468; border-radius: 10px; padding: 14px 16px; margin: 16px 0; }
   .callout .t { font-weight: 650; color: #bcd6f7; margin-bottom: 4px; }
@@ -198,61 +200,66 @@
   <hr />
 
   <h2>On-chain (gas) cost per Space — Base</h2>
-  <p>Governance, treasury and membership actions settle on the <strong>Base</strong> L2. These figures take the <strong>real gas amounts measured on Base mainnet</strong> (from the repo's <code>gas-cost-analysis</code> script) and re-price them at the current network conditions below. At these prices, on-chain activity is effectively free.</p>
+  <p>Governance, treasury and membership actions settle on <strong>Base</strong>. Gas units below come from <strong>verified Base mainnet receipts</strong> captured in <code>packages/storage-evm/scripts/base-mainnet-contracts-scripts/gas-cost-analysis-results.json</code> (Aug 2025), re-priced at the conditions below. Unmeasured operations are labeled explicitly and excluded from verified totals.</p>
   <div class="pill-row">
     <span class="tag">Gas price: 0.005 Gwei</span>
     <span class="tag">ETH: $1,748</span>
-    <span class="tag">Cost per gas unit: ~$0.0000000087</span>
-    <span class="tag">Source: Base mainnet receipts</span>
+    <span class="tag">Verified: 6 mainnet txs</span>
+    <span class="tag est">1 operation estimated (join failed)</span>
+  </div>
+
+  <div class="callout">
+    <div class="t">Execution is bundled into the deciding vote</div>
+    <p>In Hypha, a passing proposal <strong>auto-executes on the deciding vote</strong> — there is no separate execution transaction. Measured vote gas therefore <strong>includes agreement execution</strong> (447k for a mint-scale agreement; 2.5M when the vote also deploys a token). Do not add a separate "execution" line on top of vote gas.</p>
   </div>
 
   <div class="stats" style="margin-top:18px">
-    <div class="stat"><div class="v accent">$0.12</div><div class="l">Gas / month · Typical space</div></div>
-    <div class="stat"><div class="v">$1.45</div><div class="l">Gas / year · Typical space</div></div>
-    <div class="stat"><div class="v warn">$0.035</div><div class="l">One-time setup (create + token)</div></div>
-    <div class="stat"><div class="v">~140×</div><div class="l">AI cost vs gas (Composer Fast)</div></div>
+    <div class="stat"><div class="v accent">$0.05–0.13</div><div class="l">Gas / month · Typical space (range)</div></div>
+    <div class="stat"><div class="v">$0.046</div><div class="l">Verified floor · Typical space</div></div>
+    <div class="stat"><div class="v warn">$0.035</div><div class="l">One-time setup (verified)</div></div>
+    <div class="stat"><div class="v">130–360×</div><div class="l">AI cost vs gas (Composer Fast)</div></div>
   </div>
 
-  <h3>Cost per on-chain operation (at 0.005 Gwei)</h3>
-  <p>Gas units are actual on-chain measurements. In Hypha, a passing proposal auto-executes on the deciding vote, so execution gas can be bundled into that vote.</p>
+  <h3>Verified on-chain measurements (0.005 Gwei · ETH $1,748)</h3>
   <div class="frame">
     <table>
-      <thead><tr><th>Operation</th><th>When</th><th class="n">Gas units</th><th class="n">Cost (USD)</th></tr></thead>
+      <thead><tr><th>Operation</th><th>When</th><th>Status</th><th class="n">Gas units</th><th class="n">Cost (USD)</th><th>Tx / note</th></tr></thead>
       <tbody>
-        <tr><td>Token deploy — vote + auto-execute</td><td>Setup (one-time)</td><td class="n">2,549,025</td><td class="n">$0.0223</td></tr>
-        <tr><td>Space creation</td><td>Setup (one-time)</td><td class="n">960,285</td><td class="n">$0.0084</td></tr>
-        <tr><td>Token deployment proposal</td><td>Setup (one-time)</td><td class="n">527,418</td><td class="n">$0.0046</td></tr>
-        <tr><td>Proposal creation</td><td>Recurring</td><td class="n">~400,000</td><td class="n">$0.0035</td></tr>
-        <tr><td>Proposal execution (agreement)</td><td>Recurring</td><td class="n">~450,000</td><td class="n">$0.0039</td></tr>
-        <tr><td>Vote cast</td><td>Recurring</td><td class="n">~150,000</td><td class="n">$0.0013</td></tr>
-        <tr><td>Member join</td><td>Recurring</td><td class="n">~100,000</td><td class="n">$0.0009</td></tr>
-        <tr><td>Treasury transfer (ERC-20 / USDC)</td><td>Recurring</td><td class="n">62,135</td><td class="n">$0.0005</td></tr>
+        <tr><td>Vote + auto-execute (token deploy)</td><td>Setup</td><td><span class="tag verified">verified</span></td><td class="n">2,549,025</td><td class="n">$0.0223</td><td><code>0x1f7ed7f4…</code></td></tr>
+        <tr><td>Space creation</td><td>Setup</td><td><span class="tag verified">verified</span></td><td class="n">960,285</td><td class="n">$0.0084</td><td><code>0xb6b98a19…</code></td></tr>
+        <tr><td>Proposal creation (token deploy)</td><td>Setup</td><td><span class="tag verified">verified</span></td><td class="n">527,418</td><td class="n">$0.0046</td><td><code>0x64e3d917…</code></td></tr>
+        <tr><td>Vote + auto-execute (token mint)</td><td>Recurring</td><td><span class="tag verified">verified</span></td><td class="n">446,949</td><td class="n">$0.0039</td><td><code>0x3f0d5487…</code> · deciding vote incl. execution</td></tr>
+        <tr><td>Proposal creation (token mint)</td><td>Recurring</td><td><span class="tag verified">verified</span></td><td class="n">378,389</td><td class="n">$0.0033</td><td><code>0xab9a53ae…</code> · typical agreement proposal</td></tr>
+        <tr><td>USDC transfer (ERC-20)</td><td>Recurring</td><td><span class="tag verified">verified</span></td><td class="n">62,135</td><td class="n">$0.0005</td><td><code>0x80e51f14…</code></td></tr>
+        <tr><td>Member join</td><td>Recurring</td><td><span class="tag est">estimated</span></td><td class="n">100,000</td><td class="n">$0.0009</td><td>tx failed in analysis run; not verified</td></tr>
+        <tr><td>Non-executing vote</td><td>Recurring</td><td><span class="tag est">not measured</span></td><td class="n">—</td><td class="n">—</td><td>no successful mainnet receipt in repo</td></tr>
       </tbody>
     </table>
   </div>
+  <p class="sub"><strong>Verified one-time setup</strong> (create space + deploy-token proposal + deciding vote that deploys token): 4,036,728 gas → <strong>$0.035</strong>. <strong>Verified recurring proposal</strong> (mint-scale agreement): 378,389 create + 446,949 deciding vote = 825,338 gas → <strong>$0.0072</strong> per proposal, before any non-executing member votes.</p>
 
-  <h3>Recurring gas cost by Space size</h3>
-  <p>Monthly on-chain activity assumed per profile (proposals × votes dominate). Setup is one-time and excluded from the monthly figure.</p>
+  <h3>Recurring gas by Space size</h3>
+  <p>Monthly model: each proposal = 1× verified create (378,389) + 1× verified deciding vote (446,949) + treasury transfers (62,135 each). Non-executing member votes are <strong>not measured</strong>; the range adds a sensitivity band of 80k–200k gas per vote (industry-typical DAO range, unverified for Hypha).</p>
   <div class="frame">
     <table>
       <thead><tr>
-        <th>Profile</th><th class="n">Proposals/mo</th><th class="n">Votes/mo</th>
-        <th class="n">Treasury txns/mo</th><th class="n">Gas/mo</th><th class="n">Monthly</th><th class="n">Annual</th>
+        <th>Profile</th><th class="n">Proposals/mo</th><th class="n">Votes/mo</th><th class="n">Non-exec votes</th>
+        <th class="n">Treasury/mo</th><th class="n">Verified floor</th><th class="n">Range (incl. unmeasured votes)</th>
       </tr></thead>
       <tbody>
-        <tr><td>Light (~5 members)</td><td class="n">2</td><td class="n">6</td><td class="n">1</td><td class="n">2.8M</td><td class="n"><div class="bar-cell"><span class="bar alt" style="width:4px"></span><span class="barlabel">$0.024</span></div></td><td class="n">$0.29</td></tr>
-        <tr><td><strong>Typical (~15 members)</strong></td><td class="n">6</td><td class="n">54</td><td class="n">5</td><td class="n">13.8M</td><td class="n"><div class="bar-cell"><span class="bar alt" style="width:20px"></span><span class="barlabel"><strong>$0.12</strong></span></div></td><td class="n">$1.45</td></tr>
-        <tr><td>Heavy (~50 members)</td><td class="n">20</td><td class="n">600</td><td class="n">20</td><td class="n">109M</td><td class="n"><div class="bar-cell"><span class="bar alt" style="width:160px"></span><span class="barlabel">$0.96</span></div></td><td class="n">$11.46</td></tr>
+        <tr><td>Light (~5 members)</td><td class="n">2</td><td class="n">6</td><td class="n">4</td><td class="n">1</td><td class="n">$0.015</td><td class="n">$0.015–0.022</td></tr>
+        <tr><td><strong>Typical (~15 members)</strong></td><td class="n">6</td><td class="n">54</td><td class="n">48</td><td class="n">5</td><td class="n">$0.046</td><td class="n"><strong>$0.05–0.13</strong></td></tr>
+        <tr><td>Heavy (~50 members)</td><td class="n">20</td><td class="n">600</td><td class="n">580</td><td class="n">20</td><td class="n">$0.15</td><td class="n">$0.56–1.17</td></tr>
       </tbody>
     </table>
   </div>
-  <p class="sub">For the Typical space, member votes are ~59% of monthly gas (54 votes × ~150k), proposal execution ~20%, proposal creation ~17%.</p>
+  <p class="sub">Verified floor counts only measured operations. The upper bound assumes non-executing votes at 200k gas each — still unverified. A Heavy space with a token-deploy proposal in a given month would add ~$0.023 (verified deploy vote) on top of these figures.</p>
 
   <div class="callout">
-    <div class="t">Gas is negligible vs AI at these prices</div>
-    <p>A Typical space's on-chain cost is <strong>~$0.12/month</strong> — roughly <strong>140× smaller</strong> than the Composer 2.5 Fast AI estimate ($16.52), and still a fraction of even the cheapest open-source AI option (~$0.70). The AI layer, not the blockchain, is the cost driver.</p>
+    <div class="t">Gas remains negligible vs AI</div>
+    <p>Even at the upper bound, a Typical space pays <strong>$0.05–0.13/month</strong> on-chain vs <strong>$16.52/month</strong> for AI (Composer 2.5 Fast) — roughly <strong>130–360× less</strong>. The verified floor alone ($0.046/mo) is <strong>~360× smaller</strong> than AI. Gas is not the cost driver.</p>
   </div>
-  <p class="sub"><strong>Caveats.</strong> Figures are L2 execution gas at the stated 0.005 Gwei; Base also adds a small L1 data fee per transaction (typically sub-cent under current blob-fee conditions) not captured by a single L2 gas price. Gas scales linearly with gas price — a 10× spike to 0.05 Gwei makes a Typical space ~$1.20/month, still negligible. Who pays (member wallets vs. a platform paymaster) is a separate question; this is the aggregate on-chain cost of a Space's activity regardless of payer.</p>
+  <p class="sub"><strong>Caveats.</strong> L2 execution gas only at 0.005 Gwei; Base adds a small L1 data fee per tx (typically sub-cent). Gas scales linearly with gas price. Who pays (member wallets vs. paymaster) is separate from the aggregate cost shown here. Re-run <code>gas-cost-analysis.ts</code> on Base to capture a non-executing vote and a successful join.</p>
 
   <div class="grid2">
     <div>

--- a/docs/hypha-ai-cost/hypha-ai-cost-per-space.html
+++ b/docs/hypha-ai-cost/hypha-ai-cost-per-space.html
@@ -1,0 +1,227 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Hypha AI — Estimated AI Cost per Space</title>
+<style>
+  :root {
+    --bg: #0f1115;
+    --panel: #161922;
+    --panel-2: #1b1f2a;
+    --stroke: #262b38;
+    --text: #e7e9ee;
+    --text-2: #a7adbd;
+    --text-3: #767d8f;
+    --accent: #5b9cf0;
+    --accent-soft: #1d2a40;
+    --good: #4cc38a;
+    --good-soft: #163026;
+    --warn: #e0a83b;
+    --bar: #3a6ea5;
+    --bar-2: #2f9e74;
+  }
+  * { box-sizing: border-box; }
+  html { -webkit-text-size-adjust: 100%; }
+  body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--text);
+    font: 15px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    padding: 48px 24px 80px;
+  }
+  .wrap { max-width: 980px; margin: 0 auto; }
+  h1 { font-size: 30px; line-height: 1.15; margin: 0 0 8px; letter-spacing: -0.01em; }
+  h2 { font-size: 20px; margin: 44px 0 14px; letter-spacing: -0.01em; }
+  h3 { font-size: 15px; margin: 26px 0 10px; color: var(--text-2); text-transform: uppercase; letter-spacing: 0.06em; }
+  p { color: var(--text-2); margin: 0 0 12px; }
+  a { color: var(--accent); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  code { background: var(--panel-2); border: 1px solid var(--stroke); border-radius: 4px; padding: 1px 5px; font-size: 0.86em; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+  .sub { color: var(--text-3); font-size: 13px; }
+  .lede { color: var(--text-2); font-size: 16px; max-width: 760px; }
+
+  .stats { display: grid; grid-template-columns: repeat(4, 1fr); gap: 14px; margin: 28px 0 8px; }
+  .stat { background: var(--panel); border: 1px solid var(--stroke); border-radius: 10px; padding: 16px; }
+  .stat .v { font-size: 24px; font-weight: 650; letter-spacing: -0.02em; }
+  .stat .v.accent { color: var(--accent); }
+  .stat .v.warn { color: var(--warn); }
+  .stat .l { color: var(--text-3); font-size: 12px; margin-top: 6px; }
+
+  table { width: 100%; border-collapse: collapse; margin: 6px 0 4px; font-size: 14px; }
+  th, td { text-align: left; padding: 9px 12px; border-bottom: 1px solid var(--stroke); }
+  th { color: var(--text-3); font-weight: 600; font-size: 12px; text-transform: uppercase; letter-spacing: 0.04em; }
+  td.n, th.n { text-align: right; font-variant-numeric: tabular-nums; }
+  tbody tr:hover { background: var(--panel); }
+  tr.total td { border-top: 2px solid var(--stroke); border-bottom: none; font-weight: 650; color: var(--text); }
+  .frame { border: 1px solid var(--stroke); border-radius: 10px; overflow: hidden; }
+  .frame table { margin: 0; }
+  .frame th, .frame td { padding-left: 16px; padding-right: 16px; }
+
+  .tag { display: inline-block; font-size: 11px; padding: 2px 8px; border-radius: 999px; border: 1px solid var(--stroke); color: var(--text-2); }
+  .tag.live { color: var(--good); border-color: var(--good-soft); background: var(--good-soft); }
+  .tag.heur { color: var(--warn); border-color: #3a2f17; background: #251d0f; }
+
+  .callout { background: var(--accent-soft); border: 1px solid #284468; border-radius: 10px; padding: 14px 16px; margin: 16px 0; }
+  .callout .t { font-weight: 650; color: #bcd6f7; margin-bottom: 4px; }
+  .callout p { color: #cdd6e6; margin: 0; }
+
+  .bar-cell { display: flex; align-items: center; gap: 8px; justify-content: flex-end; }
+  .bar { height: 8px; border-radius: 3px; background: var(--bar); }
+  .bar.alt { background: var(--bar-2); }
+  .barlabel { min-width: 54px; text-align: right; font-variant-numeric: tabular-nums; }
+
+  ul { color: var(--text-2); margin: 4px 0 12px; padding-left: 20px; }
+  li { margin: 4px 0; }
+  .grid2 { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; }
+  .muted-card { background: var(--panel); border: 1px solid var(--stroke); border-radius: 10px; padding: 16px; }
+  hr { border: none; border-top: 1px solid var(--stroke); margin: 40px 0; }
+  footer { color: var(--text-3); font-size: 13px; margin-top: 40px; }
+  .pill-row { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 4px; }
+  @media (max-width: 760px) {
+    .stats { grid-template-columns: repeat(2, 1fr); }
+    .grid2 { grid-template-columns: 1fr; }
+    body { padding: 28px 14px 60px; }
+  }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <h1>Hypha AI — Estimated AI Cost per Space</h1>
+  <p class="lede">Cost model for running Hypha AI features against an LLM, expressed as average spend per Space. Headline numbers use <strong>Cursor Composer 2.5 Fast</strong> ($3.00 / 1M input · $15.00 / 1M output); a dedicated section estimates the same workload on the most capable open-source models.</p>
+  <p class="sub">Last updated June 2026 · Token volumes grounded in the <code>packages/chat-server</code> implementation · Pricing from public rate cards.</p>
+
+  <div class="stats">
+    <div class="stat"><div class="v accent">$16.52</div><div class="l">Avg AI cost / month · Typical space</div></div>
+    <div class="stat"><div class="v">319</div><div class="l">AI tasks / month</div></div>
+    <div class="stat"><div class="v">$0.0518</div><div class="l">Blended cost / task</div></div>
+    <div class="stat"><div class="v warn">$0.56</div><div class="l">One-time onboarding / space</div></div>
+  </div>
+
+  <div class="callout">
+    <div class="t">Headline</div>
+    <p>A typical active Space costs <strong>≈ $16.50 / month (≈ $198 / year)</strong> on Composer 2.5 Fast. Swapping in a top open-source model cuts this <strong>3×–24×</strong> — the cheapest credible option (DeepSeek V4-Flash) lands the typical Space at <strong>~$0.70 / month</strong>.</p>
+  </div>
+
+  <h2>Cost by Space size</h2>
+  <p>Two scopes: <strong>Live today</strong> bills only the chat copilot (the only surface calling a model now). <strong>Full AI vision</strong> also bills the background features — Signal Orchestrator, discussion &amp; call summaries — which are heuristic (zero LLM tokens) today, representing the cost ceiling.</p>
+  <div class="frame">
+    <table>
+      <thead><tr>
+        <th>Space profile</th><th>Members</th>
+        <th class="n">Full vision / mo</th><th class="n">Live today / mo</th>
+        <th class="n">Annualized (vision)</th><th class="n">AI tasks / mo</th>
+      </tr></thead>
+      <tbody>
+        <tr><td>Light</td><td>~5</td><td class="n">$5.48</td><td class="n">$2.45</td><td class="n">$65.76</td><td class="n">112</td></tr>
+        <tr><td><strong>Typical</strong></td><td>~15</td><td class="n"><strong>$16.52</strong></td><td class="n">$10.13</td><td class="n">$198.24</td><td class="n">319</td></tr>
+        <tr><td>Heavy</td><td>~50</td><td class="n">$45.06</td><td class="n">$31.26</td><td class="n">$540.72</td><td class="n">840</td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <h2>Per-feature breakdown — Typical Space</h2>
+  <p>Composer 2.5 Fast, full AI vision. Cost per task = input × $3/1M + output × $15/1M, summed over monthly task volume. Bars show share of monthly spend.</p>
+  <div class="frame">
+    <table>
+      <thead><tr>
+        <th>Feature</th><th>Surface</th><th>Status</th>
+        <th class="n">Tasks/mo</th><th class="n">In tok</th><th class="n">Out tok</th>
+        <th class="n">$/task</th><th class="n">Monthly</th>
+      </tr></thead>
+      <tbody>
+        <tr><td>Discussion summary (background refresh)</td><td>Space Memory</td><td><span class="tag heur">heuristic today</span></td><td class="n">120</td><td class="n">12k</td><td class="n">400</td><td class="n">$0.042</td><td class="n"><div class="bar-cell"><span class="bar" style="width:120px"></span><span class="barlabel">$5.04</span></div></td></tr>
+        <tr><td>Advisory (multi-tool reads)</td><td>Copilot</td><td><span class="tag live">live</span></td><td class="n">40</td><td class="n">28k</td><td class="n">900</td><td class="n">$0.098</td><td class="n"><div class="bar-cell"><span class="bar" style="width:93px"></span><span class="barlabel">$3.90</span></div></td></tr>
+        <tr><td>Q&amp;A &amp; navigation</td><td>Copilot</td><td><span class="tag live">live</span></td><td class="n">80</td><td class="n">9k</td><td class="n">400</td><td class="n">$0.033</td><td class="n"><div class="bar-cell"><span class="bar" style="width:63px"></span><span class="barlabel">$2.64</span></div></td></tr>
+        <tr><td>Memory deep-dive (read file/PDF)</td><td>Space Memory</td><td><span class="tag live">live</span></td><td class="n">12</td><td class="n">45k</td><td class="n">1.2k</td><td class="n">$0.153</td><td class="n"><div class="bar-cell"><span class="bar" style="width:44px"></span><span class="barlabel">$1.84</span></div></td></tr>
+        <tr><td>Signal Orchestrator (auto signal)</td><td>Signals</td><td><span class="tag heur">heuristic today</span></td><td class="n">30</td><td class="n">10k</td><td class="n">600</td><td class="n">$0.039</td><td class="n"><div class="bar-cell"><span class="bar" style="width:28px"></span><span class="barlabel">$1.17</span></div></td></tr>
+        <tr><td>Signal authoring (member, gated)</td><td>Signals</td><td><span class="tag live">live</span></td><td class="n">8</td><td class="n">30k</td><td class="n">1k</td><td class="n">$0.105</td><td class="n"><div class="bar-cell"><span class="bar" style="width:20px"></span><span class="barlabel">$0.84</span></div></td></tr>
+        <tr><td>Web search assist</td><td>Copilot</td><td><span class="tag live">live</span></td><td class="n">15</td><td class="n">12k</td><td class="n">500</td><td class="n">$0.044</td><td class="n"><div class="bar-cell"><span class="bar" style="width:16px"></span><span class="barlabel">$0.65</span></div></td></tr>
+        <tr><td>Network discovery (search spaces)</td><td>Discovery</td><td><span class="tag live">live</span></td><td class="n">8</td><td class="n">9k</td><td class="n">400</td><td class="n">$0.033</td><td class="n"><div class="bar-cell"><span class="bar" style="width:7px"></span><span class="barlabel">$0.26</span></div></td></tr>
+        <tr><td>Call transcript summary (per call)</td><td>Space Memory</td><td><span class="tag heur">heuristic today</span></td><td class="n">6</td><td class="n">8k</td><td class="n">400</td><td class="n">$0.030</td><td class="n"><div class="bar-cell"><span class="bar" style="width:5px"></span><span class="barlabel">$0.18</span></div></td></tr>
+        <tr class="total"><td>Total</td><td></td><td></td><td class="n">319</td><td class="n"></td><td class="n"></td><td class="n"></td><td class="n">$16.52</td></tr>
+      </tbody>
+    </table>
+  </div>
+  <p class="sub">Where the money goes: background Space Memory summaries (~31%) and copilot advisory reads (~24%) dominate. The workload totals ≈ 4.66M input + 0.17M output tokens/month — heavily input-bound.</p>
+
+  <h2>Open-source model pricing</h2>
+  <p>The same workload on the most capable open-weight models of 2026. Highly relevant here: <strong>Composer 2.5 is itself post-trained from Moonshot's Kimi K2.5</strong>, so running the open Kimi line directly is the closest like-for-like swap — at a fraction of Composer Fast's interactive premium.</p>
+
+  <h3>Representative rates (per 1M tokens)</h3>
+  <div class="frame">
+    <table>
+      <thead><tr><th>Model</th><th>Open weights</th><th class="n">Input $/1M</th><th class="n">Output $/1M</th><th>Why it's here</th></tr></thead>
+      <tbody>
+        <tr><td>Kimi K2.6 (Moonshot)</td><td>Yes</td><td class="n">$0.95</td><td class="n">$4.00</td><td>Leads open-source quality rankings; agentic; same lineage as Composer (OpenRouter low: $0.68 / $3.41)</td></tr>
+        <tr><td>DeepSeek V4-Pro</td><td>Yes (MIT)</td><td class="n">$0.44</td><td class="n">$0.87</td><td>Flagship open reasoning/coding model; first-party API</td></tr>
+        <tr><td>Qwen3.5-397B (Alibaba)</td><td>Yes</td><td class="n">$0.60</td><td class="n">$3.60</td><td>Strong open frontier MoE</td></tr>
+        <tr><td>Llama 4 Maverick (Meta)</td><td>Yes</td><td class="n">$0.50</td><td class="n">$2.15</td><td>400B MoE; DeepInfra-hosted rate</td></tr>
+        <tr><td>DeepSeek V4-Flash</td><td>Yes (MIT)</td><td class="n">$0.14</td><td class="n">$0.28</td><td>Budget leader; near-frontier at a fraction of the cost</td></tr>
+        <tr><td><em>Composer 2.5 Fast (baseline)</em></td><td>No</td><td class="n">$3.00</td><td class="n">$15.00</td><td><em>Reference</em></td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <h3>Estimated cost — Typical Space (full AI vision)</h3>
+  <p>Applying each model's rate to the typical Space's 4.66M input + 0.17M output tokens/month. Bars are relative to the Composer Fast baseline.</p>
+  <div class="frame">
+    <table>
+      <thead><tr><th>Model</th><th class="n">Monthly / space</th><th class="n">Annualized</th><th class="n">Onboarding</th><th class="n">vs Composer Fast</th></tr></thead>
+      <tbody>
+        <tr><td>Composer 2.5 Fast <span class="sub">(baseline)</span></td><td class="n"><div class="bar-cell"><span class="bar" style="width:160px"></span><span class="barlabel">$16.52</span></div></td><td class="n">$198.24</td><td class="n">$0.56</td><td class="n">—</td></tr>
+        <tr><td>Composer 2.5 Standard</td><td class="n"><div class="bar-cell"><span class="bar alt" style="width:27px"></span><span class="barlabel">$2.75</span></div></td><td class="n">$33.05</td><td class="n">$0.09</td><td class="n">6.0× cheaper</td></tr>
+        <tr><td>Kimi K2.6 (list)</td><td class="n"><div class="bar-cell"><span class="bar alt" style="width:49px"></span><span class="barlabel">$5.11</span></div></td><td class="n">$61.26</td><td class="n">$0.17</td><td class="n">3.2× cheaper</td></tr>
+        <tr><td>Kimi K2.6 (OpenRouter low)</td><td class="n"><div class="bar-cell"><span class="bar alt" style="width:36px"></span><span class="barlabel">$3.75</span></div></td><td class="n">$44.96</td><td class="n">$0.13</td><td class="n">4.4× cheaper</td></tr>
+        <tr><td>Qwen3.5-397B</td><td class="n"><div class="bar-cell"><span class="bar alt" style="width:33px"></span><span class="barlabel">$3.41</span></div></td><td class="n">$40.87</td><td class="n">$0.12</td><td class="n">4.8× cheaper</td></tr>
+        <tr><td>Llama 4 Maverick</td><td class="n"><div class="bar-cell"><span class="bar alt" style="width:26px"></span><span class="barlabel">$2.69</span></div></td><td class="n">$32.33</td><td class="n">$0.09</td><td class="n">6.1× cheaper</td></tr>
+        <tr><td>DeepSeek V4-Pro</td><td class="n"><div class="bar-cell"><span class="bar alt" style="width:21px"></span><span class="barlabel">$2.17</span></div></td><td class="n">$26.10</td><td class="n">$0.07</td><td class="n">7.6× cheaper</td></tr>
+        <tr><td><strong>DeepSeek V4-Flash</strong></td><td class="n"><div class="bar-cell"><span class="bar alt" style="width:7px"></span><span class="barlabel"><strong>$0.70</strong></span></div></td><td class="n">$8.40</td><td class="n">$0.02</td><td class="n"><strong>23.6× cheaper</strong></td></tr>
+      </tbody>
+    </table>
+  </div>
+  <p class="sub">Scale to other profiles: Light ≈ 0.33×, Heavy ≈ 2.73× the monthly figure. E.g. a Heavy Space on Kimi K2.6 ≈ $13.9/mo; on DeepSeek V4-Flash ≈ $1.9/mo.</p>
+
+  <h3>Takeaways</h3>
+  <ul>
+    <li><strong>The workload is input-heavy</strong> (~96% of tokens are input — large system prompt + re-sent history + tool results). Output price barely moves the total, so models with cheap input (DeepSeek) win disproportionately.</li>
+    <li><strong>Kimi K2.6</strong> is the natural "same quality, own the stack" choice given Composer's Kimi lineage, at ~3× lower cost than Composer Fast.</li>
+    <li><strong>DeepSeek V4-Flash</strong> makes the AI layer almost free per Space (~$0.70/mo) — a strong default for background features where latency and peak reasoning matter least.</li>
+    <li><strong>Tiered routing</strong> (premium model for interactive copilot, cheap model for background jobs) likely lands a typical Space at <strong>$1–3/month</strong> with no perceptible quality loss.</li>
+  </ul>
+
+  <hr />
+
+  <div class="grid2">
+    <div>
+      <h3>Methodology &amp; assumptions</h3>
+      <ul>
+        <li>In-space system prompt ≈ 5.6k tokens, re-sent on every step.</li>
+        <li>Tool loop capped at 6 steps; full history re-sent each step (no truncation).</li>
+        <li>No <code>max_tokens</code> cap configured → output sizes are conservative estimates.</li>
+        <li>Org-memory reads capped at 48k chars (~12k tokens) per fetch.</li>
+        <li>Orchestrator capped at 3 auto-signals/day/space; discussion refresh ~4 runs/day.</li>
+        <li>Costs scale ~linearly with task volume across profiles.</li>
+      </ul>
+    </div>
+    <div>
+      <h3>Levers to reduce cost (any model)</h3>
+      <ul>
+        <li>Trim / cache the system prompt (cached reads 60–80% cheaper on most open hosts).</li>
+        <li>Truncate conversation history instead of re-sending the full transcript.</li>
+        <li>Route background work to a cheap/standard tier.</li>
+        <li>Set a <code>max_tokens</code> cap to bound output.</li>
+        <li>Cap memory deep-dive context below 48k chars for routine summarization.</li>
+      </ul>
+    </div>
+  </div>
+
+  <footer>
+    <p><strong>Sources.</strong> Composer 2.5 pricing: Cursor (Fast $3/$15, Standard $0.50/$2.50; post-trained from Kimi K2.5). Open-source rates: OpenRouter, DeepSeek first-party, and public LLM price comparators (June 2026) — open-weight rates vary by host; verify on the live provider dashboard. Token volumes &amp; feature inventory: <code>packages/chat-server</code>, <code>packages/core/src/coherence/server/signal-orchestrator.ts</code>, <code>packages/core/src/governance/server/call-artifacts.ts</code>.</p>
+    <p>Estimates only. Task-volume assumptions per profile are modeled; replace with real usage data from the flag-gated rollout to refine the dollar figures.</p>
+  </footer>
+
+</div>
+</body>
+</html>

--- a/docs/hypha-ai-cost/tokenomics-simulator-phase1.html
+++ b/docs/hypha-ai-cost/tokenomics-simulator-phase1.html
@@ -70,7 +70,7 @@ const HyphaTokenomicsCalculator = () => {
   const [tokensForSale, setTokensForSale] = useState(10000000);
   const [yieldMultiplier, setYieldMultiplier] = useState(30);
   const [saleMonths, setSaleMonths] = useState(12);
-  const [tokenPrice, setTokenPrice] = useState(0.25);
+  const [tokenPrice, setTokenPrice] = useState(0.20);
   const [totalSupply, setTotalSupply] = useState(555555555);
   const [existingLockedSupply, setExistingLockedSupply] = useState(111111111);
 
@@ -258,7 +258,7 @@ const HyphaTokenomicsCalculator = () => {
     setTokensForSale(10000000);
     setYieldMultiplier(30);
     setSaleMonths(12);
-    setTokenPrice(0.25);
+    setTokenPrice(0.20);
     setTotalSupply(555555555);
     setExistingLockedSupply(111111111);
     setNumberOfAOs(50);
@@ -279,6 +279,7 @@ const HyphaTokenomicsCalculator = () => {
   return (
     <div className="p-6 bg-gray-50 rounded-lg shadow-lg">
       <h1 className="text-2xl font-bold mb-1 text-center">HYPHA Tokenomics Simulator (Phase I)</h1>
+      <p className="text-sm text-gray-500 mb-6 text-center">Phase I uses a fixed reference token price; Phase II derives price from IEX dynamics.</p>
       <p className="text-sm text-gray-500 mb-6 text-center">With per-Space AI + Base L2 gas operating cost model — closed-source vs open-source LLMs.</p>
 
       <div className="mb-8 border border-indigo-200 bg-indigo-50 p-4 rounded-lg">

--- a/docs/hypha-ai-cost/tokenomics-simulator-phase1.html
+++ b/docs/hypha-ai-cost/tokenomics-simulator-phase1.html
@@ -302,7 +302,7 @@ const HyphaTokenomicsCalculator = () => {
           </div>
           <div className="bg-white p-3 rounded border border-slate-200">
             <div className="font-semibold text-slate-700">Phase II — Years 2–5</div>
-            <p className="text-xs text-gray-600 mt-1">$44/Space/mo, dynamic IEX. Year-5 paying / created: Low ~15k/250k · Mid ~50k/1M · High ~500k/10M. <a href="/tokenomics2/" className="text-indigo-600 underline">Phase II →</a></p>
+            <p className="text-xs text-gray-600 mt-1">$44/Space/mo, dynamic IEX. Year-5 paying Spaces: Low ~250k · Mid ~1M · High ~10M. <a href="/tokenomics2/" className="text-indigo-600 underline">Phase II →</a></p>
           </div>
         </div>
       </div>

--- a/docs/hypha-ai-cost/tokenomics-simulator-phase1.html
+++ b/docs/hypha-ai-cost/tokenomics-simulator-phase1.html
@@ -75,7 +75,7 @@ const HyphaTokenomicsCalculator = () => {
   const [existingLockedSupply, setExistingLockedSupply] = useState(111111111);
 
   const [numberOfAOs, setNumberOfAOs] = useState(50);
-  const [paymentPerAO, setPaymentPerAO] = useState(22);
+  const [paymentPerAO, setPaymentPerAO] = useState(44);
   const [usdcFromInvestors, setUsdcFromInvestors] = useState(100000);
   const [aoGrowthRate, setAoGrowthRate] = useState(50);
 
@@ -262,7 +262,7 @@ const HyphaTokenomicsCalculator = () => {
     setTotalSupply(555555555);
     setExistingLockedSupply(111111111);
     setNumberOfAOs(50);
-    setPaymentPerAO(11);
+    setPaymentPerAO(44);
     setUsdcFromInvestors(100000);
     setAoGrowthRate(50);
     setMonthlyOverrides({});

--- a/docs/hypha-ai-cost/tokenomics-simulator-phase1.html
+++ b/docs/hypha-ai-cost/tokenomics-simulator-phase1.html
@@ -66,15 +66,12 @@ const GAS_MONTHLY_BY_PROFILE = { light: 0.06, typical: 0.37, heavy: 3.27 };
 const GAS_SETUP_ONE_TIME = 0.035;
 const perSpaceMonthlyGas = (profile) => GAS_MONTHLY_BY_PROFILE[profile] || GAS_MONTHLY_BY_PROFILE.typical;
 
-const PHASE0_ACTIVE_SPACES = 4373;
+// Phase I bootstraps from a near-zero seed to ~4,373 paying Spaces over 12 months.
+const PHASE_I_END_SPACES = 4373;
 const PHASE_I_MONTHS = 12;
-const PHASE_I_MONTHLY_GROWTH = 0.72;
-const phaseIHandoffSpaces = () => {
-  let n = PHASE0_ACTIVE_SPACES;
-  for (let m = 2; m <= PHASE_I_MONTHS; m++) n = Math.round(n * (1 + PHASE_I_MONTHLY_GROWTH / 100));
-  return n;
-};
-const PHASE_II_START_SPACES = phaseIHandoffSpaces();
+const PHASE_I_SEED_SPACES = 50;       // month 1 seed (~0 Spaces at month 0)
+const PHASE_I_MONTHLY_GROWTH = 50;    // %/mo → ~4,373 by month 12
+const PHASE_II_START_SPACES = PHASE_I_END_SPACES;
 
 const HyphaTokenomicsCalculator = () => {
   const [tokensForSale, setTokensForSale] = useState(10000000);
@@ -84,7 +81,7 @@ const HyphaTokenomicsCalculator = () => {
   const [totalSupply, setTotalSupply] = useState(555555555);
   const [existingLockedSupply, setExistingLockedSupply] = useState(111111111);
 
-  const [numberOfAOs, setNumberOfAOs] = useState(PHASE0_ACTIVE_SPACES);
+  const [numberOfAOs, setNumberOfAOs] = useState(PHASE_I_SEED_SPACES);
   const [paymentPerAO, setPaymentPerAO] = useState(44);
   const [usdcFromInvestors, setUsdcFromInvestors] = useState(100000);
   const [aoGrowthRate, setAoGrowthRate] = useState(PHASE_I_MONTHLY_GROWTH);
@@ -271,7 +268,7 @@ const HyphaTokenomicsCalculator = () => {
     setTokenPrice(0.20);
     setTotalSupply(555555555);
     setExistingLockedSupply(111111111);
-    setNumberOfAOs(PHASE0_ACTIVE_SPACES);
+    setNumberOfAOs(PHASE_I_SEED_SPACES);
     setPaymentPerAO(44);
     setUsdcFromInvestors(100000);
     setAoGrowthRate(PHASE_I_MONTHLY_GROWTH);
@@ -297,15 +294,15 @@ const HyphaTokenomicsCalculator = () => {
         <div className="grid grid-cols-1 md:grid-cols-3 gap-3 text-sm">
           <div className="bg-white p-3 rounded border border-slate-200">
             <div className="font-semibold text-slate-600">Phase 0 — Today</div>
-            <p className="text-xs text-gray-600 mt-1">~4,373 Spaces on Hypha. Tokenomics Phase I begins at month 0. Reference FDV ~$111M at $0.20.</p>
+            <p className="text-xs text-gray-600 mt-1">Pre-launch. Reference FDV ~$111M at $0.20 (111M locked supply).</p>
           </div>
           <div className="bg-indigo-600 text-white p-3 rounded border border-indigo-700">
-            <div className="font-semibold">Phase I — Month 0+ (this sim)</div>
-            <p className="text-xs text-indigo-100 mt-1">{PHASE0_ACTIVE_SPACES.toLocaleString()} Spaces at month 0 → ~{PHASE_II_START_SPACES.toLocaleString()} at month {PHASE_I_MONTHS} ({PHASE_I_MONTHLY_GROWTH}%/mo). Same rate continues in Phase II Low.</p>
+            <div className="font-semibold">Phase I — Year 1 (this sim)</div>
+            <p className="text-xs text-indigo-100 mt-1">Bootstrap: ~0 Spaces at month 0 → ~{PHASE_I_END_SPACES.toLocaleString()} by month {PHASE_I_MONTHS} ({PHASE_I_MONTHLY_GROWTH}%/mo from a {PHASE_I_SEED_SPACES}-Space seed). Phase II continues from here.</p>
           </div>
           <div className="bg-white p-3 rounded border border-slate-200">
-            <div className="font-semibold text-slate-700">Phase II — After Phase I</div>
-            <p className="text-xs text-gray-600 mt-1">$44/Space/mo, dynamic IEX pricing. <a href="/tokenomics2/" className="text-indigo-600 underline">Phase II simulator →</a></p>
+            <div className="font-semibold text-slate-700">Phase II — Years 2–5</div>
+            <p className="text-xs text-gray-600 mt-1">$44/Space/mo, dynamic IEX. Year-5 active: Low ~25k · Mid ~250k · High ~2M. <a href="/tokenomics2/" className="text-indigo-600 underline">Phase II →</a></p>
           </div>
         </div>
       </div>

--- a/docs/hypha-ai-cost/tokenomics-simulator-phase1.html
+++ b/docs/hypha-ai-cost/tokenomics-simulator-phase1.html
@@ -1,0 +1,717 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>HYPHA Tokenomics Simulator (Phase I)</title>
+<link rel="icon" href="https://hypha.earth/wp-content/uploads/2023/07/cropped-favicon-32x32.png" sizes="32x32" />
+<script type="importmap">
+{
+  "imports": {
+    "react": "https://esm.sh/react@18.3.1",
+    "react/jsx-runtime": "https://esm.sh/react@18.3.1/jsx-runtime",
+    "react/jsx-dev-runtime": "https://esm.sh/react@18.3.1/jsx-dev-runtime",
+    "react-dom": "https://esm.sh/react-dom@18.3.1",
+    "react-dom/client": "https://esm.sh/react-dom@18.3.1/client",
+    "recharts": "https://esm.sh/recharts@2.12.7?external=react,react-dom"
+  }
+}
+</script>
+<script src="https://cdn.tailwindcss.com"></script>
+<script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+<style> body { background:#f3f4f6; } </style>
+</head>
+<body>
+<div id="root" class="p-4"></div>
+<script type="text/babel" data-type="module" data-presets="react" data-presets-options='{"react":{"runtime":"classic"}}'>
+import React, { useState, useEffect } from 'react';
+import { createRoot } from 'react-dom/client';
+import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, AreaChart, Area } from 'recharts';
+
+const HyphaTokenomicsCalculator = () => {
+  const [tokensForSale, setTokensForSale] = useState(10000000);
+  const [yieldMultiplier, setYieldMultiplier] = useState(30);
+  const [saleMonths, setSaleMonths] = useState(12);
+  const [tokenPrice, setTokenPrice] = useState(0.25);
+  const [totalSupply, setTotalSupply] = useState(555555555);
+  const [existingLockedSupply, setExistingLockedSupply] = useState(111111111);
+
+  const [numberOfAOs, setNumberOfAOs] = useState(50);
+  const [paymentPerAO, setPaymentPerAO] = useState(11);
+  const [usdcFromInvestors, setUsdcFromInvestors] = useState(100000);
+  const [aoGrowthRate, setAoGrowthRate] = useState(50);
+
+  const [showMonthlyConfig, setShowMonthlyConfig] = useState(false);
+  const [monthlyOverrides, setMonthlyOverrides] = useState({});
+  const [selectedMonth, setSelectedMonth] = useState(1);
+
+  const [monthlyData, setMonthlyData] = useState([]);
+  const [cumulativeData, setCumulativeData] = useState([]);
+  const [fdv, setFdv] = useState(0);
+  const [marketCap, setMarketCap] = useState(0);
+  const [totalValue, setTotalValue] = useState(0);
+  const [totalYieldTokens, setTotalYieldTokens] = useState(0);
+  const [totalTokensSold, setTotalTokensSold] = useState(0);
+  const [yieldPerLockedToken, setYieldPerLockedToken] = useState(0);
+
+  useEffect(() => {
+    calculateTokenomics();
+  }, [
+    tokensForSale, yieldMultiplier, saleMonths, tokenPrice, totalSupply,
+    numberOfAOs, paymentPerAO, usdcFromInvestors, aoGrowthRate,
+    existingLockedSupply, monthlyOverrides
+  ]);
+
+  const getParamForMonth = (month, paramName, defaultValue) => {
+    if (monthlyOverrides[month-1] && monthlyOverrides[month-1][paramName] !== undefined) {
+      return monthlyOverrides[month-1][paramName];
+    }
+    return defaultValue;
+  };
+
+  const calculateTokenomics = () => {
+    const calculatedFdv = totalSupply * tokenPrice;
+    setFdv(calculatedFdv);
+
+    const calculatedMarketCap = existingLockedSupply * tokenPrice;
+    setMarketCap(calculatedMarketCap);
+
+    const monthlyTokenSales = [];
+    const cumulativeTokenSales = [];
+
+    let cumulativeSold = 0;
+    let cumulativeYield = 0;
+    let totalYield = 0;
+    let currentNumberOfAOs = numberOfAOs;
+    let totalUSDC = 0;
+    let calculatedTotalValue = 0;
+
+    for (let month = 1; month <= saleMonths; month++) {
+      const monthTokenPrice = tokenPrice;
+      const monthYieldMultiplier = getParamForMonth(month, 'yieldMultiplier', yieldMultiplier);
+
+      if (month > 1) {
+        if (monthlyOverrides[month-1] && monthlyOverrides[month-1]['numberOfAOs'] !== undefined) {
+          currentNumberOfAOs = monthlyOverrides[month-1]['numberOfAOs'];
+        } else {
+          const monthAoGrowthRate = getParamForMonth(month, 'aoGrowthRate', aoGrowthRate) / 100;
+          currentNumberOfAOs = Math.round(currentNumberOfAOs * (1 + monthAoGrowthRate));
+        }
+      } else {
+        currentNumberOfAOs = numberOfAOs;
+      }
+
+      const monthPaymentPerAO = getParamForMonth(month, 'paymentPerAO', paymentPerAO);
+      const monthInvestorUSDC = getParamForMonth(month, 'usdcFromInvestors', usdcFromInvestors);
+
+      const aoIncome = currentNumberOfAOs * monthPaymentPerAO;
+      const monthlyUSDC = aoIncome + monthInvestorUSDC;
+      totalUSDC += monthlyUSDC;
+
+      const tokensSold = monthlyUSDC / monthTokenPrice;
+      cumulativeSold += tokensSold;
+      calculatedTotalValue += monthlyUSDC;
+
+      const monthlyYield = (aoIncome * monthYieldMultiplier) / monthTokenPrice;
+      cumulativeYield += monthlyYield;
+      totalYield += monthlyYield;
+
+      monthlyTokenSales.push({
+        month,
+        tokensSold,
+        yield: monthlyYield,
+        yieldMultiplier: monthYieldMultiplier,
+        tokenPrice: monthTokenPrice,
+        numberOfAOs: currentNumberOfAOs,
+        aoIncome,
+        investorUSDC: monthInvestorUSDC,
+        totalMonthlyUSDC: monthlyUSDC,
+        totalUSDC,
+        aoPaymentYield: aoIncome * monthYieldMultiplier
+      });
+
+      cumulativeTokenSales.push({
+        month,
+        cumulativeSold,
+        cumulativeYield,
+        initialLockedSupply: existingLockedSupply,
+        totalEarningTokens: cumulativeSold + existingLockedSupply,
+        tokenPrice: monthTokenPrice,
+        fdv: totalSupply * monthTokenPrice,
+        totalUSDC
+      });
+    }
+
+    const totalLockedTokens = existingLockedSupply + cumulativeSold;
+    const calculatedYieldPerLockedToken = totalLockedTokens > 0 ? totalYield / totalLockedTokens : 0;
+
+    setMonthlyData(monthlyTokenSales);
+    setCumulativeData(cumulativeTokenSales);
+    setTotalYieldTokens(totalYield);
+    setTotalValue(calculatedTotalValue);
+    setTotalTokensSold(cumulativeSold);
+    setYieldPerLockedToken(calculatedYieldPerLockedToken);
+  };
+
+  const handleMonthlyOverride = (paramName, value) => {
+    const newOverrides = { ...monthlyOverrides };
+
+    if (!newOverrides[selectedMonth-1]) {
+      newOverrides[selectedMonth-1] = {};
+    }
+
+    newOverrides[selectedMonth-1][paramName] = value;
+    setMonthlyOverrides(newOverrides);
+  };
+
+  const removeMonthlyOverride = (month, paramName) => {
+    const newOverrides = { ...monthlyOverrides };
+
+    if (newOverrides[month-1] && newOverrides[month-1][paramName] !== undefined) {
+      delete newOverrides[month-1][paramName];
+
+      if (Object.keys(newOverrides[month-1]).length === 0) {
+        delete newOverrides[month-1];
+      }
+
+      setMonthlyOverrides(newOverrides);
+    }
+  };
+
+  const formatCurrency = (value) => {
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: 'USD',
+      minimumFractionDigits: value < 1 ? 3 : 0,
+      maximumFractionDigits: value < 1 ? 3 : 0,
+    }).format(value);
+  };
+
+  const formatNumber = (value) => {
+    return new Intl.NumberFormat('en-US').format(Math.round(value));
+  };
+
+  const resetParameters = () => {
+    setTokensForSale(10000000);
+    setYieldMultiplier(30);
+    setSaleMonths(12);
+    setTokenPrice(0.25);
+    setTotalSupply(555555555);
+    setExistingLockedSupply(111111111);
+    setNumberOfAOs(50);
+    setPaymentPerAO(11);
+    setUsdcFromInvestors(100000);
+    setAoGrowthRate(50);
+    setMonthlyOverrides({});
+  };
+
+  return (
+    <div className="p-6 bg-gray-50 rounded-lg shadow-lg">
+      <h1 className="text-2xl font-bold mb-6 text-center">HYPHA Tokenomics Simulator (Phase I)</h1>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
+        <div className="bg-white p-4 rounded-lg shadow">
+          <h2 className="text-lg font-semibold mb-4">Initial Parameters</h2>
+
+          <div className="mb-4">
+            <label className="block text-sm font-medium mb-1">Total Supply of HYPHA</label>
+            <div className="flex items-center">
+              <input
+                type="range"
+                min="100000000"
+                max="1000000000"
+                step="10000000"
+                value={totalSupply}
+                onChange={(e) => setTotalSupply(Number(e.target.value))}
+                className="w-full mr-3"
+              />
+              <input
+                type="text"
+                value={totalSupply.toLocaleString('en-US')}
+                onChange={(e) => setTotalSupply(Number(e.target.value.replace(/,/g, '')))}
+                className="w-32 p-1 border rounded text-right"
+                min="1"
+                step="1000000"
+              />
+            </div>
+          </div>
+
+          <div className="mb-4">
+            <label className="block text-sm font-medium mb-1">Existing Locked Tokens Allocation</label>
+            <div className="flex items-center">
+              <input
+                type="range"
+                min="0"
+                max="100000000"
+                step="1000000"
+                value={existingLockedSupply}
+                onChange={(e) => setExistingLockedSupply(Number(e.target.value))}
+                className="w-full mr-3"
+              />
+              <input
+                type="text"
+                value={existingLockedSupply.toLocaleString('en-US')}
+                onChange={(e) => setExistingLockedSupply(Number(e.target.value.replace(/,/g, '')))}
+                className="w-32 p-1 border rounded text-right"
+                min="0"
+                step="1000"
+              />
+            </div>
+          </div>
+
+          <div className="mb-4">
+            <label className="block text-sm font-medium mb-1">HYPHA Token Price (USD)</label>
+            <div className="flex items-center">
+              <input
+                type="range"
+                min="0.001"
+                max="0.5"
+                step="0.001"
+                value={tokenPrice}
+                onChange={(e) => setTokenPrice(Number(e.target.value))}
+                className="w-full mr-3"
+              />
+              <input
+                type="number"
+                value={tokenPrice}
+                onChange={(e) => setTokenPrice(Number(e.target.value))}
+                className="w-24 p-1 border rounded text-right"
+                min="0.0001"
+                step="0.001"
+              />
+            </div>
+          </div>
+
+          <div className="mb-4">
+            <label className="block text-sm font-medium mb-1">Sale Duration (Months)</label>
+            <div className="flex items-center">
+              <input
+                type="range"
+                min="1"
+                max="60"
+                step="1"
+                value={saleMonths}
+                onChange={(e) => setSaleMonths(Number(e.target.value))}
+                className="w-full mr-3"
+              />
+              <input
+                type="number"
+                value={saleMonths}
+                onChange={(e) => setSaleMonths(Number(e.target.value))}
+                className="w-16 p-1 border rounded text-right"
+                min="1"
+                max="60"
+              />
+            </div>
+          </div>
+        </div>
+
+        <div className="bg-white p-4 rounded-lg shadow">
+          <div className="flex justify-between items-center mb-4">
+            <h2 className="text-lg font-semibold">Monthly Parameters</h2>
+            <button
+              onClick={() => setShowMonthlyConfig(!showMonthlyConfig)}
+              className="px-3 py-1 bg-blue-500 text-white rounded hover:bg-blue-600 text-sm"
+            >
+              {showMonthlyConfig ? 'Hide' : 'Show'} Configuration
+            </button>
+          </div>
+
+          <div className="mb-4">
+            <label className="block text-sm font-medium mb-1">Initial Number of Spaces</label>
+            <div className="flex items-center">
+              <input
+                type="range"
+                min="0"
+                max="100"
+                step="1"
+                value={numberOfAOs}
+                onChange={(e) => setNumberOfAOs(Number(e.target.value))}
+                className="w-full mr-3"
+              />
+              <input
+                type="number"
+                value={numberOfAOs}
+                onChange={(e) => setNumberOfAOs(Number(e.target.value))}
+                className="w-16 p-1 border rounded text-right"
+                min="0"
+              />
+            </div>
+          </div>
+
+          <div className="mb-4">
+            <label className="block text-sm font-medium mb-1">Spaces Growth Rate (%)</label>
+            <div className="flex items-center">
+              <input
+                type="range"
+                min="0"
+                max="100"
+                step="1"
+                value={aoGrowthRate}
+                onChange={(e) => setAoGrowthRate(Number(e.target.value))}
+                className="w-full mr-3"
+              />
+              <input
+                type="number"
+                value={aoGrowthRate}
+                onChange={(e) => setAoGrowthRate(Number(e.target.value))}
+                className="w-16 p-1 border rounded text-right"
+                min="0"
+                max="100"
+              />
+              <span className="ml-1">%</span>
+            </div>
+            <p className="text-xs text-gray-500 mt-1">Monthly growth rate of Spaces (if not explicitly set per month)</p>
+          </div>
+
+          <div className="mb-4">
+            <label className="block text-sm font-medium mb-1">Space&apos;s contribution to Hypha Network (USDC)</label>
+            <div className="flex items-center">
+              <input
+                type="range"
+                min="0"
+                max="1000"
+                step="10"
+                value={paymentPerAO}
+                onChange={(e) => setPaymentPerAO(Number(e.target.value))}
+                className="w-full mr-3"
+              />
+              <input
+                type="number"
+                value={paymentPerAO}
+                onChange={(e) => setPaymentPerAO(Number(e.target.value))}
+                className="w-20 p-1 border rounded text-right"
+                min="0"
+                step="1"
+              />
+              <span className="ml-1">USDC</span>
+            </div>
+          </div>
+
+          <div className="mb-4">
+            <label className="block text-sm font-medium mb-1">Distribution Multiplier</label>
+            <div className="flex items-center">
+              <input
+                type="range"
+                min="0"
+                max="50"
+                step="0.1"
+                value={yieldMultiplier}
+                onChange={(e) => setYieldMultiplier(Number(e.target.value))}
+                className="w-full mr-3"
+              />
+              <input
+                type="number"
+                value={yieldMultiplier}
+                onChange={(e) => setYieldMultiplier(Number(e.target.value))}
+                className="w-16 p-1 border rounded text-right"
+                min="0"
+                step="0.1"
+              />
+            </div>
+            <p className="text-xs text-gray-500 mt-1">Tokens distributed = Spaces&apos; contributions to Hypha Network (HYPHA) × Distribution Multiplier</p>
+          </div>
+
+          <div className="mb-4">
+            <label className="block text-sm font-medium mb-1">Initial HYPHA purchases from investors (USDC)</label>
+            <div className="flex items-center">
+              <input
+                type="range"
+                min="0"
+                max="150000"
+                step="1000"
+                value={usdcFromInvestors}
+                onChange={(e) => setUsdcFromInvestors(Number(e.target.value))}
+                className="w-full mr-3"
+              />
+              <input
+                type="text"
+                value={usdcFromInvestors.toLocaleString('en-US')}
+                onChange={(e) => setUsdcFromInvestors(Number(e.target.value.replace(/,/g, '')))}
+                className="w-24 p-1 border rounded text-right"
+                min="0"
+                step="1000"
+              />
+              <span className="ml-1">USDC</span>
+            </div>
+            <p className="text-xs text-gray-500 mt-1">This value is used for all months unless customized per month.</p>
+          </div>
+
+          {showMonthlyConfig && (
+            <div className="border rounded p-4 mt-4">
+              <div className="mb-4">
+                <label className="block text-sm font-medium mb-1">Select Month</label>
+                <select
+                  value={selectedMonth}
+                  onChange={(e) => setSelectedMonth(Number(e.target.value))}
+                  className="w-full p-2 border rounded"
+                >
+                  {Array.from({ length: saleMonths }, (_, i) => (
+                    <option key={i+1} value={i+1}>
+                      Month {i+1} {monthlyOverrides[i] ? '(Custom)' : ''}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              <h3 className="font-semibold text-sm mb-2">Month {selectedMonth} Parameters</h3>
+
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+                <div>
+                  <label className="block text-xs font-medium mb-1">Distribution Multiplier</label>
+                  <div className="flex items-center">
+                    <input
+                      type="number"
+                      value={monthlyOverrides[selectedMonth-1]?.yieldMultiplier !== undefined
+                        ? monthlyOverrides[selectedMonth-1].yieldMultiplier
+                        : ''}
+                      onChange={(e) => handleMonthlyOverride('yieldMultiplier', Number(e.target.value))}
+                      placeholder={yieldMultiplier}
+                      className="w-full p-1 border rounded text-sm"
+                      min="0"
+                      step="0.1"
+                    />
+                    {monthlyOverrides[selectedMonth-1]?.yieldMultiplier !== undefined && (
+                      <button
+                        onClick={() => removeMonthlyOverride(selectedMonth, 'yieldMultiplier')}
+                        className="ml-1 text-red-500 text-lg"
+                        title="Reset to global value"
+                      >
+                        ×
+                      </button>
+                    )}
+                  </div>
+                </div>
+
+                <div>
+                  <label className="block text-xs font-medium mb-1">Payment per AO</label>
+                  <div className="flex items-center">
+                    <input
+                      type="number"
+                      value={monthlyOverrides[selectedMonth-1]?.paymentPerAO !== undefined
+                        ? monthlyOverrides[selectedMonth-1].paymentPerAO
+                        : ''}
+                      onChange={(e) => handleMonthlyOverride('paymentPerAO', Number(e.target.value))}
+                      placeholder={paymentPerAO}
+                      className="w-full p-1 border rounded text-sm"
+                      min="0"
+                      step="1"
+                    />
+                    {monthlyOverrides[selectedMonth-1]?.paymentPerAO !== undefined && (
+                      <button
+                        onClick={() => removeMonthlyOverride(selectedMonth, 'paymentPerAO')}
+                        className="ml-1 text-red-500 text-lg"
+                        title="Reset to global value"
+                      >
+                        ×
+                      </button>
+                    )}
+                  </div>
+                </div>
+
+                <div>
+                  <label className="block text-xs font-medium mb-1">Investor USDC</label>
+                  <div className="flex items-center">
+                    <input
+                      type="number"
+                      value={monthlyOverrides[selectedMonth-1]?.usdcFromInvestors !== undefined
+                        ? monthlyOverrides[selectedMonth-1].usdcFromInvestors
+                        : ''}
+                      onChange={(e) => handleMonthlyOverride('usdcFromInvestors', Number(e.target.value))}
+                      placeholder={usdcFromInvestors}
+                      className="w-full p-1 border rounded text-sm"
+                      min="0"
+                      step="1000"
+                    />
+                    {monthlyOverrides[selectedMonth-1]?.usdcFromInvestors !== undefined && (
+                      <button
+                        onClick={() => removeMonthlyOverride(selectedMonth, 'usdcFromInvestors')}
+                        className="ml-1 text-red-500 text-lg"
+                        title="Reset to global value"
+                      >
+                        ×
+                      </button>
+                    )}
+                  </div>
+                </div>
+
+                {selectedMonth > 1 && (
+                  <div>
+                    <label className="block text-xs font-medium mb-1">Spaces Growth Rate (%)</label>
+                    <div className="flex items-center">
+                      <input
+                        type="number"
+                        value={monthlyOverrides[selectedMonth-1]?.aoGrowthRate !== undefined
+                          ? monthlyOverrides[selectedMonth-1].aoGrowthRate
+                          : ''}
+                        onChange={(e) => handleMonthlyOverride('aoGrowthRate', Number(e.target.value))}
+                        placeholder={aoGrowthRate}
+                        className="w-full p-1 border rounded text-sm"
+                        min="0"
+                        max="100"
+                        step="1"
+                      />
+                      {monthlyOverrides[selectedMonth-1]?.aoGrowthRate !== undefined && (
+                        <button
+                          onClick={() => removeMonthlyOverride(selectedMonth, 'aoGrowthRate')}
+                          className="ml-1 text-red-500 text-lg"
+                          title="Reset to global value"
+                        >
+                          ×
+                        </button>
+                      )}
+                    </div>
+                  </div>
+                )}
+              </div>
+
+              <div className="mt-3 text-xs text-gray-500">
+                Empty fields use the global values. For Number of Spaces after month 1, the value is calculated based on growth rate if not explicitly set.
+              </div>
+            </div>
+          )}
+
+          {Object.keys(monthlyOverrides).length > 0 && (
+            <div className="mt-2 text-sm text-gray-500">
+              Customized months: {Object.keys(monthlyOverrides).map(m => Number(m) + 1).sort((a, b) => a - b).join(', ')}
+            </div>
+          )}
+
+          <button
+            onClick={resetParameters}
+            className="mt-4 px-4 py-2 bg-gray-200 rounded hover:bg-gray-300"
+          >
+            Reset All Parameters
+          </button>
+        </div>
+      </div>
+
+      <div className="bg-white p-4 rounded-lg shadow mb-8">
+        <h2 className="text-lg font-semibold mb-4">Key Metrics</h2>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-4">
+          <div className="p-4 bg-indigo-50 rounded-lg">
+            <div className="text-sm text-indigo-600">Current Valuation (Market Cap.)</div>
+            <div className="text-2xl font-bold">{formatCurrency(marketCap)}</div>
+          </div>
+
+          <div className="p-4 bg-blue-50 rounded-lg">
+            <div className="text-sm text-blue-600">Fully Diluted Valuation (FDV)</div>
+            <div className="text-2xl font-bold">{formatCurrency(fdv)}</div>
+          </div>
+
+          <div className="p-4 bg-green-50 rounded-lg">
+            <div className="text-sm text-green-600">Total Dollar Value Sold</div>
+            <div className="text-2xl font-bold">{formatCurrency(totalValue)}</div>
+          </div>
+
+          <div className="p-4 bg-purple-50 rounded-lg">
+            <div className="text-sm text-purple-600">Total Tokens Locked</div>
+            <div className="text-2xl font-bold">{formatNumber(totalTokensSold)}</div>
+          </div>
+
+          <div className="p-4 bg-amber-50 rounded-lg">
+            <div className="text-sm text-amber-600">Total Tokens Distributed</div>
+            <div className="text-2xl font-bold">{formatNumber(totalYieldTokens)}</div>
+            <div className="text-sm text-amber-600 mt-2">Reward per Locked Token</div>
+            <div className="text-xl font-bold">{yieldPerLockedToken.toFixed(4)}</div>
+            <div className="text-xs text-amber-600 mt-1">(Not including monthly compounding effects)</div>
+          </div>
+        </div>
+      </div>
+
+      <div className="bg-white p-4 rounded-lg shadow mb-8">
+        <h2 className="text-lg font-semibold mb-4">Token Distribution Over Time</h2>
+        <ResponsiveContainer width="100%" height={300}>
+          <AreaChart
+            data={cumulativeData}
+            margin={{ top: 5, right: 30, left: 60, bottom: 5 }}
+          >
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="month" label={{ value: 'Month', position: 'insideBottom', offset: -5 }} />
+            <YAxis
+              tickFormatter={(value) => new Intl.NumberFormat('en-US').format(value)}
+            />
+            <Tooltip
+              formatter={(value, name) => {
+                if (name === "cumulativeSold") {
+                  return [formatNumber(value), "Tokens Locked"];
+                } else if (name === "cumulativeYield") {
+                  return [formatNumber(value), "Tokens Distributed"];
+                } else if (name === "initialLockedSupply") {
+                  return [formatNumber(value), "Existing Locked Tokens Allocation"];
+                }
+                return [formatNumber(value), name];
+              }}
+            />
+            <Legend />
+            <Area type="monotone" dataKey="initialLockedSupply" name="Existing Locked Tokens Allocation" stackId="1" stroke="#ff8c00" fill="#ffcc80" />
+            <Area type="monotone" dataKey="cumulativeSold" name="Tokens Locked" stackId="1" stroke="#8884d8" fill="#8884d8" />
+            <Area type="monotone" dataKey="cumulativeYield" name="Tokens Distributed" stackId="2" stroke="#82ca9d" fill="#82ca9d" />
+          </AreaChart>
+        </ResponsiveContainer>
+      </div>
+
+      <div className="bg-white p-4 rounded-lg shadow mb-8">
+        <h2 className="text-lg font-semibold mb-4">Spaces Growth Over Time</h2>
+        <ResponsiveContainer width="100%" height={300}>
+          <LineChart
+            data={monthlyData}
+            margin={{ top: 5, right: 30, left: 40, bottom: 5 }}
+          >
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="month" label={{ value: 'Month', position: 'insideBottom', offset: -5 }} />
+            <YAxis
+              tickFormatter={(value) => new Intl.NumberFormat('en-US').format(value)}
+            />
+            <Tooltip formatter={(value) => [formatNumber(value)]} />
+            <Legend />
+            <Line type="monotone" dataKey="numberOfAOs" name="Number of Spaces" stroke="#8884d8" activeDot={{ r: 8 }} />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+
+      <div className="bg-white p-4 rounded-lg shadow">
+        <h2 className="text-lg font-semibold mb-4">Monthly Breakdown</h2>
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead>
+              <tr className="bg-gray-100">
+                <th className="px-4 py-3 text-center font-semibold text-gray-700">Month</th>
+                <th className="px-4 py-3 text-center font-semibold text-gray-700">USDC Income</th>
+                <th className="px-4 py-3 text-center font-semibold text-gray-700">Token Price</th>
+                <th className="px-4 py-3 text-center font-semibold text-gray-700">Tokens Locked</th>
+                <th className="px-4 py-3 text-center font-semibold text-gray-700">Tokens Distributed</th>
+                <th className="px-4 py-3 text-center font-semibold text-gray-700">Total Tokens Locked</th>
+                <th className="px-4 py-3 text-center font-semibold text-gray-700">Number of Spaces</th>
+                <th className="px-4 py-3 text-center font-semibold text-gray-700">Distribution Multiplier</th>
+              </tr>
+            </thead>
+            <tbody>
+              {monthlyData.map((month, index) => (
+                <tr key={index} className={index % 2 === 0 ? 'bg-white' : 'bg-gray-50'}>
+                  <td className="px-4 py-3 text-center font-medium">{month.month}</td>
+                  <td className="px-4 py-3 text-center">{formatCurrency(month.totalMonthlyUSDC)}</td>
+                  <td className="px-4 py-3 text-center">{formatCurrency(month.tokenPrice)}</td>
+                  <td className="px-4 py-3 text-center">{formatNumber(month.tokensSold)}</td>
+                  <td className="px-4 py-3 text-center">{formatNumber(month.yield)}</td>
+                  <td className="px-4 py-3 text-center">
+                    {formatNumber(cumulativeData[index].cumulativeSold + cumulativeData[index].cumulativeYield + existingLockedSupply)}
+                  </td>
+                  <td className="px-4 py-3 text-center">{formatNumber(month.numberOfAOs)}</td>
+                  <td className="px-4 py-3 text-center">{month.yieldMultiplier}x</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const root = createRoot(document.getElementById('root'));
+root.render(<HyphaTokenomicsCalculator />);
+</script>
+</body>
+</html>

--- a/docs/hypha-ai-cost/tokenomics-simulator-phase1.html
+++ b/docs/hypha-ai-cost/tokenomics-simulator-phase1.html
@@ -302,7 +302,7 @@ const HyphaTokenomicsCalculator = () => {
           </div>
           <div className="bg-white p-3 rounded border border-slate-200">
             <div className="font-semibold text-slate-700">Phase II — Years 2–5</div>
-            <p className="text-xs text-gray-600 mt-1">$44/Space/mo, dynamic IEX. Year-5 active: Low ~25k · Mid ~250k · High ~2M. <a href="/tokenomics2/" className="text-indigo-600 underline">Phase II →</a></p>
+            <p className="text-xs text-gray-600 mt-1">$44/Space/mo, dynamic IEX. Year-5 paying / created: Low ~15k/250k · Mid ~50k/1M · High ~500k/10M. <a href="/tokenomics2/" className="text-indigo-600 underline">Phase II →</a></p>
           </div>
         </div>
       </div>

--- a/docs/hypha-ai-cost/tokenomics-simulator-phase1.html
+++ b/docs/hypha-ai-cost/tokenomics-simulator-phase1.html
@@ -66,18 +66,28 @@ const GAS_MONTHLY_BY_PROFILE = { light: 0.06, typical: 0.37, heavy: 3.27 };
 const GAS_SETUP_ONE_TIME = 0.035;
 const perSpaceMonthlyGas = (profile) => GAS_MONTHLY_BY_PROFILE[profile] || GAS_MONTHLY_BY_PROFILE.typical;
 
+const PHASE0_ACTIVE_SPACES = 4373;
+const PHASE_I_MONTHS = 12;
+const PHASE_I_MONTHLY_GROWTH = 0.72;
+const phaseIHandoffSpaces = () => {
+  let n = PHASE0_ACTIVE_SPACES;
+  for (let m = 2; m <= PHASE_I_MONTHS; m++) n = Math.round(n * (1 + PHASE_I_MONTHLY_GROWTH / 100));
+  return n;
+};
+const PHASE_II_START_SPACES = phaseIHandoffSpaces();
+
 const HyphaTokenomicsCalculator = () => {
   const [tokensForSale, setTokensForSale] = useState(10000000);
   const [yieldMultiplier, setYieldMultiplier] = useState(30);
-  const [saleMonths, setSaleMonths] = useState(12);
+  const [saleMonths, setSaleMonths] = useState(PHASE_I_MONTHS);
   const [tokenPrice, setTokenPrice] = useState(0.20);
   const [totalSupply, setTotalSupply] = useState(555555555);
   const [existingLockedSupply, setExistingLockedSupply] = useState(111111111);
 
-  const [numberOfAOs, setNumberOfAOs] = useState(50);
+  const [numberOfAOs, setNumberOfAOs] = useState(PHASE0_ACTIVE_SPACES);
   const [paymentPerAO, setPaymentPerAO] = useState(44);
   const [usdcFromInvestors, setUsdcFromInvestors] = useState(100000);
-  const [aoGrowthRate, setAoGrowthRate] = useState(50);
+  const [aoGrowthRate, setAoGrowthRate] = useState(PHASE_I_MONTHLY_GROWTH);
 
   const [aiModelId, setAiModelId] = useState('kimi-or');
   const [aiProfile, setAiProfile] = useState('typical');
@@ -257,14 +267,14 @@ const HyphaTokenomicsCalculator = () => {
   const resetParameters = () => {
     setTokensForSale(10000000);
     setYieldMultiplier(30);
-    setSaleMonths(12);
+    setSaleMonths(PHASE_I_MONTHS);
     setTokenPrice(0.20);
     setTotalSupply(555555555);
     setExistingLockedSupply(111111111);
-    setNumberOfAOs(50);
+    setNumberOfAOs(PHASE0_ACTIVE_SPACES);
     setPaymentPerAO(44);
     setUsdcFromInvestors(100000);
-    setAoGrowthRate(50);
+    setAoGrowthRate(PHASE_I_MONTHLY_GROWTH);
     setMonthlyOverrides({});
     setAiModelId('kimi-or');
     setAiProfile('typical');
@@ -291,7 +301,7 @@ const HyphaTokenomicsCalculator = () => {
           </div>
           <div className="bg-indigo-600 text-white p-3 rounded border border-indigo-700">
             <div className="font-semibold">Phase I — Month 0+ (this sim)</div>
-            <p className="text-xs text-indigo-100 mt-1">Default: 50 Spaces → ~4,325 by month 12 at 50%/mo growth. Handoff to Phase II at ~4,373 paying Spaces.</p>
+            <p className="text-xs text-indigo-100 mt-1">{PHASE0_ACTIVE_SPACES.toLocaleString()} Spaces at month 0 → ~{PHASE_II_START_SPACES.toLocaleString()} at month {PHASE_I_MONTHS} ({PHASE_I_MONTHLY_GROWTH}%/mo). Same rate continues in Phase II Low.</p>
           </div>
           <div className="bg-white p-3 rounded border border-slate-200">
             <div className="font-semibold text-slate-700">Phase II — After Phase I</div>
@@ -828,6 +838,12 @@ const HyphaTokenomicsCalculator = () => {
 
           {lastMonth && (
             <>
+              <div className="p-4 bg-slate-50 rounded-lg border-l-4 border-slate-400">
+                <div className="text-sm text-slate-600">Phase II handoff (month {saleMonths})</div>
+                <div className="text-2xl font-bold text-slate-800">{formatNumber(lastMonth.numberOfAOs)} active Spaces</div>
+                <div className="text-xs text-slate-600 mt-1">Phase II sim starts here — <a href="/tokenomics2/" className="text-indigo-600 underline">open Phase II →</a></div>
+              </div>
+
               <div className="p-4 bg-green-50 rounded-lg border-l-4 border-green-400">
                 <div className="text-sm text-green-600">Run-rate ARR (month {saleMonths})</div>
                 <div className="text-2xl font-bold text-green-700">{formatCurrency(phase1RunRateArr)}</div>

--- a/docs/hypha-ai-cost/tokenomics-simulator-phase1.html
+++ b/docs/hypha-ai-cost/tokenomics-simulator-phase1.html
@@ -275,12 +275,32 @@ const HyphaTokenomicsCalculator = () => {
   const perSpaceGas = perSpaceMonthlyGas(aiProfile);
   const baselinePerSpace = perSpaceMonthlyAICost(getModel('composer-fast'), aiProfile);
   const lastMonth = monthlyData.length > 0 ? monthlyData[monthlyData.length - 1] : null;
+  const phase1RunRateArr = lastMonth ? lastMonth.aoIncome * 12 : 0;
 
   return (
     <div className="p-6 bg-gray-50 rounded-lg shadow-lg">
       <h1 className="text-2xl font-bold mb-1 text-center">HYPHA Tokenomics Simulator (Phase I)</h1>
-      <p className="text-sm text-gray-500 mb-6 text-center">Phase I uses a fixed reference token price; Phase II derives price from IEX dynamics.</p>
-      <p className="text-sm text-gray-500 mb-6 text-center">With per-Space AI + Base L2 gas operating cost model — closed-source vs open-source LLMs.</p>
+      <p className="text-sm text-gray-500 mb-3 text-center">Fixed $0.20 reference price — token sale, locking &amp; yield distribution at Phase I month 0+.</p>
+
+      <div className="mb-6 border border-slate-200 bg-slate-50 p-4 rounded-lg">
+        <h2 className="text-xs font-semibold text-slate-600 uppercase tracking-wide mb-2 text-center">Roadmap: Phase 0 → Phase I → Phase II</h2>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-3 text-sm">
+          <div className="bg-white p-3 rounded border border-slate-200">
+            <div className="font-semibold text-slate-600">Phase 0 — Today</div>
+            <p className="text-xs text-gray-600 mt-1">~4,373 Spaces on Hypha. Tokenomics Phase I begins at month 0. Reference FDV ~$111M at $0.20.</p>
+          </div>
+          <div className="bg-indigo-600 text-white p-3 rounded border border-indigo-700">
+            <div className="font-semibold">Phase I — Month 0+ (this sim)</div>
+            <p className="text-xs text-indigo-100 mt-1">Default: 50 Spaces → ~4,325 by month 12 at 50%/mo growth. Handoff to Phase II at ~4,373 paying Spaces.</p>
+          </div>
+          <div className="bg-white p-3 rounded border border-slate-200">
+            <div className="font-semibold text-slate-700">Phase II — After Phase I</div>
+            <p className="text-xs text-gray-600 mt-1">$44/Space/mo, dynamic IEX pricing. <a href="/tokenomics2/" className="text-indigo-600 underline">Phase II simulator →</a></p>
+          </div>
+        </div>
+      </div>
+
+      <p className="text-sm text-gray-500 mb-6 text-center">Per-Space AI + Base L2 gas operating cost model — closed-source vs open-source LLMs.</p>
 
       <div className="mb-8 border border-indigo-200 bg-indigo-50 p-4 rounded-lg">
         <h2 className="text-lg font-semibold mb-1">AI &amp; On-Chain Operating Cost per Space</h2>
@@ -808,6 +828,14 @@ const HyphaTokenomicsCalculator = () => {
 
           {lastMonth && (
             <>
+              <div className="p-4 bg-green-50 rounded-lg border-l-4 border-green-400">
+                <div className="text-sm text-green-600">Run-rate ARR (month {saleMonths})</div>
+                <div className="text-2xl font-bold text-green-700">{formatCurrency(phase1RunRateArr)}</div>
+                <div className="text-xs text-green-600 mt-1">
+                  {formatNumber(lastMonth.numberOfAOs)} active Spaces × ${paymentPerAO} × 12
+                </div>
+              </div>
+
               <div className="p-4 bg-green-50 rounded-lg border-l-4 border-green-400">
                 <div className="text-sm text-green-600">Cumulated Space Contributions</div>
                 <div className="text-2xl font-bold text-green-700">

--- a/docs/hypha-ai-cost/tokenomics-simulator-phase1.html
+++ b/docs/hypha-ai-cost/tokenomics-simulator-phase1.html
@@ -28,6 +28,44 @@ import React, { useState, useEffect } from 'react';
 import { createRoot } from 'react-dom/client';
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, AreaChart, Area } from 'recharts';
 
+// ============================================================
+// AI Operating Cost model (from docs/hypha-ai-cost)
+// Typical Space workload = 4.66M input + 0.17M output tokens / month.
+// Per-space monthly $ = (in_M * inPrice + out_M * outPrice) * profileMult.
+// ============================================================
+const TYPICAL_INPUT_M = 4.66;
+const TYPICAL_OUTPUT_M = 0.17;
+const PROFILE_MULT = { light: 0.33, typical: 1, heavy: 2.73 };
+
+const AI_MODELS = {
+  closed: [
+    { id: 'composer-fast', name: 'Composer 2.5 Fast', input: 3.0, output: 15.0, note: 'IDE default reference / baseline' },
+    { id: 'composer-standard', name: 'Composer 2.5 Standard', input: 0.5, output: 2.5, note: 'Same model, lower throughput' },
+  ],
+  open: [
+    { id: 'kimi-list', name: 'Kimi K2.6 (list)', input: 0.95, output: 4.0, note: 'Leads open quality; Composer lineage' },
+    { id: 'kimi-or', name: 'Kimi K2.6 (OpenRouter low)', input: 0.68, output: 3.41, note: 'Cheapest Kimi host' },
+    { id: 'qwen', name: 'Qwen3.5-397B', input: 0.6, output: 3.6, note: 'Strong open frontier MoE' },
+    { id: 'llama', name: 'Llama 4 Maverick', input: 0.5, output: 2.15, note: '400B MoE (DeepInfra)' },
+    { id: 'deepseek-pro', name: 'DeepSeek V4-Pro', input: 0.44, output: 0.87, note: 'Flagship open reasoning/coding' },
+    { id: 'deepseek-flash', name: 'DeepSeek V4-Flash', input: 0.14, output: 0.28, note: 'Budget leader' },
+  ],
+};
+const ALL_MODELS = [...AI_MODELS.closed, ...AI_MODELS.open];
+const getModel = (id) => ALL_MODELS.find((m) => m.id === id) || ALL_MODELS[0];
+const perSpaceMonthlyAICost = (model, profile) =>
+  (TYPICAL_INPUT_M * model.input + TYPICAL_OUTPUT_M * model.output) * PROFILE_MULT[profile];
+const ONBOARDING_BASELINE = 0.56;
+const onboardingCost = (model) => ONBOARDING_BASELINE * (model.input / 3.0);
+
+// ============================================================
+// Base L2 gas cost model (from docs/hypha-ai-cost)
+// Active governance · 0.005 Gwei · ETH $1,748 · non-exec vote @ 150k gas
+// ============================================================
+const GAS_MONTHLY_BY_PROFILE = { light: 0.06, typical: 0.37, heavy: 3.27 };
+const GAS_SETUP_ONE_TIME = 0.035;
+const perSpaceMonthlyGas = (profile) => GAS_MONTHLY_BY_PROFILE[profile] || GAS_MONTHLY_BY_PROFILE.typical;
+
 const HyphaTokenomicsCalculator = () => {
   const [tokensForSale, setTokensForSale] = useState(10000000);
   const [yieldMultiplier, setYieldMultiplier] = useState(30);
@@ -37,9 +75,12 @@ const HyphaTokenomicsCalculator = () => {
   const [existingLockedSupply, setExistingLockedSupply] = useState(111111111);
 
   const [numberOfAOs, setNumberOfAOs] = useState(50);
-  const [paymentPerAO, setPaymentPerAO] = useState(11);
+  const [paymentPerAO, setPaymentPerAO] = useState(22);
   const [usdcFromInvestors, setUsdcFromInvestors] = useState(100000);
   const [aoGrowthRate, setAoGrowthRate] = useState(50);
+
+  const [aiModelId, setAiModelId] = useState('kimi-or');
+  const [aiProfile, setAiProfile] = useState('typical');
 
   const [showMonthlyConfig, setShowMonthlyConfig] = useState(false);
   const [monthlyOverrides, setMonthlyOverrides] = useState({});
@@ -53,13 +94,15 @@ const HyphaTokenomicsCalculator = () => {
   const [totalYieldTokens, setTotalYieldTokens] = useState(0);
   const [totalTokensSold, setTotalTokensSold] = useState(0);
   const [yieldPerLockedToken, setYieldPerLockedToken] = useState(0);
+  const [totalAICost, setTotalAICost] = useState(0);
+  const [totalGasCost, setTotalGasCost] = useState(0);
 
   useEffect(() => {
     calculateTokenomics();
   }, [
     tokensForSale, yieldMultiplier, saleMonths, tokenPrice, totalSupply,
     numberOfAOs, paymentPerAO, usdcFromInvestors, aoGrowthRate,
-    existingLockedSupply, monthlyOverrides
+    existingLockedSupply, monthlyOverrides, aiModelId, aiProfile
   ]);
 
   const getParamForMonth = (month, paramName, defaultValue) => {
@@ -86,6 +129,12 @@ const HyphaTokenomicsCalculator = () => {
     let totalUSDC = 0;
     let calculatedTotalValue = 0;
 
+    const aiModel = getModel(aiModelId);
+    const perSpaceAI = perSpaceMonthlyAICost(aiModel, aiProfile);
+    const perSpaceGas = perSpaceMonthlyGas(aiProfile);
+    let cumulativeAICost = 0;
+    let cumulativeGasCost = 0;
+
     for (let month = 1; month <= saleMonths; month++) {
       const monthTokenPrice = tokenPrice;
       const monthYieldMultiplier = getParamForMonth(month, 'yieldMultiplier', yieldMultiplier);
@@ -105,6 +154,12 @@ const HyphaTokenomicsCalculator = () => {
       const monthInvestorUSDC = getParamForMonth(month, 'usdcFromInvestors', usdcFromInvestors);
 
       const aoIncome = currentNumberOfAOs * monthPaymentPerAO;
+      const monthAICost = currentNumberOfAOs * perSpaceAI;
+      cumulativeAICost += monthAICost;
+      const monthGasCost = currentNumberOfAOs * perSpaceGas;
+      cumulativeGasCost += monthGasCost;
+      const netContribution = aoIncome - monthAICost;
+      const netAfterGas = netContribution - monthGasCost;
       const monthlyUSDC = aoIncome + monthInvestorUSDC;
       totalUSDC += monthlyUSDC;
 
@@ -127,7 +182,13 @@ const HyphaTokenomicsCalculator = () => {
         investorUSDC: monthInvestorUSDC,
         totalMonthlyUSDC: monthlyUSDC,
         totalUSDC,
-        aoPaymentYield: aoIncome * monthYieldMultiplier
+        aoPaymentYield: aoIncome * monthYieldMultiplier,
+        aiCost: monthAICost,
+        cumulativeAICost,
+        gasCost: monthGasCost,
+        cumulativeGasCost,
+        netContribution,
+        netAfterGas,
       });
 
       cumulativeTokenSales.push({
@@ -151,6 +212,8 @@ const HyphaTokenomicsCalculator = () => {
     setTotalValue(calculatedTotalValue);
     setTotalTokensSold(cumulativeSold);
     setYieldPerLockedToken(calculatedYieldPerLockedToken);
+    setTotalAICost(cumulativeAICost);
+    setTotalGasCost(cumulativeGasCost);
   };
 
   const handleMonthlyOverride = (paramName, value) => {
@@ -203,11 +266,129 @@ const HyphaTokenomicsCalculator = () => {
     setUsdcFromInvestors(100000);
     setAoGrowthRate(50);
     setMonthlyOverrides({});
+    setAiModelId('kimi-or');
+    setAiProfile('typical');
   };
+
+  const aiModel = getModel(aiModelId);
+  const perSpaceAI = perSpaceMonthlyAICost(aiModel, aiProfile);
+  const perSpaceGas = perSpaceMonthlyGas(aiProfile);
+  const baselinePerSpace = perSpaceMonthlyAICost(getModel('composer-fast'), aiProfile);
+  const lastMonth = monthlyData.length > 0 ? monthlyData[monthlyData.length - 1] : null;
 
   return (
     <div className="p-6 bg-gray-50 rounded-lg shadow-lg">
-      <h1 className="text-2xl font-bold mb-6 text-center">HYPHA Tokenomics Simulator (Phase I)</h1>
+      <h1 className="text-2xl font-bold mb-1 text-center">HYPHA Tokenomics Simulator (Phase I)</h1>
+      <p className="text-sm text-gray-500 mb-6 text-center">With per-Space AI + Base L2 gas operating cost model — closed-source vs open-source LLMs.</p>
+
+      <div className="mb-8 border border-indigo-200 bg-indigo-50 p-4 rounded-lg">
+        <h2 className="text-lg font-semibold mb-1">AI &amp; On-Chain Operating Cost per Space</h2>
+        <p className="text-xs text-gray-600 mb-3">
+          A Space&apos;s AI workload (full vision) is ~{TYPICAL_INPUT_M}M input + {TYPICAL_OUTPUT_M}M output tokens/month for a Typical space.
+          Pick the inference model and Space profile; the simulator bills every active Space each month for AI inference and Base L2 gas (active governance).
+        </p>
+
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <div>
+            <label className="block text-sm font-medium mb-1">Inference Model</label>
+            <select
+              value={aiModelId}
+              onChange={(e) => setAiModelId(e.target.value)}
+              className="w-full p-2 border rounded bg-white"
+            >
+              <optgroup label="Closed source">
+                {AI_MODELS.closed.map((m) => (
+                  <option key={m.id} value={m.id}>{m.name} — ${m.input}/${m.output} per 1M</option>
+                ))}
+              </optgroup>
+              <optgroup label="Open source">
+                {AI_MODELS.open.map((m) => (
+                  <option key={m.id} value={m.id}>{m.name} — ${m.input}/${m.output} per 1M</option>
+                ))}
+              </optgroup>
+            </select>
+            <p className="text-xs text-gray-500 mt-1">{aiModel.note}</p>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium mb-1">Space Profile</label>
+            <select
+              value={aiProfile}
+              onChange={(e) => setAiProfile(e.target.value)}
+              className="w-full p-2 border rounded bg-white"
+            >
+              <option value="light">Light (~5 members · 0.33×)</option>
+              <option value="typical">Typical (~15 members · 1×)</option>
+              <option value="heavy">Heavy (~50 members · 2.73×)</option>
+            </select>
+            <p className="text-xs text-gray-500 mt-1">Scales AI token volume and gas activity (proposals/votes).</p>
+          </div>
+
+          <div className="bg-white border rounded p-3">
+            <div className="text-xs text-gray-500">AI cost / Space / month</div>
+            <div className="text-2xl font-bold text-indigo-700">${perSpaceAI.toFixed(2)}</div>
+            <div className="text-xs text-gray-500 mt-1">
+              One-time onboarding ≈ ${onboardingCost(aiModel).toFixed(2)} / Space
+            </div>
+            <div className="text-xs text-gray-500">
+              vs Composer Fast: {(baselinePerSpace / perSpaceAI).toFixed(1)}× cheaper
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-4 border border-amber-200 bg-amber-50 rounded p-3">
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div>
+              <div className="text-xs text-gray-600 font-medium">Base L2 gas / Space / month ({aiProfile})</div>
+              <div className="text-2xl font-bold text-amber-700">${perSpaceGas.toFixed(2)}</div>
+              <div className="text-xs text-gray-500 mt-1">Active governance · 0.005 Gwei · ETH $1,748</div>
+            </div>
+            <div>
+              <div className="text-xs text-gray-600 font-medium">One-time setup / Space</div>
+              <div className="text-2xl font-bold text-amber-700">${GAS_SETUP_ONE_TIME.toFixed(3)}</div>
+              <div className="text-xs text-gray-500 mt-1">Create space + deploy-token proposal + deciding vote</div>
+            </div>
+            <div>
+              <div className="text-xs text-gray-600 font-medium">Combined ops / Space / month</div>
+              <div className="text-2xl font-bold text-gray-800">${(perSpaceAI + perSpaceGas).toFixed(2)}</div>
+              <div className="text-xs text-gray-500 mt-1">AI ${perSpaceAI.toFixed(2)} + gas ${perSpaceGas.toFixed(2)}</div>
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-4 overflow-x-auto">
+          <table className="min-w-full bg-white border text-sm">
+            <thead className="bg-gray-100">
+              <tr>
+                <th className="py-1 px-3 border text-left">Model</th>
+                <th className="py-1 px-3 border">Type</th>
+                <th className="py-1 px-3 border text-right">In $/1M</th>
+                <th className="py-1 px-3 border text-right">Out $/1M</th>
+                <th className="py-1 px-3 border text-right">$/Space/mo ({aiProfile})</th>
+                <th className="py-1 px-3 border text-right">vs Composer Fast</th>
+              </tr>
+            </thead>
+            <tbody>
+              {ALL_MODELS.map((m) => {
+                const cost = perSpaceMonthlyAICost(m, aiProfile);
+                const isOpen = AI_MODELS.open.some((o) => o.id === m.id);
+                return (
+                  <tr key={m.id} className={m.id === aiModelId ? 'bg-indigo-100 font-semibold' : ''}>
+                    <td className="py-1 px-3 border">{m.name}</td>
+                    <td className="py-1 px-3 border text-center">{isOpen ? 'Open' : 'Closed'}</td>
+                    <td className="py-1 px-3 border text-right">${m.input.toFixed(2)}</td>
+                    <td className="py-1 px-3 border text-right">${m.output.toFixed(2)}</td>
+                    <td className="py-1 px-3 border text-right">${cost.toFixed(2)}</td>
+                    <td className="py-1 px-3 border text-right">
+                      {m.id === 'composer-fast' ? '—' : `${(baselinePerSpace / cost).toFixed(1)}×`}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </div>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
         <div className="bg-white p-4 rounded-lg shadow">
@@ -370,7 +551,7 @@ const HyphaTokenomicsCalculator = () => {
               <input
                 type="range"
                 min="0"
-                max="1000"
+                max="130"
                 step="10"
                 value={paymentPerAO}
                 onChange={(e) => setPaymentPerAO(Number(e.target.value))}
@@ -382,6 +563,7 @@ const HyphaTokenomicsCalculator = () => {
                 onChange={(e) => setPaymentPerAO(Number(e.target.value))}
                 className="w-20 p-1 border rounded text-right"
                 min="0"
+                max="130"
                 step="1"
               />
               <span className="ml-1">USDC</span>
@@ -410,6 +592,7 @@ const HyphaTokenomicsCalculator = () => {
               />
             </div>
             <p className="text-xs text-gray-500 mt-1">Tokens distributed = Spaces&apos; contributions to Hypha Network (HYPHA) × Distribution Multiplier</p>
+            <p className="text-xs text-gray-500">AI cost (${perSpaceAI.toFixed(2)}/Space) is tracked separately from token sales.</p>
           </div>
 
           <div className="mb-4">
@@ -587,27 +770,31 @@ const HyphaTokenomicsCalculator = () => {
       </div>
 
       <div className="bg-white p-4 rounded-lg shadow mb-8">
-        <h2 className="text-lg font-semibold mb-4">Key Metrics</h2>
+        <h2 className="text-lg font-semibold mb-4">Key Metrics at Month {saleMonths}</h2>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-4">
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
           <div className="p-4 bg-indigo-50 rounded-lg">
             <div className="text-sm text-indigo-600">Current Valuation (Market Cap.)</div>
             <div className="text-2xl font-bold">{formatCurrency(marketCap)}</div>
+            <div className="text-xs text-indigo-600 mt-1">At month {saleMonths} token price</div>
           </div>
 
           <div className="p-4 bg-blue-50 rounded-lg">
             <div className="text-sm text-blue-600">Fully Diluted Valuation (FDV)</div>
             <div className="text-2xl font-bold">{formatCurrency(fdv)}</div>
+            <div className="text-xs text-blue-600 mt-1">At month {saleMonths} token price</div>
           </div>
 
           <div className="p-4 bg-green-50 rounded-lg">
             <div className="text-sm text-green-600">Total Dollar Value Sold</div>
             <div className="text-2xl font-bold">{formatCurrency(totalValue)}</div>
+            <div className="text-xs text-green-600 mt-1">Cumulative over {saleMonths} months</div>
           </div>
 
           <div className="p-4 bg-purple-50 rounded-lg">
             <div className="text-sm text-purple-600">Total Tokens Locked</div>
             <div className="text-2xl font-bold">{formatNumber(totalTokensSold)}</div>
+            <div className="text-xs text-purple-600 mt-1">Cumulative through month {saleMonths}</div>
           </div>
 
           <div className="p-4 bg-amber-50 rounded-lg">
@@ -615,8 +802,62 @@ const HyphaTokenomicsCalculator = () => {
             <div className="text-2xl font-bold">{formatNumber(totalYieldTokens)}</div>
             <div className="text-sm text-amber-600 mt-2">Reward per Locked Token</div>
             <div className="text-xl font-bold">{yieldPerLockedToken.toFixed(4)}</div>
-            <div className="text-xs text-amber-600 mt-1">(Not including monthly compounding effects)</div>
+            <div className="text-xs text-amber-600 mt-1">Cumulative through month {saleMonths}</div>
           </div>
+
+          {lastMonth && (
+            <>
+              <div className="p-4 bg-green-50 rounded-lg border-l-4 border-green-400">
+                <div className="text-sm text-green-600">Cumulated Space Contributions</div>
+                <div className="text-2xl font-bold text-green-700">
+                  {formatCurrency(monthlyData.reduce((s, m) => s + m.aoIncome, 0))}
+                </div>
+                <div className="text-xs text-green-600 mt-1">
+                  Month {saleMonths}: {formatCurrency(lastMonth.aoIncome)} from {formatNumber(lastMonth.numberOfAOs)} Spaces
+                </div>
+              </div>
+
+              <div className="p-4 bg-indigo-50 rounded-lg border-l-4 border-indigo-400">
+                <div className="text-sm text-indigo-600">Monthly AI Cost</div>
+                <div className="text-2xl font-bold text-indigo-700">{formatCurrency(lastMonth.aiCost)}</div>
+                <div className="text-xs text-indigo-600 mt-1">{aiModel.name} · ${perSpaceAI.toFixed(2)}/Space</div>
+              </div>
+
+              <div className="p-4 bg-indigo-50 rounded-lg border-l-4 border-indigo-400">
+                <div className="text-sm text-indigo-600">Cumulative AI Cost</div>
+                <div className="text-2xl font-bold text-indigo-700">{formatCurrency(totalAICost)}</div>
+                <div className="text-xs text-indigo-600 mt-1">Total inference spend over {saleMonths} months</div>
+              </div>
+
+              <div className="p-4 bg-indigo-50 rounded-lg border-l-4 border-indigo-400">
+                <div className="text-sm text-indigo-600">Net After AI (monthly)</div>
+                <div className={`text-2xl font-bold ${lastMonth.netContribution >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+                  {formatCurrency(lastMonth.netContribution)}
+                </div>
+                <div className="text-xs text-indigo-600 mt-1">Space contributions − AI cost (month {saleMonths})</div>
+              </div>
+
+              <div className="p-4 bg-amber-50 rounded-lg border-l-4 border-amber-400">
+                <div className="text-sm text-amber-700">Monthly Gas Cost</div>
+                <div className="text-2xl font-bold text-amber-800">{formatCurrency(lastMonth.gasCost)}</div>
+                <div className="text-xs text-amber-700 mt-1">${perSpaceGas.toFixed(2)}/Space · {aiProfile} profile</div>
+              </div>
+
+              <div className="p-4 bg-amber-50 rounded-lg border-l-4 border-amber-400">
+                <div className="text-sm text-amber-700">Cumulative Gas Cost</div>
+                <div className="text-2xl font-bold text-amber-800">{formatCurrency(totalGasCost)}</div>
+                <div className="text-xs text-amber-700 mt-1">Base L2 governance gas over {saleMonths} months</div>
+              </div>
+
+              <div className="p-4 bg-teal-50 rounded-lg border-l-4 border-teal-400">
+                <div className="text-sm text-teal-700">Net After AI + Gas (monthly)</div>
+                <div className={`text-2xl font-bold ${lastMonth.netAfterGas >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+                  {formatCurrency(lastMonth.netAfterGas)}
+                </div>
+                <div className="text-xs text-teal-700 mt-1">Contributions − AI − gas (month {saleMonths})</div>
+              </div>
+            </>
+          )}
         </div>
       </div>
 
@@ -671,6 +912,48 @@ const HyphaTokenomicsCalculator = () => {
         </ResponsiveContainer>
       </div>
 
+      <div className="bg-white p-4 rounded-lg shadow mb-8">
+        <h2 className="text-lg font-semibold mb-1">Space Contributions vs AI &amp; Gas Cost</h2>
+        <p className="text-xs text-gray-500 mb-4">
+          Space contributions = Spaces × ${paymentPerAO} USDC/Space. AI and gas costs scale with the same Space count × selected model/profile rates.
+        </p>
+        <ResponsiveContainer width="100%" height={300}>
+          <LineChart
+            data={monthlyData}
+            margin={{ top: 5, right: 30, left: 50, bottom: 5 }}
+          >
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="month" label={{ value: 'Month', position: 'insideBottom', offset: -5 }} />
+            <YAxis tickFormatter={(value) => formatCurrency(value)} width={70} />
+            <Tooltip formatter={(value, name) => [formatCurrency(value), name]} />
+            <Legend />
+            <Line type="monotone" dataKey="aoIncome" name="Space Contributions (USD)" stroke="#82ca9d" strokeWidth={2} />
+            <Line type="monotone" dataKey="aiCost" name="AI Cost (USD)" stroke="#6366f1" strokeWidth={2} />
+            <Line type="monotone" dataKey="gasCost" name="Gas Cost (USD)" stroke="#d97706" strokeWidth={2} />
+            <Line type="monotone" dataKey="netContribution" name="Net Contributions (USD)" stroke="#ff7300" strokeWidth={2} />
+            <Line type="monotone" dataKey="netAfterGas" name="Net After AI + Gas (USD)" stroke="#0d9488" strokeWidth={2} strokeDasharray="5 5" />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+
+      <div className="bg-white p-4 rounded-lg shadow mb-8">
+        <h2 className="text-lg font-semibold mb-4">Cumulative AI &amp; Gas Cost</h2>
+        <ResponsiveContainer width="100%" height={300}>
+          <LineChart
+            data={monthlyData}
+            margin={{ top: 5, right: 30, left: 50, bottom: 5 }}
+          >
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="month" label={{ value: 'Month', position: 'insideBottom', offset: -5 }} />
+            <YAxis tickFormatter={(value) => formatCurrency(value)} width={70} />
+            <Tooltip formatter={(value, name) => [formatCurrency(value), name]} />
+            <Legend />
+            <Line type="monotone" dataKey="cumulativeAICost" name="Cumulative AI Cost (USD)" stroke="#6366f1" strokeWidth={2} />
+            <Line type="monotone" dataKey="cumulativeGasCost" name="Cumulative Gas Cost (USD)" stroke="#d97706" strokeWidth={2} />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+
       <div className="bg-white p-4 rounded-lg shadow">
         <h2 className="text-lg font-semibold mb-4">Monthly Breakdown</h2>
         <div className="overflow-x-auto">
@@ -684,6 +967,13 @@ const HyphaTokenomicsCalculator = () => {
                 <th className="px-4 py-3 text-center font-semibold text-gray-700">Tokens Distributed</th>
                 <th className="px-4 py-3 text-center font-semibold text-gray-700">Total Tokens Locked</th>
                 <th className="px-4 py-3 text-center font-semibold text-gray-700">Number of Spaces</th>
+                <th className="px-4 py-3 text-center font-semibold text-gray-700">Space Contributions (USD)</th>
+                <th className="px-4 py-3 text-center font-semibold text-gray-700">AI Cost (USD)</th>
+                <th className="px-4 py-3 text-center font-semibold text-gray-700">Gas Cost (USD)</th>
+                <th className="px-4 py-3 text-center font-semibold text-gray-700">Net After AI (USD)</th>
+                <th className="px-4 py-3 text-center font-semibold text-gray-700">Net After AI + Gas (USD)</th>
+                <th className="px-4 py-3 text-center font-semibold text-gray-700">Cumulative AI Cost (USD)</th>
+                <th className="px-4 py-3 text-center font-semibold text-gray-700">Cumulative Gas Cost (USD)</th>
                 <th className="px-4 py-3 text-center font-semibold text-gray-700">Distribution Multiplier</th>
               </tr>
             </thead>
@@ -699,6 +989,17 @@ const HyphaTokenomicsCalculator = () => {
                     {formatNumber(cumulativeData[index].cumulativeSold + cumulativeData[index].cumulativeYield + existingLockedSupply)}
                   </td>
                   <td className="px-4 py-3 text-center">{formatNumber(month.numberOfAOs)}</td>
+                  <td className="px-4 py-3 text-center">{formatCurrency(month.aoIncome)}</td>
+                  <td className="px-4 py-3 text-center text-indigo-700">{formatCurrency(month.aiCost)}</td>
+                  <td className="px-4 py-3 text-center text-amber-700">{formatCurrency(month.gasCost)}</td>
+                  <td className={`px-4 py-3 text-center ${month.netContribution >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+                    {formatCurrency(month.netContribution)}
+                  </td>
+                  <td className={`px-4 py-3 text-center ${month.netAfterGas >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+                    {formatCurrency(month.netAfterGas)}
+                  </td>
+                  <td className="px-4 py-3 text-center text-indigo-700">{formatCurrency(month.cumulativeAICost)}</td>
+                  <td className="px-4 py-3 text-center text-amber-700">{formatCurrency(month.cumulativeGasCost)}</td>
                   <td className="px-4 py-3 text-center">{month.yieldMultiplier}x</td>
                 </tr>
               ))}

--- a/docs/hypha-ai-cost/tokenomics-simulator.html
+++ b/docs/hypha-ai-cost/tokenomics-simulator.html
@@ -73,18 +73,19 @@ const GROWTH_PRESETS = {
     subtitle: '~250k Spaces',
     defaults: {
       orgPayment: 44,
-      investorSelling: 10,
-      additionalPurchase: 10,
-      unlockRate: 5,
-      initialHypha: 3333333,
-      initialUsdc: 1000000,
+      iexAllocationPct: 8,
+      investorSelling: 5,
+      additionalPurchase: 5,
+      unlockRate: 4,
+      initialHypha: 20000000,
+      initialUsdc: 4000000,
       orgCount: 4373,
-      orgGrowthRate: 25,
+      orgGrowthRate: 9,
     },
+    // Target ~250k Spaces at month 48 (~9.0%/mo, months 2–48)
     build: () => {
-      const m = { 1: { orgGrowthRate: 25 } };
-      for (let i = 2; i <= 26; i++) m[i] = { orgGrowthRate: 0 };
-      for (let i = 27; i <= 48; i++) m[i] = { orgGrowthRate: 3 };
+      const m = {};
+      for (let i = 2; i <= 48; i++) m[i] = { orgGrowthRate: 9.0 };
       return m;
     },
   },
@@ -93,45 +94,40 @@ const GROWTH_PRESETS = {
     subtitle: '~1M Spaces',
     defaults: {
       orgPayment: 44,
-      investorSelling: 10,
-      additionalPurchase: 10,
-      unlockRate: 4,
-      initialHypha: 12000000,
-      initialUsdc: 750000,
+      iexAllocationPct: 10,
+      investorSelling: 5,
+      additionalPurchase: 5,
+      unlockRate: 3.5,
+      initialHypha: 40000000,
+      initialUsdc: 8000000,
       orgCount: 4373,
-      orgGrowthRate: 25,
+      orgGrowthRate: 12.26,
     },
-    build: () => ({
-      1: { orgGrowthRate: 25 }, 2: { orgGrowthRate: 1 }, 3: { orgGrowthRate: 2 }, 4: { orgGrowthRate: 2 },
-      5: { orgGrowthRate: 2 }, 6: { orgGrowthRate: 2 }, 7: { orgGrowthRate: 3 }, 8: { orgGrowthRate: 2 },
-      9: { orgGrowthRate: 3 }, 10: { orgGrowthRate: 27 }, 11: { orgGrowthRate: 15 }, 12: { orgGrowthRate: 14 },
-      13: { orgGrowthRate: 13 }, 14: { orgGrowthRate: 12 }, 15: { orgGrowthRate: 25 }, 16: { orgGrowthRate: 10 },
-      17: { orgGrowthRate: 3 }, 18: { orgGrowthRate: 8 }, 19: { orgGrowthRate: 7 }, 20: { orgGrowthRate: 2 },
-      21: { orgGrowthRate: 1 }, 22: { orgGrowthRate: 4 }, 23: { orgGrowthRate: 4 }, 24: { orgGrowthRate: 4 },
-      25: { orgGrowthRate: 4 }, 26: { orgGrowthRate: 4 }, 27: { orgGrowthRate: 3 }, 28: { orgGrowthRate: 3 },
-      29: { orgGrowthRate: 3 }, 30: { orgGrowthRate: 3 }, 31: { orgGrowthRate: 3 }, 32: { orgGrowthRate: 3 },
-      33: { orgGrowthRate: 3 }, 34: { orgGrowthRate: 3 }, 35: { orgGrowthRate: 3 }, 36: { orgGrowthRate: 3 },
-      37: { orgGrowthRate: 3 }, 38: { orgGrowthRate: 3 }, 39: { orgGrowthRate: 3 }, 40: { orgGrowthRate: 3 },
-      41: { orgGrowthRate: 3 }, 42: { orgGrowthRate: 3 }, 43: { orgGrowthRate: 3 }, 44: { orgGrowthRate: 3 },
-      45: { orgGrowthRate: 3 }, 46: { orgGrowthRate: 3 }, 47: { orgGrowthRate: 3 }, 48: { orgGrowthRate: 3 },
-    }),
+    // Target ~1M Spaces at month 48 (~12.26%/mo, months 2–48)
+    build: () => {
+      const m = {};
+      for (let i = 2; i <= 48; i++) m[i] = { orgGrowthRate: 12.26 };
+      return m;
+    },
   },
   high: {
     label: 'High',
     subtitle: '~10M Spaces',
     defaults: {
       orgPayment: 44,
-      investorSelling: 10,
-      additionalPurchase: 10,
-      unlockRate: 4,
-      initialHypha: 20000000,
-      initialUsdc: 1000000,
+      iexAllocationPct: 12,
+      investorSelling: 5,
+      additionalPurchase: 5,
+      unlockRate: 3,
+      initialHypha: 100000000,
+      initialUsdc: 25000000,
       orgCount: 4373,
-      orgGrowthRate: 25,
+      orgGrowthRate: 17.9,
     },
+    // Target ~10M Spaces at month 48 (~17.9%/mo, months 2–48)
     build: () => {
-      const m = { 1: { orgGrowthRate: 25 } };
-      for (let i = 2; i <= 48; i++) m[i] = { orgGrowthRate: 18 };
+      const m = {};
+      for (let i = 2; i <= 48; i++) m[i] = { orgGrowthRate: 17.9 };
       return m;
     },
   },
@@ -151,6 +147,7 @@ const TokenomicsSimulator = () => {
   const [additionalPurchase, setAdditionalPurchase] = useState(GROWTH_PRESETS.low.defaults.additionalPurchase);
   const [orgCount, setOrgCount] = useState(GROWTH_PRESETS.low.defaults.orgCount);
   const [orgPayment, setOrgPayment] = useState(GROWTH_PRESETS.low.defaults.orgPayment);
+  const [iexAllocationPct, setIexAllocationPct] = useState(GROWTH_PRESETS.low.defaults.iexAllocationPct);
   const [orgGrowthRate, setOrgGrowthRate] = useState(GROWTH_PRESETS.low.defaults.orgGrowthRate);
 
   // AI operating cost controls
@@ -169,7 +166,7 @@ const TokenomicsSimulator = () => {
     calculateTokenomics();
   }, [initialHypha, initialUsdc, months, unlockRate, stakingRate, sellRate,
       investorSelling, additionalPurchase, stakingRewards, rewardSplit, maxSupply,
-      orgCount, orgPayment, orgGrowthRate, monthlyParams, aiModelId, aiProfile]);
+      orgCount, orgPayment, iexAllocationPct, orgGrowthRate, monthlyParams, aiModelId, aiProfile]);
 
   const getMonthlyParameter = (paramName, month) => {
     if (monthlyParams[month] && monthlyParams[month][paramName] !== undefined) {
@@ -189,6 +186,7 @@ const TokenomicsSimulator = () => {
       case 'additionalPurchase': return additionalPurchase;
       case 'orgCount': return orgCount;
       case 'orgPayment': return orgPayment;
+      case 'iexAllocationPct': return iexAllocationPct;
       case 'orgGrowthRate': return orgGrowthRate;
       default: return 0;
     }
@@ -246,14 +244,16 @@ const TokenomicsSimulator = () => {
       }
 
       const monthOrgPayment = getMonthlyParameter('orgPayment', month);
-      const orgTotalPurchase = currentOrgCount * monthOrgPayment;
+      const grossContribution = currentOrgCount * monthOrgPayment;
+      const iexPct = getMonthlyParameter('iexAllocationPct', month) / 100;
+      const orgTotalPurchase = grossContribution * iexPct;
 
       // AI operating cost for this month (all active spaces)
       const monthAICost = currentOrgCount * perSpaceAI;
       cumulativeAICost += monthAICost;
       const monthGasCost = currentOrgCount * perSpaceGas;
       cumulativeGasCost += monthGasCost;
-      const netContribution = orgTotalPurchase - monthAICost;
+      const netContribution = grossContribution - monthAICost;
       const netAfterGas = netContribution - monthGasCost;
 
       const dexPrice = dexUsdc / dexHypha;
@@ -360,7 +360,8 @@ const TokenomicsSimulator = () => {
         dexHypha: Math.round(dexHypha), dexUsdc: Math.round(dexUsdc),
         tokenPrice: endOfMonthPrice.toFixed(6), deltaPrice: priceChange.toFixed(2),
         orgCount: currentOrgCount, cumulativeOrgCount,
-        orgUsdcPurchase: orgTotalPurchase,
+        orgUsdcPurchase: grossContribution,
+        iexUsdcPurchase: orgTotalPurchase,
         orgPurchasedTokens: Math.round(actualOrgPurchasedTokens),
         investorPurchasedTokens: Math.round(investorPurchasedTokens),
         totalPurchasedTokens: Math.round(totalPurchasedTokens),
@@ -387,7 +388,8 @@ const TokenomicsSimulator = () => {
         'Price (USDC)': parseFloat(endOfMonthPrice.toFixed(6)),
         'FDV (Million $)': Math.round(fdv / 1000000),
         'Space Purchases': Math.round(actualOrgPurchasedTokens),
-        'Space Contributions (USD)': Math.round(orgTotalPurchase),
+        'Space Contributions (USD)': Math.round(grossContribution),
+        'IEX Buy (USD)': Math.round(orgTotalPurchase),
         'AI Cost (USD)': Math.round(monthAICost),
         'Gas Cost (USD)': Math.round(monthGasCost),
         'Net Contributions (USD)': Math.round(netContribution),
@@ -404,6 +406,7 @@ const TokenomicsSimulator = () => {
   const applyScenarioDefaults = (scenario) => {
     const d = GROWTH_PRESETS[scenario].defaults;
     setOrgPayment(d.orgPayment);
+    setIexAllocationPct(d.iexAllocationPct);
     setInvestorSelling(d.investorSelling);
     setAdditionalPurchase(d.additionalPurchase);
     setUnlockRate(d.unlockRate);
@@ -662,7 +665,16 @@ const TokenomicsSimulator = () => {
               <input type="number" min="0" max="200" value={monthlyParams[selectedMonth]?.orgPayment ?? orgPayment} onChange={(e) => { const v = Number(e.target.value); selectedMonth === 1 ? setOrgPayment(v) : updateMonthlyParameter('orgPayment', v); }} className="w-20 p-1 border rounded text-right" />
               <span className="ml-1">USDC</span>
             </div>
-            <p className="text-xs text-gray-500 mt-1">AI (${perSpaceAI.toFixed(2)}/Space) and gas (${perSpaceGas.toFixed(2)}/Space) tracked separately from IEX purchases.</p>
+            <p className="text-xs text-gray-500 mt-1">Gross revenue per Space. AI (${perSpaceAI.toFixed(2)}/Space) and gas (${perSpaceGas.toFixed(2)}/Space) tracked separately; only a % routes to IEX.</p>
+          </div>
+          <div className="mb-4">
+            <label className="block text-sm font-medium mb-1">% routed to IEX (buy pressure)</label>
+            <div className="flex items-center">
+              <input type="range" min="0" max="30" step="1" value={monthlyParams[selectedMonth]?.iexAllocationPct ?? iexAllocationPct} onChange={(e) => { const v = Number(e.target.value); selectedMonth === 1 ? setIexAllocationPct(v) : updateMonthlyParameter('iexAllocationPct', v); }} className="w-full mr-3" />
+              <input type="number" min="0" max="30" value={monthlyParams[selectedMonth]?.iexAllocationPct ?? iexAllocationPct} onChange={(e) => { const v = Number(e.target.value); selectedMonth === 1 ? setIexAllocationPct(v) : updateMonthlyParameter('iexAllocationPct', v); }} className="w-16 p-1 border rounded text-right" />
+              <span className="ml-1">%</span>
+            </div>
+            <p className="text-xs text-gray-500 mt-1">Remainder = treasury / ops / rewards off-pool.</p>
           </div>
           <div className="mb-4">
             <label className="block text-sm font-medium mb-1">Additional Investor Purchases + buybacks (% of USDC on IEX)</label>
@@ -677,8 +689,8 @@ const TokenomicsSimulator = () => {
           <div className="mb-4">
             <label className="block text-sm font-medium mb-1">Investor Selling (% of HYPHA on IEX)</label>
             <div className="flex items-center">
-              <input type="range" min="10" max="30" step="0.5" value={monthlyParams[selectedMonth]?.investorSelling ?? investorSelling} onChange={(e) => { const v = Number(e.target.value); selectedMonth === 1 ? setInvestorSelling(v) : updateMonthlyParameter('investorSelling', v); }} className="w-full mr-3" />
-              <input type="number" min="10" max="30" step="0.5" value={monthlyParams[selectedMonth]?.investorSelling ?? investorSelling} onChange={(e) => { const v = Number(e.target.value); selectedMonth === 1 ? setInvestorSelling(v) : updateMonthlyParameter('investorSelling', v); }} className="w-16 p-1 border rounded text-right" />
+              <input type="range" min="0" max="30" step="0.5" value={monthlyParams[selectedMonth]?.investorSelling ?? investorSelling} onChange={(e) => { const v = Number(e.target.value); selectedMonth === 1 ? setInvestorSelling(v) : updateMonthlyParameter('investorSelling', v); }} className="w-full mr-3" />
+              <input type="number" min="0" max="30" step="0.5" value={monthlyParams[selectedMonth]?.investorSelling ?? investorSelling} onChange={(e) => { const v = Number(e.target.value); selectedMonth === 1 ? setInvestorSelling(v) : updateMonthlyParameter('investorSelling', v); }} className="w-16 p-1 border rounded text-right" />
               <span className="ml-1">%</span>
             </div>
           </div>
@@ -866,7 +878,7 @@ const TokenomicsSimulator = () => {
           <div className="h-80 bg-white p-4 rounded-lg shadow md:col-span-2">
             <h3 className="text-md font-medium mb-1">Space Contributions vs AI &amp; Gas Cost</h3>
             <p className="text-xs text-gray-500 mb-2">
-              Contributions = Spaces × ${orgPayment} USDC/Space. Flat stretches happen when per-month Space Growth Rate is 0% (default: months 2–26). AI and gas costs scale with the same Space count × selected model/profile rates.
+              Gross contributions = Spaces × ${orgPayment} USDC/Space. Only {iexAllocationPct}% routes to IEX each month; AI and gas costs scale with Space count × selected model/profile rates.
             </p>
             <ResponsiveContainer width="100%" height="85%">
               <LineChart data={chartData} margin={{ top: 5, right: 50, left: 50, bottom: 5 }}>

--- a/docs/hypha-ai-cost/tokenomics-simulator.html
+++ b/docs/hypha-ai-cost/tokenomics-simulator.html
@@ -66,11 +66,22 @@ const GAS_MONTHLY_BY_PROFILE = { light: 0.06, typical: 0.37, heavy: 3.27 };
 const GAS_SETUP_ONE_TIME = 0.035;
 const perSpaceMonthlyGas = (profile) => GAS_MONTHLY_BY_PROFILE[profile] || GAS_MONTHLY_BY_PROFILE.typical;
 
+// Phase 0 → Phase I → Phase II continuity (same network, one growth story)
+const PHASE0_ACTIVE_SPACES = 4373;
+const PHASE_I_MONTHS = 12;
+const PHASE_I_MONTHLY_GROWTH = 0.72; // continues into Phase II Low preset
+const phaseIHandoffSpaces = () => {
+  let n = PHASE0_ACTIVE_SPACES;
+  for (let m = 2; m <= PHASE_I_MONTHS; m++) n = Math.round(n * (1 + PHASE_I_MONTHLY_GROWTH / 100));
+  return n;
+};
+const PHASE_II_START_SPACES = phaseIHandoffSpaces(); // ~4,732 after 12 mo Phase I
+
 
 const GROWTH_PRESETS = {
   low: {
     label: 'Low',
-    subtitle: '~250k cumulative',
+    subtitle: '~270k cumulative',
     defaults: {
       orgPayment: 44,
       iexAllocationPct: 25,
@@ -79,10 +90,10 @@ const GROWTH_PRESETS = {
       unlockRate: 4,
       initialHypha: 5000000,
       initialUsdc: 1000000,
-      orgCount: 4373,
+      orgCount: PHASE_II_START_SPACES,
       orgGrowthRate: 0.72,
     },
-    // Target ~250k cumulative Space-months at month 48 (~0.72%/mo, months 2–48)
+    // ~270k cumulative Space-months at month 48 (0.72%/mo from Phase I handoff)
     build: () => {
       const m = {};
       for (let i = 2; i <= 48; i++) m[i] = { orgGrowthRate: 0.72 };
@@ -100,13 +111,13 @@ const GROWTH_PRESETS = {
       unlockRate: 3.5,
       initialHypha: 40000000,
       initialUsdc: 8000000,
-      orgCount: 4373,
-      orgGrowthRate: 5.63,
+      orgCount: PHASE_II_START_SPACES,
+      orgGrowthRate: 5.38,
     },
-    // Target ~1M cumulative Space-months at month 48 (~5.63%/mo, months 2–48)
+    // Target ~1M cumulative Space-months at month 48 (~5.38%/mo from handoff)
     build: () => {
       const m = {};
-      for (let i = 2; i <= 48; i++) m[i] = { orgGrowthRate: 5.63 };
+      for (let i = 2; i <= 48; i++) m[i] = { orgGrowthRate: 5.38 };
       return m;
     },
   },
@@ -121,13 +132,13 @@ const GROWTH_PRESETS = {
       unlockRate: 3,
       initialHypha: 100000000,
       initialUsdc: 25000000,
-      orgCount: 4373,
-      orgGrowthRate: 12.52,
+      orgCount: PHASE_II_START_SPACES,
+      orgGrowthRate: 12.29,
     },
-    // Target ~10M cumulative Space-months at month 48 (~12.52%/mo, months 2–48)
+    // Target ~10M cumulative Space-months at month 48 (~12.29%/mo from handoff)
     build: () => {
       const m = {};
-      for (let i = 2; i <= 48; i++) m[i] = { orgGrowthRate: 12.52 };
+      for (let i = 2; i <= 48; i++) m[i] = { orgGrowthRate: 12.29 };
       return m;
     },
   },
@@ -469,7 +480,7 @@ const TokenomicsSimulator = () => {
           </div>
           <div className="bg-indigo-600 text-white p-3 rounded border border-indigo-700">
             <div className="font-semibold">Phase II — After Phase I (this sim)</div>
-            <p className="text-xs text-indigo-100 mt-1">Starts ~4,373 paying Spaces × $44/mo. Month 1 = first month after handoff.</p>
+            <p className="text-xs text-indigo-100 mt-1">Starts ~{PHASE_II_START_SPACES.toLocaleString()} paying Spaces (Phase I handoff) × $44/mo. Month 1 = first month after Phase I.</p>
           </div>
         </div>
       </div>

--- a/docs/hypha-ai-cost/tokenomics-simulator.html
+++ b/docs/hypha-ai-cost/tokenomics-simulator.html
@@ -67,72 +67,81 @@ const GAS_SETUP_ONE_TIME = 0.035;
 const perSpaceMonthlyGas = (profile) => GAS_MONTHLY_BY_PROFILE[profile] || GAS_MONTHLY_BY_PROFILE.typical;
 
 // Phase 0 → Phase I → Phase II continuity (same network, one growth story)
-// Phase I bootstraps 0 → ~4,373 active Spaces over 12 months. Phase II starts there.
+// Phase I bootstraps 0 → ~4,373 active (paying) Spaces over 12 months. Phase II starts there.
 const PHASE_I_END_SPACES = 4373;
 const PHASE_II_START_SPACES = PHASE_I_END_SPACES;
 
-// Year-5 (Phase II month 48) ACTIVE Space targets: Low ~25k, Mid ~250k, High ~2M
+// Two distinct series, both starting from the ~4,373 Phase I handoff:
+//  • ACTIVE (paying) Spaces — grow at orgGrowthRate/mo, pay $44/mo, drive all revenue.
+//  • CUMULATIVE Spaces created (funnel top) — grow at cumulativeGrowthRate/mo (free + paid).
+// Year-5 (Phase II month 48) targets, active / cumulative created (implied paying rate):
+//   Low  — ~15k active / ~250k created (≈6% paying)
+//   Mid  — ~50k active / ~1M created   (≈5% paying)
+//   High — ~500k active / ~10M created (≈5% paying)
 const GROWTH_PRESETS = {
   low: {
     label: 'Low',
-    subtitle: '~25k active (year 5)',
+    subtitle: '~15k paying · ~250k created (yr 5)',
     defaults: {
       orgPayment: 44,
       iexAllocationPct: 25,
-      investorSelling: 3,
-      additionalPurchase: 5,
+      investorSelling: 4,
+      additionalPurchase: 4,
       unlockRate: 4,
-      initialHypha: 40000000,
-      initialUsdc: 8000000,
+      initialHypha: 25000000,
+      initialUsdc: 5000000,
       orgCount: PHASE_II_START_SPACES,
-      orgGrowthRate: 3.78,
+      orgGrowthRate: 2.66,
+      cumulativeGrowthRate: 8.99,
     },
-    // ~25k active / ~570k cumulative Space-months at Phase II month 48 (~3.78%/mo)
+    // active 4,373 → ~15k (2.66%/mo); created 4,373 → ~250k (8.99%/mo) at month 48
     build: () => {
       const m = {};
-      for (let i = 2; i <= 48; i++) m[i] = { orgGrowthRate: 3.78 };
+      for (let i = 2; i <= 48; i++) m[i] = { orgGrowthRate: 2.66 };
       return m;
     },
   },
   mid: {
     label: 'Mid',
-    subtitle: '~250k active (year 5)',
+    subtitle: '~50k paying · ~1M created (yr 5)',
     defaults: {
       orgPayment: 44,
-      iexAllocationPct: 19,
+      iexAllocationPct: 22,
       investorSelling: 5,
-      additionalPurchase: 8,
+      additionalPurchase: 6,
       unlockRate: 3.5,
-      initialHypha: 80000000,
-      initialUsdc: 16000000,
+      initialHypha: 35000000,
+      initialUsdc: 7000000,
       orgCount: PHASE_II_START_SPACES,
-      orgGrowthRate: 8.99,
+      orgGrowthRate: 5.32,
+      cumulativeGrowthRate: 12.25,
     },
-    // ~250k active / ~3M cumulative Space-months at Phase II month 48 (~8.99%/mo)
+    // active 4,373 → ~50k (5.32%/mo); created 4,373 → ~1M (12.25%/mo) at month 48
     build: () => {
       const m = {};
-      for (let i = 2; i <= 48; i++) m[i] = { orgGrowthRate: 8.99 };
+      for (let i = 2; i <= 48; i++) m[i] = { orgGrowthRate: 5.32 };
       return m;
     },
   },
   high: {
     label: 'High',
-    subtitle: '~2M active (year 5)',
+    subtitle: '~500k paying · ~10M created (yr 5)',
     defaults: {
       orgPayment: 44,
       iexAllocationPct: 19,
-      investorSelling: 3,
+      investorSelling: 5,
       additionalPurchase: 8,
       unlockRate: 3,
-      initialHypha: 150000000,
-      initialUsdc: 30000000,
+      initialHypha: 63000000,
+      initialUsdc: 12600000,
       orgCount: PHASE_II_START_SPACES,
-      orgGrowthRate: 13.92,
+      orgGrowthRate: 10.61,
+      cumulativeGrowthRate: 17.89,
     },
-    // ~2M active / ~16M cumulative Space-months at Phase II month 48 (~13.92%/mo)
+    // active 4,373 → ~500k (10.61%/mo); created 4,373 → ~10M (17.89%/mo) at month 48
     build: () => {
       const m = {};
-      for (let i = 2; i <= 48; i++) m[i] = { orgGrowthRate: 13.92 };
+      for (let i = 2; i <= 48; i++) m[i] = { orgGrowthRate: 10.61 };
       return m;
     },
   },
@@ -154,6 +163,7 @@ const TokenomicsSimulator = () => {
   const [orgPayment, setOrgPayment] = useState(GROWTH_PRESETS.low.defaults.orgPayment);
   const [iexAllocationPct, setIexAllocationPct] = useState(GROWTH_PRESETS.low.defaults.iexAllocationPct);
   const [orgGrowthRate, setOrgGrowthRate] = useState(GROWTH_PRESETS.low.defaults.orgGrowthRate);
+  const [cumulativeGrowthRate, setCumulativeGrowthRate] = useState(GROWTH_PRESETS.low.defaults.cumulativeGrowthRate);
 
   // AI operating cost controls
   const [aiModelId, setAiModelId] = useState('kimi-or');
@@ -171,7 +181,7 @@ const TokenomicsSimulator = () => {
     calculateTokenomics();
   }, [initialHypha, initialUsdc, months, unlockRate, stakingRate, sellRate,
       investorSelling, additionalPurchase, stakingRewards, rewardSplit, maxSupply,
-      orgCount, orgPayment, iexAllocationPct, orgGrowthRate, monthlyParams, aiModelId, aiProfile]);
+      orgCount, orgPayment, iexAllocationPct, orgGrowthRate, cumulativeGrowthRate, monthlyParams, aiModelId, aiProfile]);
 
   const getMonthlyParameter = (paramName, month) => {
     if (monthlyParams[month] && monthlyParams[month][paramName] !== undefined) {
@@ -215,7 +225,7 @@ const TokenomicsSimulator = () => {
     let circulatingSupply = 0;
     let cumulativeIssued = 0;
     let prevPrice = dexUsdc / dexHypha;
-    let cumulativeOrgCountTracker = 0;
+    let cumulativeCreated = 0;
     const feeRate = 0.003;
     const tokenResults = [];
     const graphData = [];
@@ -282,8 +292,15 @@ const TokenomicsSimulator = () => {
         }
       }
 
-      cumulativeOrgCountTracker += currentOrgCount;
-      const cumulativeOrgCount = cumulativeOrgCountTracker;
+      // Cumulative Spaces ever created (funnel top: free + paid). Starts at the same
+      // ~4,373 handoff as active payers, then grows faster — so the paying rate
+      // (active / created) declines from 100% toward the year-5 target (~5–6%).
+      if (month === 1) {
+        cumulativeCreated = currentOrgCount;
+      } else {
+        cumulativeCreated = Math.round(cumulativeCreated * (1 + cumulativeGrowthRate / 100));
+      }
+      const cumulativeOrgCount = cumulativeCreated;
       cumulativeGrossRevenue += grossContribution;
       const runRateArr = currentOrgCount * monthOrgPayment * 12;
 
@@ -425,6 +442,7 @@ const TokenomicsSimulator = () => {
     setInitialUsdc(d.initialUsdc);
     setOrgCount(d.orgCount);
     setOrgGrowthRate(d.orgGrowthRate);
+    setCumulativeGrowthRate(d.cumulativeGrowthRate);
   };
 
   const applyGrowthScenario = (scenario) => {
@@ -474,7 +492,7 @@ const TokenomicsSimulator = () => {
           </div>
           <div className="bg-indigo-600 text-white p-3 rounded border border-indigo-700">
             <div className="font-semibold">Phase II — Years 2–5 (this sim)</div>
-            <p className="text-xs text-indigo-100 mt-1">Starts ~{PHASE_II_START_SPACES.toLocaleString()} paying Spaces × $44/mo. Month 1 = first month of year 2. Year 5 = month 48.</p>
+            <p className="text-xs text-indigo-100 mt-1">Starts ~{PHASE_II_START_SPACES.toLocaleString()} paying Spaces × $44/mo. Year-5 paying / created: Low ~15k/250k · Mid ~50k/1M · High ~500k/10M.</p>
           </div>
         </div>
       </div>
@@ -484,7 +502,7 @@ const TokenomicsSimulator = () => {
         <span className="text-teal-900">{iexAllocationPct}% → IEX buy pressure</span>
         <span className="text-teal-700"> · </span>
         <span className="text-teal-900">{offPoolPct}% → AI (~${perSpaceAI.toFixed(2)}/Space), gas, ops, rewards, treasury</span>
-        <span className="text-xs text-teal-700 block mt-1">Only active Spaces in each month pay $44. Cumulative totals are Space-months over the horizon, not concurrent payers.</span>
+        <span className="text-xs text-teal-700 block mt-1">Only active (paying) Spaces pay $44/mo and drive revenue. "Cumulative Spaces" = total Spaces ever created (free + paid funnel); active payers are ~5–6% of created at year 5.</span>
       </div>
 
       {/* ============ AI OPERATING COST SECTION ============ */}
@@ -742,9 +760,14 @@ const TokenomicsSimulator = () => {
           <h2 className="text-xl font-bold mb-4">Key Metrics at Month {months}</h2>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
             <div className="bg-white p-4 rounded shadow">
-              <h3 className="text-sm font-medium text-gray-500">Cumulative Spaces</h3>
+              <h3 className="text-sm font-medium text-gray-500">Cumulative Spaces Created</h3>
               <p className="text-2xl font-bold">{results[results.length - 1].cumulativeOrgCount.toLocaleString()}</p>
-              <p className="text-sm text-gray-500">Active (month {months}): {results[results.length - 1].orgCount.toLocaleString()}</p>
+              <p className="text-sm text-gray-500">
+                Active payers (month {months}): {results[results.length - 1].orgCount.toLocaleString()}
+                {results[results.length - 1].cumulativeOrgCount > 0
+                  ? ` (${(results[results.length - 1].orgCount / results[results.length - 1].cumulativeOrgCount * 100).toFixed(1)}%)`
+                  : ''}
+              </p>
             </div>
             <div className="bg-white p-4 rounded shadow border-l-4 border-green-500">
               <h3 className="text-sm font-medium text-gray-500">Run-rate ARR (month {months})</h3>
@@ -969,8 +992,8 @@ const TokenomicsSimulator = () => {
                 <th className="py-2 px-4 border text-right">Staking Rewards</th>
                 <th className="py-2 px-4 border text-right">Unlock Rewards</th>
                 <th className="py-2 px-4 border text-right">Actual Rewards</th>
-                <th className="py-2 px-4 border text-right">Spaces (monthly)</th>
-                <th className="py-2 px-4 border text-right">Spaces (cumulative)</th>
+                <th className="py-2 px-4 border text-right">Active Spaces (monthly)</th>
+                <th className="py-2 px-4 border text-right">Cumulative Created</th>
                 <th className="py-2 px-4 border text-right">Staked Tokens (cumulative)</th>
                 <th className="py-2 px-4 border text-right">Circulating Supply</th>
                 <th className="py-2 px-4 border text-right">IEX HYPHA Before</th>
@@ -1063,7 +1086,7 @@ const TokenomicsSimulator = () => {
               </button>
             ))}
             <p className="px-3 py-2 text-xs text-gray-500 bg-gray-50 border-t border-gray-200">
-              Targets cumulative Space-months (sum of active Spaces each month) at month 48. Override growth per month via Per-Month Configuration.
+              Targets active (paying) and total created Spaces at year 5 (month 48). Active payers drive revenue; override their growth per month via Per-Month Configuration.
             </p>
           </div>
         </div>

--- a/docs/hypha-ai-cost/tokenomics-simulator.html
+++ b/docs/hypha-ai-cost/tokenomics-simulator.html
@@ -67,78 +67,72 @@ const GAS_SETUP_ONE_TIME = 0.035;
 const perSpaceMonthlyGas = (profile) => GAS_MONTHLY_BY_PROFILE[profile] || GAS_MONTHLY_BY_PROFILE.typical;
 
 // Phase 0 → Phase I → Phase II continuity (same network, one growth story)
-const PHASE0_ACTIVE_SPACES = 4373;
-const PHASE_I_MONTHS = 12;
-const PHASE_I_MONTHLY_GROWTH = 0.72; // continues into Phase II Low preset
-const phaseIHandoffSpaces = () => {
-  let n = PHASE0_ACTIVE_SPACES;
-  for (let m = 2; m <= PHASE_I_MONTHS; m++) n = Math.round(n * (1 + PHASE_I_MONTHLY_GROWTH / 100));
-  return n;
-};
-const PHASE_II_START_SPACES = phaseIHandoffSpaces(); // ~4,732 after 12 mo Phase I
+// Phase I bootstraps 0 → ~4,373 active Spaces over 12 months. Phase II starts there.
+const PHASE_I_END_SPACES = 4373;
+const PHASE_II_START_SPACES = PHASE_I_END_SPACES;
 
-
+// Year-5 (Phase II month 48) ACTIVE Space targets: Low ~25k, Mid ~250k, High ~2M
 const GROWTH_PRESETS = {
   low: {
     label: 'Low',
-    subtitle: '~270k cumulative',
+    subtitle: '~25k active (year 5)',
     defaults: {
       orgPayment: 44,
       iexAllocationPct: 25,
-      investorSelling: 5,
+      investorSelling: 3,
       additionalPurchase: 5,
       unlockRate: 4,
-      initialHypha: 5000000,
-      initialUsdc: 1000000,
+      initialHypha: 40000000,
+      initialUsdc: 8000000,
       orgCount: PHASE_II_START_SPACES,
-      orgGrowthRate: 0.72,
+      orgGrowthRate: 3.78,
     },
-    // ~270k cumulative Space-months at month 48 (0.72%/mo from Phase I handoff)
+    // ~25k active / ~570k cumulative Space-months at Phase II month 48 (~3.78%/mo)
     build: () => {
       const m = {};
-      for (let i = 2; i <= 48; i++) m[i] = { orgGrowthRate: 0.72 };
+      for (let i = 2; i <= 48; i++) m[i] = { orgGrowthRate: 3.78 };
       return m;
     },
   },
   mid: {
     label: 'Mid',
-    subtitle: '~1M cumulative',
+    subtitle: '~250k active (year 5)',
     defaults: {
       orgPayment: 44,
-      iexAllocationPct: 25,
+      iexAllocationPct: 19,
       investorSelling: 5,
       additionalPurchase: 8,
       unlockRate: 3.5,
-      initialHypha: 40000000,
-      initialUsdc: 8000000,
+      initialHypha: 80000000,
+      initialUsdc: 16000000,
       orgCount: PHASE_II_START_SPACES,
-      orgGrowthRate: 5.38,
+      orgGrowthRate: 8.99,
     },
-    // Target ~1M cumulative Space-months at month 48 (~5.38%/mo from handoff)
+    // ~250k active / ~3M cumulative Space-months at Phase II month 48 (~8.99%/mo)
     build: () => {
       const m = {};
-      for (let i = 2; i <= 48; i++) m[i] = { orgGrowthRate: 5.38 };
+      for (let i = 2; i <= 48; i++) m[i] = { orgGrowthRate: 8.99 };
       return m;
     },
   },
   high: {
     label: 'High',
-    subtitle: '~10M cumulative',
+    subtitle: '~2M active (year 5)',
     defaults: {
       orgPayment: 44,
       iexAllocationPct: 19,
       investorSelling: 3,
       additionalPurchase: 8,
       unlockRate: 3,
-      initialHypha: 100000000,
-      initialUsdc: 25000000,
+      initialHypha: 150000000,
+      initialUsdc: 30000000,
       orgCount: PHASE_II_START_SPACES,
-      orgGrowthRate: 12.29,
+      orgGrowthRate: 13.92,
     },
-    // Target ~10M cumulative Space-months at month 48 (~12.29%/mo from handoff)
+    // ~2M active / ~16M cumulative Space-months at Phase II month 48 (~13.92%/mo)
     build: () => {
       const m = {};
-      for (let i = 2; i <= 48; i++) m[i] = { orgGrowthRate: 12.29 };
+      for (let i = 2; i <= 48; i++) m[i] = { orgGrowthRate: 13.92 };
       return m;
     },
   },
@@ -472,15 +466,15 @@ const TokenomicsSimulator = () => {
         <div className="grid grid-cols-1 md:grid-cols-3 gap-3 text-sm">
           <div className="bg-white p-3 rounded border border-slate-200">
             <div className="font-semibold text-slate-600">Phase 0 — Today</div>
-            <p className="text-xs text-gray-600 mt-1">~4,373 Spaces live. Phase I at month 0. Reference FDV ~$111M at $0.20.</p>
+            <p className="text-xs text-gray-600 mt-1">Pre-launch. Reference FDV ~$111M at $0.20 (111M locked supply).</p>
           </div>
           <div className="bg-white p-3 rounded border border-slate-200">
-            <div className="font-semibold text-slate-700">Phase I — Month 0+</div>
-            <p className="text-xs text-gray-600 mt-1">Fixed $0.20 price, token sale &amp; locking. <a href="/tokenomics1/" className="text-indigo-600 underline">Phase I simulator →</a></p>
+            <div className="font-semibold text-slate-700">Phase I — Year 1 (months 0–12)</div>
+            <p className="text-xs text-gray-600 mt-1">Bootstrap 0 → ~4,373 paying Spaces, fixed $0.20. <a href="/tokenomics1/" className="text-indigo-600 underline">Phase I simulator →</a></p>
           </div>
           <div className="bg-indigo-600 text-white p-3 rounded border border-indigo-700">
-            <div className="font-semibold">Phase II — After Phase I (this sim)</div>
-            <p className="text-xs text-indigo-100 mt-1">Starts ~{PHASE_II_START_SPACES.toLocaleString()} paying Spaces (Phase I handoff) × $44/mo. Month 1 = first month after Phase I.</p>
+            <div className="font-semibold">Phase II — Years 2–5 (this sim)</div>
+            <p className="text-xs text-indigo-100 mt-1">Starts ~{PHASE_II_START_SPACES.toLocaleString()} paying Spaces × $44/mo. Month 1 = first month of year 2. Year 5 = month 48.</p>
           </div>
         </div>
       </div>
@@ -615,14 +609,14 @@ const TokenomicsSimulator = () => {
           <div className="mb-4">
             <label className="block text-sm font-medium mb-1">Initial HYPHA on IEX</label>
             <div className="flex items-center">
-              <input type="range" min="1000000" max="50000000" step="1000000" value={initialHypha} onChange={(e) => setInitialHypha(Number(e.target.value))} className="w-full mr-3" />
+              <input type="range" min="1000000" max="200000000" step="1000000" value={initialHypha} onChange={(e) => setInitialHypha(Number(e.target.value))} className="w-full mr-3" />
               <input type="text" value={formatNumber(initialHypha)} onChange={(e) => { const v = Number(e.target.value.replace(/,/g, '')); if (!isNaN(v)) setInitialHypha(v); }} className="w-24 p-1 border rounded text-right" />
             </div>
           </div>
           <div className="mb-4">
             <label className="block text-sm font-medium mb-1">Initial USDC on IEX</label>
             <div className="flex items-center">
-              <input type="range" min="100000" max="2000000" step="50000" value={initialUsdc} onChange={(e) => setInitialUsdc(Number(e.target.value))} className="w-full mr-3" />
+              <input type="range" min="100000" max="40000000" step="100000" value={initialUsdc} onChange={(e) => setInitialUsdc(Number(e.target.value))} className="w-full mr-3" />
               <input type="text" value={formatNumber(initialUsdc)} onChange={(e) => { const v = Number(e.target.value.replace(/,/g, '')); if (!isNaN(v)) setInitialUsdc(v); }} className="w-24 p-1 border rounded text-right" />
             </div>
           </div>

--- a/docs/hypha-ai-cost/tokenomics-simulator.html
+++ b/docs/hypha-ai-cost/tokenomics-simulator.html
@@ -58,6 +58,14 @@ const perSpaceMonthlyAICost = (model, profile) =>
 const ONBOARDING_BASELINE = 0.56; // Composer Fast one-time onboarding / space
 const onboardingCost = (model) => ONBOARDING_BASELINE * (model.input / 3.0); // scales with input price
 
+// ============================================================
+// Base L2 gas cost model (from docs/hypha-ai-cost)
+// Active governance · 0.005 Gwei · ETH $1,748 · non-exec vote @ 150k gas
+// ============================================================
+const GAS_MONTHLY_BY_PROFILE = { light: 0.06, typical: 0.37, heavy: 3.27 };
+const GAS_SETUP_ONE_TIME = 0.035;
+const perSpaceMonthlyGas = (profile) => GAS_MONTHLY_BY_PROFILE[profile] || GAS_MONTHLY_BY_PROFILE.typical;
+
 
 const GROWTH_PRESETS = {
   min: {
@@ -222,7 +230,9 @@ const TokenomicsSimulator = () => {
 
     const aiModel = getModel(aiModelId);
     const perSpaceAI = perSpaceMonthlyAICost(aiModel, aiProfile);
+    const perSpaceGas = perSpaceMonthlyGas(aiProfile);
     let cumulativeAICost = 0;
+    let cumulativeGasCost = 0;
 
     for (let month = 1; month <= months; month++) {
       const monthStakingRate = getMonthlyParameter('stakingRate', month) / 100;
@@ -250,7 +260,10 @@ const TokenomicsSimulator = () => {
       // AI operating cost for this month (all active spaces)
       const monthAICost = currentOrgCount * perSpaceAI;
       cumulativeAICost += monthAICost;
+      const monthGasCost = currentOrgCount * perSpaceGas;
+      cumulativeGasCost += monthGasCost;
       const netContribution = orgTotalPurchase - monthAICost;
+      const netAfterGas = netContribution - monthGasCost;
 
       const dexPrice = dexUsdc / dexHypha;
       const dexHyphaBefore = dexHypha;
@@ -363,7 +376,8 @@ const TokenomicsSimulator = () => {
         investorSellingUsdc: monthInvestorSelling, tokensSold,
         fdv: Math.round(fdv),
         aiCost: monthAICost, cumulativeAICost,
-        netContribution,
+        gasCost: monthGasCost, cumulativeGasCost,
+        netContribution, netAfterGas,
       });
 
       graphData.push({
@@ -384,8 +398,11 @@ const TokenomicsSimulator = () => {
         'Space Purchases': Math.round(actualOrgPurchasedTokens),
         'Space Contributions (USD)': Math.round(orgTotalPurchase),
         'AI Cost (USD)': Math.round(monthAICost),
+        'Gas Cost (USD)': Math.round(monthGasCost),
         'Net Contributions (USD)': Math.round(netContribution),
+        'Net After AI + Gas (USD)': Math.round(netAfterGas),
         'Cumulative AI Cost (USD)': Math.round(cumulativeAICost),
+        'Cumulative Gas Cost (USD)': Math.round(cumulativeGasCost),
       });
     }
 
@@ -426,6 +443,7 @@ const TokenomicsSimulator = () => {
 
   const aiModel = getModel(aiModelId);
   const perSpaceAI = perSpaceMonthlyAICost(aiModel, aiProfile);
+  const perSpaceGas = perSpaceMonthlyGas(aiProfile);
   const baselinePerSpace = perSpaceMonthlyAICost(getModel('composer-fast'), aiProfile);
 
 
@@ -434,14 +452,14 @@ const TokenomicsSimulator = () => {
       <div className="flex gap-6">
         <div className="flex-1 min-w-0">
       <h1 className="text-2xl font-bold mb-1">HYPHA Tokenomics Simulator (Phase II)</h1>
-      <p className="text-sm text-gray-500 mb-4">With per-Space AI operating cost model — closed-source vs open-source LLMs.</p>
+      <p className="text-sm text-gray-500 mb-4">With per-Space AI + Base L2 gas operating cost model — closed-source vs open-source LLMs.</p>
 
       {/* ============ AI OPERATING COST SECTION ============ */}
       <div className="mb-6 border border-indigo-200 bg-indigo-50 p-4 rounded-lg">
-        <h2 className="text-lg font-semibold mb-1">AI Operating Cost per Space</h2>
+        <h2 className="text-lg font-semibold mb-1">AI &amp; On-Chain Operating Cost per Space</h2>
         <p className="text-xs text-gray-600 mb-3">
           A Space's AI workload (full vision) is ~{TYPICAL_INPUT_M}M input + {TYPICAL_OUTPUT_M}M output tokens/month for a Typical space.
-          Pick the inference model and Space profile; the simulator bills every active Space each month.
+          Pick the inference model and Space profile; the simulator bills every active Space each month for AI inference and Base L2 gas (active governance).
         </p>
 
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
@@ -477,7 +495,7 @@ const TokenomicsSimulator = () => {
               <option value="typical">Typical (~15 members · 1×)</option>
               <option value="heavy">Heavy (~50 members · 2.73×)</option>
             </select>
-            <p className="text-xs text-gray-500 mt-1">Scales the per-Space token volume.</p>
+            <p className="text-xs text-gray-500 mt-1">Scales AI token volume and gas activity (proposals/votes).</p>
           </div>
 
           <div className="bg-white border rounded p-3">
@@ -488,6 +506,26 @@ const TokenomicsSimulator = () => {
             </div>
             <div className="text-xs text-gray-500">
               vs Composer Fast: {(baselinePerSpace / perSpaceAI).toFixed(1)}× cheaper
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-4 border border-amber-200 bg-amber-50 rounded p-3">
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div>
+              <div className="text-xs text-gray-600 font-medium">Base L2 gas / Space / month ({aiProfile})</div>
+              <div className="text-2xl font-bold text-amber-700">${perSpaceGas.toFixed(2)}</div>
+              <div className="text-xs text-gray-500 mt-1">Active governance · 0.005 Gwei · ETH $1,748</div>
+            </div>
+            <div>
+              <div className="text-xs text-gray-600 font-medium">One-time setup / Space</div>
+              <div className="text-2xl font-bold text-amber-700">${GAS_SETUP_ONE_TIME.toFixed(3)}</div>
+              <div className="text-xs text-gray-500 mt-1">Create space + deploy-token proposal + deciding vote</div>
+            </div>
+            <div>
+              <div className="text-xs text-gray-600 font-medium">Combined ops / Space / month</div>
+              <div className="text-2xl font-bold text-gray-800">${(perSpaceAI + perSpaceGas).toFixed(2)}</div>
+              <div className="text-xs text-gray-500 mt-1">AI ${perSpaceAI.toFixed(2)} + gas ${perSpaceGas.toFixed(2)}</div>
             </div>
           </div>
         </div>
@@ -633,7 +671,7 @@ const TokenomicsSimulator = () => {
               <input type="number" min="0" max="200" value={monthlyParams[selectedMonth]?.orgPayment ?? orgPayment} onChange={(e) => { const v = Number(e.target.value); selectedMonth === 1 ? setOrgPayment(v) : updateMonthlyParameter('orgPayment', v); }} className="w-20 p-1 border rounded text-right" />
               <span className="ml-1">USDC</span>
             </div>
-            <p className="text-xs text-gray-500 mt-1">AI cost (${perSpaceAI.toFixed(2)}/Space) is tracked separately from IEX purchases.</p>
+            <p className="text-xs text-gray-500 mt-1">AI (${perSpaceAI.toFixed(2)}/Space) and gas (${perSpaceGas.toFixed(2)}/Space) tracked separately from IEX purchases.</p>
           </div>
           <div className="mb-4">
             <label className="block text-sm font-medium mb-1">Additional Investor Purchases + buybacks (% of USDC on IEX)</label>
@@ -727,6 +765,22 @@ const TokenomicsSimulator = () => {
               </p>
               <p className="text-sm text-gray-500">Contributions − AI cost</p>
             </div>
+            <div className="bg-white p-4 rounded shadow border-l-4 border-amber-400">
+              <h3 className="text-sm font-medium text-gray-500">Monthly Gas Cost</h3>
+              <p className="text-2xl font-bold text-amber-800">${Math.round(results[results.length - 1].gasCost).toLocaleString()}</p>
+              <p className="text-sm text-gray-500">${perSpaceGas.toFixed(2)}/Space · {aiProfile} profile</p>
+            </div>
+            <div className="bg-white p-4 rounded shadow border-l-4 border-amber-400">
+              <h3 className="text-sm font-medium text-gray-500">Cumulative Gas Cost</h3>
+              <p className="text-2xl font-bold text-amber-800">${Math.round(results[results.length - 1].cumulativeGasCost).toLocaleString()}</p>
+            </div>
+            <div className="bg-white p-4 rounded shadow border-l-4 border-teal-400">
+              <h3 className="text-sm font-medium text-gray-500">Net After AI + Gas (monthly)</h3>
+              <p className={`text-2xl font-bold ${results[results.length - 1].netAfterGas >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+                ${Math.round(results[results.length - 1].netAfterGas).toLocaleString()}
+              </p>
+              <p className="text-sm text-gray-500">Contributions − AI − gas</p>
+            </div>
           </div>
         </div>
       )}
@@ -819,9 +873,9 @@ const TokenomicsSimulator = () => {
             </ResponsiveContainer>
           </div>
           <div className="h-80 bg-white p-4 rounded-lg shadow md:col-span-2">
-            <h3 className="text-md font-medium mb-1">Space Contributions vs AI Cost</h3>
+            <h3 className="text-md font-medium mb-1">Space Contributions vs AI &amp; Gas Cost</h3>
             <p className="text-xs text-gray-500 mb-2">
-              Contributions = Spaces × ${orgPayment} USDC/Space. Flat stretches happen when per-month Space Growth Rate is 0% (default: months 2–26). AI cost scales with the same Space count × selected model rate.
+              Contributions = Spaces × ${orgPayment} USDC/Space. Flat stretches happen when per-month Space Growth Rate is 0% (default: months 2–26). AI and gas costs scale with the same Space count × selected model/profile rates.
             </p>
             <ResponsiveContainer width="100%" height="85%">
               <LineChart data={chartData} margin={{ top: 5, right: 50, left: 50, bottom: 5 }}>
@@ -832,19 +886,23 @@ const TokenomicsSimulator = () => {
                 <Legend />
                 <Line type="monotone" dataKey="Space Contributions (USD)" stroke="#82ca9d" strokeWidth={2} />
                 <Line type="monotone" dataKey="AI Cost (USD)" stroke="#6366f1" strokeWidth={2} />
+                <Line type="monotone" dataKey="Gas Cost (USD)" stroke="#d97706" strokeWidth={2} />
                 <Line type="monotone" dataKey="Net Contributions (USD)" stroke="#ff7300" strokeWidth={2} />
+                <Line type="monotone" dataKey="Net After AI + Gas (USD)" stroke="#0d9488" strokeWidth={2} strokeDasharray="5 5" />
               </LineChart>
             </ResponsiveContainer>
           </div>
           <div className="h-80 bg-white p-4 rounded-lg shadow">
-            <h3 className="text-md font-medium mb-2">Cumulative AI Cost</h3>
+            <h3 className="text-md font-medium mb-2">Cumulative AI &amp; Gas Cost</h3>
             <ResponsiveContainer width="100%" height="90%">
               <LineChart data={chartData} margin={{ top: 5, right: 40, left: 40, bottom: 5 }}>
                 <CartesianGrid strokeDasharray="3 3" />
                 <XAxis dataKey="name" />
                 <YAxis tickFormatter={(v) => v.toLocaleString()} width={60} />
                 <Tooltip formatter={(v) => v.toLocaleString()} />
+                <Legend />
                 <Line type="monotone" dataKey="Cumulative AI Cost (USD)" stroke="#6366f1" strokeWidth={2} />
+                <Line type="monotone" dataKey="Cumulative Gas Cost (USD)" stroke="#d97706" strokeWidth={2} />
               </LineChart>
             </ResponsiveContainer>
           </div>
@@ -872,8 +930,11 @@ const TokenomicsSimulator = () => {
                 <th className="py-2 px-4 border text-right">IEX USDC</th>
                 <th className="py-2 px-4 border text-right">Space Contributions (USD)</th>
                 <th className="py-2 px-4 border text-right">AI Cost (USD)</th>
+                <th className="py-2 px-4 border text-right">Gas Cost (USD)</th>
                 <th className="py-2 px-4 border text-right">Net After AI (USD)</th>
+                <th className="py-2 px-4 border text-right">Net After AI + Gas (USD)</th>
                 <th className="py-2 px-4 border text-right">Cumulative AI Cost (USD)</th>
+                <th className="py-2 px-4 border text-right">Cumulative Gas Cost (USD)</th>
                 <th className="py-2 px-4 border text-right">Token Price</th>
                 <th className="py-2 px-4 border text-right">Price Change</th>
                 <th className="py-2 px-4 border text-right">FDV (USD)</th>
@@ -903,10 +964,15 @@ const TokenomicsSimulator = () => {
                   <td className="py-2 px-4 border text-right">{row.dexUsdc.toLocaleString()}</td>
                   <td className="py-2 px-4 border text-right">${Math.round(row.orgUsdcPurchase).toLocaleString()}</td>
                   <td className="py-2 px-4 border text-right text-indigo-700">${Math.round(row.aiCost).toLocaleString()}</td>
+                  <td className="py-2 px-4 border text-right text-amber-700">${Math.round(row.gasCost).toLocaleString()}</td>
                   <td className={`py-2 px-4 border text-right ${row.netContribution >= 0 ? 'text-green-600' : 'text-red-600'}`}>
                     ${Math.round(row.netContribution).toLocaleString()}
                   </td>
+                  <td className={`py-2 px-4 border text-right ${row.netAfterGas >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+                    ${Math.round(row.netAfterGas).toLocaleString()}
+                  </td>
                   <td className="py-2 px-4 border text-right text-indigo-700">${Math.round(row.cumulativeAICost).toLocaleString()}</td>
+                  <td className="py-2 px-4 border text-right text-amber-700">${Math.round(row.cumulativeGasCost).toLocaleString()}</td>
                   <td className="py-2 px-4 border text-right">${row.tokenPrice}</td>
                   <td className="py-2 px-4 border text-right">{row.deltaPrice}%</td>
                   <td className="py-2 px-4 border text-right">${row.fdv.toLocaleString()}</td>

--- a/docs/hypha-ai-cost/tokenomics-simulator.html
+++ b/docs/hypha-ai-cost/tokenomics-simulator.html
@@ -1,0 +1,962 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>HYPHA Tokenomics Simulator</title>
+<link rel="icon" href="https://hypha.earth/wp-content/uploads/2023/07/cropped-favicon-32x32.png" sizes="32x32" />
+<script type="importmap">
+{
+  "imports": {
+    "react": "https://esm.sh/react@18.3.1",
+    "react/jsx-runtime": "https://esm.sh/react@18.3.1/jsx-runtime",
+    "react/jsx-dev-runtime": "https://esm.sh/react@18.3.1/jsx-dev-runtime",
+    "react-dom": "https://esm.sh/react-dom@18.3.1",
+    "react-dom/client": "https://esm.sh/react-dom@18.3.1/client",
+    "recharts": "https://esm.sh/recharts@2.12.7?external=react,react-dom"
+  }
+}
+</script>
+<script src="https://cdn.tailwindcss.com"></script>
+<script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+<style> body { background:#f3f4f6; } </style>
+</head>
+<body>
+<div id="root" class="p-4"></div>
+<script type="text/babel" data-type="module" data-presets="react" data-presets-options='{"react":{"runtime":"classic"}}'>
+import React, { useState, useEffect } from 'react';
+import { createRoot } from 'react-dom/client';
+import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+
+// ============================================================
+// AI Operating Cost model (from docs/hypha-ai-cost)
+// Typical Space workload = 4.66M input + 0.17M output tokens / month.
+// Per-space monthly $ = (in_M * inPrice + out_M * outPrice) * profileMult.
+// ============================================================
+const TYPICAL_INPUT_M = 4.66;
+const TYPICAL_OUTPUT_M = 0.17;
+const PROFILE_MULT = { light: 0.33, typical: 1, heavy: 2.73 };
+
+const AI_MODELS = {
+  closed: [
+    { id: 'composer-fast', name: 'Composer 2.5 Fast', input: 3.0, output: 15.0, note: 'IDE default reference / baseline' },
+    { id: 'composer-standard', name: 'Composer 2.5 Standard', input: 0.5, output: 2.5, note: 'Same model, lower throughput' },
+  ],
+  open: [
+    { id: 'kimi-list', name: 'Kimi K2.6 (list)', input: 0.95, output: 4.0, note: 'Leads open quality; Composer lineage' },
+    { id: 'kimi-or', name: 'Kimi K2.6 (OpenRouter low)', input: 0.68, output: 3.41, note: 'Cheapest Kimi host' },
+    { id: 'qwen', name: 'Qwen3.5-397B', input: 0.6, output: 3.6, note: 'Strong open frontier MoE' },
+    { id: 'llama', name: 'Llama 4 Maverick', input: 0.5, output: 2.15, note: '400B MoE (DeepInfra)' },
+    { id: 'deepseek-pro', name: 'DeepSeek V4-Pro', input: 0.44, output: 0.87, note: 'Flagship open reasoning/coding' },
+    { id: 'deepseek-flash', name: 'DeepSeek V4-Flash', input: 0.14, output: 0.28, note: 'Budget leader' },
+  ],
+};
+const ALL_MODELS = [...AI_MODELS.closed, ...AI_MODELS.open];
+const getModel = (id) => ALL_MODELS.find((m) => m.id === id) || ALL_MODELS[0];
+const perSpaceMonthlyAICost = (model, profile) =>
+  (TYPICAL_INPUT_M * model.input + TYPICAL_OUTPUT_M * model.output) * PROFILE_MULT[profile];
+const ONBOARDING_BASELINE = 0.56; // Composer Fast one-time onboarding / space
+const onboardingCost = (model) => ONBOARDING_BASELINE * (model.input / 3.0); // scales with input price
+
+
+const GROWTH_PRESETS = {
+  min: {
+    label: 'Min',
+    subtitle: '~250k Spaces',
+    defaults: {
+      orgPayment: 22,
+      investorSelling: 13.5,
+      additionalPurchase: 7,
+      unlockRate: 5,
+      initialHypha: 3333333,
+      initialUsdc: 1000000,
+      orgCount: 4373,
+      orgGrowthRate: 25,
+    },
+    build: () => {
+      const m = { 1: { orgGrowthRate: 25 } };
+      for (let i = 2; i <= 26; i++) m[i] = { orgGrowthRate: 0 };
+      for (let i = 27; i <= 48; i++) m[i] = { orgGrowthRate: 3 };
+      return m;
+    },
+  },
+  medium: {
+    label: 'Medium',
+    subtitle: '~1M Spaces',
+    defaults: {
+      orgPayment: 22,
+      investorSelling: 26,
+      additionalPurchase: 11,
+      unlockRate: 4,
+      initialHypha: 12000000,
+      initialUsdc: 750000,
+      orgCount: 4373,
+      orgGrowthRate: 25,
+    },
+    build: () => ({
+      1: { orgGrowthRate: 25 }, 2: { orgGrowthRate: 1 }, 3: { orgGrowthRate: 2 }, 4: { orgGrowthRate: 2 },
+      5: { orgGrowthRate: 2 }, 6: { orgGrowthRate: 2 }, 7: { orgGrowthRate: 3 }, 8: { orgGrowthRate: 2 },
+      9: { orgGrowthRate: 3 }, 10: { orgGrowthRate: 27 }, 11: { orgGrowthRate: 15 }, 12: { orgGrowthRate: 14 },
+      13: { orgGrowthRate: 13 }, 14: { orgGrowthRate: 12 }, 15: { orgGrowthRate: 25 }, 16: { orgGrowthRate: 10 },
+      17: { orgGrowthRate: 3 }, 18: { orgGrowthRate: 8 }, 19: { orgGrowthRate: 7 }, 20: { orgGrowthRate: 2 },
+      21: { orgGrowthRate: 1 }, 22: { orgGrowthRate: 4 }, 23: { orgGrowthRate: 4 }, 24: { orgGrowthRate: 4 },
+      25: { orgGrowthRate: 4 }, 26: { orgGrowthRate: 4 }, 27: { orgGrowthRate: 3 }, 28: { orgGrowthRate: 3 },
+      29: { orgGrowthRate: 3 }, 30: { orgGrowthRate: 3 }, 31: { orgGrowthRate: 3 }, 32: { orgGrowthRate: 3 },
+      33: { orgGrowthRate: 3 }, 34: { orgGrowthRate: 3 }, 35: { orgGrowthRate: 3 }, 36: { orgGrowthRate: 3 },
+      37: { orgGrowthRate: 3 }, 38: { orgGrowthRate: 3 }, 39: { orgGrowthRate: 3 }, 40: { orgGrowthRate: 3 },
+      41: { orgGrowthRate: 3 }, 42: { orgGrowthRate: 3 }, 43: { orgGrowthRate: 3 }, 44: { orgGrowthRate: 3 },
+      45: { orgGrowthRate: 3 }, 46: { orgGrowthRate: 3 }, 47: { orgGrowthRate: 3 }, 48: { orgGrowthRate: 3 },
+    }),
+  },
+  max: {
+    label: 'Max',
+    subtitle: '~2M Spaces',
+    defaults: {
+      orgPayment: 22,
+      investorSelling: 14.5,
+      additionalPurchase: 3,
+      unlockRate: 4,
+      initialHypha: 20000000,
+      initialUsdc: 1000000,
+      orgCount: 4373,
+      orgGrowthRate: 25,
+    },
+    build: () => ({
+      1: { orgGrowthRate: 25 }, 2: { orgGrowthRate: 10 }, 3: { orgGrowthRate: 10 }, 4: { orgGrowthRate: 10 },
+      5: { orgGrowthRate: 10 }, 6: { orgGrowthRate: 10 }, 7: { orgGrowthRate: 10 }, 8: { orgGrowthRate: 10 },
+      9: { orgGrowthRate: 10 }, 10: { orgGrowthRate: 27 }, 11: { orgGrowthRate: 15 }, 12: { orgGrowthRate: 14 },
+      13: { orgGrowthRate: 13 }, 14: { orgGrowthRate: 12 }, 15: { orgGrowthRate: 25 }, 16: { orgGrowthRate: 23 },
+      17: { orgGrowthRate: 3 }, 18: { orgGrowthRate: 8 }, 19: { orgGrowthRate: 7 }, 20: { orgGrowthRate: 2 },
+      21: { orgGrowthRate: 1 }, 22: { orgGrowthRate: 4 }, 23: { orgGrowthRate: 4 }, 24: { orgGrowthRate: 4 },
+      25: { orgGrowthRate: 4 }, 26: { orgGrowthRate: 4 }, 27: { orgGrowthRate: 3 }, 28: { orgGrowthRate: 3 },
+      29: { orgGrowthRate: 3 }, 30: { orgGrowthRate: 3 }, 31: { orgGrowthRate: 3 }, 32: { orgGrowthRate: 3 },
+      33: { orgGrowthRate: 3 }, 34: { orgGrowthRate: 3 }, 35: { orgGrowthRate: 3 }, 36: { orgGrowthRate: 3 },
+      37: { orgGrowthRate: 3 }, 38: { orgGrowthRate: 3 }, 39: { orgGrowthRate: 3 }, 40: { orgGrowthRate: 3 },
+      41: { orgGrowthRate: 3 }, 42: { orgGrowthRate: 3 }, 43: { orgGrowthRate: 3 }, 44: { orgGrowthRate: 3 },
+      45: { orgGrowthRate: 3 }, 46: { orgGrowthRate: 3 }, 47: { orgGrowthRate: 3 }, 48: { orgGrowthRate: 3 },
+    }),
+  },
+};
+
+const TokenomicsSimulator = () => {
+  const [maxSupply, setMaxSupply] = useState(555555555);
+  const [initialHypha, setInitialHypha] = useState(GROWTH_PRESETS.min.defaults.initialHypha);
+  const [initialUsdc, setInitialUsdc] = useState(GROWTH_PRESETS.min.defaults.initialUsdc);
+  const [months, setMonths] = useState(48);
+  const [unlockRate, setUnlockRate] = useState(GROWTH_PRESETS.min.defaults.unlockRate);
+  const [stakingRewards, setStakingRewards] = useState(30);
+  const [rewardSplit, setRewardSplit] = useState(50);
+  const [stakingRate, setStakingRate] = useState(75);
+  const [sellRate, setSellRate] = useState(30);
+  const [investorSelling, setInvestorSelling] = useState(GROWTH_PRESETS.min.defaults.investorSelling);
+  const [additionalPurchase, setAdditionalPurchase] = useState(GROWTH_PRESETS.min.defaults.additionalPurchase);
+  const [orgCount, setOrgCount] = useState(GROWTH_PRESETS.min.defaults.orgCount);
+  const [orgPayment, setOrgPayment] = useState(GROWTH_PRESETS.min.defaults.orgPayment);
+  const [orgGrowthRate, setOrgGrowthRate] = useState(GROWTH_PRESETS.min.defaults.orgGrowthRate);
+
+  // AI operating cost controls
+  const [aiModelId, setAiModelId] = useState('kimi-or');
+  const [aiProfile, setAiProfile] = useState('typical');
+  const [growthScenario, setGrowthScenario] = useState('min');
+
+  const [selectedMonth, setSelectedMonth] = useState(1);
+  const [monthlyParams, setMonthlyParams] = useState(GROWTH_PRESETS.min.build());
+  const [showMonthlyConfig, setShowMonthlyConfig] = useState(false);
+
+  const [results, setResults] = useState([]);
+  const [chartData, setChartData] = useState([]);
+
+  useEffect(() => {
+    calculateTokenomics();
+  }, [initialHypha, initialUsdc, months, unlockRate, stakingRate, sellRate,
+      investorSelling, additionalPurchase, stakingRewards, rewardSplit, maxSupply,
+      orgCount, orgPayment, orgGrowthRate, monthlyParams, aiModelId, aiProfile]);
+
+  const getMonthlyParameter = (paramName, month) => {
+    if (monthlyParams[month] && monthlyParams[month][paramName] !== undefined) {
+      return monthlyParams[month][paramName];
+    }
+    for (let prevMonth = month - 1; prevMonth >= 1; prevMonth--) {
+      if (monthlyParams[prevMonth] && monthlyParams[prevMonth][paramName] !== undefined) {
+        return monthlyParams[prevMonth][paramName];
+      }
+    }
+    switch (paramName) {
+      case 'unlockRate': return unlockRate;
+      case 'rewardSplit': return rewardSplit;
+      case 'stakingRate': return stakingRate;
+      case 'sellRate': return sellRate;
+      case 'investorSelling': return investorSelling;
+      case 'additionalPurchase': return additionalPurchase;
+      case 'orgCount': return orgCount;
+      case 'orgPayment': return orgPayment;
+      case 'orgGrowthRate': return orgGrowthRate;
+      default: return 0;
+    }
+  };
+
+  const updateMonthlyParameter = (paramName, value) => {
+    setMonthlyParams((prev) => {
+      const newParams = { ...prev };
+      if (!newParams[selectedMonth]) newParams[selectedMonth] = {};
+      newParams[selectedMonth][paramName] = value;
+      return newParams;
+    });
+  };
+
+  const formatNumber = (number) => number.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+
+
+  const calculateTokenomics = () => {
+    let dexHypha = initialHypha;
+    let dexUsdc = initialUsdc;
+    let circulatingSupply = 0;
+    let cumulativeIssued = 0;
+    let prevPrice = dexUsdc / dexHypha;
+    let cumulativeOrgCountTracker = 0;
+    const feeRate = 0.003;
+    const tokenResults = [];
+    const graphData = [];
+    let currentOrgCount = getMonthlyParameter('orgCount', 1);
+    let cumulativeStaked = 0;
+
+    const aiModel = getModel(aiModelId);
+    const perSpaceAI = perSpaceMonthlyAICost(aiModel, aiProfile);
+    let cumulativeAICost = 0;
+
+    for (let month = 1; month <= months; month++) {
+      const monthStakingRate = getMonthlyParameter('stakingRate', month) / 100;
+      const monthSellRate = getMonthlyParameter('sellRate', month) / 100;
+      const monthInvestorSelling = getMonthlyParameter('investorSelling', month);
+      const monthPurchase = getMonthlyParameter('additionalPurchase', month);
+
+      const minUnlockRate = 0.02;
+      const actualUnlockRate = minUnlockRate + (monthStakingRate * (unlockRate - minUnlockRate));
+
+      if (month > 1) {
+        if (monthlyParams[month] && monthlyParams[month].orgCount !== undefined) {
+          currentOrgCount = monthlyParams[month].orgCount;
+        } else {
+          const monthOrgGrowthRate = getMonthlyParameter('orgGrowthRate', month) / 100;
+          currentOrgCount = Math.round(currentOrgCount * (1 + monthOrgGrowthRate));
+        }
+      } else {
+        currentOrgCount = getMonthlyParameter('orgCount', month);
+      }
+
+      const monthOrgPayment = getMonthlyParameter('orgPayment', month);
+      const orgTotalPurchase = currentOrgCount * monthOrgPayment;
+
+      // AI operating cost for this month (all active spaces)
+      const monthAICost = currentOrgCount * perSpaceAI;
+      cumulativeAICost += monthAICost;
+      const netContribution = orgTotalPurchase - monthAICost;
+
+      const dexPrice = dexUsdc / dexHypha;
+      const dexHyphaBefore = dexHypha;
+
+      let actualOrgPurchasedTokens = 0;
+      if (orgTotalPurchase > 0) {
+        const k = dexHypha * dexUsdc;
+        const usdcWithFee = orgTotalPurchase * (1 - feeRate);
+        const newDexUsdc = dexUsdc + usdcWithFee;
+        const newDexHypha = k / newDexUsdc;
+        const hyphaReceived = dexHypha - newDexHypha;
+        if (hyphaReceived > 0) {
+          const limitedHyphaReceived = Math.min(hyphaReceived, dexHypha * 0.25);
+          const limitedNewDexHypha = dexHypha - limitedHyphaReceived;
+          const limitedNewDexUsdc = k / limitedNewDexHypha;
+          dexHypha = limitedNewDexHypha;
+          dexUsdc = limitedNewDexUsdc;
+          actualOrgPurchasedTokens = limitedHyphaReceived;
+        }
+      }
+
+      cumulativeOrgCountTracker += currentOrgCount;
+      const cumulativeOrgCount = cumulativeOrgCountTracker;
+
+      const distributionMultiplier = getMonthlyParameter('unlockRate', month);
+      const safeStakingRate = Math.min(monthStakingRate, 0.9);
+      const stakingRateModifier = 1 / (1 - safeStakingRate);
+      let totalIssuance = Math.round(actualOrgPurchasedTokens * stakingRateModifier * distributionMultiplier);
+      const maxMonthlyIssuance = 10000000;
+      totalIssuance = Math.min(totalIssuance, maxMonthlyIssuance);
+      if (cumulativeIssued + totalIssuance > maxSupply) {
+        totalIssuance = Math.max(0, maxSupply - cumulativeIssued);
+      }
+      cumulativeIssued += totalIssuance;
+      circulatingSupply = cumulativeIssued;
+
+      const monthlyStakedAmount = circulatingSupply * monthStakingRate;
+      cumulativeStaked = monthlyStakedAmount;
+
+      const initialStakingAllocation = Math.round(totalIssuance * (rewardSplit / 100));
+      const initialUnlockAllocation = totalIssuance - initialStakingAllocation;
+      const monthlyRewardsRate = stakingRewards / 1200;
+      const requiredForStakingRewards = Math.round(monthlyStakedAmount * monthlyRewardsRate);
+
+      let stakingRewardsAmount, unlockRewards;
+      if (requiredForStakingRewards <= initialStakingAllocation) {
+        stakingRewardsAmount = requiredForStakingRewards;
+        unlockRewards = totalIssuance - stakingRewardsAmount;
+      } else {
+        stakingRewardsAmount = initialStakingAllocation;
+        unlockRewards = initialUnlockAllocation;
+      }
+
+      const actualMonthlyRewardsRate = monthlyStakedAmount > 0 ? (stakingRewardsAmount / monthlyStakedAmount) * 100 : 0;
+      const actualRewards = actualMonthlyRewardsRate * 12;
+
+      let investorPurchasedTokens = 0;
+      if (monthPurchase > 0) {
+        const actualPurchaseAmount = (dexUsdc * monthPurchase) / 100;
+        if (actualPurchaseAmount > 0) {
+          const k = dexHypha * dexUsdc;
+          const usdcWithFee = actualPurchaseAmount * (1 - feeRate);
+          const newDexUsdc = dexUsdc + usdcWithFee;
+          const newDexHypha = k / newDexUsdc;
+          const hyphaReceived = dexHypha - newDexHypha;
+          if (hyphaReceived > 0 && hyphaReceived < dexHypha * 0.5) {
+            dexHypha = newDexHypha;
+            dexUsdc = newDexUsdc;
+            investorPurchasedTokens = hyphaReceived;
+            circulatingSupply += investorPurchasedTokens;
+          }
+        }
+      }
+
+      let tokensSold = 0;
+      if (monthInvestorSelling > 0 && dexHypha > 0 && dexUsdc > 0) {
+        const tokensToSell = Math.round((dexHypha * monthInvestorSelling) / 100);
+        if (tokensToSell > 0) {
+          const k = dexHypha * dexUsdc;
+          const newDexHypha = dexHypha + tokensToSell;
+          const newDexUsdc = k / newDexHypha;
+          const usdcReceived = dexUsdc - newDexUsdc;
+          dexHypha = newDexHypha;
+          dexUsdc = newDexUsdc;
+          tokensSold = tokensToSell;
+        }
+      }
+
+      const totalPurchasedTokens = actualOrgPurchasedTokens + investorPurchasedTokens;
+      const endOfMonthPrice = dexUsdc / dexHypha;
+      const priceChange = prevPrice > 0 ? ((endOfMonthPrice / prevPrice) - 1) * 100 : 0;
+      prevPrice = endOfMonthPrice;
+      const fdv = endOfMonthPrice * maxSupply;
+
+      tokenResults.push({
+        month, totalIssuance, cumulativeIssuance: cumulativeIssued,
+        stakingRewards: stakingRewardsAmount, unlockRewards,
+        stakingRewardsPercentage: totalIssuance > 0 ? Math.round((stakingRewardsAmount / totalIssuance) * 100) : 0,
+        actualRewards: actualRewards.toFixed(2),
+        circulatingSupply: Math.round(circulatingSupply),
+        stakedAmount: Math.round(cumulativeStaked),
+        dexHyphaBefore: Math.round(dexHyphaBefore),
+        dexHypha: Math.round(dexHypha), dexUsdc: Math.round(dexUsdc),
+        tokenPrice: endOfMonthPrice.toFixed(6), deltaPrice: priceChange.toFixed(2),
+        orgCount: currentOrgCount, cumulativeOrgCount,
+        orgUsdcPurchase: orgTotalPurchase,
+        orgPurchasedTokens: Math.round(actualOrgPurchasedTokens),
+        investorPurchasedTokens: Math.round(investorPurchasedTokens),
+        totalPurchasedTokens: Math.round(totalPurchasedTokens),
+        investorSellingUsdc: monthInvestorSelling, tokensSold,
+        fdv: Math.round(fdv),
+        aiCost: monthAICost, cumulativeAICost,
+        netContribution,
+      });
+
+      graphData.push({
+        name: `Month ${month}`,
+        'Circulating Supply': Math.round(circulatingSupply),
+        'Total Unlocked': cumulativeIssued,
+        'IEX HYPHA': Math.round(dexHypha),
+        'IEX USDC': Math.round(dexUsdc),
+        'Monthly Issuance': totalIssuance,
+        'Staking Rewards': stakingRewardsAmount,
+        'Unlock Rewards': unlockRewards,
+        'Investor Selling (% of HYPHA)': monthInvestorSelling,
+        'Total Tokens Sold': tokensSold,
+        'Number of Spaces': currentOrgCount,
+        'Cumulative Spaces': cumulativeOrgCount,
+        'Price (USDC)': parseFloat(endOfMonthPrice.toFixed(6)),
+        'FDV (Million $)': Math.round(fdv / 1000000),
+        'Space Purchases': Math.round(actualOrgPurchasedTokens),
+        'Space Contributions (USD)': Math.round(orgTotalPurchase),
+        'AI Cost (USD)': Math.round(monthAICost),
+        'Net Contributions (USD)': Math.round(netContribution),
+        'Cumulative AI Cost (USD)': Math.round(cumulativeAICost),
+      });
+    }
+
+    setResults(tokenResults);
+    setChartData(graphData);
+  };
+
+  const applyScenarioDefaults = (scenario) => {
+    const d = GROWTH_PRESETS[scenario].defaults;
+    setOrgPayment(d.orgPayment);
+    setInvestorSelling(d.investorSelling);
+    setAdditionalPurchase(d.additionalPurchase);
+    setUnlockRate(d.unlockRate);
+    setInitialHypha(d.initialHypha);
+    setInitialUsdc(d.initialUsdc);
+    setOrgCount(d.orgCount);
+    setOrgGrowthRate(d.orgGrowthRate);
+  };
+
+  const applyGrowthScenario = (scenario) => {
+    setGrowthScenario(scenario);
+    setMonthlyParams(GROWTH_PRESETS[scenario].build());
+    applyScenarioDefaults(scenario);
+  };
+
+  const resetParameters = () => {
+    setMaxSupply(555555555);
+    setMonths(48);
+    setStakingRewards(30);
+    setRewardSplit(50);
+    setStakingRate(75);
+    setSellRate(30);
+    setAiModelId('kimi-or');
+    setAiProfile('typical');
+    setMonthlyParams(GROWTH_PRESETS[growthScenario].build());
+    applyScenarioDefaults(growthScenario);
+  };
+
+  const aiModel = getModel(aiModelId);
+  const perSpaceAI = perSpaceMonthlyAICost(aiModel, aiProfile);
+  const baselinePerSpace = perSpaceMonthlyAICost(getModel('composer-fast'), aiProfile);
+
+
+  return (
+    <div className="p-4 max-w-7xl mx-auto bg-white rounded-xl shadow-md">
+      <div className="flex gap-6">
+        <div className="flex-1 min-w-0">
+      <h1 className="text-2xl font-bold mb-1">HYPHA Tokenomics Simulator (Phase II)</h1>
+      <p className="text-sm text-gray-500 mb-4">With per-Space AI operating cost model — closed-source vs open-source LLMs.</p>
+
+      {/* ============ AI OPERATING COST SECTION ============ */}
+      <div className="mb-6 border border-indigo-200 bg-indigo-50 p-4 rounded-lg">
+        <h2 className="text-lg font-semibold mb-1">AI Operating Cost per Space</h2>
+        <p className="text-xs text-gray-600 mb-3">
+          A Space's AI workload (full vision) is ~{TYPICAL_INPUT_M}M input + {TYPICAL_OUTPUT_M}M output tokens/month for a Typical space.
+          Pick the inference model and Space profile; the simulator bills every active Space each month.
+        </p>
+
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <div>
+            <label className="block text-sm font-medium mb-1">Inference Model</label>
+            <select
+              value={aiModelId}
+              onChange={(e) => setAiModelId(e.target.value)}
+              className="w-full p-2 border rounded bg-white"
+            >
+              <optgroup label="Closed source">
+                {AI_MODELS.closed.map((m) => (
+                  <option key={m.id} value={m.id}>{m.name} — ${m.input}/${m.output} per 1M</option>
+                ))}
+              </optgroup>
+              <optgroup label="Open source">
+                {AI_MODELS.open.map((m) => (
+                  <option key={m.id} value={m.id}>{m.name} — ${m.input}/${m.output} per 1M</option>
+                ))}
+              </optgroup>
+            </select>
+            <p className="text-xs text-gray-500 mt-1">{aiModel.note}</p>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium mb-1">Space Profile</label>
+            <select
+              value={aiProfile}
+              onChange={(e) => setAiProfile(e.target.value)}
+              className="w-full p-2 border rounded bg-white"
+            >
+              <option value="light">Light (~5 members · 0.33×)</option>
+              <option value="typical">Typical (~15 members · 1×)</option>
+              <option value="heavy">Heavy (~50 members · 2.73×)</option>
+            </select>
+            <p className="text-xs text-gray-500 mt-1">Scales the per-Space token volume.</p>
+          </div>
+
+          <div className="bg-white border rounded p-3">
+            <div className="text-xs text-gray-500">AI cost / Space / month</div>
+            <div className="text-2xl font-bold text-indigo-700">${perSpaceAI.toFixed(2)}</div>
+            <div className="text-xs text-gray-500 mt-1">
+              One-time onboarding ≈ ${onboardingCost(aiModel).toFixed(2)} / Space
+            </div>
+            <div className="text-xs text-gray-500">
+              vs Composer Fast: {(baselinePerSpace / perSpaceAI).toFixed(1)}× cheaper
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-4 overflow-x-auto">
+          <table className="min-w-full bg-white border text-sm">
+            <thead className="bg-gray-100">
+              <tr>
+                <th className="py-1 px-3 border text-left">Model</th>
+                <th className="py-1 px-3 border">Type</th>
+                <th className="py-1 px-3 border text-right">In $/1M</th>
+                <th className="py-1 px-3 border text-right">Out $/1M</th>
+                <th className="py-1 px-3 border text-right">$/Space/mo ({aiProfile})</th>
+                <th className="py-1 px-3 border text-right">vs Composer Fast</th>
+              </tr>
+            </thead>
+            <tbody>
+              {ALL_MODELS.map((m) => {
+                const cost = perSpaceMonthlyAICost(m, aiProfile);
+                const isOpen = AI_MODELS.open.some((o) => o.id === m.id);
+                return (
+                  <tr key={m.id} className={m.id === aiModelId ? 'bg-indigo-100 font-semibold' : ''}>
+                    <td className="py-1 px-3 border">{m.name}</td>
+                    <td className="py-1 px-3 border text-center">{isOpen ? 'Open' : 'Closed'}</td>
+                    <td className="py-1 px-3 border text-right">${m.input.toFixed(2)}</td>
+                    <td className="py-1 px-3 border text-right">${m.output.toFixed(2)}</td>
+                    <td className="py-1 px-3 border text-right">${cost.toFixed(2)}</td>
+                    <td className="py-1 px-3 border text-right">
+                      {m.id === 'composer-fast' ? '—' : `${(baselinePerSpace / cost).toFixed(1)}×`}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
+        <div className="bg-gray-50 p-4 rounded-lg">
+          <h2 className="text-lg font-semibold mb-3">Initial Parameters</h2>
+          <div className="mb-4">
+            <label className="block text-sm font-medium mb-1">Total Supply of HYPHA</label>
+            <div className="flex items-center">
+              <input type="range" min="100000000" max="1000000000" step="10000000" value={maxSupply} onChange={(e) => setMaxSupply(Number(e.target.value))} className="w-full mr-3" />
+              <input type="text" value={formatNumber(maxSupply)} onChange={(e) => { const v = Number(e.target.value.replace(/,/g, '')); if (!isNaN(v)) setMaxSupply(v); }} className="w-32 p-1 border rounded text-right" />
+            </div>
+          </div>
+          <div className="mb-4">
+            <label className="block text-sm font-medium mb-1">Initial HYPHA on IEX</label>
+            <div className="flex items-center">
+              <input type="range" min="1000000" max="50000000" step="1000000" value={initialHypha} onChange={(e) => setInitialHypha(Number(e.target.value))} className="w-full mr-3" />
+              <input type="text" value={formatNumber(initialHypha)} onChange={(e) => { const v = Number(e.target.value.replace(/,/g, '')); if (!isNaN(v)) setInitialHypha(v); }} className="w-24 p-1 border rounded text-right" />
+            </div>
+          </div>
+          <div className="mb-4">
+            <label className="block text-sm font-medium mb-1">Initial USDC on IEX</label>
+            <div className="flex items-center">
+              <input type="range" min="100000" max="2000000" step="50000" value={initialUsdc} onChange={(e) => setInitialUsdc(Number(e.target.value))} className="w-full mr-3" />
+              <input type="text" value={formatNumber(initialUsdc)} onChange={(e) => { const v = Number(e.target.value.replace(/,/g, '')); if (!isNaN(v)) setInitialUsdc(v); }} className="w-24 p-1 border rounded text-right" />
+            </div>
+          </div>
+          <div className="mb-4">
+            <label className="block text-sm font-medium mb-1">Simulation Months</label>
+            <div className="flex items-center">
+              <input type="range" min="6" max="60" step="1" value={months} onChange={(e) => setMonths(Number(e.target.value))} className="w-full mr-3" />
+              <input type="number" value={months} onChange={(e) => setMonths(Number(e.target.value))} className="w-16 p-1 border rounded text-right" />
+            </div>
+          </div>
+        </div>
+
+        <div className="bg-gray-50 p-4 rounded-lg">
+          <h2 className="text-lg font-semibold mb-3">Monthly Parameters</h2>
+          <div className="mb-4 bg-blue-50 p-3 rounded-lg">
+            <div className="flex justify-between items-center mb-2">
+              <h3 className="text-md font-medium">Per-Month Configuration</h3>
+              <button onClick={() => setShowMonthlyConfig(!showMonthlyConfig)} className="px-2 py-1 bg-blue-100 rounded hover:bg-blue-200 text-sm">{showMonthlyConfig ? 'Hide Details' : 'Show Details'}</button>
+            </div>
+            {showMonthlyConfig && (
+              <div className="mb-3">
+                <div className="flex items-center mb-3">
+                  <label className="block text-sm font-medium mr-2">Select Month:</label>
+                  <select value={selectedMonth} onChange={(e) => setSelectedMonth(Number(e.target.value))} className="p-1 border rounded">
+                    {Array.from({length: months}, (_, i) => i + 1).map(month => (<option key={month} value={month}>Month {month}</option>))}
+                  </select>
+                </div>
+              </div>
+            )}
+          </div>
+
+          <h3 className="text-md font-medium mb-2">Issuance Distribution</h3>
+          <div className="mb-4">
+            <label className="block text-sm font-medium mb-1">Staking Rate (%)</label>
+            <div className="flex items-center">
+              <input type="range" min="0" max="90" step="1" value={monthlyParams[selectedMonth]?.stakingRate ?? stakingRate} onChange={(e) => { const v = Number(e.target.value); selectedMonth === 1 ? setStakingRate(v) : updateMonthlyParameter('stakingRate', v); }} className="w-full mr-3" />
+              <input type="number" min="0" max="90" value={monthlyParams[selectedMonth]?.stakingRate ?? stakingRate} onChange={(e) => { const v = Number(e.target.value); selectedMonth === 1 ? setStakingRate(v) : updateMonthlyParameter('stakingRate', v); }} className="w-16 p-1 border rounded text-right" />
+              <span className="ml-1">%</span>
+            </div>
+          </div>
+          <div className="mb-4">
+            <label className="block text-sm font-medium mb-1">Distribution Multiplier</label>
+            <div className="flex items-center">
+              <input type="range" min="0.1" max="10" step="0.1" value={monthlyParams[selectedMonth]?.unlockRate ?? unlockRate} onChange={(e) => { const v = Number(e.target.value); selectedMonth === 1 ? setUnlockRate(v) : updateMonthlyParameter('unlockRate', v); }} className="w-full mr-3" />
+              <input type="number" min="0.1" max="10" step="0.1" value={monthlyParams[selectedMonth]?.unlockRate ?? unlockRate} onChange={(e) => { const v = Number(e.target.value); selectedMonth === 1 ? setUnlockRate(v) : updateMonthlyParameter('unlockRate', v); }} className="w-16 p-1 border rounded text-right" />
+            </div>
+          </div>
+          <div className="mb-4">
+            <label className="block text-sm font-medium mb-1">Max. Staking Rewards (Yearly)</label>
+            <div className="flex items-center">
+              <input type="range" min="5" max="30" step="1" value={monthlyParams[selectedMonth]?.stakingRewards ?? stakingRewards} onChange={(e) => { const v = Number(e.target.value); selectedMonth === 1 ? setStakingRewards(v) : updateMonthlyParameter('stakingRewards', v); }} className="w-full mr-3" />
+              <input type="number" value={monthlyParams[selectedMonth]?.stakingRewards ?? stakingRewards} onChange={(e) => { const v = Number(e.target.value); selectedMonth === 1 ? setStakingRewards(v) : updateMonthlyParameter('stakingRewards', v); }} className="w-16 p-1 border rounded text-right" />
+              <span className="ml-1">%</span>
+            </div>
+          </div>
+          <div className="mb-4">
+            <label className="block text-sm font-medium mb-1">Issuance Split (% to Staking)</label>
+            <div className="flex items-center">
+              <input type="range" min="10" max="90" step="5" value={monthlyParams[selectedMonth]?.rewardSplit ?? rewardSplit} onChange={(e) => { const v = Number(e.target.value); selectedMonth === 1 ? setRewardSplit(v) : updateMonthlyParameter('rewardSplit', v); }} className="w-full mr-3" />
+              <input type="number" value={monthlyParams[selectedMonth]?.rewardSplit ?? rewardSplit} onChange={(e) => { const v = Number(e.target.value); selectedMonth === 1 ? setRewardSplit(v) : updateMonthlyParameter('rewardSplit', v); }} className="w-16 p-1 border rounded text-right" />
+              <span className="ml-1">%</span>
+            </div>
+          </div>
+
+          <h3 className="text-md font-medium mb-2 mt-4">Buying Pressure on IEX</h3>
+          <div className="mb-4">
+            <label className="block text-sm font-medium mb-1">Number of Spaces</label>
+            <div className="flex items-center">
+              <input type="range" min="0" max="5000" step="10" value={monthlyParams[selectedMonth]?.orgCount ?? orgCount} onChange={(e) => { const v = Number(e.target.value); selectedMonth === 1 ? setOrgCount(v) : updateMonthlyParameter('orgCount', v); }} className="w-full mr-3" />
+              <input type="number" min="0" value={monthlyParams[selectedMonth]?.orgCount ?? orgCount} onChange={(e) => { const v = Number(e.target.value); selectedMonth === 1 ? setOrgCount(v) : updateMonthlyParameter('orgCount', v); }} className="w-16 p-1 border rounded text-right" />
+            </div>
+          </div>
+          <div className="mb-4">
+            <label className="block text-sm font-medium mb-1">Space Growth Rate (%)</label>
+            <div className="flex items-center">
+              <input type="range" min="0" max="50" step="1" value={monthlyParams[selectedMonth]?.orgGrowthRate ?? orgGrowthRate} onChange={(e) => { const v = Number(e.target.value); selectedMonth === 1 ? setOrgGrowthRate(v) : updateMonthlyParameter('orgGrowthRate', v); }} className="w-full mr-3" />
+              <input type="number" min="0" max="50" value={monthlyParams[selectedMonth]?.orgGrowthRate ?? orgGrowthRate} onChange={(e) => { const v = Number(e.target.value); selectedMonth === 1 ? setOrgGrowthRate(v) : updateMonthlyParameter('orgGrowthRate', v); }} className="w-16 p-1 border rounded text-right" />
+              <span className="ml-1">%</span>
+            </div>
+          </div>
+          <div className="mb-4">
+            <label className="block text-sm font-medium mb-1">USDC Contribution per Space (monthly)</label>
+            <div className="flex items-center">
+              <input type="range" min="0" max="200" step="1" value={monthlyParams[selectedMonth]?.orgPayment ?? orgPayment} onChange={(e) => { const v = Number(e.target.value); selectedMonth === 1 ? setOrgPayment(v) : updateMonthlyParameter('orgPayment', v); }} className="w-full mr-3" />
+              <input type="number" min="0" max="200" value={monthlyParams[selectedMonth]?.orgPayment ?? orgPayment} onChange={(e) => { const v = Number(e.target.value); selectedMonth === 1 ? setOrgPayment(v) : updateMonthlyParameter('orgPayment', v); }} className="w-20 p-1 border rounded text-right" />
+              <span className="ml-1">USDC</span>
+            </div>
+            <p className="text-xs text-gray-500 mt-1">AI cost (${perSpaceAI.toFixed(2)}/Space) is tracked separately from IEX purchases.</p>
+          </div>
+          <div className="mb-4">
+            <label className="block text-sm font-medium mb-1">Additional Investor Purchases + buybacks (% of USDC on IEX)</label>
+            <div className="flex items-center">
+              <input type="range" min="0" max="50" step="1" value={monthlyParams[selectedMonth]?.additionalPurchase ?? additionalPurchase} onChange={(e) => { const v = Number(e.target.value); selectedMonth === 1 ? setAdditionalPurchase(v) : updateMonthlyParameter('additionalPurchase', v); }} className="w-full mr-3" />
+              <input type="number" min="0" max="50" value={monthlyParams[selectedMonth]?.additionalPurchase ?? additionalPurchase} onChange={(e) => { const v = Number(e.target.value); selectedMonth === 1 ? setAdditionalPurchase(v) : updateMonthlyParameter('additionalPurchase', v); }} className="w-16 p-1 border rounded text-right" />
+              <span className="ml-1">%</span>
+            </div>
+          </div>
+
+          <h3 className="text-md font-medium mb-2 mt-4">Selling Pressure on IEX</h3>
+          <div className="mb-4">
+            <label className="block text-sm font-medium mb-1">Investor Selling (% of HYPHA on IEX)</label>
+            <div className="flex items-center">
+              <input type="range" min="10" max="30" step="0.5" value={monthlyParams[selectedMonth]?.investorSelling ?? investorSelling} onChange={(e) => { const v = Number(e.target.value); selectedMonth === 1 ? setInvestorSelling(v) : updateMonthlyParameter('investorSelling', v); }} className="w-full mr-3" />
+              <input type="number" min="10" max="30" step="0.5" value={monthlyParams[selectedMonth]?.investorSelling ?? investorSelling} onChange={(e) => { const v = Number(e.target.value); selectedMonth === 1 ? setInvestorSelling(v) : updateMonthlyParameter('investorSelling', v); }} className="w-16 p-1 border rounded text-right" />
+              <span className="ml-1">%</span>
+            </div>
+          </div>
+          <button onClick={resetParameters} className="mt-2 px-4 py-2 bg-gray-200 rounded hover:bg-gray-300">Reset All Parameters</button>
+        </div>
+      </div>
+
+      {results.length > 0 && (
+        <div className="mt-4 mb-6 bg-blue-50 p-6 rounded-lg shadow">
+          <h2 className="text-xl font-bold mb-4">Key Metrics at Month {months}</h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+            <div className="bg-white p-4 rounded shadow">
+              <h3 className="text-sm font-medium text-gray-500">Spaces</h3>
+              <p className="text-2xl font-bold">{results[results.length - 1].cumulativeOrgCount.toLocaleString()}</p>
+              <p className="text-sm text-gray-500">Current Month: {results[results.length - 1].orgCount.toLocaleString()}</p>
+            </div>
+            <div className="bg-white p-4 rounded shadow">
+              <h3 className="text-sm font-medium text-gray-500">Token Price</h3>
+              <p className="text-2xl font-bold">${results[results.length - 1].tokenPrice}</p>
+              <p className="text-sm text-gray-500">Last Month Change: {results[results.length - 1].deltaPrice}%</p>
+            </div>
+            <div className="bg-white p-4 rounded shadow">
+              <h3 className="text-sm font-medium text-gray-500">Circulating Supply</h3>
+              <p className="text-2xl font-bold">{results[results.length - 1].circulatingSupply.toLocaleString()}</p>
+              <p className="text-sm text-gray-500">
+                Staked: {results[results.length - 1].stakedAmount.toLocaleString()} ({results[results.length - 1].circulatingSupply > 0 ? (results[results.length - 1].stakedAmount / results[results.length - 1].circulatingSupply * 100).toFixed(1) : 0}%)
+              </p>
+            </div>
+            <div className="bg-white p-4 rounded shadow">
+              <h3 className="text-sm font-medium text-gray-500">IEX HYPHA Balance</h3>
+              <p className="text-2xl font-bold">{results[results.length - 1].dexHypha.toLocaleString()}</p>
+            </div>
+            <div className="bg-white p-4 rounded shadow">
+              <h3 className="text-sm font-medium text-gray-500">IEX USDC Balance</h3>
+              <p className="text-2xl font-bold">${results[results.length - 1].dexUsdc.toLocaleString()}</p>
+            </div>
+            <div className="bg-white p-4 rounded shadow">
+              <h3 className="text-sm font-medium text-gray-500">Cumulated Space Contributions</h3>
+              <p className="text-2xl font-bold">${results.reduce((s, r) => s + r.orgUsdcPurchase, 0).toLocaleString()}</p>
+            </div>
+            <div className="bg-white p-4 rounded shadow">
+              <h3 className="text-sm font-medium text-gray-500">Tokens Purchased by Spaces</h3>
+              <p className="text-2xl font-bold">{results.reduce((s, r) => s + r.orgPurchasedTokens, 0).toLocaleString()}</p>
+            </div>
+            <div className="bg-white p-4 rounded shadow">
+              <h3 className="text-sm font-medium text-gray-500">Tokens Purchased by Investors</h3>
+              <p className="text-2xl font-bold">{results.reduce((s, r) => s + r.investorPurchasedTokens, 0).toLocaleString()}</p>
+            </div>
+            <div className="bg-white p-4 rounded shadow">
+              <h3 className="text-sm font-medium text-gray-500">Total Issuance</h3>
+              <p className="text-2xl font-bold">{results[results.length - 1].cumulativeIssuance.toLocaleString()}</p>
+              <p className="text-sm text-gray-500">{(results[results.length - 1].cumulativeIssuance / maxSupply * 100).toFixed(1)}% of Max Supply</p>
+            </div>
+            <div className="bg-white p-4 rounded shadow">
+              <h3 className="text-sm font-medium text-gray-500">Average Rewards</h3>
+              <p className="text-2xl font-bold">{(results.reduce((s, r) => s + parseFloat(r.actualRewards), 0) / results.length).toFixed(2)}%</p>
+            </div>
+            <div className="bg-white p-4 rounded shadow">
+              <h3 className="text-sm font-medium text-gray-500">FDV (Full Diluted Value)</h3>
+              <p className="text-2xl font-bold">${results[results.length - 1].fdv.toLocaleString()}</p>
+            </div>
+            <div className="bg-white p-4 rounded shadow border-l-4 border-indigo-400">
+              <h3 className="text-sm font-medium text-gray-500">Monthly AI Cost</h3>
+              <p className="text-2xl font-bold text-indigo-700">${Math.round(results[results.length - 1].aiCost).toLocaleString()}</p>
+              <p className="text-sm text-gray-500">{aiModel.name} · ${perSpaceAI.toFixed(2)}/Space</p>
+            </div>
+            <div className="bg-white p-4 rounded shadow border-l-4 border-indigo-400">
+              <h3 className="text-sm font-medium text-gray-500">Cumulative AI Cost</h3>
+              <p className="text-2xl font-bold text-indigo-700">${Math.round(results[results.length - 1].cumulativeAICost).toLocaleString()}</p>
+            </div>
+            <div className="bg-white p-4 rounded shadow border-l-4 border-indigo-400">
+              <h3 className="text-sm font-medium text-gray-500">Net After AI (monthly)</h3>
+              <p className={`text-2xl font-bold ${results[results.length - 1].netContribution >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+                ${Math.round(results[results.length - 1].netContribution).toLocaleString()}
+              </p>
+              <p className="text-sm text-gray-500">Contributions − AI cost</p>
+            </div>
+          </div>
+        </div>
+      )}
+
+      <div className="mb-6">
+        <h2 className="text-lg font-semibold mb-3">Simulation Results</h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
+          <div className="h-80 bg-white p-4 rounded-lg shadow">
+            <h3 className="text-md font-medium mb-2">Reward Distribution</h3>
+            <ResponsiveContainer width="100%" height="90%">
+              <LineChart data={chartData} margin={{ top: 5, right: 50, left: 50, bottom: 5 }}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="name" />
+                <YAxis tickFormatter={(v) => v.toLocaleString()} width={60} />
+                <Tooltip formatter={(v) => v.toLocaleString()} />
+                <Legend />
+                <Line type="monotone" dataKey="Staking Rewards" stroke="#8884d8" strokeWidth={2} />
+                <Line type="monotone" dataKey="Unlock Rewards" stroke="#82ca9d" strokeWidth={2} />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+          <div className="h-80 bg-white p-4 rounded-lg shadow">
+            <h3 className="text-md font-medium mb-2">Circulating Supply &amp; Total Unlocked</h3>
+            <ResponsiveContainer width="100%" height="90%">
+              <LineChart data={chartData} margin={{ top: 5, right: 40, left: 40, bottom: 5 }}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="name" />
+                <YAxis tickFormatter={(v) => v.toLocaleString()} width={60} />
+                <Tooltip formatter={(v) => v.toLocaleString()} />
+                <Legend />
+                <Line type="monotone" dataKey="Circulating Supply" stroke="#8884d8" activeDot={{ r: 8 }} />
+                <Line type="monotone" dataKey="Total Unlocked" stroke="#82ca9d" strokeWidth={2} />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+          <div className="h-80 bg-white p-4 rounded-lg shadow">
+            <h3 className="text-md font-medium mb-2">IEX HYPHA Balance &amp; Space Purchases</h3>
+            <ResponsiveContainer width="100%" height="90%">
+              <LineChart data={chartData} margin={{ top: 5, right: 50, left: 50, bottom: 5 }}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="name" />
+                <YAxis tickFormatter={(v) => v.toLocaleString()} />
+                <Tooltip formatter={(v) => v.toLocaleString()} />
+                <Legend />
+                <Line type="monotone" dataKey="IEX HYPHA" stroke="#82ca9d" strokeWidth={2} activeDot={{ r: 8 }} />
+                <Line type="monotone" dataKey="Space Purchases" stroke="#8884d8" strokeWidth={1.5} dot={{ r: 4 }} />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+          <div className="h-80 bg-white p-4 rounded-lg shadow">
+            <h3 className="text-md font-medium mb-2">IEX USDC</h3>
+            <ResponsiveContainer width="100%" height="90%">
+              <LineChart data={chartData} margin={{ top: 5, right: 40, left: 40, bottom: 5 }}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="name" />
+                <YAxis tickFormatter={(v) => v.toLocaleString()} />
+                <Tooltip formatter={(v) => v.toLocaleString()} />
+                <Line type="monotone" dataKey="IEX USDC" stroke="#8884d8" />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+          <div className="h-80 bg-white p-4 rounded-lg shadow">
+            <h3 className="text-md font-medium mb-2">Space Growth</h3>
+            <ResponsiveContainer width="100%" height="90%">
+              <LineChart data={chartData} margin={{ top: 5, right: 30, left: 30, bottom: 5 }}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="name" />
+                <YAxis yAxisId="left" tickFormatter={(v) => v.toLocaleString()} width={60} />
+                <YAxis yAxisId="right" orientation="right" tickFormatter={(v) => v.toLocaleString()} width={60} />
+                <Tooltip formatter={(v) => v.toLocaleString()} />
+                <Legend />
+                <Line yAxisId="left" type="monotone" dataKey="Number of Spaces" stroke="#8884d8" strokeWidth={2} />
+                <Line yAxisId="right" type="monotone" dataKey="Cumulative Spaces" stroke="#82ca9d" strokeWidth={2} />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+          <div className="h-80 bg-white p-4 rounded-lg shadow">
+            <h3 className="text-md font-medium mb-2">Token Price &amp; FDV</h3>
+            <ResponsiveContainer width="100%" height="90%">
+              <LineChart data={chartData} margin={{ top: 5, right: 30, left: 30, bottom: 5 }}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="name" />
+                <YAxis yAxisId="left" tickFormatter={(v) => v.toLocaleString()} width={60} />
+                <YAxis yAxisId="right" orientation="right" tickFormatter={(v) => v.toLocaleString()} width={60} />
+                <Tooltip formatter={(v) => v.toLocaleString()} />
+                <Legend />
+                <Line yAxisId="left" type="monotone" dataKey="Price (USDC)" stroke="#ff7300" />
+                <Line yAxisId="right" type="monotone" dataKey="FDV (Million $)" stroke="#0088FE" />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+          <div className="h-80 bg-white p-4 rounded-lg shadow md:col-span-2">
+            <h3 className="text-md font-medium mb-1">Space Contributions vs AI Cost</h3>
+            <p className="text-xs text-gray-500 mb-2">
+              Contributions = Spaces × ${orgPayment} USDC/Space. Flat stretches happen when per-month Space Growth Rate is 0% (default: months 2–26). AI cost scales with the same Space count × selected model rate.
+            </p>
+            <ResponsiveContainer width="100%" height="85%">
+              <LineChart data={chartData} margin={{ top: 5, right: 50, left: 50, bottom: 5 }}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="name" />
+                <YAxis tickFormatter={(v) => v.toLocaleString()} width={60} />
+                <Tooltip formatter={(v) => v.toLocaleString()} />
+                <Legend />
+                <Line type="monotone" dataKey="Space Contributions (USD)" stroke="#82ca9d" strokeWidth={2} />
+                <Line type="monotone" dataKey="AI Cost (USD)" stroke="#6366f1" strokeWidth={2} />
+                <Line type="monotone" dataKey="Net Contributions (USD)" stroke="#ff7300" strokeWidth={2} />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+          <div className="h-80 bg-white p-4 rounded-lg shadow">
+            <h3 className="text-md font-medium mb-2">Cumulative AI Cost</h3>
+            <ResponsiveContainer width="100%" height="90%">
+              <LineChart data={chartData} margin={{ top: 5, right: 40, left: 40, bottom: 5 }}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="name" />
+                <YAxis tickFormatter={(v) => v.toLocaleString()} width={60} />
+                <Tooltip formatter={(v) => v.toLocaleString()} />
+                <Line type="monotone" dataKey="Cumulative AI Cost (USD)" stroke="#6366f1" strokeWidth={2} />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+        </div>
+
+        <div className="overflow-x-auto">
+          <table className="min-w-full bg-white border text-sm">
+            <thead className="bg-gray-100">
+              <tr>
+                <th className="py-2 px-4 border">Month</th>
+                <th className="py-2 px-4 border text-right">Total Issuance (monthly)</th>
+                <th className="py-2 px-4 border text-right">Total Unlocked (cumulative)</th>
+                <th className="py-2 px-4 border text-right">Staking Rewards</th>
+                <th className="py-2 px-4 border text-right">Unlock Rewards</th>
+                <th className="py-2 px-4 border text-right">Actual Rewards</th>
+                <th className="py-2 px-4 border text-right">Spaces (monthly)</th>
+                <th className="py-2 px-4 border text-right">Spaces (cumulative)</th>
+                <th className="py-2 px-4 border text-right">Staked Tokens (cumulative)</th>
+                <th className="py-2 px-4 border text-right">Circulating Supply</th>
+                <th className="py-2 px-4 border text-right">IEX HYPHA Before</th>
+                <th className="py-2 px-4 border text-right">Space HYPHA Purchased</th>
+                <th className="py-2 px-4 border text-right">Investor HYPHA Purchased</th>
+                <th className="py-2 px-4 border text-right">Tokens Sold on IEX</th>
+                <th className="py-2 px-4 border text-right">IEX HYPHA After</th>
+                <th className="py-2 px-4 border text-right">IEX USDC</th>
+                <th className="py-2 px-4 border text-right">Space Contributions (USD)</th>
+                <th className="py-2 px-4 border text-right">AI Cost (USD)</th>
+                <th className="py-2 px-4 border text-right">Net After AI (USD)</th>
+                <th className="py-2 px-4 border text-right">Cumulative AI Cost (USD)</th>
+                <th className="py-2 px-4 border text-right">Token Price</th>
+                <th className="py-2 px-4 border text-right">Price Change</th>
+                <th className="py-2 px-4 border text-right">FDV (USD)</th>
+              </tr>
+            </thead>
+            <tbody>
+              {results.map((row) => (
+                <tr key={row.month}>
+                  <td className="py-2 px-4 border text-center">{row.month}</td>
+                  <td className="py-2 px-4 border text-right">{row.totalIssuance.toLocaleString()}</td>
+                  <td className="py-2 px-4 border text-right">{row.cumulativeIssuance.toLocaleString()}</td>
+                  <td className="py-2 px-4 border text-right">
+                    {row.stakingRewards.toLocaleString()}
+                    <span className="text-xs text-gray-500 ml-1">({row.stakingRewardsPercentage}%)</span>
+                  </td>
+                  <td className="py-2 px-4 border text-right">{row.unlockRewards.toLocaleString()}</td>
+                  <td className="py-2 px-4 border text-right">{row.actualRewards}%</td>
+                  <td className="py-2 px-4 border text-right">{row.orgCount.toLocaleString()}</td>
+                  <td className="py-2 px-4 border text-right">{row.cumulativeOrgCount.toLocaleString()}</td>
+                  <td className="py-2 px-4 border text-right">{row.stakedAmount.toLocaleString()}</td>
+                  <td className="py-2 px-4 border text-right">{row.circulatingSupply.toLocaleString()}</td>
+                  <td className="py-2 px-4 border text-right">{row.dexHyphaBefore.toLocaleString()}</td>
+                  <td className="py-2 px-4 border text-right">{row.orgPurchasedTokens.toLocaleString()}</td>
+                  <td className="py-2 px-4 border text-right">{row.investorPurchasedTokens.toLocaleString()}</td>
+                  <td className="py-2 px-4 border text-right">{row.tokensSold.toLocaleString()}</td>
+                  <td className="py-2 px-4 border text-right">{row.dexHypha.toLocaleString()}</td>
+                  <td className="py-2 px-4 border text-right">{row.dexUsdc.toLocaleString()}</td>
+                  <td className="py-2 px-4 border text-right">${Math.round(row.orgUsdcPurchase).toLocaleString()}</td>
+                  <td className="py-2 px-4 border text-right text-indigo-700">${Math.round(row.aiCost).toLocaleString()}</td>
+                  <td className={`py-2 px-4 border text-right ${row.netContribution >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+                    ${Math.round(row.netContribution).toLocaleString()}
+                  </td>
+                  <td className="py-2 px-4 border text-right text-indigo-700">${Math.round(row.cumulativeAICost).toLocaleString()}</td>
+                  <td className="py-2 px-4 border text-right">${row.tokenPrice}</td>
+                  <td className="py-2 px-4 border text-right">{row.deltaPrice}%</td>
+                  <td className="py-2 px-4 border text-right">${row.fdv.toLocaleString()}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+        </div>
+
+        <div className="w-48 flex-shrink-0">
+          <div className="sticky top-4 border border-gray-200 rounded-lg overflow-hidden shadow-sm">
+            <div className="bg-gray-100 px-3 py-2 text-xs font-semibold text-gray-600 uppercase tracking-wide">
+              Growth Scenario
+            </div>
+            {Object.entries(GROWTH_PRESETS).map(([key, preset]) => (
+              <button
+                key={key}
+                type="button"
+                onClick={() => applyGrowthScenario(key)}
+                className={`w-full text-left px-3 py-3 border-t border-gray-200 transition-colors ${
+                  growthScenario === key
+                    ? 'bg-indigo-600 text-white'
+                    : 'bg-white hover:bg-indigo-50 text-gray-800'
+                }`}
+              >
+                <div className="font-semibold text-sm">{preset.label}</div>
+                <div className={`text-xs mt-0.5 ${growthScenario === key ? 'text-indigo-100' : 'text-gray-500'}`}>
+                  {preset.subtitle}
+                </div>
+                {results.length > 0 && growthScenario === key && (
+                  <div className="text-xs mt-1 text-indigo-100">
+                    {results[results.length - 1].orgCount.toLocaleString()} Spaces · FDV ${(results[results.length - 1].fdv / 1e6).toFixed(0)}M
+                  </div>
+                )}
+              </button>
+            ))}
+            <p className="px-3 py-2 text-xs text-gray-500 bg-gray-50 border-t border-gray-200">
+              Sets per-month Space Growth Rate presets. Override individual months via Per-Month Configuration.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const root = createRoot(document.getElementById('root'));
+root.render(<TokenomicsSimulator />);
+</script>
+</body>
+</html>

--- a/docs/hypha-ai-cost/tokenomics-simulator.html
+++ b/docs/hypha-ai-cost/tokenomics-simulator.html
@@ -70,64 +70,64 @@ const perSpaceMonthlyGas = (profile) => GAS_MONTHLY_BY_PROFILE[profile] || GAS_M
 const GROWTH_PRESETS = {
   low: {
     label: 'Low',
-    subtitle: '~250k Spaces',
+    subtitle: '~250k cumulative',
     defaults: {
       orgPayment: 44,
-      iexAllocationPct: 8,
+      iexAllocationPct: 25,
       investorSelling: 5,
       additionalPurchase: 5,
       unlockRate: 4,
-      initialHypha: 20000000,
-      initialUsdc: 4000000,
+      initialHypha: 5000000,
+      initialUsdc: 1000000,
       orgCount: 4373,
-      orgGrowthRate: 9,
+      orgGrowthRate: 0.72,
     },
-    // Target ~250k Spaces at month 48 (~9.0%/mo, months 2–48)
+    // Target ~250k cumulative Space-months at month 48 (~0.72%/mo, months 2–48)
     build: () => {
       const m = {};
-      for (let i = 2; i <= 48; i++) m[i] = { orgGrowthRate: 9.0 };
+      for (let i = 2; i <= 48; i++) m[i] = { orgGrowthRate: 0.72 };
       return m;
     },
   },
   mid: {
     label: 'Mid',
-    subtitle: '~1M Spaces',
+    subtitle: '~1M cumulative',
     defaults: {
       orgPayment: 44,
-      iexAllocationPct: 10,
+      iexAllocationPct: 25,
       investorSelling: 5,
-      additionalPurchase: 5,
+      additionalPurchase: 8,
       unlockRate: 3.5,
       initialHypha: 40000000,
       initialUsdc: 8000000,
       orgCount: 4373,
-      orgGrowthRate: 12.26,
+      orgGrowthRate: 5.63,
     },
-    // Target ~1M Spaces at month 48 (~12.26%/mo, months 2–48)
+    // Target ~1M cumulative Space-months at month 48 (~5.63%/mo, months 2–48)
     build: () => {
       const m = {};
-      for (let i = 2; i <= 48; i++) m[i] = { orgGrowthRate: 12.26 };
+      for (let i = 2; i <= 48; i++) m[i] = { orgGrowthRate: 5.63 };
       return m;
     },
   },
   high: {
     label: 'High',
-    subtitle: '~10M Spaces',
+    subtitle: '~10M cumulative',
     defaults: {
       orgPayment: 44,
-      iexAllocationPct: 12,
-      investorSelling: 5,
-      additionalPurchase: 5,
+      iexAllocationPct: 19,
+      investorSelling: 3,
+      additionalPurchase: 8,
       unlockRate: 3,
       initialHypha: 100000000,
       initialUsdc: 25000000,
       orgCount: 4373,
-      orgGrowthRate: 17.9,
+      orgGrowthRate: 12.52,
     },
-    // Target ~10M Spaces at month 48 (~17.9%/mo, months 2–48)
+    // Target ~10M cumulative Space-months at month 48 (~12.52%/mo, months 2–48)
     build: () => {
       const m = {};
-      for (let i = 2; i <= 48; i++) m[i] = { orgGrowthRate: 17.9 };
+      for (let i = 2; i <= 48; i++) m[i] = { orgGrowthRate: 12.52 };
       return m;
     },
   },
@@ -222,6 +222,7 @@ const TokenomicsSimulator = () => {
     const perSpaceGas = perSpaceMonthlyGas(aiProfile);
     let cumulativeAICost = 0;
     let cumulativeGasCost = 0;
+    let cumulativeGrossRevenue = 0;
 
     for (let month = 1; month <= months; month++) {
       const monthStakingRate = getMonthlyParameter('stakingRate', month) / 100;
@@ -278,6 +279,8 @@ const TokenomicsSimulator = () => {
 
       cumulativeOrgCountTracker += currentOrgCount;
       const cumulativeOrgCount = cumulativeOrgCountTracker;
+      cumulativeGrossRevenue += grossContribution;
+      const runRateArr = currentOrgCount * monthOrgPayment * 12;
 
       const distributionMultiplier = getMonthlyParameter('unlockRate', month);
       const safeStakingRate = Math.min(monthStakingRate, 0.9);
@@ -367,6 +370,9 @@ const TokenomicsSimulator = () => {
         totalPurchasedTokens: Math.round(totalPurchasedTokens),
         investorSellingUsdc: monthInvestorSelling, tokensSold,
         fdv: Math.round(fdv),
+        runRateArr: Math.round(runRateArr),
+        fdvArr: runRateArr > 0 ? +(fdv / runRateArr).toFixed(1) : null,
+        cumulativeGrossRevenue: Math.round(cumulativeGrossRevenue),
         aiCost: monthAICost, cumulativeAICost,
         gasCost: monthGasCost, cumulativeGasCost,
         netContribution, netAfterGas,
@@ -439,6 +445,8 @@ const TokenomicsSimulator = () => {
   const perSpaceAI = perSpaceMonthlyAICost(aiModel, aiProfile);
   const perSpaceGas = perSpaceMonthlyGas(aiProfile);
   const baselinePerSpace = perSpaceMonthlyAICost(getModel('composer-fast'), aiProfile);
+  const lastResult = results.length > 0 ? results[results.length - 1] : null;
+  const offPoolPct = 100 - (monthlyParams[selectedMonth]?.iexAllocationPct ?? iexAllocationPct);
 
 
   return (
@@ -446,7 +454,33 @@ const TokenomicsSimulator = () => {
       <div className="flex gap-6">
         <div className="flex-1 min-w-0">
       <h1 className="text-2xl font-bold mb-1">HYPHA Tokenomics Simulator (Phase II)</h1>
-      <p className="text-sm text-gray-500 mb-4">With per-Space AI + Base L2 gas operating cost model — closed-source vs open-source LLMs.</p>
+      <p className="text-sm text-gray-500 mb-3">Dynamic IEX pricing after Phase I handoff — per-Space AI + Base L2 gas operating cost model.</p>
+
+      <div className="mb-4 border border-slate-200 bg-slate-50 p-4 rounded-lg">
+        <h2 className="text-xs font-semibold text-slate-600 uppercase tracking-wide mb-2">Roadmap: Phase 0 → Phase I → Phase II</h2>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-3 text-sm">
+          <div className="bg-white p-3 rounded border border-slate-200">
+            <div className="font-semibold text-slate-600">Phase 0 — Today</div>
+            <p className="text-xs text-gray-600 mt-1">~4,373 Spaces live. Phase I at month 0. Reference FDV ~$111M at $0.20.</p>
+          </div>
+          <div className="bg-white p-3 rounded border border-slate-200">
+            <div className="font-semibold text-slate-700">Phase I — Month 0+</div>
+            <p className="text-xs text-gray-600 mt-1">Fixed $0.20 price, token sale &amp; locking. <a href="/tokenomics1/" className="text-indigo-600 underline">Phase I simulator →</a></p>
+          </div>
+          <div className="bg-indigo-600 text-white p-3 rounded border border-indigo-700">
+            <div className="font-semibold">Phase II — After Phase I (this sim)</div>
+            <p className="text-xs text-indigo-100 mt-1">Starts ~4,373 paying Spaces × $44/mo. Month 1 = first month after handoff.</p>
+          </div>
+        </div>
+      </div>
+
+      <div className="mb-4 border border-teal-200 bg-teal-50 p-3 rounded-lg text-sm">
+        <span className="font-semibold text-teal-800">Revenue split:</span>{' '}
+        <span className="text-teal-900">{iexAllocationPct}% → IEX buy pressure</span>
+        <span className="text-teal-700"> · </span>
+        <span className="text-teal-900">{offPoolPct}% → AI (~${perSpaceAI.toFixed(2)}/Space), gas, ops, rewards, treasury</span>
+        <span className="text-xs text-teal-700 block mt-1">Only active Spaces in each month pay $44. Cumulative totals are Space-months over the horizon, not concurrent payers.</span>
+      </div>
 
       {/* ============ AI OPERATING COST SECTION ============ */}
       <div className="mb-6 border border-indigo-200 bg-indigo-50 p-4 rounded-lg">
@@ -665,16 +699,16 @@ const TokenomicsSimulator = () => {
               <input type="number" min="0" max="200" value={monthlyParams[selectedMonth]?.orgPayment ?? orgPayment} onChange={(e) => { const v = Number(e.target.value); selectedMonth === 1 ? setOrgPayment(v) : updateMonthlyParameter('orgPayment', v); }} className="w-20 p-1 border rounded text-right" />
               <span className="ml-1">USDC</span>
             </div>
-            <p className="text-xs text-gray-500 mt-1">Gross revenue per Space. AI (${perSpaceAI.toFixed(2)}/Space) and gas (${perSpaceGas.toFixed(2)}/Space) tracked separately; only a % routes to IEX.</p>
+            <p className="text-xs text-gray-500 mt-1">Gross revenue per Space. Default AI ~${perSpaceAI.toFixed(2)}/Space (open-weight); Composer reference ~${baselinePerSpace.toFixed(2)}/Space. Only {iexAllocationPct}% routes to IEX; {offPoolPct}% off-pool.</p>
           </div>
           <div className="mb-4">
             <label className="block text-sm font-medium mb-1">% routed to IEX (buy pressure)</label>
             <div className="flex items-center">
-              <input type="range" min="0" max="30" step="1" value={monthlyParams[selectedMonth]?.iexAllocationPct ?? iexAllocationPct} onChange={(e) => { const v = Number(e.target.value); selectedMonth === 1 ? setIexAllocationPct(v) : updateMonthlyParameter('iexAllocationPct', v); }} className="w-full mr-3" />
-              <input type="number" min="0" max="30" value={monthlyParams[selectedMonth]?.iexAllocationPct ?? iexAllocationPct} onChange={(e) => { const v = Number(e.target.value); selectedMonth === 1 ? setIexAllocationPct(v) : updateMonthlyParameter('iexAllocationPct', v); }} className="w-16 p-1 border rounded text-right" />
+              <input type="range" min="0" max="50" step="1" value={monthlyParams[selectedMonth]?.iexAllocationPct ?? iexAllocationPct} onChange={(e) => { const v = Number(e.target.value); selectedMonth === 1 ? setIexAllocationPct(v) : updateMonthlyParameter('iexAllocationPct', v); }} className="w-full mr-3" />
+              <input type="number" min="0" max="50" value={monthlyParams[selectedMonth]?.iexAllocationPct ?? iexAllocationPct} onChange={(e) => { const v = Number(e.target.value); selectedMonth === 1 ? setIexAllocationPct(v) : updateMonthlyParameter('iexAllocationPct', v); }} className="w-16 p-1 border rounded text-right" />
               <span className="ml-1">%</span>
             </div>
-            <p className="text-xs text-gray-500 mt-1">Remainder = treasury / ops / rewards off-pool.</p>
+            <p className="text-xs text-gray-500 mt-1">Remainder ({offPoolPct}%) = AI, gas, treasury / ops / off-pool rewards.</p>
           </div>
           <div className="mb-4">
             <label className="block text-sm font-medium mb-1">Additional Investor Purchases + buybacks (% of USDC on IEX)</label>
@@ -703,9 +737,19 @@ const TokenomicsSimulator = () => {
           <h2 className="text-xl font-bold mb-4">Key Metrics at Month {months}</h2>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
             <div className="bg-white p-4 rounded shadow">
-              <h3 className="text-sm font-medium text-gray-500">Spaces</h3>
+              <h3 className="text-sm font-medium text-gray-500">Cumulative Spaces</h3>
               <p className="text-2xl font-bold">{results[results.length - 1].cumulativeOrgCount.toLocaleString()}</p>
-              <p className="text-sm text-gray-500">Current Month: {results[results.length - 1].orgCount.toLocaleString()}</p>
+              <p className="text-sm text-gray-500">Active (month {months}): {results[results.length - 1].orgCount.toLocaleString()}</p>
+            </div>
+            <div className="bg-white p-4 rounded shadow border-l-4 border-green-500">
+              <h3 className="text-sm font-medium text-gray-500">Run-rate ARR (month {months})</h3>
+              <p className="text-2xl font-bold text-green-700">${lastResult ? lastResult.runRateArr.toLocaleString() : 0}</p>
+              <p className="text-sm text-gray-500">{lastResult ? lastResult.orgCount.toLocaleString() : 0} active Spaces × ${orgPayment} × 12</p>
+            </div>
+            <div className="bg-white p-4 rounded shadow border-l-4 border-green-500">
+              <h3 className="text-sm font-medium text-gray-500">4-year gross billed</h3>
+              <p className="text-2xl font-bold text-green-700">${lastResult ? lastResult.cumulativeGrossRevenue.toLocaleString() : 0}</p>
+              <p className="text-sm text-gray-500">Sum of all monthly Space contributions</p>
             </div>
             <div className="bg-white p-4 rounded shadow">
               <h3 className="text-sm font-medium text-gray-500">Token Price</h3>
@@ -728,10 +772,6 @@ const TokenomicsSimulator = () => {
               <p className="text-2xl font-bold">${results[results.length - 1].dexUsdc.toLocaleString()}</p>
             </div>
             <div className="bg-white p-4 rounded shadow">
-              <h3 className="text-sm font-medium text-gray-500">Cumulated Space Contributions</h3>
-              <p className="text-2xl font-bold">${results.reduce((s, r) => s + r.orgUsdcPurchase, 0).toLocaleString()}</p>
-            </div>
-            <div className="bg-white p-4 rounded shadow">
               <h3 className="text-sm font-medium text-gray-500">Tokens Purchased by Spaces</h3>
               <p className="text-2xl font-bold">{results.reduce((s, r) => s + r.orgPurchasedTokens, 0).toLocaleString()}</p>
             </div>
@@ -751,6 +791,9 @@ const TokenomicsSimulator = () => {
             <div className="bg-white p-4 rounded shadow">
               <h3 className="text-sm font-medium text-gray-500">FDV (Full Diluted Value)</h3>
               <p className="text-2xl font-bold">${results[results.length - 1].fdv.toLocaleString()}</p>
+              {lastResult && lastResult.fdvArr != null && (
+                <p className="text-sm text-gray-500">FDV / ARR: {lastResult.fdvArr}× (ramp narrative at Low/Mid)</p>
+              )}
             </div>
             <div className="bg-white p-4 rounded shadow border-l-4 border-indigo-400">
               <h3 className="text-sm font-medium text-gray-500">Monthly AI Cost</h3>
@@ -1009,13 +1052,13 @@ const TokenomicsSimulator = () => {
                 </div>
                 {results.length > 0 && growthScenario === key && (
                   <div className="text-xs mt-1 text-indigo-100">
-                    {results[results.length - 1].orgCount.toLocaleString()} Spaces · FDV ${(results[results.length - 1].fdv / 1e6).toFixed(0)}M
+                    {results[results.length - 1].orgCount.toLocaleString()} paying · FDV ${(results[results.length - 1].fdv / 1e6).toFixed(0)}M
                   </div>
                 )}
               </button>
             ))}
             <p className="px-3 py-2 text-xs text-gray-500 bg-gray-50 border-t border-gray-200">
-              Sets per-month Space Growth Rate presets. Override individual months via Per-Month Configuration.
+              Targets cumulative Space-months (sum of active Spaces each month) at month 48. Override growth per month via Per-Month Configuration.
             </p>
           </div>
         </div>

--- a/docs/hypha-ai-cost/tokenomics-simulator.html
+++ b/docs/hypha-ai-cost/tokenomics-simulator.html
@@ -68,13 +68,13 @@ const perSpaceMonthlyGas = (profile) => GAS_MONTHLY_BY_PROFILE[profile] || GAS_M
 
 
 const GROWTH_PRESETS = {
-  min: {
-    label: 'Min',
+  low: {
+    label: 'Low',
     subtitle: '~250k Spaces',
     defaults: {
-      orgPayment: 22,
-      investorSelling: 13.5,
-      additionalPurchase: 7,
+      orgPayment: 44,
+      investorSelling: 10,
+      additionalPurchase: 10,
       unlockRate: 5,
       initialHypha: 3333333,
       initialUsdc: 1000000,
@@ -88,13 +88,13 @@ const GROWTH_PRESETS = {
       return m;
     },
   },
-  medium: {
-    label: 'Medium',
+  mid: {
+    label: 'Mid',
     subtitle: '~1M Spaces',
     defaults: {
-      orgPayment: 22,
-      investorSelling: 26,
-      additionalPurchase: 11,
+      orgPayment: 44,
+      investorSelling: 10,
+      additionalPurchase: 10,
       unlockRate: 4,
       initialHypha: 12000000,
       initialUsdc: 750000,
@@ -116,59 +116,50 @@ const GROWTH_PRESETS = {
       45: { orgGrowthRate: 3 }, 46: { orgGrowthRate: 3 }, 47: { orgGrowthRate: 3 }, 48: { orgGrowthRate: 3 },
     }),
   },
-  max: {
-    label: 'Max',
-    subtitle: '~2M Spaces',
+  high: {
+    label: 'High',
+    subtitle: '~10M Spaces',
     defaults: {
-      orgPayment: 22,
-      investorSelling: 14.5,
-      additionalPurchase: 3,
+      orgPayment: 44,
+      investorSelling: 10,
+      additionalPurchase: 10,
       unlockRate: 4,
       initialHypha: 20000000,
       initialUsdc: 1000000,
       orgCount: 4373,
       orgGrowthRate: 25,
     },
-    build: () => ({
-      1: { orgGrowthRate: 25 }, 2: { orgGrowthRate: 10 }, 3: { orgGrowthRate: 10 }, 4: { orgGrowthRate: 10 },
-      5: { orgGrowthRate: 10 }, 6: { orgGrowthRate: 10 }, 7: { orgGrowthRate: 10 }, 8: { orgGrowthRate: 10 },
-      9: { orgGrowthRate: 10 }, 10: { orgGrowthRate: 27 }, 11: { orgGrowthRate: 15 }, 12: { orgGrowthRate: 14 },
-      13: { orgGrowthRate: 13 }, 14: { orgGrowthRate: 12 }, 15: { orgGrowthRate: 25 }, 16: { orgGrowthRate: 23 },
-      17: { orgGrowthRate: 3 }, 18: { orgGrowthRate: 8 }, 19: { orgGrowthRate: 7 }, 20: { orgGrowthRate: 2 },
-      21: { orgGrowthRate: 1 }, 22: { orgGrowthRate: 4 }, 23: { orgGrowthRate: 4 }, 24: { orgGrowthRate: 4 },
-      25: { orgGrowthRate: 4 }, 26: { orgGrowthRate: 4 }, 27: { orgGrowthRate: 3 }, 28: { orgGrowthRate: 3 },
-      29: { orgGrowthRate: 3 }, 30: { orgGrowthRate: 3 }, 31: { orgGrowthRate: 3 }, 32: { orgGrowthRate: 3 },
-      33: { orgGrowthRate: 3 }, 34: { orgGrowthRate: 3 }, 35: { orgGrowthRate: 3 }, 36: { orgGrowthRate: 3 },
-      37: { orgGrowthRate: 3 }, 38: { orgGrowthRate: 3 }, 39: { orgGrowthRate: 3 }, 40: { orgGrowthRate: 3 },
-      41: { orgGrowthRate: 3 }, 42: { orgGrowthRate: 3 }, 43: { orgGrowthRate: 3 }, 44: { orgGrowthRate: 3 },
-      45: { orgGrowthRate: 3 }, 46: { orgGrowthRate: 3 }, 47: { orgGrowthRate: 3 }, 48: { orgGrowthRate: 3 },
-    }),
+    build: () => {
+      const m = { 1: { orgGrowthRate: 25 } };
+      for (let i = 2; i <= 48; i++) m[i] = { orgGrowthRate: 18 };
+      return m;
+    },
   },
 };
 
 const TokenomicsSimulator = () => {
   const [maxSupply, setMaxSupply] = useState(555555555);
-  const [initialHypha, setInitialHypha] = useState(GROWTH_PRESETS.min.defaults.initialHypha);
-  const [initialUsdc, setInitialUsdc] = useState(GROWTH_PRESETS.min.defaults.initialUsdc);
+  const [initialHypha, setInitialHypha] = useState(GROWTH_PRESETS.low.defaults.initialHypha);
+  const [initialUsdc, setInitialUsdc] = useState(GROWTH_PRESETS.low.defaults.initialUsdc);
   const [months, setMonths] = useState(48);
-  const [unlockRate, setUnlockRate] = useState(GROWTH_PRESETS.min.defaults.unlockRate);
+  const [unlockRate, setUnlockRate] = useState(GROWTH_PRESETS.low.defaults.unlockRate);
   const [stakingRewards, setStakingRewards] = useState(30);
   const [rewardSplit, setRewardSplit] = useState(50);
   const [stakingRate, setStakingRate] = useState(75);
   const [sellRate, setSellRate] = useState(30);
-  const [investorSelling, setInvestorSelling] = useState(GROWTH_PRESETS.min.defaults.investorSelling);
-  const [additionalPurchase, setAdditionalPurchase] = useState(GROWTH_PRESETS.min.defaults.additionalPurchase);
-  const [orgCount, setOrgCount] = useState(GROWTH_PRESETS.min.defaults.orgCount);
-  const [orgPayment, setOrgPayment] = useState(GROWTH_PRESETS.min.defaults.orgPayment);
-  const [orgGrowthRate, setOrgGrowthRate] = useState(GROWTH_PRESETS.min.defaults.orgGrowthRate);
+  const [investorSelling, setInvestorSelling] = useState(GROWTH_PRESETS.low.defaults.investorSelling);
+  const [additionalPurchase, setAdditionalPurchase] = useState(GROWTH_PRESETS.low.defaults.additionalPurchase);
+  const [orgCount, setOrgCount] = useState(GROWTH_PRESETS.low.defaults.orgCount);
+  const [orgPayment, setOrgPayment] = useState(GROWTH_PRESETS.low.defaults.orgPayment);
+  const [orgGrowthRate, setOrgGrowthRate] = useState(GROWTH_PRESETS.low.defaults.orgGrowthRate);
 
   // AI operating cost controls
   const [aiModelId, setAiModelId] = useState('kimi-or');
   const [aiProfile, setAiProfile] = useState('typical');
-  const [growthScenario, setGrowthScenario] = useState('min');
+  const [growthScenario, setGrowthScenario] = useState('low');
 
   const [selectedMonth, setSelectedMonth] = useState(1);
-  const [monthlyParams, setMonthlyParams] = useState(GROWTH_PRESETS.min.build());
+  const [monthlyParams, setMonthlyParams] = useState(GROWTH_PRESETS.low.build());
   const [showMonthlyConfig, setShowMonthlyConfig] = useState(false);
 
   const [results, setResults] = useState([]);

--- a/docs/hypha-ai-cost/tokenomics-simulator.html
+++ b/docs/hypha-ai-cost/tokenomics-simulator.html
@@ -67,81 +67,74 @@ const GAS_SETUP_ONE_TIME = 0.035;
 const perSpaceMonthlyGas = (profile) => GAS_MONTHLY_BY_PROFILE[profile] || GAS_MONTHLY_BY_PROFILE.typical;
 
 // Phase 0 → Phase I → Phase II continuity (same network, one growth story)
-// Phase I bootstraps 0 → ~4,373 active (paying) Spaces over 12 months. Phase II starts there.
+// Phase I bootstraps 0 → ~4,373 paying Spaces over 12 months. Phase II starts there.
 const PHASE_I_END_SPACES = 4373;
 const PHASE_II_START_SPACES = PHASE_I_END_SPACES;
 
-// Two distinct series, both starting from the ~4,373 Phase I handoff:
-//  • ACTIVE (paying) Spaces — grow at orgGrowthRate/mo, pay $44/mo, drive all revenue.
-//  • CUMULATIVE Spaces created (funnel top) — grow at cumulativeGrowthRate/mo (free + paid).
-// Year-5 (Phase II month 48) targets, active / cumulative created (implied paying rate):
-//   Low  — ~15k active / ~250k created (≈6% paying)
-//   Mid  — ~50k active / ~1M created   (≈5% paying)
-//   High — ~500k active / ~10M created (≈5% paying)
+// One series only: every Space pays $44/mo (no free tier). The Space count grows from the
+// ~4,373 Phase I handoff to the year-5 (Phase II month 48) target and drives all revenue.
+// Year-5 cumulative Space targets: Low ~250k, Mid ~1M, High ~10M.
 const GROWTH_PRESETS = {
   low: {
     label: 'Low',
-    subtitle: '~15k paying · ~250k created (yr 5)',
+    subtitle: '~250k paying Spaces (yr 5)',
     defaults: {
       orgPayment: 44,
-      iexAllocationPct: 25,
-      investorSelling: 4,
-      additionalPurchase: 4,
+      iexAllocationPct: 22,
+      investorSelling: 5,
+      additionalPurchase: 5,
       unlockRate: 4,
-      initialHypha: 25000000,
-      initialUsdc: 5000000,
+      initialHypha: 29000000,
+      initialUsdc: 5800000,
       orgCount: PHASE_II_START_SPACES,
-      orgGrowthRate: 2.66,
-      cumulativeGrowthRate: 8.99,
+      orgGrowthRate: 8.99,
     },
-    // active 4,373 → ~15k (2.66%/mo); created 4,373 → ~250k (8.99%/mo) at month 48
+    // 4,373 → ~250k paying Spaces at month 48 (~8.99%/mo)
     build: () => {
       const m = {};
-      for (let i = 2; i <= 48; i++) m[i] = { orgGrowthRate: 2.66 };
+      for (let i = 2; i <= 48; i++) m[i] = { orgGrowthRate: 8.99 };
       return m;
     },
   },
   mid: {
     label: 'Mid',
-    subtitle: '~50k paying · ~1M created (yr 5)',
+    subtitle: '~1M paying Spaces (yr 5)',
     defaults: {
       orgPayment: 44,
-      iexAllocationPct: 22,
-      investorSelling: 5,
+      iexAllocationPct: 20,
+      investorSelling: 6,
       additionalPurchase: 6,
       unlockRate: 3.5,
-      initialHypha: 35000000,
-      initialUsdc: 7000000,
+      initialHypha: 41000000,
+      initialUsdc: 8200000,
       orgCount: PHASE_II_START_SPACES,
-      orgGrowthRate: 5.32,
-      cumulativeGrowthRate: 12.25,
+      orgGrowthRate: 12.25,
     },
-    // active 4,373 → ~50k (5.32%/mo); created 4,373 → ~1M (12.25%/mo) at month 48
+    // 4,373 → ~1M paying Spaces at month 48 (~12.25%/mo)
     build: () => {
       const m = {};
-      for (let i = 2; i <= 48; i++) m[i] = { orgGrowthRate: 5.32 };
+      for (let i = 2; i <= 48; i++) m[i] = { orgGrowthRate: 12.25 };
       return m;
     },
   },
   high: {
     label: 'High',
-    subtitle: '~500k paying · ~10M created (yr 5)',
+    subtitle: '~10M paying Spaces (yr 5)',
     defaults: {
       orgPayment: 44,
-      iexAllocationPct: 19,
-      investorSelling: 5,
-      additionalPurchase: 8,
+      iexAllocationPct: 18,
+      investorSelling: 7,
+      additionalPurchase: 7,
       unlockRate: 3,
-      initialHypha: 63000000,
-      initialUsdc: 12600000,
+      initialHypha: 111000000,
+      initialUsdc: 22200000,
       orgCount: PHASE_II_START_SPACES,
-      orgGrowthRate: 10.61,
-      cumulativeGrowthRate: 17.89,
+      orgGrowthRate: 17.89,
     },
-    // active 4,373 → ~500k (10.61%/mo); created 4,373 → ~10M (17.89%/mo) at month 48
+    // 4,373 → ~10M paying Spaces at month 48 (~17.89%/mo)
     build: () => {
       const m = {};
-      for (let i = 2; i <= 48; i++) m[i] = { orgGrowthRate: 10.61 };
+      for (let i = 2; i <= 48; i++) m[i] = { orgGrowthRate: 17.89 };
       return m;
     },
   },
@@ -163,7 +156,6 @@ const TokenomicsSimulator = () => {
   const [orgPayment, setOrgPayment] = useState(GROWTH_PRESETS.low.defaults.orgPayment);
   const [iexAllocationPct, setIexAllocationPct] = useState(GROWTH_PRESETS.low.defaults.iexAllocationPct);
   const [orgGrowthRate, setOrgGrowthRate] = useState(GROWTH_PRESETS.low.defaults.orgGrowthRate);
-  const [cumulativeGrowthRate, setCumulativeGrowthRate] = useState(GROWTH_PRESETS.low.defaults.cumulativeGrowthRate);
 
   // AI operating cost controls
   const [aiModelId, setAiModelId] = useState('kimi-or');
@@ -181,7 +173,7 @@ const TokenomicsSimulator = () => {
     calculateTokenomics();
   }, [initialHypha, initialUsdc, months, unlockRate, stakingRate, sellRate,
       investorSelling, additionalPurchase, stakingRewards, rewardSplit, maxSupply,
-      orgCount, orgPayment, iexAllocationPct, orgGrowthRate, cumulativeGrowthRate, monthlyParams, aiModelId, aiProfile]);
+      orgCount, orgPayment, iexAllocationPct, orgGrowthRate, monthlyParams, aiModelId, aiProfile]);
 
   const getMonthlyParameter = (paramName, month) => {
     if (monthlyParams[month] && monthlyParams[month][paramName] !== undefined) {
@@ -225,7 +217,6 @@ const TokenomicsSimulator = () => {
     let circulatingSupply = 0;
     let cumulativeIssued = 0;
     let prevPrice = dexUsdc / dexHypha;
-    let cumulativeCreated = 0;
     const feeRate = 0.003;
     const tokenResults = [];
     const graphData = [];
@@ -292,15 +283,9 @@ const TokenomicsSimulator = () => {
         }
       }
 
-      // Cumulative Spaces ever created (funnel top: free + paid). Starts at the same
-      // ~4,373 handoff as active payers, then grows faster — so the paying rate
-      // (active / created) declines from 100% toward the year-5 target (~5–6%).
-      if (month === 1) {
-        cumulativeCreated = currentOrgCount;
-      } else {
-        cumulativeCreated = Math.round(cumulativeCreated * (1 + cumulativeGrowthRate / 100));
-      }
-      const cumulativeOrgCount = cumulativeCreated;
+      // Every Space pays — no free tier and no churn — so the running Space count
+      // is itself the cumulative Space total. Both metrics track the same series.
+      const cumulativeOrgCount = currentOrgCount;
       cumulativeGrossRevenue += grossContribution;
       const runRateArr = currentOrgCount * monthOrgPayment * 12;
 
@@ -442,7 +427,6 @@ const TokenomicsSimulator = () => {
     setInitialUsdc(d.initialUsdc);
     setOrgCount(d.orgCount);
     setOrgGrowthRate(d.orgGrowthRate);
-    setCumulativeGrowthRate(d.cumulativeGrowthRate);
   };
 
   const applyGrowthScenario = (scenario) => {
@@ -492,17 +476,9 @@ const TokenomicsSimulator = () => {
           </div>
           <div className="bg-indigo-600 text-white p-3 rounded border border-indigo-700">
             <div className="font-semibold">Phase II — Years 2–5 (this sim)</div>
-            <p className="text-xs text-indigo-100 mt-1">Starts ~{PHASE_II_START_SPACES.toLocaleString()} paying Spaces × $44/mo. Year-5 paying / created: Low ~15k/250k · Mid ~50k/1M · High ~500k/10M.</p>
+            <p className="text-xs text-indigo-100 mt-1">Starts ~{PHASE_II_START_SPACES.toLocaleString()} paying Spaces × $44/mo. Year-5 paying Spaces: Low ~250k · Mid ~1M · High ~10M.</p>
           </div>
         </div>
-      </div>
-
-      <div className="mb-4 border border-teal-200 bg-teal-50 p-3 rounded-lg text-sm">
-        <span className="font-semibold text-teal-800">Revenue split:</span>{' '}
-        <span className="text-teal-900">{iexAllocationPct}% → IEX buy pressure</span>
-        <span className="text-teal-700"> · </span>
-        <span className="text-teal-900">{offPoolPct}% → AI (~${perSpaceAI.toFixed(2)}/Space), gas, ops, rewards, treasury</span>
-        <span className="text-xs text-teal-700 block mt-1">Only active (paying) Spaces pay $44/mo and drive revenue. "Cumulative Spaces" = total Spaces ever created (free + paid funnel); active payers are ~5–6% of created at year 5.</span>
       </div>
 
       {/* ============ AI OPERATING COST SECTION ============ */}
@@ -760,14 +736,9 @@ const TokenomicsSimulator = () => {
           <h2 className="text-xl font-bold mb-4">Key Metrics at Month {months}</h2>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
             <div className="bg-white p-4 rounded shadow">
-              <h3 className="text-sm font-medium text-gray-500">Cumulative Spaces Created</h3>
+              <h3 className="text-sm font-medium text-gray-500">Cumulative Spaces</h3>
               <p className="text-2xl font-bold">{results[results.length - 1].cumulativeOrgCount.toLocaleString()}</p>
-              <p className="text-sm text-gray-500">
-                Active payers (month {months}): {results[results.length - 1].orgCount.toLocaleString()}
-                {results[results.length - 1].cumulativeOrgCount > 0
-                  ? ` (${(results[results.length - 1].orgCount / results[results.length - 1].cumulativeOrgCount * 100).toFixed(1)}%)`
-                  : ''}
-              </p>
+              <p className="text-sm text-gray-500">All paying · $44/mo (month {months})</p>
             </div>
             <div className="bg-white p-4 rounded shadow border-l-4 border-green-500">
               <h3 className="text-sm font-medium text-gray-500">Run-rate ARR (month {months})</h3>
@@ -917,17 +888,15 @@ const TokenomicsSimulator = () => {
             </ResponsiveContainer>
           </div>
           <div className="h-80 bg-white p-4 rounded-lg shadow">
-            <h3 className="text-md font-medium mb-2">Space Growth</h3>
+            <h3 className="text-md font-medium mb-2">Space Growth (all paying)</h3>
             <ResponsiveContainer width="100%" height="90%">
               <LineChart data={chartData} margin={{ top: 5, right: 30, left: 30, bottom: 5 }}>
                 <CartesianGrid strokeDasharray="3 3" />
                 <XAxis dataKey="name" />
-                <YAxis yAxisId="left" tickFormatter={(v) => v.toLocaleString()} width={60} />
-                <YAxis yAxisId="right" orientation="right" tickFormatter={(v) => v.toLocaleString()} width={60} />
+                <YAxis tickFormatter={(v) => v.toLocaleString()} width={60} />
                 <Tooltip formatter={(v) => v.toLocaleString()} />
                 <Legend />
-                <Line yAxisId="left" type="monotone" dataKey="Number of Spaces" stroke="#8884d8" strokeWidth={2} />
-                <Line yAxisId="right" type="monotone" dataKey="Cumulative Spaces" stroke="#82ca9d" strokeWidth={2} />
+                <Line type="monotone" dataKey="Cumulative Spaces" stroke="#82ca9d" strokeWidth={2} />
               </LineChart>
             </ResponsiveContainer>
           </div>
@@ -992,8 +961,8 @@ const TokenomicsSimulator = () => {
                 <th className="py-2 px-4 border text-right">Staking Rewards</th>
                 <th className="py-2 px-4 border text-right">Unlock Rewards</th>
                 <th className="py-2 px-4 border text-right">Actual Rewards</th>
-                <th className="py-2 px-4 border text-right">Active Spaces (monthly)</th>
-                <th className="py-2 px-4 border text-right">Cumulative Created</th>
+                <th className="py-2 px-4 border text-right">Spaces (monthly)</th>
+                <th className="py-2 px-4 border text-right">Cumulative Spaces</th>
                 <th className="py-2 px-4 border text-right">Staked Tokens (cumulative)</th>
                 <th className="py-2 px-4 border text-right">Circulating Supply</th>
                 <th className="py-2 px-4 border text-right">IEX HYPHA Before</th>
@@ -1078,15 +1047,10 @@ const TokenomicsSimulator = () => {
                 <div className={`text-xs mt-0.5 ${growthScenario === key ? 'text-indigo-100' : 'text-gray-500'}`}>
                   {preset.subtitle}
                 </div>
-                {results.length > 0 && growthScenario === key && (
-                  <div className="text-xs mt-1 text-indigo-100">
-                    {results[results.length - 1].orgCount.toLocaleString()} paying · FDV ${(results[results.length - 1].fdv / 1e6).toFixed(0)}M
-                  </div>
-                )}
               </button>
             ))}
             <p className="px-3 py-2 text-xs text-gray-500 bg-gray-50 border-t border-gray-200">
-              Targets active (paying) and total created Spaces at year 5 (month 48). Active payers drive revenue; override their growth per month via Per-Month Configuration.
+              Targets total paying Spaces at year 5 (month 48). Every Space pays $44/mo; override Space growth per month via Per-Month Configuration.
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Add Hypha AI per-space cost model documentation (`docs/hypha-ai-cost/`) with README and static HTML report covering closed-source vs open-source model pricing.
- Ship an interactive **Phase II tokenomics simulator** at `/tokenomics2` on `app.hypha.earth` (and PR previews), integrating per-space AI operating costs with Min / Medium / Max growth scenarios and tuned FDV targets (~$766M / ~$2B / ~$5B).
- Exclude `/tokenomics2` from Next.js i18n + CSP middleware so the standalone page can load Babel, Tailwind, and esm.sh CDN scripts.

## Test plan
- [ ] Open preview URL at `/tokenomics2/` and confirm the simulator loads (charts, tables, scenario tabs)
- [ ] Switch Min / Medium / Max growth scenarios and verify FDV targets (~$766M / ~$2B / ~$5B)
- [ ] Confirm AI model selector defaults to Kimi K2.6 (OpenRouter low) and USDC contribution defaults to $22/Space
- [ ] After merge, verify production at https://app.hypha.earth/tokenomics2/


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added interactive HYPHA tokenomics simulator pages (Phase I and Phase II) with configurable inputs, growth scenarios, cost models, charts, and month-by-month results.
  * Published enhanced AI + on-chain cost documentation, including per-feature breakdowns, model pricing comparisons, gas vs. AI cost analysis, and an investor pitch guide.
* **Improvements**
  * Streamlined access to `/tokenomics1/` and `/tokenomics2/` via permanent redirects and targeted middleware exclusion.
* **Chores**
  * Added an automated sync step to copy tokenomics simulator assets into versioned public paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->