### PR TITLE
fix(spaces): align UI gates with transparency matrix

### DIFF
--- a/apps/web/src/app/[lang]/dho/[id]/@aside/[tab]/new-signal/page.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@aside/[tab]/new-signal/page.tsx
@@ -1,4 +1,5 @@
 import { ConnectedCreateSignalForm } from '@web/components/connected-create-signal-form';
+import { ConnectedSpaceMemberAsideGuard } from '@web/components/connected-space-member-aside-guard';
 import { ProposalOverlayShell } from '@hypha-platform/epics';
 import { getDhoPathCoherence } from '../../../@tab/coherence/constants';
 import { Locale } from '@hypha-platform/i18n';
@@ -35,17 +36,22 @@ export default async function NewSignalPage({
   const successfulUrl = getDhoPathCoherence(lang, id);
   return (
     <ProposalOverlayShell>
-      <ConnectedCreateSignalForm
-        successfulUrl={successfulUrl}
-        closeUrl={successfulUrl}
-        backUrl={successfulUrl}
-        spaceId={spaceFromDb.id}
-        initialValues={
-          inheritedBoardTags.length > 0
-            ? { tags: inheritedBoardTags }
-            : undefined
-        }
-      />
+      <ConnectedSpaceMemberAsideGuard
+        spaceSlug={id}
+        spaceId={spaceFromDb.web3SpaceId ?? undefined}
+      >
+        <ConnectedCreateSignalForm
+          successfulUrl={successfulUrl}
+          closeUrl={successfulUrl}
+          backUrl={successfulUrl}
+          spaceId={spaceFromDb.id}
+          initialValues={
+            inheritedBoardTags.length > 0
+              ? { tags: inheritedBoardTags }
+              : undefined
+          }
+        />
+      </ConnectedSpaceMemberAsideGuard>
     </ProposalOverlayShell>
   );
 }

--- a/apps/web/src/app/[lang]/dho/[id]/@aside/ecosystem-navigation/space/create/page.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@aside/ecosystem-navigation/space/create/page.tsx
@@ -3,6 +3,7 @@
 import {
   CreateSubspaceForm,
   ProposalOverlayShell,
+  SpaceMemberAsideGuard,
 } from '@hypha-platform/epics';
 import { useSpaceBySlug } from '@hypha-platform/core/client';
 import { LoadingBackdrop } from '@hypha-platform/ui/server';
@@ -50,12 +51,14 @@ export default function CreateSubspacePage() {
 
   return (
     <ProposalOverlayShell>
-      <CreateSubspaceForm
-        successfulUrl={successfulUrl}
-        backUrl={`${successfulUrl}${PATH_SELECT_SETTINGS_ACTION}`}
-        parentSpaceId={space.id}
-        parentSpaceSlug={space.slug}
-      />
+      <SpaceMemberAsideGuard spaceSlug={spaceSlug ?? ''} space={space}>
+        <CreateSubspaceForm
+          successfulUrl={successfulUrl}
+          backUrl={`${successfulUrl}${PATH_SELECT_SETTINGS_ACTION}`}
+          parentSpaceId={space.id}
+          parentSpaceSlug={space.slug}
+        />
+      </SpaceMemberAsideGuard>
     </ProposalOverlayShell>
   );
 }

--- a/apps/web/src/app/[lang]/dho/[id]/@aside/memory/new-memory/page.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@aside/memory/new-memory/page.tsx
@@ -6,6 +6,7 @@ import { Locale } from '@hypha-platform/i18n';
 import { findSpaceBySlug } from '@hypha-platform/core/server';
 import { db } from '@hypha-platform/storage-postgres';
 import { notFound } from 'next/navigation';
+import { ConnectedSpaceMemberAsideGuard } from '@web/components/connected-space-member-aside-guard';
 import { getTranslations } from 'next-intl/server';
 
 type PageProps = {
@@ -23,15 +24,20 @@ export default async function NewMemoryPage({ params }: PageProps) {
 
   return (
     <ProposalOverlayShell>
-      <CreateAgreementForm
-        successfulUrl={successfulUrl}
-        backUrl={successfulUrl}
-        closeUrl={successfulUrl}
-        spaceId={spaceFromDb.id}
-        web3SpaceId={spaceFromDb.web3SpaceId}
-        stickyHeaderTitle={tCoherence('newMemory')}
-        mode="memory"
-      />
+      <ConnectedSpaceMemberAsideGuard
+        spaceSlug={id}
+        spaceId={spaceFromDb.web3SpaceId ?? undefined}
+      >
+        <CreateAgreementForm
+          successfulUrl={successfulUrl}
+          backUrl={successfulUrl}
+          closeUrl={successfulUrl}
+          spaceId={spaceFromDb.id}
+          web3SpaceId={spaceFromDb.web3SpaceId}
+          stickyHeaderTitle={tCoherence('newMemory')}
+          mode="memory"
+        />
+      </ConnectedSpaceMemberAsideGuard>
     </ProposalOverlayShell>
   );
 }

--- a/apps/web/src/app/[lang]/dho/[id]/@aside/overview/space/create/page.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@aside/overview/space/create/page.tsx
@@ -3,6 +3,7 @@
 import {
   CreateSubspaceForm,
   ProposalOverlayShell,
+  SpaceMemberAsideGuard,
 } from '@hypha-platform/epics';
 import { useSpaceBySlug } from '@hypha-platform/core/client';
 import { useParams, usePathname } from 'next/navigation';
@@ -28,12 +29,14 @@ export default function CreateSubspacePage() {
 
   return (
     <ProposalOverlayShell>
-      <CreateSubspaceForm
-        successfulUrl={successfulUrl}
-        backUrl={`${successfulUrl}${PATH_SELECT_SETTINGS_ACTION}`}
-        parentSpaceId={space?.id ?? null}
-        parentSpaceSlug={space?.slug ?? ''}
-      />
+      <SpaceMemberAsideGuard spaceSlug={spaceSlug ?? ''} space={space}>
+        <CreateSubspaceForm
+          successfulUrl={successfulUrl}
+          backUrl={`${successfulUrl}${PATH_SELECT_SETTINGS_ACTION}`}
+          parentSpaceId={space?.id ?? null}
+          parentSpaceSlug={space?.slug ?? ''}
+        />
+      </SpaceMemberAsideGuard>
     </ProposalOverlayShell>
   );
 }

--- a/apps/web/src/app/[lang]/dho/[id]/@aside/space/create/page.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@aside/space/create/page.tsx
@@ -3,6 +3,7 @@
 import {
   CreateSubspaceForm,
   ProposalOverlayShell,
+  SpaceMemberAsideGuard,
 } from '@hypha-platform/epics';
 import { useSpaceBySlug } from '@hypha-platform/core/client';
 import { useParams, usePathname } from 'next/navigation';
@@ -28,12 +29,14 @@ export default function CreateSubspacePage() {
 
   return (
     <ProposalOverlayShell>
-      <CreateSubspaceForm
-        successfulUrl={successfulUrl}
-        backUrl={`${successfulUrl}${PATH_SELECT_SETTINGS_ACTION}`}
-        parentSpaceId={space?.id ?? null}
-        parentSpaceSlug={space?.slug ?? ''}
-      />
+      <SpaceMemberAsideGuard spaceSlug={spaceSlug ?? ''} space={space}>
+        <CreateSubspaceForm
+          successfulUrl={successfulUrl}
+          backUrl={`${successfulUrl}${PATH_SELECT_SETTINGS_ACTION}`}
+          parentSpaceId={space?.id ?? null}
+          parentSpaceSlug={space?.slug ?? ''}
+        />
+      </SpaceMemberAsideGuard>
     </ProposalOverlayShell>
   );
 }

--- a/apps/web/src/app/[lang]/dho/[id]/_components/ecosystem-navigation-main-panel.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/ecosystem-navigation-main-panel.tsx
@@ -8,6 +8,7 @@ import {
   useSpaceBySlug,
 } from '@hypha-platform/core/client';
 import {
+  useCanMutateInSpace,
   useFilterSpacesListWithDiscoverability,
   EcosystemNavigationShell,
   getDhoSpaceContextPath,
@@ -114,6 +115,11 @@ export function EcosystemNavigationMainPanel({
   );
   const { space: currentSpace, isLoading: isLoadingSpace } =
     useSpaceBySlug(daoSlug);
+  const { canMutate, isLoading: isMutateLoading } = useCanMutateInSpace({
+    spaceSlug: daoSlug,
+    space: currentSpace,
+    spaceId: currentSpace?.web3SpaceId,
+  });
   const { spaces: allSpaces, isLoading: isLoadingSpaces } =
     useOrganisationSpacesBySingleSlug(daoSlug);
 
@@ -196,7 +202,9 @@ export function EcosystemNavigationMainPanel({
   const selectedSpaceTitle =
     selectedSpace?.name ?? currentSpaceTitle ?? t('title');
   const selectedSpaceSlug = selectedSpace?.slug ?? currentSpaceSlug;
-  const canRenderSpaceActions = Boolean(currentSpace && selectedSpaceSlug);
+  const canRenderSpaceActions = Boolean(
+    currentSpace && selectedSpaceSlug && !isMutateLoading && canMutate,
+  );
   const visitSpaceHref =
     canRenderSpaceActions && selectedSpaceSlug
       ? getDhoSpaceContextPath({

--- a/apps/web/src/app/[lang]/dho/[id]/_components/ecosystem-navigation-main-panel.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/ecosystem-navigation-main-panel.tsx
@@ -118,7 +118,7 @@ export function EcosystemNavigationMainPanel({
   const { canMutate, isLoading: isMutateLoading } = useCanMutateInSpace({
     spaceSlug: daoSlug,
     space: currentSpace,
-    spaceId: currentSpace?.web3SpaceId,
+    spaceId: currentSpace?.web3SpaceId ?? undefined,
   });
   const { spaces: allSpaces, isLoading: isLoadingSpaces } =
     useOrganisationSpacesBySingleSlug(daoSlug);

--- a/apps/web/src/app/[lang]/dho/[id]/_components/select-create-action.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/select-create-action.tsx
@@ -1,6 +1,10 @@
 'use client';
 
-import { SelectAction, useActionGating } from '@hypha-platform/epics';
+import {
+  SelectAction,
+  useActionGating,
+  useCanMutateInSpace,
+} from '@hypha-platform/epics';
 import { Locale } from '@hypha-platform/i18n';
 import { useTranslations } from 'next-intl';
 import {
@@ -27,6 +31,11 @@ export const SelectCreateAction = ({
   children,
 }: SelectCreateActionProps) => {
   const { isPaymentExpired, fundWallet, space } = useActionGating(daoSlug);
+  const { canMutate, isLoading: isMutateLoading } = useCanMutateInSpace({
+    spaceSlug: daoSlug,
+    space,
+    spaceId: space?.web3SpaceId,
+  });
   const t = useTranslations('SelectCreateAction');
   const tSettings = useTranslations('SpaceSettingsAction');
 
@@ -37,7 +46,7 @@ export const SelectCreateAction = ({
       description: t('actions.makeCollectiveAgreement.description'),
       href: 'agreements/create',
       icon: <FileText className="size-[22px] shrink-0" strokeWidth={1.75} />,
-      disabled: isPaymentExpired,
+      disabled: isPaymentExpired || isMutateLoading || !canMutate,
     },
     {
       defaultDurationDays: 4,
@@ -45,7 +54,7 @@ export const SelectCreateAction = ({
       description: t('actions.proposeContribution.description'),
       href: 'agreements/create/propose-contribution',
       icon: <Rocket className="size-[22px] shrink-0" strokeWidth={1.75} />,
-      disabled: isPaymentExpired,
+      disabled: isPaymentExpired || isMutateLoading || !canMutate,
     },
     {
       defaultDurationDays: 4,
@@ -53,7 +62,7 @@ export const SelectCreateAction = ({
       description: tSettings('actions.redeemTokens.description'),
       href: 'agreements/create/redeem-tokens',
       icon: <Gift className="size-[22px] shrink-0" strokeWidth={1.75} />,
-      disabled: isPaymentExpired,
+      disabled: isPaymentExpired || isMutateLoading || !canMutate,
     },
     {
       defaultDurationDays: 7,
@@ -61,7 +70,7 @@ export const SelectCreateAction = ({
       description: t('actions.payExpenses.description'),
       href: 'agreements/create/pay-for-expenses',
       icon: <TrendingUp className="size-[22px] shrink-0" strokeWidth={1.75} />,
-      disabled: isPaymentExpired,
+      disabled: isPaymentExpired || isMutateLoading || !canMutate,
     },
     {
       defaultDurationDays: 7,
@@ -69,7 +78,7 @@ export const SelectCreateAction = ({
       description: t('actions.acceptInvestment.description'),
       href: 'agreements/create/accept-investment',
       icon: <PiggyBank className="size-[22px] shrink-0" strokeWidth={1.75} />,
-      disabled: isPaymentExpired,
+      disabled: isPaymentExpired || isMutateLoading || !canMutate,
     },
     {
       defaultDurationDays: 7,
@@ -77,7 +86,7 @@ export const SelectCreateAction = ({
       description: t('actions.exchangeStakesAndTokens.description'),
       href: 'agreements/create/exchange-stakes-and-tokens',
       icon: <Package className="size-[22px] shrink-0" strokeWidth={1.75} />,
-      disabled: isPaymentExpired,
+      disabled: isPaymentExpired || isMutateLoading || !canMutate,
     },
     {
       defaultDurationDays: 7,
@@ -85,7 +94,7 @@ export const SelectCreateAction = ({
       description: t('actions.deployFunds.description'),
       href: 'agreements/create/deploy-funds',
       icon: <Workflow className="size-[22px] shrink-0" strokeWidth={1.75} />,
-      disabled: isPaymentExpired,
+      disabled: isPaymentExpired || isMutateLoading || !canMutate,
     },
     {
       defaultDurationDays: 7,
@@ -93,7 +102,7 @@ export const SelectCreateAction = ({
       description: t('actions.airdrop.description'),
       href: 'agreements/create/airdrop',
       icon: <Send className="size-[22px] shrink-0" strokeWidth={1.75} />,
-      disabled: isPaymentExpired,
+      disabled: isPaymentExpired || isMutateLoading || !canMutate,
     },
     {
       title: t('actions.depositFunds.title'),
@@ -102,7 +111,7 @@ export const SelectCreateAction = ({
       onAction: () => {
         fundWallet();
       },
-      disabled: !space?.address,
+      disabled: !space?.address || isMutateLoading || !canMutate,
     },
   ];
   return (

--- a/apps/web/src/app/[lang]/dho/[id]/_components/select-create-action.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/select-create-action.tsx
@@ -34,7 +34,7 @@ export const SelectCreateAction = ({
   const { canMutate, isLoading: isMutateLoading } = useCanMutateInSpace({
     spaceSlug: daoSlug,
     space,
-    spaceId: space?.web3SpaceId,
+    spaceId: space?.web3SpaceId ?? undefined,
   });
   const t = useTranslations('SelectCreateAction');
   const tSettings = useTranslations('SpaceSettingsAction');

--- a/apps/web/src/app/[lang]/dho/[id]/_components/select-settings-action.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/select-settings-action.tsx
@@ -3,6 +3,7 @@
 import {
   SelectAction,
   useActionGating,
+  useCanMutateInSpace,
   type ActionProps,
 } from '@hypha-platform/epics';
 import { Locale } from '@hypha-platform/i18n';
@@ -47,7 +48,13 @@ export const SelectSettingsAction = ({
   children,
 }: SelectSettingsActionProps) => {
   const { isPaymentExpired, fundWallet, space } = useActionGating(daoSlug);
+  const { canMutate, isLoading: isMutateLoading } = useCanMutateInSpace({
+    spaceSlug: daoSlug,
+    space,
+    spaceId: space?.web3SpaceId,
+  });
   const t = useTranslations('SpaceSettingsAction');
+  const isActionDisabled = isMutateLoading || !canMutate;
 
   const SETTINGS_ACTIONS = [
     {
@@ -278,6 +285,9 @@ export const SelectSettingsAction = ({
         return {
           ...action,
           href,
+          disabled:
+            action.disabled ||
+            (isActionDisabled && action.href !== 'https://hypha.energy'),
         };
       })}
     >

--- a/apps/web/src/app/[lang]/dho/[id]/_components/select-settings-action.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/select-settings-action.tsx
@@ -51,7 +51,7 @@ export const SelectSettingsAction = ({
   const { canMutate, isLoading: isMutateLoading } = useCanMutateInSpace({
     spaceSlug: daoSlug,
     space,
-    spaceId: space?.web3SpaceId,
+    spaceId: space?.web3SpaceId ?? undefined,
   });
   const t = useTranslations('SpaceSettingsAction');
   const isActionDisabled = isMutateLoading || !canMutate;

--- a/apps/web/src/app/[lang]/dho/[id]/_components/visible-spaces-list.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/visible-spaces-list.tsx
@@ -14,11 +14,9 @@ import {
 } from '@hypha-platform/ui';
 import { PlusIcon } from '@radix-ui/react-icons';
 import Link from 'next/link';
-import { getDhoSpaceContextPath } from '@hypha-platform/epics';
 import {
-  useSpaceDiscoverability,
-  useUserSpaceState,
-  checkAccess,
+  useCanMutateInSpace,
+  getDhoSpaceContextPath,
 } from '@hypha-platform/epics';
 import type { VisibleSpace } from './types';
 import { useTranslations } from 'next-intl';
@@ -46,11 +44,7 @@ function AddSpaceButton({ space, allSpaces, lang }: AddSpaceButtonProps) {
   const spaceSlug = fullSpace?.slug || space.slug;
   const hasSpaceInfo = !!web3SpaceId && !!spaceSlug;
 
-  const { access, isLoading: isAccessLoading } = useSpaceDiscoverability({
-    spaceId: web3SpaceId ? BigInt(web3SpaceId) : undefined,
-  });
-
-  const { userState, isLoading: isUserStateLoading } = useUserSpaceState({
+  const { canMutate, isLoading } = useCanMutateInSpace({
     spaceId: typeof web3SpaceId === 'number' ? web3SpaceId : undefined,
     spaceSlug,
     space: fullSpace,
@@ -72,9 +66,7 @@ function AddSpaceButton({ space, allSpaces, lang }: AddSpaceButtonProps) {
     );
   }
 
-  const hasAccess = checkAccess(access, userState);
-  const isLoading = isAccessLoading || isUserStateLoading;
-  const isDisabled = isLoading || !hasAccess;
+  const isDisabled = isLoading || !canMutate;
 
   const createSpacePath = `${
     getDhoSpaceContextPath({
@@ -86,12 +78,12 @@ function AddSpaceButton({ space, allSpaces, lang }: AddSpaceButtonProps) {
 
   return (
     <Link
-      href={hasAccess && !isLoading ? createSpacePath : '#'}
+      href={canMutate && !isLoading ? createSpacePath : '#'}
       className={isDisabled ? 'cursor-not-allowed' : 'flex-1 md:flex-none'}
       title={
         isLoading
           ? t('visibleSpaces.loading')
-          : !hasAccess
+          : !canMutate
           ? t('visibleSpaces.noAccessAddSpace')
           : t('visibleSpaces.addSpace')
       }

--- a/apps/web/src/components/connected-space-member-aside-guard.tsx
+++ b/apps/web/src/components/connected-space-member-aside-guard.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { SpaceMemberAsideGuard } from '@hypha-platform/epics';
+
+type ConnectedSpaceMemberAsideGuardProps = {
+  spaceSlug: string;
+  spaceId?: number;
+  children: React.ReactNode;
+};
+
+export function ConnectedSpaceMemberAsideGuard({
+  spaceSlug,
+  spaceId,
+  children,
+}: ConnectedSpaceMemberAsideGuardProps) {
+  return (
+    <SpaceMemberAsideGuard spaceSlug={spaceSlug} spaceId={spaceId}>
+      {children}
+    </SpaceMemberAsideGuard>
+  );
+}

--- a/packages/epics/src/banking/components/banking-section.tsx
+++ b/packages/epics/src/banking/components/banking-section.tsx
@@ -205,10 +205,6 @@ export const BankingSection: FC<BankingSectionProps> = ({
     [clearOnboardingError, refresh, requestOnboarding],
   );
 
-  if (!isAuthenticated) {
-    return <p className="text-2 text-muted-foreground">{tCommon('signIn')}</p>;
-  }
-
   if (isStatusLoading) {
     return <BankingPageSkeleton />;
   }

--- a/packages/epics/src/coherence/components/coherence-block.tsx
+++ b/packages/epics/src/coherence/components/coherence-block.tsx
@@ -1,8 +1,6 @@
 'use client';
 
-import { useAuthentication } from '@hypha-platform/authentication';
-import { Button, Tabs, TabsList, TabsTrigger } from '@hypha-platform/ui';
-import { Empty } from '../../common/empty';
+import { Tabs, TabsList, TabsTrigger } from '@hypha-platform/ui';
 import {
   Coherence,
   useFindCoherences,
@@ -94,9 +92,7 @@ export function CoherenceBlock({
 }: CoherenceBlockProps) {
   const t = useTranslations('CoherenceTab');
   const format = useFormatter();
-  const tSpaces = useTranslations('Spaces');
   const [hideArchived, setHideArchived] = React.useState(true);
-  const { isAuthenticated, login } = useAuthentication();
   const { space, isLoading: isSpaceLoading } = useSpaceBySlug(spaceSlug);
   const {
     coherences: signals,
@@ -192,34 +188,20 @@ export function CoherenceBlock({
           ) : null}
         </h1>
       </div>
-      {isAuthenticated ? (
-        <div className="flex flex-col gap-4">
-          <SignalSection
-            toolbarLeft={priorityTabs}
-            basePath={chatBasePath}
-            web3SpaceId={space?.web3SpaceId ?? 0}
-            signals={filteredSignals}
-            leadImage={space?.leadImage ?? undefined}
-            isLoading={isSpaceLoading || isSignalsLoading}
-            hideArchived={hideArchived}
-            setHideArchived={setHideArchived}
-            refresh={refresh}
-            onSignalClick={onSignalClick}
-          />
-        </div>
-      ) : (
-        <Empty>
-          <div className="flex flex-col gap-7">
-            <p>{tSpaces('accessDeniedNotLoggedIn')}</p>
-            <div className="flex items-center justify-center gap-4">
-              <Button variant="outline" onClick={login}>
-                {tSpaces('signIn')}
-              </Button>
-              <Button onClick={login}>{tSpaces('getStarted')}</Button>
-            </div>
-          </div>
-        </Empty>
-      )}
+      <div className="flex flex-col gap-4">
+        <SignalSection
+          toolbarLeft={priorityTabs}
+          basePath={chatBasePath}
+          web3SpaceId={space?.web3SpaceId ?? 0}
+          signals={filteredSignals}
+          leadImage={space?.leadImage ?? undefined}
+          isLoading={isSpaceLoading || isSignalsLoading}
+          hideArchived={hideArchived}
+          setHideArchived={setHideArchived}
+          refresh={refresh}
+          onSignalClick={onSignalClick}
+        />
+      </div>
     </div>
   );
 }

--- a/packages/epics/src/coherence/components/memory-filters.tsx
+++ b/packages/epics/src/coherence/components/memory-filters.tsx
@@ -26,6 +26,8 @@ type MemoryFiltersProps = {
   searchTerm: string;
   onSearchChange: (value: string) => void;
   newMemoryHref: string;
+  canCreateMemory?: boolean;
+  isCreateMemoryLoading?: boolean;
   counts: Record<MemoryFilterValue, number>;
 };
 
@@ -35,6 +37,8 @@ export function MemoryFilters({
   searchTerm,
   onSearchChange,
   newMemoryHref,
+  canCreateMemory = false,
+  isCreateMemoryLoading = false,
   counts,
 }: MemoryFiltersProps) {
   const t = useTranslations('CoherenceTab');
@@ -97,11 +101,21 @@ export function MemoryFilters({
           className="w-full"
         />
         <div className="flex w-full items-center justify-end gap-2 lg:w-auto">
-          <Button asChild variant="default" colorVariant="accent">
-            <Link href={newMemoryHref} scroll={false}>
+          {canCreateMemory ? (
+            <Button asChild variant="default" colorVariant="accent">
+              <Link href={newMemoryHref} scroll={false}>
+                {t('newMemory')}
+              </Link>
+            </Button>
+          ) : (
+            <Button
+              variant="default"
+              colorVariant="accent"
+              disabled={isCreateMemoryLoading || !canCreateMemory}
+            >
               {t('newMemory')}
-            </Link>
-          </Button>
+            </Button>
+          )}
         </div>
       </div>
     </div>

--- a/packages/epics/src/coherence/components/signal-section.tsx
+++ b/packages/epics/src/coherence/components/signal-section.tsx
@@ -686,7 +686,9 @@ export const SignalSection: FC<SignalSectionProps> = ({
               variant="outline"
               colorVariant="accent"
               className="w-auto"
+              disabled={isMemberLoading || !isMember}
               onClick={() => {
+                if (isMemberLoading || !isMember) return;
                 resetBoardForm();
                 setCreateBoardOpen(true);
               }}

--- a/packages/epics/src/coherence/components/space-memory-section.tsx
+++ b/packages/epics/src/coherence/components/space-memory-section.tsx
@@ -13,6 +13,7 @@ import {
   useSpaceBySlug,
 } from '@hypha-platform/core/client';
 import { useSpaceMemoryOrg } from '../hooks/use-space-memory-org';
+import { useCanMutateInSpace } from '../../spaces/hooks/use-can-mutate-in-space';
 import { SpaceMemoryTimelineItem } from './space-memory-timeline-item';
 import { MemoryFilterValue, MemoryFilters } from './memory-filters';
 import { useParams } from 'next/navigation';
@@ -40,6 +41,11 @@ export const SpaceMemorySection: FC<SpaceMemorySectionProps> = ({
     loadMore,
   } = useSpaceMemoryOrg(spaceSlug);
   const { space } = useSpaceBySlug(spaceSlug);
+  const { canMutate, isLoading: isMutateLoading } = useCanMutateInSpace({
+    spaceSlug,
+    space,
+    spaceId: space?.web3SpaceId ?? undefined,
+  });
   const matrixChatRoomId = space?.chatRoomId?.trim() || null;
   const { lang, id } = useParams<{ lang: Locale; id: string }>();
   const [activeFilter, setActiveFilter] =
@@ -184,6 +190,8 @@ export const SpaceMemorySection: FC<SpaceMemorySectionProps> = ({
         searchTerm={searchTerm}
         onSearchChange={setSearchTerm}
         newMemoryHref={newMemoryHref}
+        canCreateMemory={canMutate}
+        isCreateMemoryLoading={isMutateLoading}
         counts={counts}
       />
 

--- a/packages/epics/src/common/ai-left-panel.tsx
+++ b/packages/epics/src/common/ai-left-panel.tsx
@@ -1624,6 +1624,27 @@ export function AiLeftPanel({ enableSpaceMemory = false }: AiLeftPanelProps) {
     );
   }
 
+  if (blockSpaceAiForActivityAccess) {
+    return (
+      <>
+        <SidebarHeader className="bg-background-2 p-0">
+          <AiPanelHeader
+            showCloseButton={false}
+            leftSlot={triggerButton}
+            rightSlot={closeButton}
+          />
+        </SidebarHeader>
+        <SidebarContent className="flex flex-1 items-center justify-center px-6">
+          <SpaceAccessDenied
+            userState={userSpaceState}
+            spaceId={effectiveSpaceWeb3Id}
+            spaceSlug={spaceSlug ?? undefined}
+          />
+        </SidebarContent>
+      </>
+    );
+  }
+
   if (!isAuthenticated) {
     return (
       <>
@@ -1646,27 +1667,6 @@ export function AiLeftPanel({ enableSpaceMemory = false }: AiLeftPanelProps) {
               </div>
             </div>
           </Empty>
-        </SidebarContent>
-      </>
-    );
-  }
-
-  if (blockSpaceAiForActivityAccess) {
-    return (
-      <>
-        <SidebarHeader className="bg-background-2 p-0">
-          <AiPanelHeader
-            showCloseButton={false}
-            leftSlot={triggerButton}
-            rightSlot={closeButton}
-          />
-        </SidebarHeader>
-        <SidebarContent className="flex flex-1 items-center justify-center px-6">
-          <SpaceAccessDenied
-            userState={userSpaceState}
-            spaceId={effectiveSpaceWeb3Id}
-            spaceSlug={spaceSlug ?? undefined}
-          />
         </SidebarContent>
       </>
     );

--- a/packages/epics/src/common/human-right-panel.tsx
+++ b/packages/epics/src/common/human-right-panel.tsx
@@ -4202,6 +4202,14 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
       >
         {isAuthLoading ? (
           <HumanChatPanelLoader />
+        ) : blockSpaceChatForActivityAccess ? (
+          <div className="flex flex-1 items-center justify-center px-6">
+            <SpaceAccessDenied
+              userState={userSpaceState}
+              spaceId={effectiveSpaceWeb3Id}
+              spaceSlug={spaceSlug ?? undefined}
+            />
+          </div>
         ) : showAuthPrompt ? (
           <div className="flex flex-1 items-center justify-center px-6">
             <Empty>
@@ -4215,14 +4223,6 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
                 </div>
               </div>
             </Empty>
-          </div>
-        ) : blockSpaceChatForActivityAccess ? (
-          <div className="flex flex-1 items-center justify-center px-6">
-            <SpaceAccessDenied
-              userState={userSpaceState}
-              spaceId={effectiveSpaceWeb3Id}
-              spaceSlug={spaceSlug ?? undefined}
-            />
           </div>
         ) : (
           <>

--- a/packages/epics/src/spaces/components/index.ts
+++ b/packages/epics/src/spaces/components/index.ts
@@ -37,4 +37,5 @@ export * from './space-discoverability-field';
 export * from './space-activity-access-field';
 export * from './space-access-denied';
 export * from './space-tab-access-wrapper';
+export * from './space-member-aside-guard';
 export * from './space-loading-backdrop';

--- a/packages/epics/src/spaces/components/space-access-denied.tsx
+++ b/packages/epics/src/spaces/components/space-access-denied.tsx
@@ -59,14 +59,17 @@ export function SpaceAccessDenied({
     userState === UserSpaceState.LOGGED_IN ||
     userState === UserSpaceState.LOGGED_IN_ORG
   ) {
+    const joinSpaceDbId =
+      resolvedSpaceId ?? space?.id ?? spacesByWeb3Id[0]?.id ?? undefined;
+
     return (
       <Empty>
         <div className="flex flex-col gap-7">
           <p>{t('accessDeniedNotMember')}</p>
-          {resolvedSpaceId && effectiveSpaceId ? (
+          {effectiveSpaceId && joinSpaceDbId ? (
             <div className="flex items-center justify-center">
               <JoinSpace
-                spaceId={resolvedSpaceId}
+                spaceId={joinSpaceDbId}
                 web3SpaceId={effectiveSpaceId}
                 hideWhenMember
               />

--- a/packages/epics/src/spaces/components/space-member-aside-guard.tsx
+++ b/packages/epics/src/spaces/components/space-member-aside-guard.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { Space } from '@hypha-platform/core/client';
+import { useCanMutateInSpace } from '../hooks/use-can-mutate-in-space';
+import { SpaceAccessDenied } from './space-access-denied';
+
+type SpaceMemberAsideGuardProps = {
+  spaceSlug: string;
+  spaceId?: number;
+  space?: Space | null;
+  children: React.ReactNode;
+};
+
+export function SpaceMemberAsideGuard({
+  spaceSlug,
+  spaceId,
+  space,
+  children,
+}: SpaceMemberAsideGuardProps) {
+  const { canMutate, isLoading, userState } = useCanMutateInSpace({
+    spaceId,
+    spaceSlug,
+    space,
+  });
+
+  if (isLoading) {
+    return <>{children}</>;
+  }
+
+  if (!canMutate) {
+    return (
+      <SpaceAccessDenied
+        userState={userState}
+        spaceId={spaceId}
+        spaceSlug={spaceSlug}
+      />
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/packages/epics/src/spaces/components/subspace-section.tsx
+++ b/packages/epics/src/spaces/components/subspace-section.tsx
@@ -7,9 +7,7 @@ import type { Locale } from '@hypha-platform/i18n';
 import { InnerSpaceCardList } from './inner-space-card-list';
 import { Button } from '@hypha-platform/ui';
 import type { UseMembers } from '../hooks';
-import { useSpaceDiscoverability } from '../hooks/use-space-discoverability';
-import { useUserSpaceState } from '../hooks/use-user-space-state';
-import { checkAccess } from '../utils/transparency-access';
+import { useCanMutateInSpace } from '../hooks/use-can-mutate-in-space';
 import Link from 'next/link';
 
 interface SubspaceSectionProps {
@@ -29,18 +27,11 @@ export const SubspaceSection = ({
   currentSpaceSlug,
   useMembers,
 }: SubspaceSectionProps) => {
-  const { access, isLoading: isAccessLoading } = useSpaceDiscoverability({
-    spaceId: currentSpaceWeb3Id ? BigInt(currentSpaceWeb3Id) : undefined,
-  });
-
-  const { userState, isLoading: isUserStateLoading } = useUserSpaceState({
+  const { canMutate, isLoading } = useCanMutateInSpace({
     spaceId: currentSpaceWeb3Id,
     spaceSlug: currentSpaceSlug,
   });
-
-  const hasAccess = checkAccess(access, userState);
-  const isLoading = isAccessLoading || isUserStateLoading;
-  const isDisabled = isLoading || !hasAccess;
+  const isDisabled = isLoading || !canMutate;
 
   return (
     <div className="flex flex-col gap-4">
@@ -48,13 +39,13 @@ export const SubspaceSection = ({
         <Text className="text-4">Organisation Spaces | {spaces.length}</Text>
         <div className="flex items-center">
           <Link
-            href={hasAccess && !isLoading ? 'space/create' : '#'}
+            href={canMutate && !isLoading ? 'space/create' : '#'}
             className={isDisabled ? 'cursor-not-allowed' : ''}
             title={
               isLoading
                 ? 'Loading...'
-                : !hasAccess
-                ? 'You do not have access to add spaces to this organization.'
+                : !canMutate
+                ? 'You must be a space member to add spaces to this organization.'
                 : 'Add Space'
             }
           >

--- a/packages/epics/src/spaces/hooks/index.ts
+++ b/packages/epics/src/spaces/hooks/index.ts
@@ -10,6 +10,7 @@ export * from './use-space-member';
 export * from './use-action-gating';
 export * from './use-space-discoverability';
 export * from './use-user-space-state';
+export * from './use-can-mutate-in-space';
 export * from './use-spaces-discoverability-batch';
 export {
   checkAccess,

--- a/packages/epics/src/spaces/hooks/use-can-mutate-in-space.ts
+++ b/packages/epics/src/spaces/hooks/use-can-mutate-in-space.ts
@@ -1,0 +1,30 @@
+'use client';
+
+import { Space } from '@hypha-platform/core/client';
+import { UserSpaceState, useUserSpaceState } from './use-user-space-state';
+
+export function useCanMutateInSpace({
+  spaceId,
+  spaceSlug,
+  space,
+}: {
+  spaceId?: number;
+  spaceSlug?: string;
+  space?: Space | null;
+}): {
+  canMutate: boolean;
+  isLoading: boolean;
+  userState: UserSpaceState;
+} {
+  const { userState, isLoading } = useUserSpaceState({
+    spaceId,
+    spaceSlug,
+    space,
+  });
+
+  return {
+    canMutate: !isLoading && userState === UserSpaceState.LOGGED_IN_SPACE,
+    isLoading,
+    userState,
+  };
+}

--- a/packages/epics/src/treasury/components/assets/assets-section.tsx
+++ b/packages/epics/src/treasury/components/assets/assets-section.tsx
@@ -74,8 +74,8 @@ export const AssetsSection: FC<AssetSectionProps> = ({
         leftIcon={<SearchIcon className="text-accent-9" size="16px" />}
         onChange={(e) => setSearchTerm(e.target.value)}
       />
-      <div className="flex w-full flex-col items-end justify-end gap-2 sm:w-auto">
-        <label className="flex w-full shrink-0 items-center gap-2 whitespace-nowrap text-sm text-foreground sm:w-auto">
+      <div className="flex w-full flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center sm:justify-end lg:w-auto">
+        <label className="flex shrink-0 items-center gap-2 whitespace-nowrap text-sm text-foreground">
           <Input
             type="checkbox"
             checked={hideSmallBalances}
@@ -84,7 +84,7 @@ export const AssetsSection: FC<AssetSectionProps> = ({
           />
           <span>{tTreasury('hideSmall')}</span>
         </label>
-        <div className="flex w-full flex-row flex-wrap items-center justify-end gap-2">
+        <div className="flex flex-row flex-wrap items-center justify-end gap-2">
           {isDisabled ? (
             <Button
               colorVariant="accent"

--- a/packages/epics/src/treasury/components/assets/space-pending-rewards-section.tsx
+++ b/packages/epics/src/treasury/components/assets/space-pending-rewards-section.tsx
@@ -195,10 +195,6 @@ export const SpacePendingRewardsSection: FC<
           <div className="mt-2 grid w-full grid-cols-1 gap-2 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
             <AssetCard isLoading />
           </div>
-        ) : !isAuthenticated ? (
-          <Empty>
-            <p>{tTreasury('rewardsSection.signInToViewSpaceRewards')}</p>
-          </Empty>
         ) : (
           <div className="mt-2 grid w-full grid-cols-1 gap-2 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
             <AssetCard


### PR DESCRIPTION
## Summary
- Introduce `useCanMutateInSpace` and `SpaceMemberAsideGuard` so create/mutate actions require target-space membership (`LOGGED_IN_SPACE`), not merely activity visibility.
- Remove redundant auth walls on public read paths (signals tab, banking tab entry, space rewards) and reorder AI/human panel checks so transparency denial shows join CTAs before login prompts.
- Gate Add Space, Create Board, New Memory, proposal/settings create menus, and aside create routes; fix treasury action button layout.

## Test plan
- [ ] Open a **Public** space while logged out — Signals tab shows signal list (no login wall)
- [ ] As anonymous/non-member on a public space — Add Space (+) is disabled/hidden in ecosystem navigation and subspaces
- [ ] As space member — create actions (New Signal, Create Board, New Memory, New Proposal menu) are enabled
- [ ] Deep-link to `/space/create`, `/new-signal`, `/new-memory` as non-member — shows access denied with join CTA
- [ ] Logged-in org sibling on Organisation-scoped space — activity tabs load; denied surfaces show Request Invite / Become member
- [ ] Treasury tab — New Token and Deposit funds appear on one row on desktop


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added smarter post-login redirection that returns users to the correct DHO context when possible.
* **Bug Fixes**
  * Enforced space membership requirements for creating signals, memories, and subspaces.
  * Improved disabled states for create/deposit actions while mutation permissions load or are unavailable.
  * Updated access-denied and join prompts to better reflect non-member scenarios.
* **Refactor**
  * Unified space mutation permission checks across space actions, create links, and navigation panels.
* **Style**
  * Minor UI layout/controls adjustments in asset filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->