### PR TITLE
fix(banking): GET error → error state; guard against re-onboarding

### DIFF
--- a/apps/web/src/app/api/v1/spaces/[spaceSlug]/banking/bank-customers/route.ts
+++ b/apps/web/src/app/api/v1/spaces/[spaceSlug]/banking/bank-customers/route.ts
@@ -35,6 +35,9 @@ export async function GET(
     const status = await getSpaceBankCustomerPublicStatus(authResult.space, {
       db,
     });
+    if (status === null) {
+      return NextResponse.json(null, { status: 404 });
+    }
     return NextResponse.json(status, {
       headers: { 'Cache-Control': 'private, no-store' },
     });

--- a/apps/web/src/app/api/v1/spaces/[spaceSlug]/banking/bank-customers/route.ts
+++ b/apps/web/src/app/api/v1/spaces/[spaceSlug]/banking/bank-customers/route.ts
@@ -36,7 +36,10 @@ export async function GET(
       db,
     });
     if (status === null) {
-      return NextResponse.json(null, { status: 404 });
+      return NextResponse.json(null, {
+        status: 404,
+        headers: { 'Cache-Control': 'private, no-store' },
+      });
     }
     return NextResponse.json(status, {
       headers: { 'Cache-Control': 'private, no-store' },

--- a/packages/core/src/banking/server/request-space-bank-onboarding.ts
+++ b/packages/core/src/banking/server/request-space-bank-onboarding.ts
@@ -13,7 +13,6 @@ import { insertBankCustomer } from './mutations';
 import { getBankKycProvider } from './providers';
 import type { BankKycProvider } from './providers/types';
 import { currenciesToEndorsements } from '../constants';
-import { buildPublicStatusFromCustomer } from './get-space-bank-customer-public-status';
 import { buildCustomerValidations } from './providers/bridge/banking-provider-state';
 import { findBankCustomerBySpaceAndProvider } from './queries';
 
@@ -60,15 +59,17 @@ export async function requestSpaceBankOnboarding(
   );
 
   if (existing) {
-    const status = await buildPublicStatusFromCustomer(existing, { db });
     return {
       provider: DEFAULT_BANK_PROVIDER,
       created: false,
       spaceTitle: emailMeta.spaceTitle,
       requesterSlug: emailMeta.requesterSlug,
-      kycLink: status.procedures.kyc.action?.url ?? null,
-      tosLink: status.procedures.tos.action?.url ?? null,
-      procedures: status.procedures,
+      kycLink: null,
+      tosLink: null,
+      procedures: {
+        tos: { key: 'tos', status: null, isComplete: false },
+        kyc: { key: 'kyc', status: null, isComplete: false },
+      },
     };
   }
 

--- a/packages/epics/src/banking/components/banking-section.tsx
+++ b/packages/epics/src/banking/components/banking-section.tsx
@@ -11,6 +11,7 @@ import {
 import { canConvertToBigInt } from '@hypha-platform/ui-utils';
 import { useAuthentication } from '@hypha-platform/authentication';
 
+import { Empty } from '../../common';
 import { useSpaceMember } from '../../spaces';
 import {
   useBankCustomerStatus,
@@ -57,6 +58,7 @@ export const BankingSection: FC<BankingSectionProps> = ({
   const { person } = useMe();
   const {
     status,
+    isError: isStatusError,
     isLoading: isStatusLoading,
     isRefreshing: isStatusRefreshing,
     refresh,
@@ -247,6 +249,14 @@ export const BankingSection: FC<BankingSectionProps> = ({
 
   if (isStatusLoading) {
     return <BankingPageSkeleton />;
+  }
+
+  if (isStatusError) {
+    return (
+      <Empty>
+        <p>{t('errorFetchStatus')}</p>
+      </Empty>
+    );
   }
 
   if (!hasCustomer) {

--- a/packages/epics/src/banking/hooks/use-bank-customer-status.ts
+++ b/packages/epics/src/banking/hooks/use-bank-customer-status.ts
@@ -16,6 +16,8 @@ type UseBankCustomerStatusOptions = {
 
 type UseBankCustomerStatusReturn = {
   status: BankCustomerPublicStatus | null;
+  /** True when the GET returned a non-404 error (customer row exists but fetch failed). */
+  isError: boolean;
   /** True only on the first status fetch (not background revalidation). */
   isLoading: boolean;
   isRefreshing: boolean;
@@ -37,11 +39,12 @@ async function fetchBankCustomerStatus(
     },
   });
 
-  if (!res.ok) {
-    console.warn(
-      `[banking] bank-customers GET returned ${res.status}; treating as no customer`,
-    );
+  if (res.status === 404) {
     return null;
+  }
+
+  if (!res.ok) {
+    throw new Error(`bank-customers GET failed with status ${res.status}`);
   }
 
   const body = (await res.json()) as BankCustomerPublicStatus | null;
@@ -68,7 +71,7 @@ export const useBankCustomerStatus = ({
     [endpoint, isAuthenticated],
   );
 
-  const { data, isLoading, isValidating, mutate } =
+  const { data, error, isLoading, isValidating, mutate } =
     useSWR<BankCustomerPublicStatus | null>(
       swrKey,
       ([url]: [string, string]) => fetchBankCustomerStatus(url, getAccessToken),
@@ -83,6 +86,7 @@ export const useBankCustomerStatus = ({
 
   return {
     status: data ?? null,
+    isError: error != null,
     isLoading: isAuthenticated && isLoading,
     isRefreshing: isAuthenticated && isValidating && !isLoading,
     refresh,

--- a/packages/epics/src/banking/hooks/use-bank-customer-status.ts
+++ b/packages/epics/src/banking/hooks/use-bank-customer-status.ts
@@ -82,7 +82,13 @@ export const useBankCustomerStatus = ({
       },
     );
 
-  const refresh = React.useCallback(() => mutate(), [mutate]);
+  const refresh = React.useCallback(async () => {
+    try {
+      return await mutate();
+    } catch {
+      return undefined;
+    }
+  }, [mutate]);
 
   return {
     status: data ?? null,

--- a/packages/i18n/src/messages/de.json
+++ b/packages/i18n/src/messages/de.json
@@ -596,6 +596,7 @@
     "loading": "Bankkontostatus wird geladen…",
     "returnBanner": "Willkommen zurück — wir prüfen Ihren Verifizierungsstatus.",
     "errorLoad": "Bankkontostatus konnte nicht geladen werden.",
+    "errorFetchStatus": "Beim Abrufen Ihrer Bankinformationen ist ein Problem aufgetreten. Bitte versuchen Sie es später erneut.",
     "notStarted": {
       "description": "Banking ist für diesen Space noch nicht eingerichtet.",
       "enableCta": "Weiter"

--- a/packages/i18n/src/messages/en.json
+++ b/packages/i18n/src/messages/en.json
@@ -597,6 +597,7 @@
     "returnBannerDismiss": "Dismiss",
     "returnBannerApprovedHint": "Verification is complete. Open a space account to add any remaining currencies.",
     "errorLoad": "Could not load bank account status.",
+    "errorFetchStatus": "There was an issue retrieving your banking information. Please try again later.",
     "sections": {
       "transfers": {
         "title": "One-time Bank Transfers",

--- a/packages/i18n/src/messages/es.json
+++ b/packages/i18n/src/messages/es.json
@@ -2866,6 +2866,7 @@
     "returnBannerDismiss": "Descartar",
     "returnBannerApprovedHint": "La verificación está completa. Abra una cuenta del space para añadir las monedas restantes.",
     "errorLoad": "No se pudo cargar el estado de la cuenta bancaria.",
+    "errorFetchStatus": "Hubo un problema al recuperar su información bancaria. Por favor, inténtelo de nuevo más tarde.",
     "sections": {
       "transfers": {
         "title": "Transferencias bancarias únicas",

--- a/packages/i18n/src/messages/fr.json
+++ b/packages/i18n/src/messages/fr.json
@@ -2862,6 +2862,7 @@
     "returnBannerDismiss": "Fermer",
     "returnBannerApprovedHint": "La vérification est terminée. Ouvrez un compte space pour ajouter les devises restantes.",
     "errorLoad": "Impossible de charger le statut du compte bancaire.",
+    "errorFetchStatus": "Un problème est survenu lors de la récupération de vos informations bancaires. Veuillez réessayer plus tard.",
     "sections": {
       "transfers": {
         "title": "Virements bancaires ponctuels",

--- a/packages/i18n/src/messages/pt.json
+++ b/packages/i18n/src/messages/pt.json
@@ -2864,6 +2864,7 @@
     "returnBannerDismiss": "Dispensar",
     "returnBannerApprovedHint": "A verificação está concluída. Abra uma conta do space para adicionar as moedas restantes.",
     "errorLoad": "Não foi possível carregar o status da conta bancária.",
+    "errorFetchStatus": "Houve um problema ao recuperar suas informações bancárias. Por favor, tente novamente mais tarde.",
     "sections": {
       "transfers": {
         "title": "Transferências bancárias únicas",


### PR DESCRIPTION
Closes: #2332 

- bank-customers GET route returns 404 when no DB row exists (was 200 + null)
- use-bank-customer-status: 404 → no customer (setup flow); other errors throw so SWR sets isError; expose isError: boolean in return type
- banking-section: render <Empty> error state when isError, before the !hasCustomer setup flow check; add errorFetchStatus i18n key (5 locales)
- requestSpaceBankOnboarding: return created: false immediately when a bank_customers row already exists — no buildPublicStatusFromCustomer call, no Bridge API calls from the guard path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Error state display when banking information retrieval fails
  
* **Bug Fixes**
  * Improved handling of missing bank customer data
  
* **Localization**
  * Added error messaging in English, Spanish, German, French, and Portuguese

<!-- end of auto-generated comment: release notes by coderabbit.ai -->