### PR TITLE
fix(banking): on-ramp UX polish — tab count, skeleton, request button, status cleanup (#2328)

### DIFF
--- a/apps/web/src/app/[lang]/dho/[id]/_components/treasury-tabs.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/treasury-tabs.tsx
@@ -11,6 +11,7 @@ import {
   useBankCustomerStatus,
   useTransfers,
   useVaults,
+  useVirtualAccounts,
 } from '@hypha-platform/epics';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@hypha-platform/ui';
 import { useFormatter, useTranslations } from 'next-intl';
@@ -43,16 +44,14 @@ export function TreasuryTabs({
   const { transfers } = useTransfers({ spaceSlug });
   const { vaults } = useVaults({ spaceSlug });
   const { status: bankCustomerStatus } = useBankCustomerStatus({ spaceSlug });
+  const { accounts: virtualAccounts } = useVirtualAccounts({
+    spaceSlug,
+    enabled: Boolean(bankCustomerStatus),
+  });
   const walletCount = assets.filter((asset) => asset.value > 0).length;
   const transactionCount = transfers.length;
   const vaultCount = vaults.length;
-  // Count currencies usable for banking (approved/active) — derived from the
-  // already-loaded status; counting actual virtual accounts would need an
-  // extra Bridge list call just to render this badge.
-  const supportedCurrencyCount =
-    bankCustomerStatus?.currencyStatuses?.filter(
-      (currency) => currency.isApproved,
-    ).length ?? 0;
+  const bankAccountCount = virtualAccounts.length;
 
   return (
     <div className="flex w-full flex-col gap-4 py-4">
@@ -92,7 +91,7 @@ export function TreasuryTabs({
               <span className="inline-flex items-center gap-1">
                 <span>{tTreasury('bankAccounts')}</span>
                 <span className="text-xs text-muted-foreground">
-                  ({format.number(supportedCurrencyCount)})
+                  ({format.number(bankAccountCount)})
                 </span>
               </span>
             </TabsTrigger>

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "dev": "turbo run dev",
+    "dev:web": "turbo run dev --filter=web --filter=@hypha-platform/ui-utils",
     "build": "turbo run build",
     "start": "turbo run start",
     "migrate": "turbo run migrate",

--- a/packages/core/src/banking/server/bridge-customer-endorsements.ts
+++ b/packages/core/src/banking/server/bridge-customer-endorsements.ts
@@ -39,6 +39,33 @@ export function parseBridgeCustomerEndorsements(
   return map;
 }
 
+/**
+ * Returns the set of endorsement names that Bridge has effectively rejected:
+ * incomplete status + no pending requirements + at least one blocking issue.
+ * This matches Bridge's own "Rejected" display on their dashboard.
+ */
+export function parseBridgeEndorsementRejections(
+  endorsements: BridgeCustomerEndorsement[] | undefined,
+): Set<string> {
+  const rejected = new Set<string>();
+  for (const entry of endorsements ?? []) {
+    if (typeof entry.name !== 'string' || entry.status !== 'incomplete') {
+      continue;
+    }
+    const pending = entry.requirements?.pending;
+    const issues = entry.requirements?.issues;
+    if (
+      Array.isArray(pending) &&
+      pending.length === 0 &&
+      Array.isArray(issues) &&
+      issues.length > 0
+    ) {
+      rejected.add(entry.name);
+    }
+  }
+  return rejected;
+}
+
 export type CustomerMissingFlags = {
   sofMissing: boolean;
   pendingUbos: BankPendingUbo[];

--- a/packages/core/src/banking/server/create-space-bank-payout-account.ts
+++ b/packages/core/src/banking/server/create-space-bank-payout-account.ts
@@ -19,10 +19,8 @@ import {
   laPairKey,
   loadBankingProviderState,
   resolveCustomerApproved,
-  syncProviderCustomerIdFromKycLink,
 } from './providers/bridge/banking-provider-state';
 import { mapBridgePayoutAccountToPublic } from './map-bridge-resources';
-import { updateBankCustomer } from './mutations';
 
 export type CreateSpaceBankPayoutAccountOptions = {
   kycProvider?: BankKycProvider;
@@ -73,16 +71,7 @@ export async function createSpaceBankPayoutAccount(
     );
   }
 
-  let customerId = customer.providerCustomerId;
-  if (!customerId) {
-    customerId = await syncProviderCustomerIdFromKycLink(customer);
-    if (customerId) {
-      await updateBankCustomer(
-        { id: customer.id, providerCustomerId: customerId },
-        { db },
-      );
-    }
-  }
+  const customerId = customer.providerCustomerId;
 
   if (!customerId) {
     throw new BankOnboardingError(

--- a/packages/core/src/banking/server/create-space-bank-virtual-account.ts
+++ b/packages/core/src/banking/server/create-space-bank-virtual-account.ts
@@ -19,7 +19,6 @@ import {
   buildRailStatuses,
   loadBankingProviderState,
   resolveCustomerApproved,
-  syncProviderCustomerIdFromKycLink,
   vaPairKey,
 } from './providers/bridge/banking-provider-state';
 import {
@@ -27,7 +26,6 @@ import {
   isBridgeEndorsementApproved,
 } from './bridge-customer-endorsements';
 import { mapBridgeVirtualAccountToPublic } from './map-bridge-resources';
-import { updateBankCustomer } from './mutations';
 import { requireSpaceTreasuryAddress } from './require-space-treasury-address';
 
 export type CreateSpaceBankVirtualAccountOptions = {
@@ -94,16 +92,7 @@ export async function createSpaceBankVirtualAccount(
     );
   }
 
-  let customerId = customer.providerCustomerId;
-  if (!customerId) {
-    customerId = await syncProviderCustomerIdFromKycLink(customer);
-    if (customerId) {
-      await updateBankCustomer(
-        { id: customer.id, providerCustomerId: customerId },
-        { db },
-      );
-    }
-  }
+  const customerId = customer.providerCustomerId;
 
   if (!customerId) {
     throw new BankOnboardingError(

--- a/packages/core/src/banking/server/execute-bridge-bank-transfer.ts
+++ b/packages/core/src/banking/server/execute-bridge-bank-transfer.ts
@@ -13,11 +13,7 @@ import { getBankKycProvider } from './providers';
 import type { BankKycProvider } from './providers/types';
 import { enrichBridgeDepositInstructions } from './enrich-bridge-deposit-instructions';
 import { requireSpaceTreasuryAddress } from './require-space-treasury-address';
-import {
-  resolveCustomerApproved,
-  syncProviderCustomerIdFromKycLink,
-} from './providers/bridge/banking-provider-state';
-import { updateBankCustomer } from './mutations';
+import { resolveCustomerApproved } from './providers/bridge/banking-provider-state';
 
 function mapBridgeTransferError(error: unknown): BankOnboardingError | null {
   if (!(error instanceof Error)) {
@@ -100,16 +96,7 @@ export async function executeBridgeBankTransfer(
     );
   }
 
-  let customerId = customer.providerCustomerId;
-  if (!customerId) {
-    customerId = await syncProviderCustomerIdFromKycLink(customer);
-    if (customerId) {
-      await updateBankCustomer(
-        { id: customer.id, providerCustomerId: customerId },
-        { db },
-      );
-    }
-  }
+  const customerId = customer.providerCustomerId;
 
   if (!customerId) {
     throw new BankOnboardingError(

--- a/packages/core/src/banking/server/get-space-bank-customer-public-status.ts
+++ b/packages/core/src/banking/server/get-space-bank-customer-public-status.ts
@@ -17,12 +17,10 @@ import {
   buildRailStatuses,
   loadBankingProviderState,
   resolveCustomerApproved,
-  syncProviderCustomerIdFromKycLink,
 } from './providers/bridge/banking-provider-state';
 import { buildBridgeSofUrl } from './providers/bridge/kyc-link-urls';
 import { extractCustomerMissingFlags } from './bridge-customer-endorsements';
 import { findBankCustomerBySpaceAndProvider } from './queries';
-import { updateBankCustomer } from './mutations';
 
 export type BankVerificationProcedurePublic = BankValidationRequirement;
 
@@ -92,17 +90,6 @@ export async function buildPublicStatusFromCustomer(
   customer: BankCustomer,
   { db }: { db: DatabaseInstance },
 ): Promise<SpaceBankCustomerPublicStatus> {
-  const providerCustomerId = await syncProviderCustomerIdFromKycLink(customer);
-  if (
-    providerCustomerId &&
-    providerCustomerId !== customer.providerCustomerId
-  ) {
-    customer = await updateBankCustomer(
-      { id: customer.id, providerCustomerId },
-      { db },
-    );
-  }
-
   const state = await loadBankingProviderState(customer);
   const validations = buildCustomerValidations(state.kycLink);
   const railStatuses = buildRailStatuses({ customer, state });

--- a/packages/core/src/banking/server/get-space-bank-customer-public-status.ts
+++ b/packages/core/src/banking/server/get-space-bank-customer-public-status.ts
@@ -61,9 +61,7 @@ function mapCurrencyStatuses(
       endorsement: entry.endorsement,
       endorsementStatus: entry.endorsementStatus,
       virtualAccountId: primary.hasVirtualAccount ? primary.railKey : null,
-      isApproved:
-        entry.operationalStatus === 'approved' ||
-        entry.operationalStatus === 'active',
+      isApproved: entry.operationalStatus === 'approved',
       operationalStatus: entry.operationalStatus,
       validation: entry.validation,
     };

--- a/packages/core/src/banking/server/get-space-bank-payout-accounts.ts
+++ b/packages/core/src/banking/server/get-space-bank-payout-accounts.ts
@@ -11,7 +11,6 @@ import type {
 } from '../types';
 import { findBankCustomerBySpaceAndProvider } from './queries';
 import { mapBridgePayoutAccountToPublic } from './map-bridge-resources';
-import { syncProviderCustomerIdFromKycLink } from './providers/bridge/banking-provider-state';
 
 export async function getSpaceBankPayoutAccounts(
   space: Pick<Space, 'id'>,
@@ -27,9 +26,7 @@ export async function getSpaceBankPayoutAccounts(
     return { accounts: [], hasMore: false, nextCursor: null };
   }
 
-  const customerId =
-    customer.providerCustomerId ??
-    (await syncProviderCustomerIdFromKycLink(customer));
+  const customerId = customer.providerCustomerId;
 
   if (!customerId) {
     return { accounts: [], hasMore: false, nextCursor: null };

--- a/packages/core/src/banking/server/get-space-bank-transfers.ts
+++ b/packages/core/src/banking/server/get-space-bank-transfers.ts
@@ -9,7 +9,6 @@ import {
   bridgeTransferTargetsSpace,
   mapBridgeTransferToPublic,
 } from './map-bridge-resources';
-import { syncProviderCustomerIdFromKycLink } from './providers/bridge/banking-provider-state';
 
 export async function getSpaceBankTransfers(
   space: Pick<Space, 'id' | 'web3SpaceId'>,
@@ -25,10 +24,7 @@ export async function getSpaceBankTransfers(
     return { transfers: [], hasMore: false, nextCursor: null };
   }
 
-  const customerIdFromKycLink = customer.providerCustomerId
-    ? null
-    : await syncProviderCustomerIdFromKycLink(customer);
-  const customerId = customer.providerCustomerId ?? customerIdFromKycLink;
+  const customerId = customer.providerCustomerId;
 
   if (!customerId) {
     return { transfers: [], hasMore: false, nextCursor: null };

--- a/packages/core/src/banking/server/get-space-bank-virtual-accounts.ts
+++ b/packages/core/src/banking/server/get-space-bank-virtual-accounts.ts
@@ -12,7 +12,6 @@ import {
   bridgeVirtualAccountTargetsSpace,
   mapBridgeVirtualAccountToPublic,
 } from './map-bridge-resources';
-import { syncProviderCustomerIdFromKycLink } from './providers/bridge/banking-provider-state';
 
 export async function getSpaceBankVirtualAccounts(
   space: Pick<Space, 'id' | 'web3SpaceId'>,
@@ -28,9 +27,7 @@ export async function getSpaceBankVirtualAccounts(
     return { accounts: [], hasMore: false, nextCursor: null };
   }
 
-  const customerId =
-    customer.providerCustomerId ??
-    (await syncProviderCustomerIdFromKycLink(customer));
+  const customerId = customer.providerCustomerId;
 
   if (!customerId) {
     return { accounts: [], hasMore: false, nextCursor: null };

--- a/packages/core/src/banking/server/providers/bridge/banking-provider-state.ts
+++ b/packages/core/src/banking/server/providers/bridge/banking-provider-state.ts
@@ -201,14 +201,9 @@ export function buildCustomerValidations(
 
 function resolveRailOperationalStatus(input: {
   endorsementStatus: string | null;
-  hasVirtualAccount: boolean;
   enabled: boolean;
   isRejected?: boolean;
 }): BankRailOperationalStatus {
-  if (input.hasVirtualAccount) {
-    return 'approved';
-  }
-
   if (!input.enabled) {
     return 'not_requested';
   }
@@ -265,7 +260,6 @@ export function buildRailStatuses(input: {
 
     const operationalStatus = resolveRailOperationalStatus({
       endorsementStatus,
-      hasVirtualAccount,
       enabled,
       isRejected: rejectedEndorsements.has(endorsement),
     });
@@ -316,7 +310,6 @@ export function buildRailStatuses(input: {
     const enabled = enabledSet.has(corridor.currency.toLowerCase());
     const operationalStatus = resolveRailOperationalStatus({
       endorsementStatus,
-      hasVirtualAccount: false,
       enabled,
       isRejected: rejectedEndorsements.has(endorsement),
     });

--- a/packages/core/src/banking/server/providers/bridge/banking-provider-state.ts
+++ b/packages/core/src/banking/server/providers/bridge/banking-provider-state.ts
@@ -343,10 +343,3 @@ export async function resolveCustomerApproved(
   const live = await fetchBridgeKycLinkLive(customer);
   return Boolean(live?.isKycApproved && live?.isTosApproved);
 }
-
-export async function syncProviderCustomerIdFromKycLink(
-  customer: BankCustomer,
-): Promise<string | null> {
-  const live = await fetchBridgeKycLinkLive(customer);
-  return live?.providerCustomerId ?? customer.providerCustomerId ?? null;
-}

--- a/packages/core/src/banking/server/providers/bridge/banking-provider-state.ts
+++ b/packages/core/src/banking/server/providers/bridge/banking-provider-state.ts
@@ -22,6 +22,7 @@ import { BRIDGE_DEFAULT_DESTINATION_CURRENCY } from '../../../bridge-destination
 import {
   isBridgeEndorsementApproved,
   parseBridgeCustomerEndorsements,
+  parseBridgeEndorsementRejections,
 } from '../../bridge-customer-endorsements';
 import {
   fetchBridgeKycLinkLive,
@@ -202,9 +203,10 @@ function resolveRailOperationalStatus(input: {
   endorsementStatus: string | null;
   hasVirtualAccount: boolean;
   enabled: boolean;
+  isRejected?: boolean;
 }): BankRailOperationalStatus {
   if (input.hasVirtualAccount) {
-    return 'active';
+    return 'approved';
   }
 
   if (!input.enabled) {
@@ -213,6 +215,10 @@ function resolveRailOperationalStatus(input: {
 
   if (isBridgeEndorsementApproved(input.endorsementStatus)) {
     return 'approved';
+  }
+
+  if (input.isRejected) {
+    return 'rejected';
   }
 
   if (
@@ -236,6 +242,9 @@ export function buildRailStatuses(input: {
   const endorsementMap = input.state.customer
     ? parseBridgeCustomerEndorsements(input.state.customer.endorsements)
     : new Map<string, string>();
+  const rejectedEndorsements = input.state.customer
+    ? parseBridgeEndorsementRejections(input.state.customer.endorsements)
+    : new Set<string>();
 
   const validations = buildCustomerValidations(input.state.kycLink);
   const enabledSet = new Set(
@@ -258,6 +267,7 @@ export function buildRailStatuses(input: {
       endorsementStatus,
       hasVirtualAccount,
       enabled,
+      isRejected: rejectedEndorsements.has(endorsement),
     });
 
     const needsAction =
@@ -274,8 +284,7 @@ export function buildRailStatuses(input: {
       validation: {
         key: endorsement,
         status: endorsementStatus,
-        isComplete:
-          operationalStatus === 'active' || operationalStatus === 'approved',
+        isComplete: operationalStatus === 'approved',
         action:
           needsAction && validations.kyc.action
             ? validations.kyc.action
@@ -309,7 +318,11 @@ export function buildRailStatuses(input: {
       endorsementStatus,
       hasVirtualAccount: false,
       enabled,
+      isRejected: rejectedEndorsements.has(endorsement),
     });
+
+    const corridorNeedsAction =
+      operationalStatus === 'not_approved' || operationalStatus === 'pending';
 
     rails.push({
       railKey: corridorKey,
@@ -323,13 +336,8 @@ export function buildRailStatuses(input: {
         key: corridorKey,
         status: endorsementStatus,
         isComplete: operationalStatus === 'approved',
-        action:
-          operationalStatus === 'not_approved' ||
-          operationalStatus === 'pending'
-            ? validations.kyc.action
-            : undefined,
-        linkDisabled:
-          operationalStatus === 'active' || operationalStatus === 'approved',
+        action: corridorNeedsAction ? validations.kyc.action : undefined,
+        linkDisabled: !corridorNeedsAction,
       },
     });
   }

--- a/packages/core/src/banking/server/request-bridge-endorsement-kyc-link.ts
+++ b/packages/core/src/banking/server/request-bridge-endorsement-kyc-link.ts
@@ -9,7 +9,6 @@ import { BankOnboardingError } from './errors';
 import { mapBridgeApiError } from './map-bridge-api-error';
 import { parseBridgeEndorsements } from './providers/bridge/endorsements';
 import { updateBankCustomer } from './mutations';
-import { syncProviderCustomerIdFromKycLink } from './providers/bridge/banking-provider-state';
 import { resolveBridgeCustomerEmail } from './resolve-bridge-customer-email';
 
 export type RequestBridgeEndorsementKycLinkResult = {
@@ -27,10 +26,7 @@ export async function requestBridgeEndorsementKycLink(
     throw new BankOnboardingError('Unsupported endorsement', 400);
   }
 
-  let providerCustomerId = customer.providerCustomerId;
-  if (!providerCustomerId) {
-    providerCustomerId = await syncProviderCustomerIdFromKycLink(customer);
-  }
+  const providerCustomerId = customer.providerCustomerId;
 
   if (!providerCustomerId) {
     throw new BankOnboardingError(

--- a/packages/core/src/banking/server/resolve-bridge-customer-email.ts
+++ b/packages/core/src/banking/server/resolve-bridge-customer-email.ts
@@ -7,7 +7,6 @@ import {
 import type { BankCustomer } from '@hypha-platform/storage-postgres';
 
 import { BankOnboardingError } from './errors';
-import { syncProviderCustomerIdFromKycLink } from './providers/bridge/banking-provider-state';
 
 function readEmailFromRecord(value: unknown): string | null {
   if (typeof value !== 'object' || value === null) {
@@ -33,12 +32,7 @@ export async function resolveBridgeCustomerEmail(
     return fromLink;
   }
 
-  let customerId = customer.providerCustomerId ?? kycLink.customer_id ?? null;
-  if (!customerId) {
-    customerId = await syncProviderCustomerIdFromKycLink(
-      customer as BankCustomer,
-    );
-  }
+  const customerId = customer.providerCustomerId ?? kycLink.customer_id ?? null;
 
   if (customerId) {
     const bridgeCustomer = await bridgeGetCustomer(customerId);

--- a/packages/core/src/banking/server/sync-space-banking-from-bridge.ts
+++ b/packages/core/src/banking/server/sync-space-banking-from-bridge.ts
@@ -5,8 +5,6 @@ import type { SyncSpaceBankingFromBridgeResult } from '../types';
 import { BankOnboardingError } from './errors';
 import { buildPublicStatusFromCustomer } from './get-space-bank-customer-public-status';
 import { findBankCustomerBySpaceAndProvider } from './queries';
-import { updateBankCustomer } from './mutations';
-import { syncProviderCustomerIdFromKycLink } from './providers/bridge/banking-provider-state';
 
 export async function syncSpaceBankingFromBridge(
   space: Pick<Space, 'id' | 'title'>,
@@ -21,18 +19,7 @@ export async function syncSpaceBankingFromBridge(
     throw new BankOnboardingError('Bank customer not found', 404);
   }
 
-  const providerCustomerId = await syncProviderCustomerIdFromKycLink(customer);
-  if (
-    providerCustomerId &&
-    providerCustomerId !== customer.providerCustomerId
-  ) {
-    await updateBankCustomer({ id: customer.id, providerCustomerId }, { db });
-  }
-
-  const status = await buildPublicStatusFromCustomer(
-    providerCustomerId ? { ...customer, providerCustomerId } : customer,
-    { db },
-  );
+  const status = await buildPublicStatusFromCustomer(customer, { db });
 
   return {
     isApproved: status.isApproved,

--- a/packages/core/src/banking/types.ts
+++ b/packages/core/src/banking/types.ts
@@ -28,9 +28,9 @@ export type BankValidationRequirement = {
 };
 
 export type BankRailOperationalStatus =
-  | 'active'
   | 'approved'
   | 'pending'
+  | 'rejected'
   | 'not_approved'
   | 'not_requested';
 

--- a/packages/core/src/common/server/bridge-client.ts
+++ b/packages/core/src/common/server/bridge-client.ts
@@ -454,6 +454,11 @@ export async function bridgeCreateKycLink(
     if (response.status === 400) {
       const existing = extractExistingKycLinkFromErrorBody(parsed);
       if (existing) {
+        if (!existing.customer_id) {
+          throw new Error(
+            'Bridge API returned existing_kyc_link with no customer_id',
+          );
+        }
         return existing;
       }
     }

--- a/packages/epics/src/banking/banking-ui.test.ts
+++ b/packages/epics/src/banking/banking-ui.test.ts
@@ -4,6 +4,8 @@ import { describe, expect, it, vi } from 'vitest';
 // storage-postgres (needs a DB URL). Mock with the real rail/destination values
 // so this stays a pure unit test of the per-pair filtering.
 vi.mock('@hypha-platform/core/client', () => ({
+  BANK_VIRTUAL_ACCOUNT_CURRENCIES: ['eur', 'usd', 'gbp', 'mxn', 'brl', 'cop'],
+  BANK_PAYOUT_RAILS: {},
   getDestinationCurrenciesForSourceRail: (rail: string) =>
     rail === 'sepa' || rail === 'spei' ? ['usdc', 'eurc'] : ['usdc'],
   getDefaultDestinationCurrency: ({
@@ -78,7 +80,7 @@ describe('getAvailableAddAccountRailOptions (per-(currency,destination) dedup)',
       rail({
         currency: 'eur',
         paymentRail: 'sepa',
-        operationalStatus: 'active',
+        operationalStatus: 'approved',
         hasVirtualAccount: true,
       }),
     ]);
@@ -98,7 +100,7 @@ describe('getAvailableAddAccountRailOptions (per-(currency,destination) dedup)',
       rail({
         currency: 'eur',
         paymentRail: 'sepa',
-        operationalStatus: 'active',
+        operationalStatus: 'approved',
         hasVirtualAccount: true,
       }),
     ]);
@@ -117,7 +119,7 @@ describe('getAvailableAddAccountRailOptions (per-(currency,destination) dedup)',
         currency: 'usd',
         paymentRail: 'ach',
         endorsement: 'base',
-        operationalStatus: 'active',
+        operationalStatus: 'approved',
         hasVirtualAccount: true,
       }),
     ]);

--- a/packages/epics/src/banking/banking-ui.ts
+++ b/packages/epics/src/banking/banking-ui.ts
@@ -148,9 +148,7 @@ export function hasApprovedBankCurrencies(
   }
 
   return getBankEndorsementStatusesForPanel(status).some(
-    (entry) =>
-      entry.operationalStatus === 'approved' ||
-      entry.operationalStatus === 'active',
+    (entry) => entry.operationalStatus === 'approved',
   );
 }
 
@@ -355,7 +353,7 @@ export function getEnabledDepositCurrencies(): readonly string[] {
 export function isBankRailSelectable(
   status: BankCustomerPublicStatus['railStatuses'][number]['operationalStatus'],
 ): boolean {
-  return status === 'approved' || status === 'active';
+  return status === 'approved';
 }
 
 export function bankRailNeedsEndorsementRequest(

--- a/packages/epics/src/banking/components/add-bank-currency-dialog.tsx
+++ b/packages/epics/src/banking/components/add-bank-currency-dialog.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { FC, useCallback, useEffect, useMemo, useState } from 'react';
+import { FC, useEffect, useMemo, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import {
   Dialog,
@@ -16,7 +16,6 @@ import {
   getAvailableAddAccountRailOptions,
   isBankRailSelectable,
 } from '../banking-ui';
-import { useRequestEndorsementKyc } from '../hooks/use-request-endorsement-kyc';
 import type {
   BankCustomerPublicStatus,
   BankVirtualAccountPublic,
@@ -41,7 +40,6 @@ type AddBankCurrencyDialogProps = {
   submittingCurrency: BankCurrencyCode | null;
   error: string | null;
   onOpenGear: () => void;
-  onRefreshStatus?: () => Promise<unknown>;
   onAddCurrency: (input: {
     currency: BankCurrencyCode;
     destinationCurrency?: string;
@@ -57,13 +55,10 @@ export const AddBankCurrencyDialog: FC<AddBankCurrencyDialogProps> = ({
   submittingCurrency,
   error,
   onOpenGear,
-  onRefreshStatus,
   onAddCurrency,
 }) => {
   const t = useTranslations('BankingTab.openAccount');
   const tOp = useTranslations('BankingTab.operationStatus');
-  const { requestEndorsementKyc, isLoading: isRequestingEndorsement } =
-    useRequestEndorsementKyc(spaceSlug);
 
   const options = useMemo(
     () =>
@@ -111,17 +106,6 @@ export const AddBankCurrencyDialog: FC<AddBankCurrencyDialogProps> = ({
     (option) => option.railKey === selectedId,
   );
   const isSubmitting = submittingCurrency != null;
-
-  const handleRequestEndorsement = useCallback(
-    async (endorsement: string) => {
-      const { kycLinkUrl } = await requestEndorsementKyc(endorsement);
-      window.open(kycLinkUrl, '_blank', 'noopener,noreferrer');
-      onOpenChange(false);
-      onOpenGear();
-      void onRefreshStatus?.();
-    },
-    [onOpenChange, onOpenGear, onRefreshStatus, requestEndorsementKyc],
-  );
 
   const handleAdd = async () => {
     if (
@@ -187,8 +171,6 @@ export const AddBankCurrencyDialog: FC<AddBankCurrencyDialogProps> = ({
                 onOpenChange(false);
                 onOpenGear();
               }}
-              requestEndorsementLoading={isRequestingEndorsement}
-              onRequestEndorsement={handleRequestEndorsement}
               disabled={isSubmitting}
             />
           )}

--- a/packages/epics/src/banking/components/bank-rail-action-picker.tsx
+++ b/packages/epics/src/banking/components/bank-rail-action-picker.tsx
@@ -10,10 +10,7 @@ import type {
   BankCurrencyCode,
   BankTransferCorridorKey,
 } from '../bank-currency-display';
-import {
-  bankRailNeedsEndorsementRequest,
-  isBankRailSelectable,
-} from '../banking-ui';
+import { isBankRailSelectable } from '../banking-ui';
 import type { BankCurrencyOperationalStatus } from '../hooks/types';
 import { BankDepositRailOptionRow } from './bank-deposit-rail-option-row';
 
@@ -39,12 +36,8 @@ type BankRailActionPickerProps = {
   primaryActionLoading?: boolean;
   primaryActionDisabled?: boolean;
   onPrimaryAction: () => void;
-  requestEndorsementLoading?: boolean;
-  onRequestEndorsement: (endorsement: string) => Promise<void>;
   disabled?: boolean;
   showPrimaryAction?: boolean;
-  /** Gear dialog uses compact; add-account / transfer dialogs match rail row height. */
-  endorsementActionSize?: 'row' | 'compact';
 };
 
 export const BankRailActionPicker: FC<BankRailActionPickerProps> = ({
@@ -59,11 +52,8 @@ export const BankRailActionPicker: FC<BankRailActionPickerProps> = ({
   primaryActionLoading = false,
   primaryActionDisabled = false,
   onPrimaryAction,
-  requestEndorsementLoading = false,
-  onRequestEndorsement,
   disabled = false,
   showPrimaryAction = true,
-  endorsementActionSize = 'row',
 }) => {
   const tOpenAccount = useTranslations('BankingTab.openAccount');
   const tCreateTransfer = useTranslations('BankingTab.createTransfer');
@@ -118,43 +108,16 @@ export const BankRailActionPicker: FC<BankRailActionPickerProps> = ({
               !isBankRailSelectable(option.operationalStatus);
 
             return (
-              <div key={option.id} className="flex items-stretch gap-2">
-                <div className="min-w-0 flex-1">
-                  <BankDepositRailOptionRow
-                    mode={mode}
-                    currency={option.currency}
-                    corridorKey={option.corridorKey}
-                    selected={selectedId === option.id}
-                    disabled={rowDisabled}
-                    radioName={radioName}
-                    onSelect={() => onSelectedIdChange(option.id)}
-                  />
-                </div>
-                {bankRailNeedsEndorsementRequest(option.operationalStatus) ? (
-                  <div className="flex shrink-0 items-stretch self-stretch">
-                    <Button
-                      type="button"
-                      size="sm"
-                      colorVariant="accent"
-                      className={
-                        endorsementActionSize === 'row'
-                          ? '!min-h-0 h-full shrink-0 rounded-lg px-3 py-0 text-2'
-                          : 'h-auto !min-h-0 shrink-0 px-2.5 py-1 text-1 leading-tight'
-                      }
-                      disabled={requestEndorsementLoading || disabled}
-                      onClick={() =>
-                        void onRequestEndorsement(option.endorsement)
-                      }
-                    >
-                      {requestEndorsementLoading ? (
-                        <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                      ) : (
-                        tOpenAccount('requestRail')
-                      )}
-                    </Button>
-                  </div>
-                ) : null}
-              </div>
+              <BankDepositRailOptionRow
+                key={option.id}
+                mode={mode}
+                currency={option.currency}
+                corridorKey={option.corridorKey}
+                selected={selectedId === option.id}
+                disabled={rowDisabled}
+                radioName={radioName}
+                onSelect={() => onSelectedIdChange(option.id)}
+              />
             );
           })}
         </div>

--- a/packages/epics/src/banking/components/banking-provider-status-panel.tsx
+++ b/packages/epics/src/banking/components/banking-provider-status-panel.tsx
@@ -250,19 +250,19 @@ function EndorsementValidationsList({
               <Badge
                 variant="outline"
                 colorVariant={
-                  entry.operationalStatus === 'active'
-                    ? 'success'
-                    : entry.operationalStatus === 'approved'
+                  entry.operationalStatus === 'approved'
                     ? 'accent'
+                    : entry.operationalStatus === 'rejected'
+                    ? 'destructive'
                     : 'neutral'
                 }
                 className="pointer-events-none cursor-default text-1 shadow-none"
               >
                 {tAdvanced(
                   `currencyStatus.${entry.operationalStatus}` as
-                    | 'currencyStatus.active'
                     | 'currencyStatus.approved'
                     | 'currencyStatus.pending'
+                    | 'currencyStatus.rejected'
                     | 'currencyStatus.not_approved'
                     | 'currencyStatus.not_requested',
                 )}

--- a/packages/epics/src/banking/components/banking-provider-status-panel.tsx
+++ b/packages/epics/src/banking/components/banking-provider-status-panel.tsx
@@ -253,7 +253,7 @@ function EndorsementValidationsList({
                   entry.operationalStatus === 'approved'
                     ? 'accent'
                     : entry.operationalStatus === 'rejected'
-                    ? 'destructive'
+                    ? 'error'
                     : 'neutral'
                 }
                 className="pointer-events-none cursor-default text-1 shadow-none"

--- a/packages/epics/src/banking/components/banking-section.tsx
+++ b/packages/epics/src/banking/components/banking-section.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { FC, useCallback, useEffect, useMemo, useState } from 'react';
+import { FC, useCallback, useMemo, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import {
   useIsDelegate,
@@ -185,19 +185,6 @@ export const BankingSection: FC<BankingSectionProps> = ({
     ? t('blockers.noTreasury')
     : null;
 
-  useEffect(() => {
-    if (showBankingListings) {
-      void refreshVirtualAccounts();
-      void refreshTransfers();
-      void refreshPayoutAccounts();
-    }
-  }, [
-    showBankingListings,
-    refreshPayoutAccounts,
-    refreshTransfers,
-    refreshVirtualAccounts,
-  ]);
-
   const verificationInProgress = isBankVerificationInProgress(status);
 
   const openVerificationGear = useCallback(() => {
@@ -211,10 +198,6 @@ export const BankingSection: FC<BankingSectionProps> = ({
   const fallbackContactEmail = person?.email?.trim() ?? '';
 
   const canAddAccount = hasAddAccountRailAvailable(status, virtualAccounts);
-
-  const isListsLoading =
-    showBankingListings &&
-    (virtualAccountsLoading || transfersLoading || payoutAccountsLoading);
 
   const openSpaceAccountDisabled = verificationInProgress || !canAddAccount;
   const openPayoutAccountDisabled = verificationInProgress;
@@ -298,10 +281,6 @@ export const BankingSection: FC<BankingSectionProps> = ({
     );
   }
 
-  if (isListsLoading) {
-    return <BankingPageSkeleton />;
-  }
-
   return (
     <div className="flex w-full flex-col gap-6">
       <BankAccountsSection
@@ -334,24 +313,21 @@ export const BankingSection: FC<BankingSectionProps> = ({
         openPayoutAccountDisabled={openPayoutAccountDisabled}
         openPayoutAccountDisabledReason={openPayoutAccountDisabledReason}
         payoutAccounts={payoutAccounts}
-        payoutAccountsLoading={false}
-        hideListLoadingState
+        payoutAccountsLoading={payoutAccountsLoading}
         depositsProps={{
           virtualAccounts,
-          virtualAccountsLoading: false,
+          virtualAccountsLoading,
           canManage,
-          hideLoadingState: true,
         }}
         transfersProps={{
           transfers,
-          transfersLoading: false,
+          transfersLoading,
           hasBankCustomer: true,
           canManage,
           newTransferDisabled: verificationInProgress,
           newTransferDisabledReason: verificationInProgress
             ? 'finishVerificationFirst'
             : null,
-          hideListLoadingState: true,
           onNewTransfer: () => {
             clearCreateTransferError();
             setCreateTransferOpen(true);
@@ -367,7 +343,6 @@ export const BankingSection: FC<BankingSectionProps> = ({
         isSubmitting={isCreatingTransfer}
         error={createTransferError}
         onOpenGear={openVerificationGear}
-        onRefreshStatus={refreshBankingState}
         onSubmit={async (input) => {
           try {
             await createTransfer(input);
@@ -392,7 +367,6 @@ export const BankingSection: FC<BankingSectionProps> = ({
         submittingCurrency={creatingCurrency}
         error={createAccountError}
         onOpenGear={openVerificationGear}
-        onRefreshStatus={refreshBankingState}
         onAddCurrency={async ({ currency, destinationCurrency }) => {
           clearCreateAccountError();
           try {

--- a/packages/epics/src/banking/components/create-transfer-dialog.tsx
+++ b/packages/epics/src/banking/components/create-transfer-dialog.tsx
@@ -1,13 +1,6 @@
 'use client';
 
-import {
-  FC,
-  FormEvent,
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-} from 'react';
+import { FC, FormEvent, useEffect, useMemo, useState } from 'react';
 import { Loader2 } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import {
@@ -31,7 +24,6 @@ import {
   isBankRailSelectable,
 } from '../banking-ui';
 import type { BankCustomerPublicStatus } from '../hooks/types';
-import { useRequestEndorsementKyc } from '../hooks/use-request-endorsement-kyc';
 import {
   BANKING_DIALOG_FOOTER_CLASS,
   BANKING_DIALOG_FORM_CONTENT_CLASS,
@@ -53,7 +45,6 @@ type CreateTransferDialogProps = {
   isSubmitting: boolean;
   error: string | null;
   onOpenGear: () => void;
-  onRefreshStatus?: () => Promise<unknown>;
   onSubmit: (input: {
     corridorKey: BankTransferCorridorKey;
     amount?: string;
@@ -70,12 +61,9 @@ export const CreateTransferDialog: FC<CreateTransferDialogProps> = ({
   isSubmitting,
   error,
   onOpenGear,
-  onRefreshStatus,
   onSubmit,
 }) => {
   const t = useTranslations('BankingTab.createTransfer');
-  const { requestEndorsementKyc, isLoading: isRequestingEndorsement } =
-    useRequestEndorsementKyc(spaceSlug);
 
   const options = useMemo(
     () => (status ? getTransferRailOptionsFromStatus(status) : []),
@@ -146,17 +134,6 @@ export const CreateTransferDialog: FC<CreateTransferDialogProps> = ({
     (option) => option.railKey === selectedId,
   );
 
-  const handleRequestEndorsement = useCallback(
-    async (endorsement: string) => {
-      const { kycLinkUrl } = await requestEndorsementKyc(endorsement);
-      window.open(kycLinkUrl, '_blank', 'noopener,noreferrer');
-      onOpenChange(false);
-      onOpenGear();
-      void onRefreshStatus?.();
-    },
-    [onOpenChange, onOpenGear, onRefreshStatus, requestEndorsementKyc],
-  );
-
   const handleSubmit = async (event: FormEvent) => {
     event.preventDefault();
     if (
@@ -217,8 +194,6 @@ export const CreateTransferDialog: FC<CreateTransferDialogProps> = ({
                 primaryActionLabel={t('submit')}
                 onPrimaryAction={() => {}}
                 showPrimaryAction={false}
-                requestEndorsementLoading={isRequestingEndorsement}
-                onRequestEndorsement={handleRequestEndorsement}
                 disabled={isSubmitting}
               />
             )}

--- a/packages/epics/src/banking/hooks/types.ts
+++ b/packages/epics/src/banking/hooks/types.ts
@@ -40,9 +40,9 @@ export type BankVerificationProcedurePublic = {
 };
 
 export type BankCurrencyOperationalStatus =
-  | 'active'
   | 'approved'
   | 'pending'
+  | 'rejected'
   | 'not_approved'
   | 'not_requested'
   | 'not_opened';

--- a/packages/i18n/src/messages/de.json
+++ b/packages/i18n/src/messages/de.json
@@ -893,9 +893,9 @@
       "currencyStatusesDescriptionAdd": "Unterstützung für einen Währungskorridor hinzufügen. Bridge kann für einige Regionen eine zusätzliche Verifizierung verlangen.",
       "addCurrencySupport": "{currency}-Konto eröffnen",
       "currencyStatus": {
-        "active": "Aktiv",
         "approved": "Genehmigt",
         "pending": "Verifizierung ausstehend",
+        "rejected": "Abgelehnt",
         "not_approved": "Nicht genehmigt",
         "not_requested": "Nicht angefordert",
         "not_opened": "Nicht eröffnet"

--- a/packages/i18n/src/messages/en.json
+++ b/packages/i18n/src/messages/en.json
@@ -817,9 +817,9 @@
       "currencyStatusesDescriptionAdd": "Add support for a currency rail. Bridge may require additional verification for some regions.",
       "addCurrencySupport": "Open {currency} account",
       "currencyStatus": {
-        "active": "Active",
         "approved": "Approved",
         "pending": "Pending verification",
+        "rejected": "Rejected",
         "not_approved": "Not approved",
         "not_requested": "Not requested",
         "not_opened": "Not opened"

--- a/packages/i18n/src/messages/es.json
+++ b/packages/i18n/src/messages/es.json
@@ -3086,9 +3086,9 @@
       "currencyStatusesDescriptionAdd": "Añada soporte para un corredor de moneda. Bridge puede requerir verificación adicional para algunas regiones.",
       "addCurrencySupport": "Abrir cuenta en {currency}",
       "currencyStatus": {
-        "active": "Activa",
         "approved": "Aprobada",
         "pending": "Verificación pendiente",
+        "rejected": "Rechazada",
         "not_approved": "No aprobada",
         "not_requested": "No solicitada",
         "not_opened": "No abierta"

--- a/packages/i18n/src/messages/fr.json
+++ b/packages/i18n/src/messages/fr.json
@@ -3082,9 +3082,9 @@
       "currencyStatusesDescriptionAdd": "Ajoutez la prise en charge d'un corridor de devise. Bridge peut exiger une vérification supplémentaire pour certaines régions.",
       "addCurrencySupport": "Ouvrir un compte {currency}",
       "currencyStatus": {
-        "active": "Actif",
         "approved": "Approuvé",
         "pending": "Vérification en attente",
+        "rejected": "Rejeté",
         "not_approved": "Non approuvé",
         "not_requested": "Non demandé",
         "not_opened": "Non ouvert"

--- a/packages/i18n/src/messages/pt.json
+++ b/packages/i18n/src/messages/pt.json
@@ -3084,9 +3084,9 @@
       "currencyStatusesDescriptionAdd": "Adicione suporte a um corredor de moeda. O Bridge pode exigir verificação adicional para algumas regiões.",
       "addCurrencySupport": "Abrir conta em {currency}",
       "currencyStatus": {
-        "active": "Ativa",
         "approved": "Aprovada",
         "pending": "Verificação pendente",
+        "rejected": "Rejeitada",
         "not_approved": "Não aprovada",
         "not_requested": "Não solicitada",
         "not_opened": "Não aberta"


### PR DESCRIPTION
Closes #2328

## Summary

Four on-ramp UX fixes after the banking flow shipped, plus two follow-up cleanups surfaced during implementation.

**Original scope (#2328):**
- **Tab count**: Treasury → Bank Accounts badge now counts provisioned virtual accounts (`useVirtualAccounts` hook, SWR-deduplicated) instead of approved endorsement rails
- **Skeleton/refresh**: Removed a `useEffect` double-fire in `banking-section.tsx` and the single `isListsLoading` gate that held the entire section behind `BankingPageSkeleton`; each list section now receives its own real loading state
- **Request button removed**: `BankRailActionPicker`, `AddBankCurrencyDialog`, and `CreateTransferDialog` — all request-endorsement wiring removed; Gear Dialog is the only request entry point
- **GET-that-writes cleanup**: `syncProviderCustomerIdFromKycLink` deleted; `bridgeCreateKycLink` throws on absent `customer_id`; all 9 downstream callers simplified to direct `customer.providerCustomerId`

**Follow-up cleanups (same PR):**
- **Remove `'active'` operationalStatus**: Was a redundant alias for `'approved'` — every logical check already dual-checked both. Gear Dialog no longer shows a distinct green "Active" badge; all approved rails show "Approved" (blue)
- **Add `'rejected'` status**: Detects Bridge-rejected endorsements (`incomplete` + empty `pending` + non-empty `issues`). Gear Dialog shows a red "Rejected" badge with no action link. Translations added for all 5 locales (en/es/fr/pt/de)

## Test plan

- [ ] Navigate to Treasury → Bank Accounts tab — badge count matches provisioned virtual accounts
- [ ] Open banking section — no full-section skeleton flash on first load or after account creation
- [ ] Open Add banking account / Add one-time transfer dialogs — confirm no "Request" button present
- [ ] Open Gear Dialog — USD/EUR both show "Approved" (no green "Active" badge for one and blue "Approved" for the other)
- [ ] For a space with a region-rejected endorsement (e.g. Kenya/`base`) — Gear Dialog shows red "Rejected" badge instead of "Pending verification"
- [ ] Network tab: banking status GET makes one Bridge KYC link call, not two

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Updated banking verification status labels to display "rejected" instead of "active" for clearer customer communication
  * Simplified endorsement request workflow in banking dialogs for improved UX
  * Enhanced virtual account management and badge counting
  * Updated currency status translations across all supported languages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->