### PR TITLE
docs(spaces): transparency API hardening spec & implementation plan

### DIFF
--- a/docs/requirements/Features/space-transparency-api-hardening/implementation-plan.md
+++ b/docs/requirements/Features/space-transparency-api-hardening/implementation-plan.md
@@ -1,0 +1,232 @@
+# Implementation plan — Space transparency API & interaction hardening
+
+## Document control
+
+| Field | Value |
+|-------|--------|
+| **Status** | Ready to implement |
+| **Requirements** | [requirements.md](./requirements.md) |
+| **Estimated PRs** | 2–3 (Phase 1+2 shippable together; Phase 3–4 optional follow-ups) |
+| **Base branch** | `main` (after merging PR #2325 or cherry-picking S-I helpers) |
+
+---
+
+## 0) Pre-merge checklist
+
+Before starting Phase 1:
+
+1. Merge [PR #2325](https://github.com/hypha-dao/hypha-web/pull/2325) **or** cherry-pick:
+   - `packages/core/src/space/server/authorize-space-panel-interaction.ts`
+   - `packages/core/src/space/server/is-on-chain-member-or-delegate.ts` (if not already on main)
+   - `apps/web/src/app/api/chat/route.ts` — **S-I** block
+   - `packages/epics/src/spaces/utils/transparency-access.ts` — `canInteractInSpace`
+2. Confirm `checkSpaceAccessForSpace` org-sibling logic matches `apps/web/src/utils/check-space-access.ts` (they should already mirror).
+
+---
+
+## Phase 1 — Consolidate evaluator + close read bypasses
+
+**Goal:** Single source of truth; gate metadata, org tree, and document-by-slug.
+
+### 1.1 Deduplicate server access helper
+
+| Step | File | Action |
+|------|------|--------|
+| 1 | `packages/core/src/space/server/check-space-access-for-roster.ts` | Keep as canonical `checkSpaceAccessForSpace` |
+| 2 | `packages/core/src/space/server/check-space-access-for-request.ts` | **New** — thin wrapper: `(request: NextRequest, web3SpaceId) => CheckSpaceAccessResult` extracting Bearer token + calling `checkSpaceAccessForSpace` after resolving space by slug |
+| 3 | `apps/web/src/utils/check-space-access.ts` | Replace body with re-export / delegate to core wrapper (preserve export name for existing imports) |
+| 4 | `packages/core/src/space/server/index.ts` | Export new helpers |
+
+**Suggested wrapper signature:**
+
+```typescript
+// packages/core/src/space/server/check-space-access-for-request.ts
+export async function checkSpaceAccessFromRequest(
+  request: Request | NextRequest,
+  web3SpaceId: number | bigint,
+): Promise<CheckSpaceAccessForRosterResult & { userAddress?: `0x${string}`; authToken?: string }>;
+```
+
+Map `httpStatus` → `NextResponse` in apps/web only.
+
+### 1.2 Gate space metadata route
+
+| File | Change |
+|------|--------|
+| `apps/web/src/app/api/v1/spaces/[spaceSlug]/route.ts` | Load space; if `web3SpaceId` null → off-chain policy (membership row or 403); else call `checkSpaceAccessFromRequest`. Remove `TODO: implement authorization`. |
+
+### 1.3 Gate organisation route
+
+| File | Change |
+|------|--------|
+| `apps/web/src/app/api/v1/spaces/[spaceSlug]/organisation/route.ts` | Resolve host space → `checkSpaceAccessFromRequest` on host `web3SpaceId` before `getAllOrganizationSpacesForNodeById`. |
+
+### 1.4 Gate document-by-slug route
+
+| File | Change |
+|------|--------|
+| `apps/web/src/app/api/v1/documents/[documentSlug]/route.ts` | `findDocumentBySlug` → join/load host space → `checkSpaceAccessFromRequest` on space's `web3SpaceId`. Return 404 if document missing; 403 if denied. |
+
+**Query addition (if needed):** extend `findDocumentBySlug` or add `findDocumentWithSpaceBySlug` in `packages/core/src/governance/server/queries.ts` to avoid N+1.
+
+### 1.5 Tests (Phase 1)
+
+| File | Coverage |
+|------|----------|
+| `packages/core/src/space/server/__tests__/check-space-access-for-roster.test.ts` | Extend org-sibling matrix cases (may exist partially) |
+| `apps/web/src/utils/__tests__/check-space-access-routes.test.ts` | **New** — table-driven tests for metadata, organisation, documents routes (mock db + viem `readContract`) |
+
+**Definition of done (Phase 1):** AC-1, AC-2, AC-3, AC-6 from requirements.md.
+
+---
+
+## Phase 2 — Mutation hardening (coherence + space update)
+
+**Goal:** Server actions and profile update require **S-M**.
+
+### 2.1 Shared member/delegate authorizer
+
+Reuse `isOnChainMemberOrDelegate` + DB membership fallback (same as `authorizeSpacePanelInteraction`):
+
+| File | Action |
+|------|--------|
+| `packages/core/src/space/server/authorize-space-mutation.ts` | **New** — alias or thin wrapper around same logic as `authorizeSpacePanelInteraction`; export `authorizeSpaceMutation({ spaceSlug, authToken })` |
+
+### 2.2 Coherence server actions
+
+| File | Change |
+|------|--------|
+| `packages/core/src/coherence/server/actions.ts` | Before each mutation: resolve space from input → `authorizeSpaceMutation`. Use `getDb({ authToken })` consistently (fix `updateCoherenceBySlugAction` global `db` usage). |
+| `packages/core/src/coherence/server/mutations.ts` | Keep creator/membership checks for edit/delete; add `createCoherence` guard: verify `creatorId` is requester and requester is **S-M** on `spaceId`. |
+
+### 2.3 Space profile update
+
+| File | Change |
+|------|--------|
+| `apps/web/src/app/api/v1/spaces/[spaceSlug]/update/route.ts` | After auth token validation → `authorizeSpaceMutation` → proceed with `updateSpaceBySlug`. |
+
+### 2.4 Tests (Phase 2)
+
+| File | Coverage |
+|------|----------|
+| `packages/core/src/coherence/server/__tests__/actions-auth.test.ts` | **New** — non-member create/update rejected |
+| `packages/core/src/space/server/__tests__/authorize-space-mutation.test.ts` | **New** — member/delegate/org-member-not-target cases |
+
+**Definition of done (Phase 2):** AC-4, AC-5 (if #2325 merged), space update blocked for non-members.
+
+---
+
+## Phase 3 — Human chat interaction (Matrix)
+
+**Goal:** **S-I** parity for human chat writes (optional separate PR).
+
+### Option A (recommended v1) — Matrix power levels on join
+
+When a user obtains Matrix token / joins space room:
+
+| File | Change |
+|------|--------|
+| `apps/web/src/app/api/matrix/token/route.ts` or join helper | After Privy auth, if user fails **S-I**, issue token but set Matrix user power level 0 and `m.room.message` send level > 0; if passes **S-I**, set power level allowing send. |
+| Document | Runbook for homeserver admin if power-level API requires elevated token |
+
+### Option B — Hypha send proxy
+
+| File | Change |
+|------|--------|
+| `apps/web/src/app/api/matrix/send/route.ts` | **New** — `authorizeSpacePanelInteraction` → forward to homeserver with service account |
+
+**Recommendation:** Option A avoids per-message latency; Option B gives strongest audit trail. Spike 1–2 days before implementing.
+
+**Definition of done (Phase 3):** Non-member with Matrix token cannot post messages in space room (manual QA + integration test if homeserver available in CI).
+
+---
+
+## Phase 4 — Discoverability on list API (optional)
+
+**Goal:** **FR-9** — server-side D filter.
+
+| File | Change |
+|------|--------|
+| `apps/web/src/app/api/v1/spaces/route.ts` | Accept optional auth; for each space batch-read `getSpaceVisibility`; filter with shared `checkDiscoverability(level, userState)` where `userState` derived from token + on-chain membership batch (performance: cache visibility per request). |
+| `packages/core/src/space/server/filter-spaces-by-discoverability.ts` | **New** — pure function + batched viem reads |
+
+**Performance note:** May require pagination changes; consider filtering only for `parentOnly` explore endpoints first.
+
+---
+
+## File touchpoint summary
+
+```
+packages/core/src/space/server/
+  check-space-access-for-roster.ts          (keep canonical)
+  check-space-access-for-request.ts       (new)
+  authorize-space-mutation.ts             (new, or reuse panel interaction)
+  authorize-space-panel-interaction.ts    (from #2325)
+  is-on-chain-member-or-delegate.ts         (existing)
+  filter-spaces-by-discoverability.ts     (Phase 4)
+  index.ts                                  (exports)
+
+apps/web/src/utils/check-space-access.ts  (delegate to core)
+
+apps/web/src/app/api/v1/spaces/[spaceSlug]/
+  route.ts                                  (Phase 1)
+  organisation/route.ts                     (Phase 1)
+  update/route.ts                           (Phase 2)
+
+apps/web/src/app/api/v1/documents/[documentSlug]/
+  route.ts                                  (Phase 1)
+
+packages/core/src/coherence/server/
+  actions.ts                                (Phase 2)
+  mutations.ts                              (Phase 2)
+
+apps/web/src/app/api/chat/route.ts          (S-I from #2325)
+```
+
+---
+
+## Implementation order (suggested commits)
+
+1. `refactor(core): dedupe checkSpaceAccess into core package`
+2. `fix(api): gate space metadata, organisation, and document-by-slug routes`
+3. `test(core): expand transparency matrix access fixtures`
+4. `fix(coherence): require space membership for signal mutations`
+5. `fix(api): require membership for space profile update`
+6. `(optional) fix(matrix): align room send power levels with membership`
+7. `(optional) feat(api): filter spaces list by discoverability`
+
+---
+
+## Rollout & compatibility
+
+- **Breaking for attackers only** — legitimate clients already send Bearer tokens on gated routes.
+- **Ecosystem navigation** may start failing for users who relied on ungated `/organisation` while lacking **A**; this is intended.
+- **Mobile / MCP clients** must send `Authorization: Bearer` on newly gated routes (already required for members/coherences).
+
+---
+
+## Open decisions (defaults if no product input)
+
+| # | Question | Default |
+|---|----------|---------|
+| OD-1 | Public space metadata for anonymous `GET /spaces/{slug}` | Require **S-A**; public level allows anonymous 200 |
+| OD-2 | Banking tab visible to org viewers | Keep UI-A; APIs stay **S-M** (no change) |
+| OD-3 | Matrix Phase 3 in same PR vs follow-up | **Follow-up PR** after Phase 1+2 |
+
+---
+
+## Verification commands
+
+```bash
+# Unit tests
+pnpm --filter @hypha-platform/core exec vitest run src/space/server/__tests__/
+pnpm --filter @hypha-platform/core exec vitest run src/coherence/server/__tests__/
+
+# Typecheck
+pnpm --filter web exec tsc --noEmit
+
+# Lint
+pnpm lint
+```
+
+Manual: run QA checklist in [requirements.md §10](./requirements.md#10-qa-checklist-manual).

--- a/docs/requirements/Features/space-transparency-api-hardening/requirements.md
+++ b/docs/requirements/Features/space-transparency-api-hardening/requirements.md
@@ -1,0 +1,182 @@
+# Space transparency matrix — API & interaction hardening
+
+## Document control
+
+| Field | Value |
+|-------|--------|
+| **Status** | Ready for implementation |
+| **Related spec** | [Organisation visibility & activity access](../space-transparency-matrix-organisation-visibility/requirements.md) (matrix semantics, org CTA parity — largely addressed in PR [#2325](https://github.com/hypha-dao/hypha-web/pull/2325)) |
+| **Scope** | Close server-side gaps where protected space data or mutations can bypass UI gates; align **interaction** (chat/AI write) with **mutation** (proposals/settings) boundaries |
+| **Out of scope** | Redesigning transparency settings UI; replacing Matrix with a custom chat backend |
+
+---
+
+## 1) Problem statement
+
+The transparency matrix defines who may **discover** a space (D), **view activity** (A), and (separately) **interact or mutate** (I/M). Client helpers in `packages/epics/src/spaces/utils/transparency-access.ts` and server helpers in `apps/web/src/utils/check-space-access.ts` / `packages/core/src/space/server/check-space-access-for-roster.ts` enforce **A** on most tab data APIs.
+
+A security review (June 2026) found **residual bypass paths**:
+
+1. **Metadata enumeration** — `GET /api/v1/spaces/{slug}` and `GET …/organisation` return data without transparency checks.
+2. **Document-by-slug leak** — `GET /api/v1/documents/{slug}` has no space access gate.
+3. **Coherence mutations** — server actions accept auth tokens but do not consistently require target-space membership or activity access.
+4. **Human chat writes** — Matrix SDK sends go directly to the homeserver; UI locks are not mirrored server-side per message.
+5. **Discoverability on list APIs** — `GET /api/v1/spaces` is not filtered by on-chain discoverability level.
+6. **Space profile update** — `POST …/update` requires auth but not role/membership.
+
+Activity-protected tab content (documents, treasury, members, coherences, org-memory, overview dashboards) is **already server-gated** via `checkSpaceAccess`. This ticket closes the remaining holes and documents the full tab→API→gate map as the canonical reference.
+
+---
+
+## 2) Definitions
+
+| Term | Meaning |
+|------|---------|
+| **D (Discoverability)** | Space appears in network/explore lists and navigation |
+| **A (Activity access)** | User may view protected tab content and call space-scoped read APIs |
+| **I (Interaction)** | User may send AI prompts or human chat messages in a space context |
+| **M (Mutation)** | User may create proposals, subspaces, signals, settings changes, treasury actions |
+| **S-A** | Server enforcement of **A** via `checkSpaceAccess` / `checkSpaceAccessForSpace` |
+| **S-I** | Server enforcement of **I** via `authorizeSpacePanelInteraction` (member/delegate of target space) |
+| **S-M** | Server enforcement of **M** — member/delegate of target space and/or on-chain governance |
+
+**Normative rule:** **S-A** is the authority for read APIs. **S-I** and **S-M** are **stricter** than **A** (org members may **view** but not **write**).
+
+---
+
+## 3) Baseline transparency matrix (normative)
+
+| User state ↓ \ Level → | Public | Network | Organisation | Space |
+|------------------------|:------:|:-------:|:------------:|:-----:|
+| Not logged in | D ✓ / A ✓ | D ✗ / A ✗ | D ✗ / A ✗ | D ✗ / A ✗ |
+| Logged in (non-member) | D ✓ / A ✓ | D ✓ / A ✓ | D ✗ / A ✗ | D ✗ / A ✗ |
+| Org member (sibling space) | D ✓ / A ✓ | D ✓ / A ✓ | D ✓ / A ✓ | D ✗ / A ✗ |
+| Target-space member/delegate | D ✓ / A ✓ | D ✓ / A ✓ | D ✓ / A ✓ | D ✓ / A ✓ |
+
+**Interaction & mutation (all transparency levels):**
+
+| Capability | Who |
+|------------|-----|
+| **I** — AI chat, human chat composer | Target-space member/delegate only |
+| **M** — Create proposal, signal, subspace, space settings | Target-space member/delegate only (+ on-chain for governance) |
+| **Banking APIs** | Target-space member/delegate only (`authorizeSpaceBankOnboarding`) — stricter than **A** |
+
+---
+
+## 4) DHO tab → API → gate map (canonical)
+
+**UI-A** = `SpaceTabAccessWrapper` + `checkAccess()`. **S-A** = `checkSpaceAccess*`. **S-M** / **S-I** as defined above.
+
+| Tab | Primary read APIs | Server read gate | Write / interact | Server write gate |
+|-----|-------------------|------------------|------------------|-------------------|
+| **Overview** | `…/overview-activity`, `…/token-holdings`, `…/token-distribution-history` | **S-A** | — | — |
+| **Ecosystem navigation** | `…/organisation`, `…/spaces/{slug}` | **None today** → **S-A (Phase 1)** | Add subspace | **S-M** + on-chain |
+| **Signals (Coherence)** | `…/coherences`, `/api/v1/signals/{slug}` | **S-A** | Create/edit/delete signal | **S-M** (Phase 2) |
+| **Agreements** | `…/documents`, `…/documents/all`, `/api/v1/documents/{slug}` | **S-A** on space routes; **None on document slug** → **S-A (Phase 1)** | Create proposal | **S-M** + **Chain** |
+| **Members** | `…/members` | **S-A** | — | — |
+| **Treasury** | `…/assets`, `…/transfers`, `…/vaults`, etc. | **S-A** | Deposit, new token | **S-M** + **Chain** |
+| **Banking** | `…/banking/*` | **S-M** (`authorizeSpaceBankOnboarding`) | Transfers, KYC | **S-M** |
+| **Rewards** | `…/assets` + on-chain RPC | **S-A** on assets; chain public | Claim | **S-M** + **Chain** |
+| **Memory** | `…/org-memory` | **S-A** | New memory | **S-M** |
+| **AI panel** | (tools use tab APIs above) | Inherited **S-A** | `POST /api/chat` | **S-I** (PR #2325) |
+| **Human chat** | Matrix sync | Matrix room membership | Matrix `sendMessage` | **None today** → Phase 3 |
+
+### Supporting routes
+
+| Route | Today | Target |
+|-------|-------|--------|
+| `GET /api/v1/spaces` | No D filter | **Phase 4:** filter by discoverability |
+| `GET /api/v1/spaces/{slug}` | No gate | **Phase 1:** **S-A** (or public-metadata subset) |
+| `GET /api/v1/spaces/{slug}/organisation` | No gate | **Phase 1:** **S-A** on host space |
+| `GET /api/v1/documents/{slug}` | No gate | **Phase 1:** **S-A** via document's space |
+| `POST /api/v1/spaces/{slug}/update` | Auth only | **Phase 2:** **S-M** |
+| Coherence server actions | Partial auth | **Phase 2:** **S-A** + **S-M** |
+
+---
+
+## 5) Gap analysis & priority
+
+| ID | Gap | Risk | Phase |
+|----|-----|------|-------|
+| **G-1** | Ungated space metadata + org tree | Slug enumeration leaks titles, hierarchy | 1 |
+| **G-2** | Ungated document-by-slug | Bypass agreements tab | 1 |
+| **G-3** | Coherence create/update without membership | Authenticated non-member mutates signals | 2 |
+| **G-4** | Space `update` without role check | Profile tampering | 2 |
+| **G-5** | Matrix send without Hypha gate | UI bypass for chat | 3 |
+| **G-6** | List API without discoverability filter | D matrix not enforced server-side | 4 |
+| **G-7** | Duplicate `checkSpaceAccess` implementations | Drift between web app and core | 1 |
+
+---
+
+## 6) Functional requirements
+
+**FR-1** All space-scoped **read** APIs that return activity-protected data SHALL call a single shared access evaluator equivalent to `checkSpaceAccessForSpace` before returning 200.
+
+**FR-2** `GET /api/v1/spaces/{slug}` SHALL either (a) require **S-A** for the full payload, or (b) return a **public metadata subset** when activity level is Public and caller is unauthenticated — document the chosen behavior in the implementation plan (default: **full S-A** for simplicity).
+
+**FR-3** `GET /api/v1/spaces/{slug}/organisation` SHALL require **S-A** on the host space before returning sibling space records.
+
+**FR-4** `GET /api/v1/documents/{slug}` SHALL resolve the document's host space, require **S-A** on that space's `web3SpaceId`, and return 403/401 consistent with other routes.
+
+**FR-5** Coherence **create**, **update**, and **delete** server actions SHALL require **S-M** (target-space member/delegate). **Read** paths remain **S-A**.
+
+**FR-6** `POST /api/v1/spaces/{slug}/update` SHALL require **S-M**.
+
+**FR-7** `POST /api/chat` with a `spaceSlug` SHALL require **S-I** (`authorizeSpacePanelInteraction`) — merge from PR #2325 if not on `main`.
+
+**FR-8** Human chat **Phase 3** SHALL document and implement one of: (a) Matrix power levels aligned with on-chain membership on join, or (b) a Hypha-proxied send endpoint that enforces **S-I** before forwarding to Matrix.
+
+**FR-9** `GET /api/v1/spaces` **Phase 4** SHALL filter results using on-chain discoverability + caller identity (same semantics as `checkDiscoverability`).
+
+**FR-10** Banking routes SHALL continue to use **S-M** only; optionally hide Banking tab unless `LOGGED_IN_SPACE` (UX follow-up, not blocking).
+
+---
+
+## 7) Non-functional requirements
+
+**NFR-1** Access denial responses SHALL use existing shapes: 401 unauthenticated, 403 not eligible, 500 evaluator failure.
+
+**NFR-2** Shared evaluator logic SHALL live in `packages/core` (`checkSpaceAccessForSpace`); `apps/web/src/utils/check-space-access.ts` SHALL delegate to it (no duplicated org-sibling logic).
+
+**NFR-3** Each new gate SHALL have unit tests with fixtures: anonymous, logged-in non-member, org sibling member, target member/delegate, for each transparency level 0–3.
+
+**NFR-4** No regression to organisation-level **A** already implemented in `checkSpaceAccessForSpace` sibling checks.
+
+---
+
+## 8) Acceptance criteria
+
+**AC-1** Unauthenticated caller requesting `GET …/spaces/{slug}` for Network+ activity space receives 401 (or public subset if FR-2 option b is chosen).
+
+**AC-2** Org-eligible user requesting `GET …/organisation` for Organisation activity space receives 200; non-org user receives 403.
+
+**AC-3** User without **A** requesting `GET /api/v1/documents/{slug}` receives 403 even if slug is known.
+
+**AC-4** Authenticated org member (not target member) calling coherence create action receives error; target member succeeds.
+
+**AC-5** Non-member calling `POST /api/chat` with `spaceSlug` receives forbidden response (after **S-I** merge).
+
+**AC-6** Existing **S-A** routes (documents/all, assets, members, coherences, org-memory, overview-*) continue to pass org-sibling and member scenarios (regression suite green).
+
+---
+
+## 9) Dependencies
+
+| Dependency | Notes |
+|------------|-------|
+| PR [#2325](https://github.com/hypha-dao/hypha-web/pull/2325) | Ships `authorizeSpacePanelInteraction`, `canInteractInSpace`, panel UI gates — **merge first** or cherry-pick **S-I** pieces into hardening PR |
+| On-chain visibility | Source of truth for levels 0–3 via `getSpaceVisibility` |
+| Matrix homeserver | Phase 3 may require Synapse/admin API or join-time power-level sync |
+
+---
+
+## 10) QA checklist (manual)
+
+- [ ] Public space: anonymous can load overview/agreements data via API
+- [ ] Network space: anonymous 401 on members API; logged-in non-member 200
+- [ ] Organisation space: sibling org member 200 on documents/all; outsider 403
+- [ ] Space level: only target member 200 on members API
+- [ ] Document-by-slug: outsider 403 after Phase 1
+- [ ] Org tree: outsider 403 on `/organisation` after Phase 1
+- [ ] AI chat: non-member POST `/api/chat` rejected
+- [ ] Coherence: non-member cannot create signal via UI **and** server action


### PR DESCRIPTION
## Summary

Adds a **ready-to-implement** spec for closing server-side gaps in the space transparency matrix — where protected metadata, documents, and mutations can bypass UI gates today.

**Docs added:**
- `docs/requirements/Features/space-transparency-api-hardening/requirements.md` — problem statement, normative matrix, canonical **tab → API → gate** map, acceptance criteria
- `docs/requirements/Features/space-transparency-api-hardening/implementation-plan.md` — phased implementation with concrete file touchpoints and test plan

## Problem

Client transparency helpers (`transparency-access.ts`) and most tab read APIs (`checkSpaceAccess`) enforce **activity access (A)**. A June 2026 review found residual bypass paths:

| Priority | Gap |
|----------|-----|
| **High** | `GET /api/v1/spaces/{slug}` — no gate |
| **High** | `GET …/organisation` — no gate |
| **High** | `GET /api/v1/documents/{slug}` — no gate |
| **High** | Matrix human chat sends — client UI only |
| **Medium** | Coherence server actions — weak membership checks |
| **Medium** | `POST …/update` — auth only |
| **Medium** | `GET /api/v1/spaces` — no discoverability filter |

## Proposed solution (phased)

1. **Phase 1** — Deduplicate access helper to core; gate metadata, org tree, document-by-slug routes
2. **Phase 2** — Coherence mutations + space update require member/delegate (**S-M**)
3. **Phase 3** — Matrix power levels or send proxy (**S-I**)
4. **Phase 4** (optional) — Discoverability filter on list API

## Dependencies

- Merge [PR #2325](https://github.com/hypha-dao/hypha-web/pull/2325) first (or cherry-pick S-I helpers: `authorizeSpacePanelInteraction`, chat route enforcement, `canInteractInSpace`) before implementation PRs.

## Test plan

- [ ] Review requirements.md tab→API→gate table against current routes
- [ ] Confirm Phase 1 file list matches current codebase paths
- [ ] Align acceptance criteria with product/security expectations before implementation PR


Made with [Cursor](https://cursor.com)