### PR TITLE
chore(dx): add hypha-board skill + board-aware agent router and task-…

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -31,3 +31,21 @@ When the user has not specified a role, select the best-matching one based on th
 ## Fallback
 
 If no role matches, work directly without a role. Do not fabricate expertise — state what you don't know.
+
+---
+
+## GitHub / board integration (opt-in, per developer)
+
+When you detect ticket-related activity — creating an issue, scaffolding a ticket workspace,
+opening a PR, moving work to review — **check the developer's local config before acting on GitHub**:
+
+1. Read the developer's general `AGENTS.local.md` (at `../hypha-context/AGENTS.local.md` or in the
+   `.hypha-context.local/` satellite if present). If `github.enabled: true` and the profile is
+   technical, the **`hypha-board` skill** is available — use it for GitHub reads and (with
+   confirmation) writes.
+2. If the config is absent or `github.enabled` is false/missing, **do not offer or attempt any
+   GitHub writes**. Skip silently.
+
+Board conventions (title format `type(scope): description`, label taxonomy, column meanings) live
+in `../hypha-context/planning/issue-guidelines.md`. The `hypha-board` skill references them —
+don't invent or duplicate conventions here.

--- a/.agents/skills/hypha-board/SKILL.md
+++ b/.agents/skills/hypha-board/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: hypha-board
+description: Read or update Hypha's GitHub issues, PRs, and project board (#14 "Hypha Platform — Active Work") via the gh CLI. Use when a technical developer (github.enabled in their config) says "update the board", "sync this to GitHub", "move #X to In Review", "open the PR", "what's assigned to me", or "check GitHub". Also fires as a soft step inside hypha-task-init and hypha-checkpoint. Reads are free; writes ALWAYS confirm first.
+audience: dev
+---
+
+# hypha-board — GitHub board & issue sync (satellite skill for hypha-web)
+
+**Triggers:** "update the board", "sync this to GitHub", "move #X to In Review", "open the PR",
+"what's assigned to me", "check GitHub", creating/closing a ticket.
+
+**Who it's for:** Technical developers with `github.enabled: true` in their general `AGENTS.local.md`.
+**Skip silently** for others — never offer it if the gate isn't set.
+
+**Gating (check first):**
+1. Developer's general `AGENTS.local.md` has `github.enabled: true` and a technical profile.
+2. `gh` CLI is installed and authenticated — run `gh auth status`. Board commands need the `project`
+   scope: `gh auth refresh -s project` (offer the command; do not run silently).
+
+**Golden rule:** reads are free; every write states the exact change and asks for a yes first.
+
+---
+
+## Canonical procedure
+
+Full procedure in `hypha-context`: [`workflow/github-sync.md`](../../../../hypha-context/workflow/github-sync.md)
+
+Issue/PR conventions (title format, label taxonomy, board columns, custom fields):
+[`planning/issue-guidelines.md`](../../../../hypha-context/planning/issue-guidelines.md)
+
+**Don't duplicate those here.** When in doubt, read them.
+
+---
+
+## Quick reference — this repo
+
+**Repo:** `hypha-dao/hypha-web`
+
+**Project board:** [Hypha Platform — Active Work](https://github.com/orgs/hypha-dao/projects/14) (board #14)
+
+**Board columns:** Backlog → Todo → In Progress → Blocked → In Review → Done
+
+**Issue title convention:** `type(scope): short description` (e.g. `fix(banking): tab count wrong`)
+
+**Label taxonomy (active labels — from issue-guidelines.md):**
+
+| Label | Use for |
+|---|---|
+| `bug` | Something broken |
+| `banking` | All Bridge/fiat banking work |
+| `new feature` | Feature or capability addition |
+| `chore` | Housekeeping, config, infra |
+| `documentation` | Docs, onboarding |
+| `analysis` | Design/research with a decision as output |
+| `blocked` | Blocked on external dependency |
+| `Hotfix` | Needs to ship urgently |
+| `AI-Generated Feature` | AI-generated issues (for transparency) |
+
+> For the complete, authoritative list see `planning/issue-guidelines.md` in hypha-context.
+
+---
+
+## Soft-step hooks (fires inside other skills)
+
+- **Inside `hypha-task-init`:** read the linked GitHub issue to ground the spec. If no issue exists
+  and the work belongs on the board, *offer* to create one with the correct title/labels/board
+  placement — then ask for a yes before creating.
+- **Inside `hypha-checkpoint`:** *offer* to reflect the session on GitHub — progress comment,
+  board-column move (e.g. In Progress → In Review when a PR opens), label/field updates. State the
+  proposed write and wait for a yes.
+- **Ad-hoc:** developer says one of the trigger phrases above → run the procedure directly.

--- a/.agents/skills/hypha-task-init/SKILL.md
+++ b/.agents/skills/hypha-task-init/SKILL.md
@@ -23,8 +23,13 @@ Ensure `../hypha-context` is current. Offer to pull if behind origin.
 ### 2. Load developer config
 Read `../hypha-context/progress/members/gerroza/AGENTS.local.md`.
 
-### 3. Read the GitHub issue
-Fetch the issue with `gh issue view <number> --repo hypha-dao/hypha-web`. If no issue exists yet, note it.
+### 3. Read the GitHub issue (board soft-step — gated)
+If the developer's general `AGENTS.local.md` has `github.enabled: true`, use the `hypha-board`
+skill: fetch the issue with `gh issue view <number> --repo hypha-dao/hypha-web` to ground the
+spec. If no issue exists yet and the work belongs on the board, *offer* to create one (correct
+`type(scope):` title, labels per `../hypha-context/planning/issue-guidelines.md`, add to project
+#14, set Priority/Target date) — state the proposed write and wait for a yes before creating.
+Skip this step silently if `github.enabled` is absent or false.
 
 ### 4. Classify the task (skip any already answered by the issue/config)
 - **Type:** analysis · feature · bug · process

--- a/.agents/skills/hypha-task-init/SKILL.md
+++ b/.agents/skills/hypha-task-init/SKILL.md
@@ -24,6 +24,7 @@ Ensure `../hypha-context` is current. Offer to pull if behind origin.
 Read `../hypha-context/progress/members/gerroza/AGENTS.local.md`.
 
 ### 3. Read the GitHub issue (board soft-step — gated)
+
 If the developer's general `AGENTS.local.md` has `github.enabled: true`, use the `hypha-board`
 skill: fetch the issue with `gh issue view <number> --repo hypha-dao/hypha-web` to ground the
 spec. If no issue exists yet and the work belongs on the board, *offer* to create one (correct
@@ -32,6 +33,7 @@ spec. If no issue exists yet and the work belongs on the board, *offer* to creat
 Skip this step silently if `github.enabled` is absent or false.
 
 ### 4. Classify the task (skip any already answered by the issue/config)
+
 - **Type:** analysis · feature · bug · process
 - **Reviewer:** will another contributor review before merge?
 - **Discovery:** is research needed, or is the area already understood?

--- a/.claude/skills/hypha-board/SKILL.md
+++ b/.claude/skills/hypha-board/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: hypha-board
+description: Read or update Hypha's GitHub issues, PRs, and project board (#14 "Hypha Platform — Active Work") via the gh CLI. Use when a technical developer (github.enabled in their config) says "update the board", "sync this to GitHub", "move #X to In Review", "open the PR", "what's assigned to me", or "check GitHub". Reads are free; writes ALWAYS confirm first. Also fires as a soft step inside hypha-task-init and hypha-checkpoint.
+---
+
+Read [`.agents/skills/hypha-board/SKILL.md`](../../../.agents/skills/hypha-board/SKILL.md) and follow it exactly.

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,8 @@ playwright-report/
 
 # Hypha context satellite (personal, machine-specific — never commit)
 .hypha-context.local/
+
+# Hypha local-only skills and draft working files (personal, never committed)
+**/.local/
+.claude/skills/*.local/
+context-local/


### PR DESCRIPTION
…init

Adds the hypha-board satellite skill to hypha-web (.agents + .claude). The skill gates on github.enabled in the developer's AGENTS.local.md, shells out to the gh CLI for all GitHub reads/writes, and delegates conventions to hypha-context/planning/issue-guidelines.md.

Also updates:
- .agents/AGENTS.md: soft note to check satellite config before any GitHub write; board conventions pointer to hypha-context
- .agents/skills/hypha-task-init/SKILL.md: Step 3 now gated on github.enabled — reads the linked issue and offers to create + add to board #14 if none exists (ask before any write)

Part of #2299 (AI-augmented dev workflow).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Optional GitHub integration for reading and updating issues, pull requests, and project board (requires developer opt-in configuration).

* **Documentation**
  * Added configuration guides and skill documentation for GitHub integration setup and usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->