### PR TITLE
feat(banking): rename Banking tab, rewrite copy, add transfer minimums (#2338)

### DIFF
--- a/apps/web/src/app/[lang]/dho/[id]/_components/treasury-tabs.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/treasury-tabs.tsx
@@ -71,6 +71,14 @@ export function TreasuryTabs({
                 </span>
               </span>
             </TabsTrigger>
+            <TabsTrigger value="bank-accounts" variant="switch">
+              <span className="inline-flex items-center gap-1">
+                <span>{tTreasury('bankingRoutes')}</span>
+                <span className="text-xs text-muted-foreground">
+                  ({format.number(bankAccountCount)})
+                </span>
+              </span>
+            </TabsTrigger>
             <TabsTrigger value="transactions" variant="switch">
               <span className="inline-flex items-center gap-1">
                 <span>{tTreasury('transactions')}</span>
@@ -87,19 +95,15 @@ export function TreasuryTabs({
                 </span>
               </span>
             </TabsTrigger>
-            <TabsTrigger value="bank-accounts" variant="switch">
-              <span className="inline-flex items-center gap-1">
-                <span>{tTreasury('bankAccounts')}</span>
-                <span className="text-xs text-muted-foreground">
-                  ({format.number(bankAccountCount)})
-                </span>
-              </span>
-            </TabsTrigger>
           </TabsList>
         </div>
 
         <TabsContent value="balance" className="mt-0">
           <AssetsSection basePath={basePath} web3SpaceId={web3SpaceId} />
+        </TabsContent>
+
+        <TabsContent value="bank-accounts" className="mt-0">
+          <BankingSection spaceSlug={spaceSlug} web3SpaceId={web3SpaceId} />
         </TabsContent>
 
         <TabsContent value="transactions" className="mt-0">
@@ -108,10 +112,6 @@ export function TreasuryTabs({
 
         <TabsContent value="vaults" className="mt-0">
           <VaultsSection />
-        </TabsContent>
-
-        <TabsContent value="bank-accounts" className="mt-0">
-          <BankingSection spaceSlug={spaceSlug} web3SpaceId={web3SpaceId} />
         </TabsContent>
       </Tabs>
     </div>

--- a/packages/epics/src/banking/banking-minimums.ts
+++ b/packages/epics/src/banking/banking-minimums.ts
@@ -1,0 +1,71 @@
+import type {
+  BankCurrencyCode,
+  BankTransferCorridorKey,
+} from './bank-currency-display';
+import { BANK_TRANSFER_CORRIDOR_METAS } from './bank-currency-display';
+import type { PayoutCurrencyKey } from './components/payout-currency-option-row';
+
+// ---- Deposit minimums ----
+
+// Canonical source: payment rail → minimum fiat amount for incoming bank transfers.
+export const DEPOSIT_RAIL_MINIMUMS: Record<string, string> = {
+  ach_push: '1 USD',
+  ach: '1 USD',
+  wire: '1 USD',
+  sepa: '1 EUR',
+  faster_payments: '2 GBP',
+  spei: '50 MXN',
+  pix: '10 BRL',
+  cop: '100 COP',
+};
+
+// Derived: one-time transfer corridor key → minimum (used when a specific corridor is selected).
+export const DEPOSIT_CORRIDOR_MINIMUMS: Record<
+  BankTransferCorridorKey,
+  string
+> = Object.fromEntries(
+  BANK_TRANSFER_CORRIDOR_METAS.map((m) => [
+    m.corridorKey,
+    DEPOSIT_RAIL_MINIMUMS[m.paymentRail] ?? '',
+  ]),
+) as Record<BankTransferCorridorKey, string>;
+
+// Derived: deposit currency → minimum (used when only the currency is known, not the corridor).
+// Takes the first corridor found per currency — all corridors for a currency share the same minimum.
+export const DEPOSIT_CURRENCY_MINIMUMS: Record<BankCurrencyCode, string> =
+  Object.fromEntries(
+    BANK_TRANSFER_CORRIDOR_METAS.filter(
+      (m, i, arr) => arr.findIndex((x) => x.currency === m.currency) === i,
+    ).map((m) => [m.currency, DEPOSIT_RAIL_MINIMUMS[m.paymentRail] ?? '']),
+  ) as Record<BankCurrencyCode, string>;
+
+// ---- Payout minimums ----
+
+// Canonical source: payment rail → fn(sourceCurrency) → minimum USDC/EURC amount for payouts.
+export const PAYOUT_RAIL_MINIMUMS: Record<
+  string,
+  (sourceCurrency: string) => string | null
+> = {
+  ach: () => '1 USDC',
+  ach_push: () => '1 USDC',
+  wire: () => '1 USDC',
+  sepa: (src) => (src === 'eurc' ? '1 EURC' : '1 USDC'),
+  faster_payments: () => '3 USDC',
+};
+
+// Payout destination currency → primary payment rail.
+const PAYOUT_CURRENCY_RAIL: Partial<Record<PayoutCurrencyKey, string>> = {
+  usd: 'ach',
+  eur: 'sepa',
+  gbp: 'faster_payments',
+};
+
+// Derived: payout destination currency + source treasury token → minimum amount.
+export function getPayoutMinimum(
+  currency: PayoutCurrencyKey,
+  sourceCurrency: 'usdc' | 'eurc',
+): string | null {
+  const rail = PAYOUT_CURRENCY_RAIL[currency];
+  if (!rail) return null;
+  return PAYOUT_RAIL_MINIMUMS[rail]?.(sourceCurrency) ?? null;
+}

--- a/packages/epics/src/banking/components/add-payout-account-dialog.tsx
+++ b/packages/epics/src/banking/components/add-payout-account-dialog.tsx
@@ -48,6 +48,22 @@ import {
 
 const ADD_PAYOUT_FORM_ID = 'add-payout-account-form';
 
+function getPayoutMinimum(
+  currency: PayoutCurrencyKey,
+  sourceCurrency: 'usdc' | 'eurc',
+): string | null {
+  switch (currency) {
+    case 'usd':
+      return '1 USDC';
+    case 'eur':
+      return sourceCurrency === 'eurc' ? '1 EURC' : '1 USDC';
+    case 'gbp':
+      return '3 USDC';
+    default:
+      return null;
+  }
+}
+
 const ENABLED_PAYOUT_CURRENCIES = getEnabledPayoutCurrencyKeys();
 
 function isValidIban(raw: string): boolean {
@@ -186,6 +202,7 @@ export const AddPayoutAccountDialog: FC<AddPayoutAccountDialogProps> = ({
   onSuccess,
 }) => {
   const t = useTranslations('BankingTab.payouts.addDialog');
+  const tMinimums = useTranslations('BankingTab.minimums');
   const REQUIRED_MSG = t('fieldRequired');
   const radioName = useId();
 
@@ -663,6 +680,12 @@ export const AddPayoutAccountDialog: FC<AddPayoutAccountDialogProps> = ({
                     ),
                   )}
                 </div>
+                {getPayoutMinimum(selectedCurrency, sourceCurrency) ? (
+                  <p className="text-1 text-muted-foreground">
+                    {tMinimums('payoutNote')}{' '}
+                    {getPayoutMinimum(selectedCurrency, sourceCurrency)}
+                  </p>
+                ) : null}
               </FormSection>
 
               {/* Bank account details */}

--- a/packages/epics/src/banking/components/add-payout-account-dialog.tsx
+++ b/packages/epics/src/banking/components/add-payout-account-dialog.tsx
@@ -45,24 +45,9 @@ import {
   getPayoutRailEndorsementStatus,
   isBankRailSelectable,
 } from '../banking-ui';
+import { getPayoutMinimum } from '../banking-minimums';
 
 const ADD_PAYOUT_FORM_ID = 'add-payout-account-form';
-
-function getPayoutMinimum(
-  currency: PayoutCurrencyKey,
-  sourceCurrency: 'usdc' | 'eurc',
-): string | null {
-  switch (currency) {
-    case 'usd':
-      return '1 USDC';
-    case 'eur':
-      return sourceCurrency === 'eurc' ? '1 EURC' : '1 USDC';
-    case 'gbp':
-      return '3 USDC';
-    default:
-      return null;
-  }
-}
 
 const ENABLED_PAYOUT_CURRENCIES = getEnabledPayoutCurrencyKeys();
 

--- a/packages/epics/src/banking/components/approved-banking-deposits.tsx
+++ b/packages/epics/src/banking/components/approved-banking-deposits.tsx
@@ -52,7 +52,6 @@ export const ApprovedBankingDeposits: FC<ApprovedBankingDepositsProps> = ({
     return (
       <Empty className="w-full">
         <p>{tAccounts('emptyTitle')}</p>
-        <p className="text-muted-foreground">{tAccounts('emptyDescription')}</p>
       </Empty>
     );
   }

--- a/packages/epics/src/banking/components/approved-banking-payouts.tsx
+++ b/packages/epics/src/banking/components/approved-banking-payouts.tsx
@@ -40,7 +40,6 @@ export const ApprovedBankingPayouts: FC<ApprovedBankingPayoutsProps> = ({
     return (
       <Empty className="w-full">
         <p>{t('emptyTitle')}</p>
-        <p className="text-muted-foreground">{t('emptyDescription')}</p>
       </Empty>
     );
   }

--- a/packages/epics/src/banking/components/bank-rail-action-picker.tsx
+++ b/packages/epics/src/banking/components/bank-rail-action-picker.tsx
@@ -176,14 +176,18 @@ export const BankRailActionPicker: FC<BankRailActionPickerProps> = ({
         </div>
       ) : null}
 
-      {selected ? (
-        <p className="text-1 text-muted-foreground">
-          {tMinimums('depositNote')}{' '}
-          {selected.corridorKey
-            ? DEPOSIT_CORRIDOR_MINIMUMS[selected.corridorKey]
-            : DEPOSIT_CURRENCY_MINIMUMS[selected.currency]}
-        </p>
-      ) : null}
+      {selected
+        ? (() => {
+            const minimum = selected.corridorKey
+              ? DEPOSIT_CORRIDOR_MINIMUMS[selected.corridorKey]
+              : DEPOSIT_CURRENCY_MINIMUMS[selected.currency];
+            return minimum ? (
+              <p className="text-1 text-muted-foreground">
+                {tMinimums('depositNote')} {minimum}
+              </p>
+            ) : null;
+          })()
+        : null}
 
       {showPrimaryAction && selected ? (
         <Button

--- a/packages/epics/src/banking/components/bank-rail-action-picker.tsx
+++ b/packages/epics/src/banking/components/bank-rail-action-picker.tsx
@@ -11,27 +11,12 @@ import type {
   BankTransferCorridorKey,
 } from '../bank-currency-display';
 import { isBankRailSelectable } from '../banking-ui';
+import {
+  DEPOSIT_CORRIDOR_MINIMUMS,
+  DEPOSIT_CURRENCY_MINIMUMS,
+} from '../banking-minimums';
 import type { BankCurrencyOperationalStatus } from '../hooks/types';
 import { BankDepositRailOptionRow } from './bank-deposit-rail-option-row';
-
-const DEPOSIT_CORRIDOR_MINIMUMS: Record<BankTransferCorridorKey, string> = {
-  'usd-ach': '1 USD',
-  'usd-wire': '1 USD',
-  eur: '1 EUR',
-  gbp: '2 GBP',
-  mxn: '50 MXN',
-  brl: '10 BRL',
-  cop: '100 COP',
-};
-
-const DEPOSIT_CURRENCY_MINIMUMS: Record<BankCurrencyCode, string> = {
-  usd: '1 USD',
-  eur: '1 EUR',
-  gbp: '2 GBP',
-  mxn: '50 MXN',
-  brl: '10 BRL',
-  cop: '100 COP',
-};
 
 export type BankRailPickerOption = {
   id: string;

--- a/packages/epics/src/banking/components/bank-rail-action-picker.tsx
+++ b/packages/epics/src/banking/components/bank-rail-action-picker.tsx
@@ -14,6 +14,25 @@ import { isBankRailSelectable } from '../banking-ui';
 import type { BankCurrencyOperationalStatus } from '../hooks/types';
 import { BankDepositRailOptionRow } from './bank-deposit-rail-option-row';
 
+const DEPOSIT_CORRIDOR_MINIMUMS: Record<BankTransferCorridorKey, string> = {
+  'usd-ach': '1 USD',
+  'usd-wire': '1 USD',
+  eur: '1 EUR',
+  gbp: '2 GBP',
+  mxn: '50 MXN',
+  brl: '10 BRL',
+  cop: '100 COP',
+};
+
+const DEPOSIT_CURRENCY_MINIMUMS: Record<BankCurrencyCode, string> = {
+  usd: '1 USD',
+  eur: '1 EUR',
+  gbp: '2 GBP',
+  mxn: '50 MXN',
+  brl: '10 BRL',
+  cop: '100 COP',
+};
+
 export type BankRailPickerOption = {
   id: string;
   currency: BankCurrencyCode;
@@ -58,6 +77,7 @@ export const BankRailActionPicker: FC<BankRailActionPickerProps> = ({
   const tOpenAccount = useTranslations('BankingTab.openAccount');
   const tCreateTransfer = useTranslations('BankingTab.createTransfer');
   const tDeposit = useTranslations('BankingTab.depositInstructions');
+  const tMinimums = useTranslations('BankingTab.minimums');
   const radioName = useId();
 
   const selected = options.find((option) => option.id === selectedId);
@@ -154,6 +174,15 @@ export const BankRailActionPicker: FC<BankRailActionPickerProps> = ({
             })}
           </div>
         </div>
+      ) : null}
+
+      {selected ? (
+        <p className="text-1 text-muted-foreground">
+          {tMinimums('depositNote')}{' '}
+          {selected.corridorKey
+            ? DEPOSIT_CORRIDOR_MINIMUMS[selected.corridorKey]
+            : DEPOSIT_CURRENCY_MINIMUMS[selected.currency]}
+        </p>
       ) : null}
 
       {showPrimaryAction && selected ? (

--- a/packages/epics/src/banking/components/bank-transfers-section.tsx
+++ b/packages/epics/src/banking/components/bank-transfers-section.tsx
@@ -39,7 +39,6 @@ export const BankTransfersSection: FC<BankTransfersSectionProps> = ({
   hideListLoadingState = false,
 }) => {
   const t = useTranslations('BankingTab.sections.transfers');
-  const tNotStarted = useTranslations('BankingTab.notStarted');
   const tToolbar = useTranslations('BankingTab.toolbar');
   const [detailsTransfer, setDetailsTransfer] =
     useState<BankTransferPublic | null>(null);
@@ -103,11 +102,6 @@ export const BankTransfersSection: FC<BankTransfersSectionProps> = ({
       ) : transfers.length === 0 ? (
         <Empty className="w-full">
           <p>{t('emptyTitle')}</p>
-          <p className="text-muted-foreground">
-            {hasBankCustomer
-              ? t('emptyDescription')
-              : tNotStarted('description')}
-          </p>
         </Empty>
       ) : (
         <div className="w-full">

--- a/packages/epics/src/banking/components/deposit-instructions-fields.tsx
+++ b/packages/epics/src/banking/components/deposit-instructions-fields.tsx
@@ -52,10 +52,22 @@ function toPanelSource(props: DepositInstructionsPanelProps) {
   return null;
 }
 
+const DEPOSIT_RAIL_MINIMUMS: Record<string, string> = {
+  ach_push: '1 USD',
+  ach: '1 USD',
+  wire: '1 USD',
+  sepa: '1 EUR',
+  faster_payments: '2 GBP',
+  spei: '50 MXN',
+  pix: '10 BRL',
+  cop: '100 COP',
+};
+
 export const DepositInstructionsPanel: FC<DepositInstructionsPanelProps> = (
   props,
 ) => {
   const t = useTranslations('BankingTab.depositInstructions');
+  const tMinimums = useTranslations('BankingTab.minimums');
   const tDetails = useTranslations('BankingTab.transferDetails');
   const source = toPanelSource(props);
 
@@ -158,6 +170,12 @@ export const DepositInstructionsPanel: FC<DepositInstructionsPanelProps> = (
               </Button>
             ) : null}
           </div>
+          {source.paymentRail && DEPOSIT_RAIL_MINIMUMS[source.paymentRail] ? (
+            <p className="text-1 text-muted-foreground">
+              {tMinimums('depositNote')}{' '}
+              {DEPOSIT_RAIL_MINIMUMS[source.paymentRail]}
+            </p>
+          ) : null}
           <div
             className={cn(
               'flex flex-col gap-2',

--- a/packages/epics/src/banking/components/deposit-instructions-fields.tsx
+++ b/packages/epics/src/banking/components/deposit-instructions-fields.tsx
@@ -23,6 +23,7 @@ import {
   BANKING_REFERENCE_WARNING_BANNER_CLASS,
   isTransferDepositInstructionsReadOnly,
 } from '../banking-ui';
+import { DEPOSIT_RAIL_MINIMUMS } from '../banking-minimums';
 import { CopyableInstructionBlock } from './copyable-instruction-block';
 import { TreasuryDestinationCard } from './treasury-destination-card';
 import { TransferReceiptBox } from './transfer-bridge-receipt-section';
@@ -51,17 +52,6 @@ function toPanelSource(props: DepositInstructionsPanelProps) {
   }
   return null;
 }
-
-const DEPOSIT_RAIL_MINIMUMS: Record<string, string> = {
-  ach_push: '1 USD',
-  ach: '1 USD',
-  wire: '1 USD',
-  sepa: '1 EUR',
-  faster_payments: '2 GBP',
-  spei: '50 MXN',
-  pix: '10 BRL',
-  cop: '100 COP',
-};
 
 export const DepositInstructionsPanel: FC<DepositInstructionsPanelProps> = (
   props,

--- a/packages/epics/src/banking/components/payout-account-detail-dialog.tsx
+++ b/packages/epics/src/banking/components/payout-account-detail-dialog.tsx
@@ -28,6 +28,17 @@ import {
 import { CurrencyFlagBadge } from './currency-flag-badge';
 import { InlineCopyRow } from './inline-copy-row';
 
+const PAYOUT_RAIL_MINIMUMS: Record<
+  string,
+  (sourceCurrency: string) => string | null
+> = {
+  ach: () => '1 USDC',
+  ach_push: () => '1 USDC',
+  wire: () => '1 USDC',
+  sepa: (src) => (src === 'eurc' ? '1 EURC' : '1 USDC'),
+  faster_payments: () => '3 USDC',
+};
+
 function statusBadgeClass(status: string): string {
   if (status === 'active') return 'bg-success-9 text-white';
   if (status === 'inactive' || status === 'deactivated')
@@ -59,6 +70,7 @@ export const PayoutAccountDetailDialog: FC<PayoutAccountDetailDialogProps> = ({
 }) => {
   const t = useTranslations('BankingTab.payouts');
   const tDialog = useTranslations('BankingTab.payouts.addDialog');
+  const tMinimums = useTranslations('BankingTab.minimums');
 
   if (!account) return null;
 
@@ -166,6 +178,17 @@ export const PayoutAccountDetailDialog: FC<PayoutAccountDetailDialogProps> = ({
               <p className="text-2 text-muted-foreground">
                 {tDialog('success.howToText')}
               </p>
+              {account.paymentRail &&
+              PAYOUT_RAIL_MINIMUMS[account.paymentRail]?.(
+                account.sourceCurrency.toLowerCase(),
+              ) ? (
+                <p className="text-1 text-muted-foreground">
+                  {tMinimums('payoutNote')}{' '}
+                  {PAYOUT_RAIL_MINIMUMS[account.paymentRail]?.(
+                    account.sourceCurrency.toLowerCase(),
+                  )}
+                </p>
+              ) : null}
             </div>
           </div>
         </BankingDialogBody>

--- a/packages/epics/src/banking/components/payout-account-detail-dialog.tsx
+++ b/packages/epics/src/banking/components/payout-account-detail-dialog.tsx
@@ -18,6 +18,7 @@ import {
   getBankCurrencyMeta,
   type BankCurrencyCode,
 } from '../bank-currency-display';
+import { PAYOUT_RAIL_MINIMUMS } from '../banking-minimums';
 import type { BankPayoutAccountPublic } from '../hooks/types';
 import {
   BANKING_DIALOG_FOOTER_CLASS,
@@ -27,17 +28,6 @@ import {
 } from './banking-dialog-layout';
 import { CurrencyFlagBadge } from './currency-flag-badge';
 import { InlineCopyRow } from './inline-copy-row';
-
-const PAYOUT_RAIL_MINIMUMS: Record<
-  string,
-  (sourceCurrency: string) => string | null
-> = {
-  ach: () => '1 USDC',
-  ach_push: () => '1 USDC',
-  wire: () => '1 USDC',
-  sepa: (src) => (src === 'eurc' ? '1 EURC' : '1 USDC'),
-  faster_payments: () => '3 USDC',
-};
 
 function statusBadgeClass(status: string): string {
   if (status === 'active') return 'bg-success-9 text-white';

--- a/packages/i18n/src/messages/de.json
+++ b/packages/i18n/src/messages/de.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "Common": {
     "Assignments": "Zuweisungen",
     "Members": "Mitglieder",
@@ -972,7 +972,7 @@
       "organizationLegend": "Organisationsdetails",
       "organizationHint": "Organisationsdetails werden zur Verifizierung an unseren Banking-Partner übermittelt und nicht auf Hypha gespeichert.",
       "currenciesTitle": "Gewünschte Währungen",
-      "currenciesDescription": "Wählen Sie die Währungen, die dieser Space per Banküberweisung akzeptieren soll. Wir verifizieren Ihre Organisation einmalig bei unserem Banking-Partner.",
+      "currenciesDescription": "Wählen Sie die Währungen, die dieser Space für Bankeinzahlungen und Auszahlungen verwenden soll. Ihre Organisation wird einmalig von unserem Banking-Partner verifiziert.",
       "currenciesHint": "Weitere Währungen können Sie später in den Banking-Einstellungen hinzufügen.",
       "submit": "Weiter"
     },

--- a/packages/i18n/src/messages/de.json
+++ b/packages/i18n/src/messages/de.json
@@ -1,4 +1,4 @@
-{
+﻿{
   "Common": {
     "Assignments": "Zuweisungen",
     "Members": "Mitglieder",
@@ -591,7 +591,7 @@
     "aiAgentsMobilizedCount": "{count, plural, one {# Mal mobilisiert} other {# Mal mobilisiert}}"
   },
   "BankingTab": {
-    "title": "Banking Routes",
+    "title": "Bankdienste",
     "loading": "Bankkontostatus wird geladen…",
     "returnBanner": "Willkommen zurück — wir prüfen Ihren Verifizierungsstatus.",
     "errorLoad": "Bankkontostatus konnte nicht geladen werden.",
@@ -672,24 +672,24 @@
       }
     },
     "returnBannerDismiss": "Schließen",
-    "returnBannerApprovedHint": "Verification is complete. Add routing accounts for any remaining currencies.",
+    "returnBannerApprovedHint": "Die Verifizierung ist abgeschlossen. Fügen Sie Routing-Konten für verbleibende Währungen hinzu.",
     "sections": {
       "transfers": {
-        "title": "One-time Transfer Routes",
-        "description": "Single-use bank transfer accounts that automatically route incoming funds to the space USDC or EURC wallets.",
-        "emptyTitle": "No one-time transfer routes yet",
-        "newTransferCta": "Add one-time route",
+        "title": "Einmalige Überweisungsrouten",
+        "description": "Einmalig nutzbare Bankkonten, die eingehende Gelder automatisch zu den USDC- oder EURC-Wallets des Spaces weiterleiten.",
+        "emptyTitle": "Noch keine einmaligen Überweisungsrouten",
+        "newTransferCta": "Einmalige Route hinzufügen",
         "loading": "Überweisungen werden geladen…"
       },
       "accounts": {
-        "title": "Deposit Routing Accounts",
-        "description": "Bank transfer accounts that automatically route incoming funds to the space USDC or EURC wallets.",
-        "emptyTitle": "No deposit routing accounts yet",
+        "title": "Einzahlungs-Routing-Konten",
+        "description": "Bankkonten, die eingehende Gelder automatisch zu den USDC- oder EURC-Wallets des Spaces weiterleiten.",
+        "emptyTitle": "Noch keine Einzahlungs-Routing-Konten",
         "pendingTitle": "Verifizierung läuft",
-        "pendingDescription": "Finish verification in Bridge to activate the currencies you selected. Your routing accounts will be set up automatically once approved.",
+        "pendingDescription": "Schließen Sie die Verifizierung in Bridge ab, um die ausgewählten Währungen zu aktivieren. Ihre Routing-Konten werden nach der Genehmigung automatisch eingerichtet.",
         "continueVerificationCta": "Verifizierung fortsetzen",
         "loadingAccounts": "Bankkonten werden geladen…",
-        "signInHint": "Sign in to manage banking routes."
+        "signInHint": "Melden Sie sich an, um Banking-Routen zu verwalten."
       }
     },
     "payouts": {
@@ -698,14 +698,14 @@
         "payouts": "Auszahlungen"
       },
       "section": {
-        "title": "Payout Bank Accounts",
-        "description": "Register an external bank account to transfer funds from your USDC or EURC wallets through proposals."
+        "title": "Auszahlungsbankkonten",
+        "description": "Registrieren Sie ein externes Bankkonto, um Gelder aus Ihren USDC- oder EURC-Wallets über Anträge zu überweisen."
       },
       "addCta": "Auszahlungskonto hinzufügen",
       "loading": "Auszahlungskonten werden geladen…",
-      "emptyTitle": "No payout bank accounts yet",
+      "emptyTitle": "Noch keine Auszahlungsbankkonten",
       "cardBankFallback": "Bankkonto",
-      "liquidationAddressLabel": "Payout address",
+      "liquidationAddressLabel": "Auszahlungsadresse",
       "payoutAddressLabel": "Auszahlungsadresse",
       "detail": {
         "title": "Auszahlungskonto",
@@ -722,7 +722,7 @@
       "addDialog": {
         "title": "Auszahlungskonto hinzufügen",
         "stepOf": "Schritt {current} von {total}",
-        "step1Description": "Indicate the currency of the destination bank account.",
+        "step1Description": "Geben Sie die Währung des Zielbankontos an.",
         "step2Description": "Geben Sie die Bankdaten des Zielkontos ein.",
         "step3Description": "Geben Sie die Adresse des Begünstigten und die Überweisungsdetails ein.",
         "step4Description": "Überprüfen und bestätigen Sie Ihre Auszahlungskontodaten.",
@@ -783,10 +783,10 @@
         "submitting": "Wird erstellt…",
         "success": {
           "title": "Auszahlungskonto registriert",
-          "subtitle": "The account is active. Copy the payout address to use in proposals.",
-          "liquidationAddressLabel": "Payout address",
+          "subtitle": "Das Konto ist aktiv. Kopieren Sie die Auszahlungsadresse zur Verwendung in Anträgen.",
+          "liquidationAddressLabel": "Auszahlungsadresse",
           "howToTitle": "So führen Sie Auszahlungen durch",
-          "howToText": "Create a Funding or Expenses proposal pointing to this address as the payout destination. Funds will be converted and transferred to your registered bank.",
+          "howToText": "Erstellen Sie einen Funding- oder Expenses-Antrag mit dieser Adresse als Auszahlungsziel. Die Gelder werden umgewandelt und an Ihre registrierte Bank überwiesen.",
           "done": "Fertig"
         },
         "swift": {
@@ -822,22 +822,22 @@
       }
     },
     "openAccount": {
-      "title": "Set up deposit routing accounts",
-      "titleAddCurrency": "Add a deposit routing account",
-      "description": "Tell us about your organization and which currencies you support. You'll verify your space once, and then be able to use deposit and payout banking routes.",
-      "descriptionAddCurrency": "Choose additional currencies to add deposit routing accounts for your space.",
-      "descriptionAddCurrencySingle": "Choose the deposit currency for this routing account. Additional verification from the provider may be required.",
+      "title": "Einzahlungs-Routing-Konten einrichten",
+      "titleAddCurrency": "Einzahlungs-Routing-Konto hinzufügen",
+      "description": "Teilen Sie uns Angaben zu Ihrer Organisation und den unterstützten Währungen mit. Sie verifizieren Ihren Space einmalig und können dann Einzahlungs- und Auszahlungsrouten nutzen.",
+      "descriptionAddCurrency": "Wählen Sie weitere Währungen aus, um Einzahlungs-Routing-Konten für Ihren Space hinzuzufügen.",
+      "descriptionAddCurrencySingle": "Erstellen Sie dauerhafte Einzahlungsanweisungen für eingehende Überweisungen. Die Gelder werden automatisch in USDC oder EURC umgewandelt und in Ihrer Treasury-Wallet verrechnet.",
       "bankAccountDepositLabel": "Einzahlungswährung",
-      "bankAccountDepositHint": "Currency this routing account will receive.",
+      "bankAccountDepositHint": "Währung, die dieses Routing-Konto empfängt.",
       "legalName": "Rechtlicher Name der Organisation",
       "contactEmail": "Kontakt-E-Mail",
       "currenciesLabel": "Währungen",
-      "currenciesHint": "Select every currency you want to receive bank deposits in.",
-      "currenciesHintSingle": "Select a currency you want to receive bank deposits in.",
-      "submit": "Set up routing accounts",
-      "submitAddCurrency": "Add routing account",
+      "currenciesHint": "Wählen Sie alle Währungen aus, in denen Sie Bankeinzahlungen empfangen möchten.",
+      "currenciesHintSingle": "Wählen Sie eine Währung aus, in der Sie Bankeinzahlungen empfangen möchten.",
+      "submit": "Routing-Konten einrichten",
+      "submitAddCurrency": "Routing-Konto hinzufügen",
       "submitting": "Wird bearbeitet…",
-      "noCurrenciesAvailable": "All supported deposit routing accounts are already set up for this space.",
+      "noCurrenciesAvailable": "Alle unterstützten Einzahlungs-Routing-Konten sind für diesen Space bereits eingerichtet.",
       "railLabel": "Zahlungsweg",
       "railPlaceholder": "Zahlungsweg auswählen",
       "requestRail": "Anfordern",
@@ -848,7 +848,7 @@
       "redirectPendingDescription": "Akzeptieren Sie die Bedingungen und schließen Sie die Verifizierung ab, um die ausgewählten Währungen zu aktivieren."
     },
     "toolbar": {
-      "addCurrency": "Add routing account",
+      "addCurrency": "Routing-Konto hinzufügen",
       "finishVerificationFirst": "Schließen Sie zuerst die laufende Verifizierung ab",
       "allCurrenciesCovered": "Für alle unterstützten Währungen existieren bereits Konten",
       "loadingAccounts": "Bankkonten werden geladen…",
@@ -866,8 +866,8 @@
       "openGearForVerification": "Klicken Sie, um Verifizierungsdetails und Bridge-Links zu öffnen."
     },
     "minimums": {
-      "depositNote": "Minimum deposit:",
-      "payoutNote": "Minimum transfer:"
+      "depositNote": "Mindesteinzahlung:",
+      "payoutNote": "Mindestüberweisung:"
     },
     "advanced": {
       "gearLabel": "Banking-Einstellungen",
@@ -1053,7 +1053,7 @@
     },
     "createTransfer": {
       "title": "Neue einmalige Überweisung",
-      "description": "Erstellen Sie Einzahlungsanweisungen für eine einzelne eingehende Überweisung. Die Mittel werden in einen Stablecoin (USDC oder EURC) in Ihrer Treasury umgewandelt.",
+      "description": "Erstellen Sie Einzahlungsanweisungen für eine einzelne eingehende Überweisung. Die Gelder werden automatisch in USDC oder EURC umgewandelt und in Ihrer Treasury-Wallet verrechnet.",
       "corridorLabel": "Korridor",
       "corridorHint": "Wählen Sie, wie der Zahler Mittel sendet. Dies bestimmt die Einzahlungsanweisungen.",
       "fixedAmountLabel": "Festen Betrag verlangen",
@@ -1115,7 +1115,7 @@
     }
   },
   "TreasuryTab": {
-    "bankingRoutes": "Banking",
+    "bankingRoutes": "Bankdienste",
     "balance": "Kontostand",
     "wallet": "Wallet",
     "searchTokens": "Tokens suchen",

--- a/packages/i18n/src/messages/de.json
+++ b/packages/i18n/src/messages/de.json
@@ -591,8 +591,7 @@
     "aiAgentsMobilizedCount": "{count, plural, one {# Mal mobilisiert} other {# Mal mobilisiert}}"
   },
   "BankingTab": {
-    "title": "Banküberweisungen",
-    "subtitle": "Empfangen Sie Banküberweisungen in Ihrer Treasury und verwalten Sie Einzahlungskonten des Space.",
+    "title": "Banking Routes",
     "loading": "Bankkontostatus wird geladen…",
     "returnBanner": "Willkommen zurück — wir prüfen Ihren Verifizierungsstatus.",
     "errorLoad": "Bankkontostatus konnte nicht geladen werden.",
@@ -673,28 +672,24 @@
       }
     },
     "returnBannerDismiss": "Schließen",
-    "returnBannerApprovedHint": "Die Verifizierung ist abgeschlossen. Eröffnen Sie ein Space-Konto, um fehlende Währungen hinzuzufügen.",
+    "returnBannerApprovedHint": "Verification is complete. Add routing accounts for any remaining currencies.",
     "sections": {
       "transfers": {
-        "title": "Einmalige Banküberweisungen",
-        "description": "Einmalige eingehende Überweisungen.",
-        "emptyTitle": "Noch keine einmaligen Überweisungen",
-        "emptyDescription": "Erstellen Sie eine einmalige Überweisung, wenn Sie eine einzelne eingehende Zahlung benötigen, ohne ein vollständiges Einzahlungskonto einzurichten.",
-        "newTransferCta": "Neue einmalige Überweisung",
+        "title": "One-time Transfer Routes",
+        "description": "Single-use bank transfer accounts that automatically route incoming funds to the space USDC or EURC wallets.",
+        "emptyTitle": "No one-time transfer routes yet",
+        "newTransferCta": "Add one-time route",
         "loading": "Überweisungen werden geladen…"
       },
       "accounts": {
-        "title": "Bankkonten",
-        "description": "Permanente Einzahlungsdetails pro Währung.",
-        "openAccountCta": "Space-Konto eröffnen",
-        "addCurrencyCta": "Bankkonto hinzufügen",
-        "emptyTitle": "Noch keine Bankkonten",
-        "emptyDescription": "Eröffnen Sie ein Space-Konto und wählen Sie die benötigten Währungen. Wir richten für jede Währung Einzahlungsdetails ein.",
+        "title": "Deposit Routing Accounts",
+        "description": "Bank transfer accounts that automatically route incoming funds to the space USDC or EURC wallets.",
+        "emptyTitle": "No deposit routing accounts yet",
         "pendingTitle": "Verifizierung läuft",
-        "pendingDescription": "Schließen Sie die Verifizierung in Bridge ab, um die ausgewählten Währungen zu aktivieren. Ihre Konten werden nach der Freigabe automatisch erstellt.",
+        "pendingDescription": "Finish verification in Bridge to activate the currencies you selected. Your routing accounts will be set up automatically once approved.",
         "continueVerificationCta": "Verifizierung fortsetzen",
         "loadingAccounts": "Bankkonten werden geladen…",
-        "signInHint": "Melden Sie sich an, um Bankkonten zu verwalten."
+        "signInHint": "Sign in to manage banking routes."
       }
     },
     "payouts": {
@@ -703,15 +698,14 @@
         "payouts": "Auszahlungen"
       },
       "section": {
-        "title": "Auszahlungskonten",
-        "description": "Registrieren Sie, wohin die Treasury nach einem genehmigten Vorschlag Fiat sendet. Jedes Konto erhält eine Liquidationsadresse für Finanzierungs- oder Ausgabenvorschläge."
+        "title": "Payout Bank Accounts",
+        "description": "Register an external bank account to transfer funds from your USDC or EURC wallets through proposals."
       },
       "addCta": "Auszahlungskonto hinzufügen",
       "loading": "Auszahlungskonten werden geladen…",
-      "emptyTitle": "Noch keine Auszahlungskonten",
-      "emptyDescription": "Registrieren Sie ein Bankkonto für Auszahlungen aus der Treasury. Treasury-USDC → Liquidationsadresse → Abstimmung → Fiat auf Ihrem Konto.",
+      "emptyTitle": "No payout bank accounts yet",
       "cardBankFallback": "Bankkonto",
-      "liquidationAddressLabel": "Liquidationsadresse",
+      "liquidationAddressLabel": "Payout address",
       "payoutAddressLabel": "Auszahlungsadresse",
       "detail": {
         "title": "Auszahlungskonto",
@@ -728,7 +722,7 @@
       "addDialog": {
         "title": "Auszahlungskonto hinzufügen",
         "stepOf": "Schritt {current} von {total}",
-        "step1Description": "Wählen Sie die Zielwährung für dieses Auszahlungskonto.",
+        "step1Description": "Indicate the currency of the destination bank account.",
         "step2Description": "Geben Sie die Bankdaten des Zielkontos ein.",
         "step3Description": "Geben Sie die Adresse des Begünstigten und die Überweisungsdetails ein.",
         "step4Description": "Überprüfen und bestätigen Sie Ihre Auszahlungskontodaten.",
@@ -789,10 +783,10 @@
         "submitting": "Wird erstellt…",
         "success": {
           "title": "Auszahlungskonto registriert",
-          "subtitle": "Das Konto ist aktiv. Kopieren Sie die Liquidationsadresse für Vorschläge.",
-          "liquidationAddressLabel": "Liquidationsadresse",
+          "subtitle": "The account is active. Copy the payout address to use in proposals.",
+          "liquidationAddressLabel": "Payout address",
           "howToTitle": "So führen Sie Auszahlungen durch",
-          "howToText": "Erstellen Sie einen Finanzierungs- oder Ausgabenvorschlag → fügen Sie diese Adresse als Empfänger ein → wählen Sie USDC oder EURC als Token → abstimmen und ausführen. Bridge konvertiert und überweist Fiat an die registrierte Bank.",
+          "howToText": "Create a Funding or Expenses proposal pointing to this address as the payout destination. Funds will be converted and transferred to your registered bank.",
           "done": "Fertig"
         },
         "swift": {
@@ -828,22 +822,22 @@
       }
     },
     "openAccount": {
-      "title": "Space-Konto eröffnen",
-      "titleAddCurrency": "Bankkonto hinzufügen",
-      "description": "Teilen Sie uns mit, welche Organisation Sie vertreten und welche Währungen Sie benötigen. Wir verifizieren Ihren Space einmalig und erstellen anschließend Konten für jede Währung.",
-      "descriptionAddCurrency": "Wählen Sie zusätzliche Währungen, für die Sie Einzahlungskonten für Ihren Space hinzufügen möchten.",
-      "descriptionAddCurrencySingle": "Wählen Sie die Einzahlungswährung für dieses Bankkonto. Möglicherweise ist eine zusätzliche Verifizierung beim Anbieter erforderlich.",
+      "title": "Set up deposit routing accounts",
+      "titleAddCurrency": "Add a deposit routing account",
+      "description": "Tell us about your organization and which currencies you support. You'll verify your space once, and then be able to use deposit and payout banking routes.",
+      "descriptionAddCurrency": "Choose additional currencies to add deposit routing accounts for your space.",
+      "descriptionAddCurrencySingle": "Choose the deposit currency for this routing account. Additional verification from the provider may be required.",
       "bankAccountDepositLabel": "Einzahlungswährung",
-      "bankAccountDepositHint": "Währung, die dieses Bankkonto empfängt.",
+      "bankAccountDepositHint": "Currency this routing account will receive.",
       "legalName": "Rechtlicher Name der Organisation",
       "contactEmail": "Kontakt-E-Mail",
       "currenciesLabel": "Währungen",
-      "currenciesHint": "Wählen Sie alle Währungen, in denen Sie Banküberweisungen empfangen möchten.",
-      "currenciesHintSingle": "Wählen Sie eine Währung, in der Sie Banküberweisungen empfangen möchten.",
-      "submit": "Konto eröffnen",
-      "submitAddCurrency": "Bankkonto hinzufügen",
+      "currenciesHint": "Select every currency you want to receive bank deposits in.",
+      "currenciesHintSingle": "Select a currency you want to receive bank deposits in.",
+      "submit": "Set up routing accounts",
+      "submitAddCurrency": "Add routing account",
       "submitting": "Wird bearbeitet…",
-      "noCurrenciesAvailable": "Alle unterstützten Bankkonten sind für diesen Space bereits eröffnet.",
+      "noCurrenciesAvailable": "All supported deposit routing accounts are already set up for this space.",
       "railLabel": "Zahlungsweg",
       "railPlaceholder": "Zahlungsweg auswählen",
       "requestRail": "Anfordern",
@@ -854,9 +848,7 @@
       "redirectPendingDescription": "Akzeptieren Sie die Bedingungen und schließen Sie die Verifizierung ab, um die ausgewählten Währungen zu aktivieren."
     },
     "toolbar": {
-      "add": "Hinzufügen",
-      "addCurrency": "Bankkonto hinzufügen",
-      "openSpaceAccount": "Space-Konto eröffnen",
+      "addCurrency": "Add routing account",
       "finishVerificationFirst": "Schließen Sie zuerst die laufende Verifizierung ab",
       "allCurrenciesCovered": "Für alle unterstützten Währungen existieren bereits Konten",
       "loadingAccounts": "Bankkonten werden geladen…",
@@ -872,6 +864,10 @@
       "activating": "Wird aktiviert…",
       "activateFailed": "Die Einrichtung konnte nicht abgeschlossen werden. Bitte versuchen Sie es später erneut. Wenn das Problem bestehen bleibt, kontaktieren Sie uns.",
       "openGearForVerification": "Klicken Sie, um Verifizierungsdetails und Bridge-Links zu öffnen."
+    },
+    "minimums": {
+      "depositNote": "Minimum deposit:",
+      "payoutNote": "Minimum transfer:"
     },
     "advanced": {
       "gearLabel": "Banking-Einstellungen",
@@ -1119,7 +1115,7 @@
     }
   },
   "TreasuryTab": {
-    "bankAccounts": "Bankkonten",
+    "bankingRoutes": "Banking",
     "balance": "Kontostand",
     "wallet": "Wallet",
     "searchTokens": "Tokens suchen",

--- a/packages/i18n/src/messages/en.json
+++ b/packages/i18n/src/messages/en.json
@@ -750,7 +750,7 @@
       "titleAddCurrency": "Add a deposit routing account",
       "description": "Tell us about your organization and which currencies you support. You'll verify your space once, and then be able to use deposit and payout banking routes.",
       "descriptionAddCurrency": "Choose additional currencies to add deposit routing accounts for your space.",
-      "descriptionAddCurrencySingle": "Choose the deposit currency for this routing account.",
+      "descriptionAddCurrencySingle": "Create permanent deposit instructions for incoming transfers. Funds are automatically converted to USDC or EURC and settled in your treasury wallet.",
       "bankAccountDepositLabel": "Deposit currency",
       "bankAccountDepositHint": "Currency this routing account will receive.",
       "legalName": "Legal entity name",

--- a/packages/i18n/src/messages/en.json
+++ b/packages/i18n/src/messages/en.json
@@ -590,35 +590,30 @@
     "aiAgentsMobilizedCount": "Mobilized {count, plural, one {# time} other {# times}}"
   },
   "BankingTab": {
-    "title": "Bank Transfers",
-    "subtitle": "Receive bank transfers into your treasury and manage space deposit accounts.",
+    "title": "Banking",
     "loading": "Loading bank account status…",
     "returnBanner": "Welcome back — we're checking your verification status.",
     "returnBannerDismiss": "Dismiss",
-    "returnBannerApprovedHint": "Verification is complete. Open a space account to add any remaining currencies.",
+    "returnBannerApprovedHint": "Verification is complete. Add routing accounts for any remaining currencies.",
     "errorLoad": "Could not load bank account status.",
     "errorFetchStatus": "There was an issue retrieving your banking information. Please try again later.",
     "sections": {
       "transfers": {
-        "title": "One-time Bank Transfers",
-        "description": "One-time incoming transfers.",
-        "emptyTitle": "No one-time transfers yet",
-        "emptyDescription": "Create a one-time transfer when you need a single incoming payment without setting up a full deposit account.",
-        "newTransferCta": "New one-time transfer",
+        "title": "One-time Transfer Routes",
+        "description": "Single-use bank transfer accounts that automatically route incoming funds to the space USDC or EURC wallets.",
+        "emptyTitle": "No one-time transfer routes yet",
+        "newTransferCta": "Add one-time route",
         "loading": "Loading transfers…"
       },
       "accounts": {
-        "title": "Bank Accounts",
-        "description": "Permanent deposit details per currency.",
-        "openAccountCta": "Open a space account",
-        "addCurrencyCta": "Add bank account",
-        "emptyTitle": "No bank accounts yet",
-        "emptyDescription": "Open a space account and choose which currencies you need. We'll set up deposit details for each one.",
+        "title": "Deposit Routing Accounts",
+        "description": "Bank transfer accounts that automatically route incoming funds to the space USDC or EURC wallets.",
+        "emptyTitle": "No deposit routing accounts yet",
         "pendingTitle": "Verification in progress",
-        "pendingDescription": "Finish verification in Bridge to activate the currencies you selected. Your accounts will be created automatically once approved.",
+        "pendingDescription": "Finish verification in Bridge to activate the currencies you selected. Your routing accounts will be set up automatically once approved.",
         "continueVerificationCta": "Continue verification",
         "loadingAccounts": "Loading bank accounts…",
-        "signInHint": "Sign in to manage bank accounts."
+        "signInHint": "Sign in to manage banking routes."
       }
     },
     "payouts": {
@@ -627,15 +622,14 @@
         "payouts": "Payouts"
       },
       "section": {
-        "title": "Payout Accounts",
-        "description": "Register where the treasury sends fiat after an approved proposal. Each account gets a liquidation address for Funding or Expenses proposals."
+        "title": "Payout Bank Accounts",
+        "description": "Register an external bank account to transfer funds from your USDC or EURC wallets through proposals."
       },
       "addCta": "Add payout account",
       "loading": "Loading payout accounts…",
-      "emptyTitle": "No payout accounts yet",
-      "emptyDescription": "Register a bank account to receive treasury payouts. Treasury USDC → liquidation address → vote → fiat in your bank.",
+      "emptyTitle": "No payout bank accounts yet",
       "cardBankFallback": "Bank account",
-      "liquidationAddressLabel": "Liquidation address",
+      "liquidationAddressLabel": "Payout address",
       "payoutAddressLabel": "Payout address",
       "detail": {
         "title": "Payout account",
@@ -650,9 +644,9 @@
         "pending": "Pending"
       },
       "addDialog": {
-        "title": "Add payout account",
+        "title": "Add payout bank account",
         "stepOf": "Step {current} of {total}",
-        "step1Description": "Choose the destination currency for this payout account.",
+        "step1Description": "Indicate the currency of the destination bank account.",
         "step2Description": "Enter the bank account details for the payout destination.",
         "step3Description": "Enter the beneficiary address and transfer details.",
         "step4Description": "Review and confirm your payout account details.",
@@ -713,10 +707,10 @@
         "submitting": "Creating…",
         "success": {
           "title": "Payout account registered",
-          "subtitle": "The account is active. Copy the liquidation address to use in proposals.",
-          "liquidationAddressLabel": "Liquidation address",
+          "subtitle": "The account is active. Copy the payout address to use in proposals.",
+          "liquidationAddressLabel": "Payout address",
           "howToTitle": "How to pay out",
-          "howToText": "Create a Funding or Expenses proposal pointing to this address as the payout destination. Bridge will convert and wire fiat to your registered bank.",
+          "howToText": "Create a Funding or Expenses proposal pointing to this address as the payout destination. Funds will be converted and transferred to your registered bank.",
           "done": "Done"
         },
         "swift": {
@@ -752,22 +746,22 @@
       }
     },
     "openAccount": {
-      "title": "Open a space account",
-      "titleAddCurrency": "Add a bank account",
-      "description": "Tell us about your organization and which currencies you need. We'll verify your space once, then create accounts for each currency.",
-      "descriptionAddCurrency": "Choose additional currencies to add deposit accounts for your space.",
-      "descriptionAddCurrencySingle": "Choose the deposit currency for this bank account. Additional verification from the provider may be required.",
+      "title": "Set up deposit routing accounts",
+      "titleAddCurrency": "Add a deposit routing account",
+      "description": "Tell us about your organization and which currencies you support. You'll verify your space once, and then be able to use deposit and payout banking routes.",
+      "descriptionAddCurrency": "Choose additional currencies to add deposit routing accounts for your space.",
+      "descriptionAddCurrencySingle": "Choose the deposit currency for this routing account.",
       "bankAccountDepositLabel": "Deposit currency",
-      "bankAccountDepositHint": "Currency this bank account will receive.",
+      "bankAccountDepositHint": "Currency this routing account will receive.",
       "legalName": "Legal entity name",
       "contactEmail": "Contact email",
       "currenciesLabel": "Currencies",
-      "currenciesHint": "Select every currency you want to receive bank transfers in.",
-      "currenciesHintSingle": "Select a currency you want to receive bank transfers in.",
-      "submit": "Open account",
-      "submitAddCurrency": "Add bank account",
+      "currenciesHint": "Select every currency you want to receive bank deposits in.",
+      "currenciesHintSingle": "Select a currency you want to receive bank deposits in.",
+      "submit": "Set up routing accounts",
+      "submitAddCurrency": "Add routing account",
       "submitting": "Working…",
-      "noCurrenciesAvailable": "All supported bank accounts are already open for this space.",
+      "noCurrenciesAvailable": "All supported deposit routing accounts are already set up for this space.",
       "railLabel": "Payment rail",
       "railPlaceholder": "Select a rail",
       "requestRail": "Request",
@@ -778,9 +772,7 @@
       "redirectPendingDescription": "Accept terms and complete verification to activate your selected currencies."
     },
     "toolbar": {
-      "add": "Add",
-      "addCurrency": "Add bank account",
-      "openSpaceAccount": "Open a space account",
+      "addCurrency": "Add routing account",
       "finishVerificationFirst": "Finish the current verification first",
       "allCurrenciesCovered": "All supported currencies already have accounts",
       "loadingAccounts": "Loading bank accounts…",
@@ -796,6 +788,10 @@
       "activating": "Activating…",
       "activateFailed": "We couldn't complete setup. Please try again later. If the problem continues, contact us.",
       "openGearForVerification": "Click to open verification details and Bridge links."
+    },
+    "minimums": {
+      "depositNote": "Minimum deposit:",
+      "payoutNote": "Minimum transfer:"
     },
     "advanced": {
       "gearLabel": "Banking settings",
@@ -996,7 +992,7 @@
     },
     "createTransfer": {
       "title": "New one-time transfer",
-      "description": "Create deposit instructions for a single incoming transfer. Funds are converted to a stablecoin (USDC or EURC) in your treasury.",
+      "description": "Create deposit instructions for a single incoming transfer. Funds are automatically converted to USDC or EURC and settled in your treasury wallet.",
       "corridorLabel": "Rail",
       "corridorHint": "Select how the payer will send funds. This determines the deposit instructions.",
       "fixedAmountLabel": "Require a fixed amount",
@@ -1118,7 +1114,7 @@
     }
   },
   "TreasuryTab": {
-    "bankAccounts": "Bank Accounts",
+    "bankingRoutes": "Banking",
     "balance": "Balance",
     "wallet": "Wallet",
     "searchTokens": "Search tokens",

--- a/packages/i18n/src/messages/en.json
+++ b/packages/i18n/src/messages/en.json
@@ -896,7 +896,7 @@
       "organizationLegend": "Organization details",
       "organizationHint": "Organization details are sent to our banking partner for verification and are not stored on Hypha.",
       "currenciesTitle": "Currencies you want to use",
-      "currenciesDescription": "Select the currencies this space will accept by bank transfer. We verify your organization once with our banking partner.",
+      "currenciesDescription": "Select the currencies this space will use for bank deposits and payouts. Your organization will be verified once with our banking partner.",
       "currenciesHint": "You can add more currencies later from Banking settings.",
       "submit": "Continue"
     },

--- a/packages/i18n/src/messages/es.json
+++ b/packages/i18n/src/messages/es.json
@@ -1349,7 +1349,7 @@
     "aiAgentsMobilizedCount": "Movilizado {count, plural, one {# vez} other {# veces}}"
   },
   "TreasuryTab": {
-    "bankAccounts": "Cuentas bancarias",
+    "bankingRoutes": "Banking",
     "balance": "Balance",
     "wallet": "Billetera",
     "searchTokens": "Buscar tokens",
@@ -2859,35 +2859,30 @@
     "deleteFailed": "No se pudo eliminar esta señal. Inténtalo de nuevo."
   },
   "BankingTab": {
-    "title": "Transferencias bancarias",
-    "subtitle": "Reciba transferencias bancarias en su tesorería y gestione las cuentas de depósito del space.",
+    "title": "Banking Routes",
     "loading": "Cargando el estado de la cuenta bancaria…",
     "returnBanner": "Bienvenido de nuevo — estamos comprobando su estado de verificación.",
     "returnBannerDismiss": "Descartar",
-    "returnBannerApprovedHint": "La verificación está completa. Abra una cuenta del space para añadir las monedas restantes.",
+    "returnBannerApprovedHint": "Verification is complete. Add routing accounts for any remaining currencies.",
     "errorLoad": "No se pudo cargar el estado de la cuenta bancaria.",
     "errorFetchStatus": "Hubo un problema al recuperar su información bancaria. Por favor, inténtelo de nuevo más tarde.",
     "sections": {
       "transfers": {
-        "title": "Transferencias bancarias únicas",
-        "description": "Transferencias entrantes puntuales.",
-        "emptyTitle": "Aún no hay transferencias únicas",
-        "emptyDescription": "Cree una transferencia única cuando necesite un solo pago entrante sin configurar una cuenta de depósito completa.",
-        "newTransferCta": "Nueva transferencia única",
+        "title": "One-time Transfer Routes",
+        "description": "Single-use bank transfer accounts that automatically route incoming funds to the space USDC or EURC wallets.",
+        "emptyTitle": "No one-time transfer routes yet",
+        "newTransferCta": "Add one-time route",
         "loading": "Cargando transferencias…"
       },
       "accounts": {
-        "title": "Cuentas bancarias",
-        "description": "Datos de depósito permanentes por moneda.",
-        "openAccountCta": "Abrir una cuenta del space",
-        "addCurrencyCta": "Añadir cuenta bancaria",
-        "emptyTitle": "Aún no hay cuentas bancarias",
-        "emptyDescription": "Abra una cuenta del space y elija las monedas que necesita. Configuraremos los datos de depósito para cada una.",
+        "title": "Deposit Routing Accounts",
+        "description": "Bank transfer accounts that automatically route incoming funds to the space USDC or EURC wallets.",
+        "emptyTitle": "No deposit routing accounts yet",
         "pendingTitle": "Verificación en curso",
-        "pendingDescription": "Complete la verificación en Bridge para activar las monedas seleccionadas. Sus cuentas se crearán automáticamente una vez aprobadas.",
+        "pendingDescription": "Finish verification in Bridge to activate the currencies you selected. Your routing accounts will be set up automatically once approved.",
         "continueVerificationCta": "Continuar verificación",
         "loadingAccounts": "Cargando cuentas bancarias…",
-        "signInHint": "Inicie sesión para gestionar cuentas bancarias."
+        "signInHint": "Sign in to manage banking routes."
       }
     },
     "payouts": {
@@ -2896,15 +2891,14 @@
         "payouts": "Pagos"
       },
       "section": {
-        "title": "Cuentas de pago",
-        "description": "Registre dónde envía el fiat la tesorería tras una propuesta aprobada. Cada cuenta obtiene una dirección de liquidación para propuestas de Financiación o Gastos."
+        "title": "Payout Bank Accounts",
+        "description": "Register an external bank account to transfer funds from your USDC or EURC wallets through proposals."
       },
       "addCta": "Añadir cuenta de pago",
       "loading": "Cargando cuentas de pago…",
-      "emptyTitle": "Aún no hay cuentas de pago",
-      "emptyDescription": "Registre una cuenta bancaria para recibir pagos de la tesorería. USDC de la tesorería → dirección de liquidación → votación → fiat en su banco.",
+      "emptyTitle": "No payout bank accounts yet",
       "cardBankFallback": "Cuenta bancaria",
-      "liquidationAddressLabel": "Dirección de liquidación",
+      "liquidationAddressLabel": "Payout address",
       "payoutAddressLabel": "Dirección de pago",
       "detail": {
         "title": "Cuenta de pago",
@@ -2921,7 +2915,7 @@
       "addDialog": {
         "title": "Añadir cuenta de pago",
         "stepOf": "Paso {current} de {total}",
-        "step1Description": "Elija la moneda de destino de esta cuenta de pago.",
+        "step1Description": "Indicate the currency of the destination bank account.",
         "step2Description": "Introduzca los datos bancarios de la cuenta de destino.",
         "step3Description": "Introduzca la dirección del beneficiario y los detalles de la transferencia.",
         "step4Description": "Revise y confirme los detalles de su cuenta de pago.",
@@ -2982,10 +2976,10 @@
         "submitting": "Creando…",
         "success": {
           "title": "Cuenta de pago registrada",
-          "subtitle": "La cuenta está activa. Copie la dirección de liquidación para usarla en propuestas.",
-          "liquidationAddressLabel": "Dirección de liquidación",
+          "subtitle": "The account is active. Copy the payout address to use in proposals.",
+          "liquidationAddressLabel": "Payout address",
           "howToTitle": "Cómo realizar pagos",
-          "howToText": "Cree una propuesta de Financiación o Gastos → pegue esta dirección como destinatario → seleccione USDC o EURC como token → vote y ejecute. Bridge convierte y transfiere el fiat al banco registrado.",
+          "howToText": "Create a Funding or Expenses proposal pointing to this address as the payout destination. Funds will be converted and transferred to your registered bank.",
           "done": "Listo"
         },
         "swift": {
@@ -3021,22 +3015,22 @@
       }
     },
     "openAccount": {
-      "title": "Abrir una cuenta del space",
-      "titleAddCurrency": "Añadir una cuenta bancaria",
-      "description": "Cuéntenos sobre su organización y qué monedas necesita. Verificaremos su space una sola vez y luego crearemos cuentas para cada moneda.",
-      "descriptionAddCurrency": "Elija monedas adicionales para añadir cuentas de depósito a su space.",
-      "descriptionAddCurrencySingle": "Elija la moneda de depósito para esta cuenta bancaria. El proveedor puede requerir verificación adicional.",
+      "title": "Set up deposit routing accounts",
+      "titleAddCurrency": "Add a deposit routing account",
+      "description": "Tell us about your organization and which currencies you support. You'll verify your space once, and then be able to use deposit and payout banking routes.",
+      "descriptionAddCurrency": "Choose additional currencies to add deposit routing accounts for your space.",
+      "descriptionAddCurrencySingle": "Choose the deposit currency for this routing account. Additional verification from the provider may be required.",
       "bankAccountDepositLabel": "Moneda de depósito",
-      "bankAccountDepositHint": "Moneda que recibirá esta cuenta bancaria.",
+      "bankAccountDepositHint": "Currency this routing account will receive.",
       "legalName": "Nombre legal de la entidad",
       "contactEmail": "Correo de contacto",
       "currenciesLabel": "Monedas",
-      "currenciesHint": "Seleccione todas las monedas en las que desea recibir transferencias bancarias.",
-      "currenciesHintSingle": "Seleccione una moneda en la que desea recibir transferencias bancarias.",
-      "submit": "Abrir cuenta",
-      "submitAddCurrency": "Añadir cuenta bancaria",
+      "currenciesHint": "Select every currency you want to receive bank deposits in.",
+      "currenciesHintSingle": "Select a currency you want to receive bank deposits in.",
+      "submit": "Set up routing accounts",
+      "submitAddCurrency": "Add routing account",
       "submitting": "Procesando…",
-      "noCurrenciesAvailable": "Todas las cuentas bancarias compatibles ya están abiertas para este space.",
+      "noCurrenciesAvailable": "All supported deposit routing accounts are already set up for this space.",
       "railLabel": "Vía de pago",
       "railPlaceholder": "Seleccionar vía",
       "requestRail": "Solicitar",
@@ -3047,9 +3041,7 @@
       "redirectPendingDescription": "Acepte los términos y complete la verificación para activar las monedas seleccionadas."
     },
     "toolbar": {
-      "add": "Añadir",
-      "addCurrency": "Añadir cuenta bancaria",
-      "openSpaceAccount": "Abrir una cuenta del space",
+      "addCurrency": "Add routing account",
       "finishVerificationFirst": "Complete primero la verificación en curso",
       "allCurrenciesCovered": "Todas las monedas compatibles ya tienen cuentas",
       "loadingAccounts": "Cargando cuentas bancarias…",
@@ -3065,6 +3057,10 @@
       "activating": "Activando…",
       "activateFailed": "No pudimos completar la configuración. Inténtelo de nuevo más tarde. Si el problema persiste, contáctenos.",
       "openGearForVerification": "Haga clic para abrir los detalles de verificación y los enlaces de Bridge."
+    },
+    "minimums": {
+      "depositNote": "Minimum deposit:",
+      "payoutNote": "Minimum transfer:"
     },
     "advanced": {
       "gearLabel": "Configuración bancaria",

--- a/packages/i18n/src/messages/es.json
+++ b/packages/i18n/src/messages/es.json
@@ -3165,7 +3165,7 @@
       "organizationLegend": "Datos de la organización",
       "organizationHint": "Los datos de la organización se envían a nuestro socio bancario para verificación y no se almacenan en Hypha.",
       "currenciesTitle": "Monedas que desea utilizar",
-      "currenciesDescription": "Seleccione las monedas que este space aceptará por transferencia bancaria. Verificamos su organización una sola vez con nuestro socio bancario.",
+      "currenciesDescription": "Seleccione las monedas que este space utilizará para depósitos y pagos bancarios. Su organización será verificada una vez con nuestro socio bancario.",
       "currenciesHint": "Puede añadir más monedas más tarde desde la configuración bancaria.",
       "submit": "Continuar"
     },

--- a/packages/i18n/src/messages/es.json
+++ b/packages/i18n/src/messages/es.json
@@ -1349,8 +1349,8 @@
     "aiAgentsMobilizedCount": "Movilizado {count, plural, one {# vez} other {# veces}}"
   },
   "TreasuryTab": {
-    "bankingRoutes": "Banking",
-    "balance": "Balance",
+    "bankingRoutes": "Banca",
+    "balance": "Saldo",
     "wallet": "Billetera",
     "searchTokens": "Buscar tokens",
     "hideSmall": "Ocultar pequeños",
@@ -2859,30 +2859,30 @@
     "deleteFailed": "No se pudo eliminar esta señal. Inténtalo de nuevo."
   },
   "BankingTab": {
-    "title": "Banking Routes",
+    "title": "Banca",
     "loading": "Cargando el estado de la cuenta bancaria…",
     "returnBanner": "Bienvenido de nuevo — estamos comprobando su estado de verificación.",
     "returnBannerDismiss": "Descartar",
-    "returnBannerApprovedHint": "Verification is complete. Add routing accounts for any remaining currencies.",
+    "returnBannerApprovedHint": "La verificación ha sido completada. Añada cuentas de enrutamiento para las monedas restantes.",
     "errorLoad": "No se pudo cargar el estado de la cuenta bancaria.",
     "errorFetchStatus": "Hubo un problema al recuperar su información bancaria. Por favor, inténtelo de nuevo más tarde.",
     "sections": {
       "transfers": {
-        "title": "One-time Transfer Routes",
-        "description": "Single-use bank transfer accounts that automatically route incoming funds to the space USDC or EURC wallets.",
-        "emptyTitle": "No one-time transfer routes yet",
-        "newTransferCta": "Add one-time route",
+        "title": "Rutas de Transferencia Única",
+        "description": "Cuentas de transferencia bancaria de un solo uso que enrutan automáticamente los fondos entrantes a las billeteras USDC o EURC del space.",
+        "emptyTitle": "Aún no hay rutas de transferencia única",
+        "newTransferCta": "Añadir ruta única",
         "loading": "Cargando transferencias…"
       },
       "accounts": {
-        "title": "Deposit Routing Accounts",
-        "description": "Bank transfer accounts that automatically route incoming funds to the space USDC or EURC wallets.",
-        "emptyTitle": "No deposit routing accounts yet",
+        "title": "Cuentas de Enrutamiento de Depósito",
+        "description": "Cuentas de transferencia bancaria que enrutan automáticamente los fondos entrantes a las billeteras USDC o EURC del space.",
+        "emptyTitle": "Aún no hay cuentas de enrutamiento de depósito",
         "pendingTitle": "Verificación en curso",
-        "pendingDescription": "Finish verification in Bridge to activate the currencies you selected. Your routing accounts will be set up automatically once approved.",
+        "pendingDescription": "Complete la verificación en Bridge para activar las monedas seleccionadas. Las cuentas de enrutamiento se configurarán automáticamente una vez aprobadas.",
         "continueVerificationCta": "Continuar verificación",
         "loadingAccounts": "Cargando cuentas bancarias…",
-        "signInHint": "Sign in to manage banking routes."
+        "signInHint": "Inicie sesión para gestionar las rutas bancarias."
       }
     },
     "payouts": {
@@ -2891,14 +2891,14 @@
         "payouts": "Pagos"
       },
       "section": {
-        "title": "Payout Bank Accounts",
-        "description": "Register an external bank account to transfer funds from your USDC or EURC wallets through proposals."
+        "title": "Cuentas Bancarias de Pago",
+        "description": "Registre una cuenta bancaria externa para transferir fondos desde sus billeteras USDC o EURC a través de propuestas."
       },
       "addCta": "Añadir cuenta de pago",
       "loading": "Cargando cuentas de pago…",
-      "emptyTitle": "No payout bank accounts yet",
+      "emptyTitle": "Aún no hay cuentas bancarias de pago",
       "cardBankFallback": "Cuenta bancaria",
-      "liquidationAddressLabel": "Payout address",
+      "liquidationAddressLabel": "Dirección de pago",
       "payoutAddressLabel": "Dirección de pago",
       "detail": {
         "title": "Cuenta de pago",
@@ -2915,7 +2915,7 @@
       "addDialog": {
         "title": "Añadir cuenta de pago",
         "stepOf": "Paso {current} de {total}",
-        "step1Description": "Indicate the currency of the destination bank account.",
+        "step1Description": "Indique la moneda de la cuenta bancaria de destino.",
         "step2Description": "Introduzca los datos bancarios de la cuenta de destino.",
         "step3Description": "Introduzca la dirección del beneficiario y los detalles de la transferencia.",
         "step4Description": "Revise y confirme los detalles de su cuenta de pago.",
@@ -2976,10 +2976,10 @@
         "submitting": "Creando…",
         "success": {
           "title": "Cuenta de pago registrada",
-          "subtitle": "The account is active. Copy the payout address to use in proposals.",
-          "liquidationAddressLabel": "Payout address",
+          "subtitle": "La cuenta está activa. Copie la dirección de pago para usarla en propuestas.",
+          "liquidationAddressLabel": "Dirección de pago",
           "howToTitle": "Cómo realizar pagos",
-          "howToText": "Create a Funding or Expenses proposal pointing to this address as the payout destination. Funds will be converted and transferred to your registered bank.",
+          "howToText": "Cree una propuesta de Funding o Expenses apuntando a esta dirección como destino de pago. Los fondos serán convertidos y transferidos a su banco registrado.",
           "done": "Listo"
         },
         "swift": {
@@ -3015,22 +3015,22 @@
       }
     },
     "openAccount": {
-      "title": "Set up deposit routing accounts",
-      "titleAddCurrency": "Add a deposit routing account",
-      "description": "Tell us about your organization and which currencies you support. You'll verify your space once, and then be able to use deposit and payout banking routes.",
-      "descriptionAddCurrency": "Choose additional currencies to add deposit routing accounts for your space.",
-      "descriptionAddCurrencySingle": "Choose the deposit currency for this routing account. Additional verification from the provider may be required.",
+      "title": "Configurar cuentas de enrutamiento de depósito",
+      "titleAddCurrency": "Añadir una cuenta de enrutamiento de depósito",
+      "description": "Cuéntenos sobre su organización y las monedas que admite. Verificará su space una sola vez y luego podrá usar rutas bancarias de depósito y pago.",
+      "descriptionAddCurrency": "Elija monedas adicionales para añadir cuentas de enrutamiento de depósito para su space.",
+      "descriptionAddCurrencySingle": "Cree instrucciones de depósito permanentes para transferencias entrantes. Los fondos se convierten automáticamente a USDC o EURC y se liquidan en su billetera de tesorería.",
       "bankAccountDepositLabel": "Moneda de depósito",
-      "bankAccountDepositHint": "Currency this routing account will receive.",
+      "bankAccountDepositHint": "Moneda que recibirá esta cuenta de enrutamiento.",
       "legalName": "Nombre legal de la entidad",
       "contactEmail": "Correo de contacto",
       "currenciesLabel": "Monedas",
-      "currenciesHint": "Select every currency you want to receive bank deposits in.",
-      "currenciesHintSingle": "Select a currency you want to receive bank deposits in.",
-      "submit": "Set up routing accounts",
-      "submitAddCurrency": "Add routing account",
+      "currenciesHint": "Seleccione todas las monedas en las que desea recibir depósitos bancarios.",
+      "currenciesHintSingle": "Seleccione una moneda en la que desea recibir depósitos bancarios.",
+      "submit": "Configurar cuentas de enrutamiento",
+      "submitAddCurrency": "Añadir cuenta de enrutamiento",
       "submitting": "Procesando…",
-      "noCurrenciesAvailable": "All supported deposit routing accounts are already set up for this space.",
+      "noCurrenciesAvailable": "Todas las cuentas de enrutamiento de depósito compatibles ya están configuradas para este space.",
       "railLabel": "Vía de pago",
       "railPlaceholder": "Seleccionar vía",
       "requestRail": "Solicitar",
@@ -3041,7 +3041,7 @@
       "redirectPendingDescription": "Acepte los términos y complete la verificación para activar las monedas seleccionadas."
     },
     "toolbar": {
-      "addCurrency": "Add routing account",
+      "addCurrency": "Añadir cuenta de enrutamiento",
       "finishVerificationFirst": "Complete primero la verificación en curso",
       "allCurrenciesCovered": "Todas las monedas compatibles ya tienen cuentas",
       "loadingAccounts": "Cargando cuentas bancarias…",
@@ -3059,8 +3059,8 @@
       "openGearForVerification": "Haga clic para abrir los detalles de verificación y los enlaces de Bridge."
     },
     "minimums": {
-      "depositNote": "Minimum deposit:",
-      "payoutNote": "Minimum transfer:"
+      "depositNote": "Depósito mínimo:",
+      "payoutNote": "Transferencia mínima:"
     },
     "advanced": {
       "gearLabel": "Configuración bancaria",
@@ -3261,7 +3261,7 @@
     },
     "createTransfer": {
       "title": "Nueva transferencia única",
-      "description": "Cree instrucciones de depósito para una sola transferencia entrante. Los fondos se convierten a una stablecoin (USDC o EURC) en su tesorería.",
+      "description": "Cree instrucciones de depósito para una sola transferencia entrante. Los fondos se convierten automáticamente a USDC o EURC y se liquidan en su billetera de tesorería.",
       "corridorLabel": "Corredor",
       "corridorHint": "Seleccione cómo enviará fondos el pagador. Esto determina las instrucciones de depósito.",
       "fixedAmountLabel": "Exigir un importe fijo",

--- a/packages/i18n/src/messages/fr.json
+++ b/packages/i18n/src/messages/fr.json
@@ -591,7 +591,7 @@
     "aiAgentsMobilizedCount": "Mobilisé {count, plural, one {# fois} other {# fois}}"
   },
   "TreasuryTab": {
-    "bankAccounts": "Comptes bancaires",
+    "bankingRoutes": "Banking",
     "balance": "Solde",
     "wallet": "Portefeuille",
     "searchTokens": "Rechercher des tokens",
@@ -2855,35 +2855,30 @@
     "deleteFailed": "Impossible de supprimer ce signal. Réessayez."
   },
   "BankingTab": {
-    "title": "Virements bancaires",
-    "subtitle": "Recevez des virements bancaires dans votre trésorerie et gérez les comptes de dépôt du space.",
+    "title": "Banking Routes",
     "loading": "Chargement du statut du compte bancaire…",
     "returnBanner": "Bon retour — nous vérifions votre statut de vérification.",
     "returnBannerDismiss": "Fermer",
-    "returnBannerApprovedHint": "La vérification est terminée. Ouvrez un compte space pour ajouter les devises restantes.",
+    "returnBannerApprovedHint": "Verification is complete. Add routing accounts for any remaining currencies.",
     "errorLoad": "Impossible de charger le statut du compte bancaire.",
     "errorFetchStatus": "Un problème est survenu lors de la récupération de vos informations bancaires. Veuillez réessayer plus tard.",
     "sections": {
       "transfers": {
-        "title": "Virements bancaires ponctuels",
-        "description": "Virements entrants ponctuels.",
-        "emptyTitle": "Aucun virement ponctuel pour le moment",
-        "emptyDescription": "Créez un virement ponctuel lorsque vous avez besoin d'un seul paiement entrant sans configurer un compte de dépôt complet.",
-        "newTransferCta": "Nouveau virement ponctuel",
+        "title": "One-time Transfer Routes",
+        "description": "Single-use bank transfer accounts that automatically route incoming funds to the space USDC or EURC wallets.",
+        "emptyTitle": "No one-time transfer routes yet",
+        "newTransferCta": "Add one-time route",
         "loading": "Chargement des virements…"
       },
       "accounts": {
-        "title": "Comptes bancaires",
-        "description": "Coordonnées de dépôt permanentes par devise.",
-        "openAccountCta": "Ouvrir un compte space",
-        "addCurrencyCta": "Ajouter un compte bancaire",
-        "emptyTitle": "Aucun compte bancaire pour le moment",
-        "emptyDescription": "Ouvrez un compte space et choisissez les devises dont vous avez besoin. Nous configurerons les coordonnées de dépôt pour chacune.",
+        "title": "Deposit Routing Accounts",
+        "description": "Bank transfer accounts that automatically route incoming funds to the space USDC or EURC wallets.",
+        "emptyTitle": "No deposit routing accounts yet",
         "pendingTitle": "Vérification en cours",
-        "pendingDescription": "Terminez la vérification dans Bridge pour activer les devises sélectionnées. Vos comptes seront créés automatiquement une fois approuvés.",
+        "pendingDescription": "Finish verification in Bridge to activate the currencies you selected. Your routing accounts will be set up automatically once approved.",
         "continueVerificationCta": "Continuer la vérification",
         "loadingAccounts": "Chargement des comptes bancaires…",
-        "signInHint": "Connectez-vous pour gérer les comptes bancaires."
+        "signInHint": "Sign in to manage banking routes."
       }
     },
     "payouts": {
@@ -2892,15 +2887,14 @@
         "payouts": "Paiements"
       },
       "section": {
-        "title": "Comptes de paiement",
-        "description": "Enregistrez où le trésor envoie les fonds après une proposition approuvée. Chaque compte reçoit une adresse de liquidation pour les propositions Financement ou Dépenses."
+        "title": "Payout Bank Accounts",
+        "description": "Register an external bank account to transfer funds from your USDC or EURC wallets through proposals."
       },
       "addCta": "Ajouter un compte de paiement",
       "loading": "Chargement des comptes de paiement…",
-      "emptyTitle": "Aucun compte de paiement pour l'instant",
-      "emptyDescription": "Enregistrez un compte bancaire pour recevoir les paiements du trésor. USDC du trésor → adresse de liquidation → vote → fiat dans votre banque.",
+      "emptyTitle": "No payout bank accounts yet",
       "cardBankFallback": "Compte bancaire",
-      "liquidationAddressLabel": "Adresse de liquidation",
+      "liquidationAddressLabel": "Payout address",
       "payoutAddressLabel": "Adresse de paiement",
       "detail": {
         "title": "Compte de paiement",
@@ -2917,7 +2911,7 @@
       "addDialog": {
         "title": "Ajouter un compte de paiement",
         "stepOf": "Étape {current} sur {total}",
-        "step1Description": "Choisissez la devise de destination de ce compte de paiement.",
+        "step1Description": "Indicate the currency of the destination bank account.",
         "step2Description": "Saisissez les coordonnées bancaires du compte de destination.",
         "step3Description": "Saisissez l'adresse du bénéficiaire et les détails du virement.",
         "step4Description": "Vérifiez et confirmez les détails de votre compte de paiement.",
@@ -2978,10 +2972,10 @@
         "submitting": "Création…",
         "success": {
           "title": "Compte de paiement enregistré",
-          "subtitle": "Le compte est actif. Copiez l'adresse de liquidation pour l'utiliser dans des propositions.",
-          "liquidationAddressLabel": "Adresse de liquidation",
+          "subtitle": "The account is active. Copy the payout address to use in proposals.",
+          "liquidationAddressLabel": "Payout address",
           "howToTitle": "Comment effectuer un paiement",
-          "howToText": "Créez une proposition Financement ou Dépenses → collez cette adresse comme destinataire → sélectionnez USDC ou EURC comme jeton → votez et exécutez. Bridge convertit et vire les fonds en fiat vers la banque enregistrée.",
+          "howToText": "Create a Funding or Expenses proposal pointing to this address as the payout destination. Funds will be converted and transferred to your registered bank.",
           "done": "Terminé"
         },
         "swift": {
@@ -3017,22 +3011,22 @@
       }
     },
     "openAccount": {
-      "title": "Ouvrir un compte space",
-      "titleAddCurrency": "Ajouter un compte bancaire",
-      "description": "Parlez-nous de votre organisation et des devises dont vous avez besoin. Nous vérifierons votre space une seule fois, puis créerons des comptes pour chaque devise.",
-      "descriptionAddCurrency": "Choisissez des devises supplémentaires pour ajouter des comptes de dépôt à votre space.",
-      "descriptionAddCurrencySingle": "Choisissez la devise de dépôt pour ce compte bancaire. Une vérification supplémentaire du fournisseur peut être requise.",
+      "title": "Set up deposit routing accounts",
+      "titleAddCurrency": "Add a deposit routing account",
+      "description": "Tell us about your organization and which currencies you support. You'll verify your space once, and then be able to use deposit and payout banking routes.",
+      "descriptionAddCurrency": "Choose additional currencies to add deposit routing accounts for your space.",
+      "descriptionAddCurrencySingle": "Choose the deposit currency for this routing account. Additional verification from the provider may be required.",
       "bankAccountDepositLabel": "Devise de dépôt",
-      "bankAccountDepositHint": "Devise que ce compte bancaire recevra.",
+      "bankAccountDepositHint": "Currency this routing account will receive.",
       "legalName": "Nom légal de l'entité",
       "contactEmail": "E-mail de contact",
       "currenciesLabel": "Devises",
-      "currenciesHint": "Sélectionnez toutes les devises dans lesquelles vous souhaitez recevoir des virements bancaires.",
-      "currenciesHintSingle": "Sélectionnez une devise dans laquelle vous souhaitez recevoir des virements bancaires.",
-      "submit": "Ouvrir le compte",
-      "submitAddCurrency": "Ajouter un compte bancaire",
+      "currenciesHint": "Select every currency you want to receive bank deposits in.",
+      "currenciesHintSingle": "Select a currency you want to receive bank deposits in.",
+      "submit": "Set up routing accounts",
+      "submitAddCurrency": "Add routing account",
       "submitting": "Traitement en cours…",
-      "noCurrenciesAvailable": "Tous les comptes bancaires pris en charge sont déjà ouverts pour ce space.",
+      "noCurrenciesAvailable": "All supported deposit routing accounts are already set up for this space.",
       "railLabel": "Canal de paiement",
       "railPlaceholder": "Sélectionner un canal",
       "requestRail": "Demander",
@@ -3043,9 +3037,7 @@
       "redirectPendingDescription": "Acceptez les conditions et terminez la vérification pour activer les devises sélectionnées."
     },
     "toolbar": {
-      "add": "Ajouter",
-      "addCurrency": "Ajouter un compte bancaire",
-      "openSpaceAccount": "Ouvrir un compte space",
+      "addCurrency": "Add routing account",
       "finishVerificationFirst": "Terminez d'abord la vérification en cours",
       "allCurrenciesCovered": "Toutes les devises prises en charge ont déjà des comptes",
       "loadingAccounts": "Chargement des comptes bancaires…",
@@ -3061,6 +3053,10 @@
       "activating": "Activation…",
       "activateFailed": "Nous n'avons pas pu terminer la configuration. Veuillez réessayer plus tard. Si le problème persiste, contactez-nous.",
       "openGearForVerification": "Cliquez pour ouvrir les détails de vérification et les liens Bridge."
+    },
+    "minimums": {
+      "depositNote": "Minimum deposit:",
+      "payoutNote": "Minimum transfer:"
     },
     "advanced": {
       "gearLabel": "Paramètres bancaires",

--- a/packages/i18n/src/messages/fr.json
+++ b/packages/i18n/src/messages/fr.json
@@ -3161,7 +3161,7 @@
       "organizationLegend": "Informations sur l'organisation",
       "organizationHint": "Les informations sur l'organisation sont envoyées à notre partenaire bancaire pour vérification et ne sont pas stockées sur Hypha.",
       "currenciesTitle": "Devises que vous souhaitez utiliser",
-      "currenciesDescription": "Sélectionnez les devises que ce space acceptera par virement bancaire. Nous vérifions votre organisation une seule fois avec notre partenaire bancaire.",
+      "currenciesDescription": "Sélectionnez les devises que cet espace utilisera pour les dépôts et paiements bancaires. Votre organisation sera vérifiée une fois avec notre partenaire bancaire.",
       "currenciesHint": "Vous pourrez ajouter d'autres devises plus tard depuis les paramètres bancaires.",
       "submit": "Continuer"
     },

--- a/packages/i18n/src/messages/fr.json
+++ b/packages/i18n/src/messages/fr.json
@@ -591,7 +591,7 @@
     "aiAgentsMobilizedCount": "Mobilisé {count, plural, one {# fois} other {# fois}}"
   },
   "TreasuryTab": {
-    "bankingRoutes": "Banking",
+    "bankingRoutes": "Banque",
     "balance": "Solde",
     "wallet": "Portefeuille",
     "searchTokens": "Rechercher des tokens",
@@ -2855,30 +2855,30 @@
     "deleteFailed": "Impossible de supprimer ce signal. Réessayez."
   },
   "BankingTab": {
-    "title": "Banking Routes",
+    "title": "Banque",
     "loading": "Chargement du statut du compte bancaire…",
     "returnBanner": "Bon retour — nous vérifions votre statut de vérification.",
     "returnBannerDismiss": "Fermer",
-    "returnBannerApprovedHint": "Verification is complete. Add routing accounts for any remaining currencies.",
+    "returnBannerApprovedHint": "La vérification est terminée. Ajoutez des comptes de routage pour les devises restantes.",
     "errorLoad": "Impossible de charger le statut du compte bancaire.",
     "errorFetchStatus": "Un problème est survenu lors de la récupération de vos informations bancaires. Veuillez réessayer plus tard.",
     "sections": {
       "transfers": {
-        "title": "One-time Transfer Routes",
-        "description": "Single-use bank transfer accounts that automatically route incoming funds to the space USDC or EURC wallets.",
-        "emptyTitle": "No one-time transfer routes yet",
-        "newTransferCta": "Add one-time route",
+        "title": "Virements ponctuels",
+        "description": "Comptes de virement bancaire à usage unique qui acheminent automatiquement les fonds entrants vers les portefeuilles USDC ou EURC de l’espace.",
+        "emptyTitle": "Aucun virement ponctuel pour l’instant",
+        "newTransferCta": "Ajouter un virement ponctuel",
         "loading": "Chargement des virements…"
       },
       "accounts": {
-        "title": "Deposit Routing Accounts",
-        "description": "Bank transfer accounts that automatically route incoming funds to the space USDC or EURC wallets.",
-        "emptyTitle": "No deposit routing accounts yet",
+        "title": "Comptes de routage des dépôts",
+        "description": "Comptes de virement bancaire qui acheminent automatiquement les fonds entrants vers les portefeuilles USDC ou EURC de l’espace.",
+        "emptyTitle": "Aucun compte de routage des dépôts pour l’instant",
         "pendingTitle": "Vérification en cours",
-        "pendingDescription": "Finish verification in Bridge to activate the currencies you selected. Your routing accounts will be set up automatically once approved.",
+        "pendingDescription": "Terminez la vérification dans Bridge pour activer les devises sélectionnées. Vos comptes de routage seront configurés automatiquement une fois approuvés.",
         "continueVerificationCta": "Continuer la vérification",
         "loadingAccounts": "Chargement des comptes bancaires…",
-        "signInHint": "Sign in to manage banking routes."
+        "signInHint": "Connectez-vous pour gérer vos routes bancaires."
       }
     },
     "payouts": {
@@ -2887,14 +2887,14 @@
         "payouts": "Paiements"
       },
       "section": {
-        "title": "Payout Bank Accounts",
-        "description": "Register an external bank account to transfer funds from your USDC or EURC wallets through proposals."
+        "title": "Comptes bancaires de paiement",
+        "description": "Enregistrez un compte bancaire externe pour transférer des fonds depuis vos portefeuilles USDC ou EURC via des propositions."
       },
       "addCta": "Ajouter un compte de paiement",
       "loading": "Chargement des comptes de paiement…",
-      "emptyTitle": "No payout bank accounts yet",
+      "emptyTitle": "Aucun compte bancaire de paiement pour l’instant",
       "cardBankFallback": "Compte bancaire",
-      "liquidationAddressLabel": "Payout address",
+      "liquidationAddressLabel": "Adresse de paiement",
       "payoutAddressLabel": "Adresse de paiement",
       "detail": {
         "title": "Compte de paiement",
@@ -2911,7 +2911,7 @@
       "addDialog": {
         "title": "Ajouter un compte de paiement",
         "stepOf": "Étape {current} sur {total}",
-        "step1Description": "Indicate the currency of the destination bank account.",
+        "step1Description": "Indiquez la devise du compte bancaire de destination.",
         "step2Description": "Saisissez les coordonnées bancaires du compte de destination.",
         "step3Description": "Saisissez l'adresse du bénéficiaire et les détails du virement.",
         "step4Description": "Vérifiez et confirmez les détails de votre compte de paiement.",
@@ -2972,10 +2972,10 @@
         "submitting": "Création…",
         "success": {
           "title": "Compte de paiement enregistré",
-          "subtitle": "The account is active. Copy the payout address to use in proposals.",
-          "liquidationAddressLabel": "Payout address",
+          "subtitle": "Le compte est actif. Copiez l’adresse de paiement pour l’utiliser dans vos propositions.",
+          "liquidationAddressLabel": "Adresse de paiement",
           "howToTitle": "Comment effectuer un paiement",
-          "howToText": "Create a Funding or Expenses proposal pointing to this address as the payout destination. Funds will be converted and transferred to your registered bank.",
+          "howToText": "Créez une proposition Funding ou Expenses en indiquant cette adresse comme destination de paiement. Les fonds seront convertis et transférés vers votre banque enregistrée.",
           "done": "Terminé"
         },
         "swift": {
@@ -3011,22 +3011,22 @@
       }
     },
     "openAccount": {
-      "title": "Set up deposit routing accounts",
-      "titleAddCurrency": "Add a deposit routing account",
-      "description": "Tell us about your organization and which currencies you support. You'll verify your space once, and then be able to use deposit and payout banking routes.",
-      "descriptionAddCurrency": "Choose additional currencies to add deposit routing accounts for your space.",
-      "descriptionAddCurrencySingle": "Choose the deposit currency for this routing account. Additional verification from the provider may be required.",
+      "title": "Configurer les comptes de routage des dépôts",
+      "titleAddCurrency": "Ajouter un compte de routage des dépôts",
+      "description": "Parlez-nous de votre organisation et des devises que vous prenez en charge. Vous vérifierez votre espace une seule fois, puis pourrez utiliser les routes bancaires de dépôt et de paiement.",
+      "descriptionAddCurrency": "Choisissez des devises supplémentaires pour ajouter des comptes de routage des dépôts à votre espace.",
+      "descriptionAddCurrencySingle": "Créez des instructions de dépôt permanentes pour les virements entrants. Les fonds sont automatiquement convertis en USDC ou EURC et réglés dans votre portefeuille de trésorerie.",
       "bankAccountDepositLabel": "Devise de dépôt",
-      "bankAccountDepositHint": "Currency this routing account will receive.",
+      "bankAccountDepositHint": "Devise que ce compte de routage recevra.",
       "legalName": "Nom légal de l'entité",
       "contactEmail": "E-mail de contact",
       "currenciesLabel": "Devises",
-      "currenciesHint": "Select every currency you want to receive bank deposits in.",
-      "currenciesHintSingle": "Select a currency you want to receive bank deposits in.",
-      "submit": "Set up routing accounts",
-      "submitAddCurrency": "Add routing account",
+      "currenciesHint": "Sélectionnez toutes les devises dans lesquelles vous souhaitez recevoir des dépôts bancaires.",
+      "currenciesHintSingle": "Sélectionnez une devise dans laquelle vous souhaitez recevoir des dépôts bancaires.",
+      "submit": "Configurer les comptes de routage",
+      "submitAddCurrency": "Ajouter un compte de routage",
       "submitting": "Traitement en cours…",
-      "noCurrenciesAvailable": "All supported deposit routing accounts are already set up for this space.",
+      "noCurrenciesAvailable": "Tous les comptes de routage des dépôts pris en charge sont déjà configurés pour cet espace.",
       "railLabel": "Canal de paiement",
       "railPlaceholder": "Sélectionner un canal",
       "requestRail": "Demander",
@@ -3037,7 +3037,7 @@
       "redirectPendingDescription": "Acceptez les conditions et terminez la vérification pour activer les devises sélectionnées."
     },
     "toolbar": {
-      "addCurrency": "Add routing account",
+      "addCurrency": "Ajouter un compte de routage",
       "finishVerificationFirst": "Terminez d'abord la vérification en cours",
       "allCurrenciesCovered": "Toutes les devises prises en charge ont déjà des comptes",
       "loadingAccounts": "Chargement des comptes bancaires…",
@@ -3055,8 +3055,8 @@
       "openGearForVerification": "Cliquez pour ouvrir les détails de vérification et les liens Bridge."
     },
     "minimums": {
-      "depositNote": "Minimum deposit:",
-      "payoutNote": "Minimum transfer:"
+      "depositNote": "Dépôt minimum :",
+      "payoutNote": "Virement minimum :"
     },
     "advanced": {
       "gearLabel": "Paramètres bancaires",
@@ -3257,7 +3257,7 @@
     },
     "createTransfer": {
       "title": "Nouveau virement ponctuel",
-      "description": "Créez des instructions de dépôt pour un seul virement entrant. Les fonds sont convertis en stablecoin (USDC ou EURC) dans votre trésorerie.",
+      "description": "Créez des instructions de dépôt pour un seul virement entrant. Les fonds sont automatiquement convertis en USDC ou EURC et réglés dans votre portefeuille de trésorerie.",
       "corridorLabel": "Corridor",
       "corridorHint": "Sélectionnez comment le payeur enverra les fonds. Cela détermine les instructions de dépôt.",
       "fixedAmountLabel": "Exiger un montant fixe",

--- a/packages/i18n/src/messages/pt.json
+++ b/packages/i18n/src/messages/pt.json
@@ -3163,7 +3163,7 @@
       "organizationLegend": "Dados da organização",
       "organizationHint": "Os dados da organização são enviados ao nosso parceiro bancário para verificação e não são armazenados na Hypha.",
       "currenciesTitle": "Moedas que deseja utilizar",
-      "currenciesDescription": "Selecione as moedas que este space aceitará por transferência bancária. Verificamos sua organização uma vez com nosso parceiro bancário.",
+      "currenciesDescription": "Selecione as moedas que este space utilizará para depósitos e pagamentos bancários. Sua organização será verificada uma vez com nosso parceiro bancário.",
       "currenciesHint": "Você pode adicionar mais moedas depois nas configurações bancárias.",
       "submit": "Continuar"
     },

--- a/packages/i18n/src/messages/pt.json
+++ b/packages/i18n/src/messages/pt.json
@@ -1349,8 +1349,8 @@
     "aiAgentsMobilizedCount": "Mobilizado {count, plural, one {# vez} other {# vezes}}"
   },
   "TreasuryTab": {
-    "bankingRoutes": "Banking",
-    "balance": "Equilíbrio",
+    "bankingRoutes": "Banco",
+    "balance": "Saldo",
     "wallet": "Carteira",
     "searchTokens": "Tokens de pesquisa",
     "hideSmall": "Ocultar pequenos",
@@ -2857,30 +2857,30 @@
     "deleteFailed": "Não foi possível eliminar este sinal. Tente novamente."
   },
   "BankingTab": {
-    "title": "Banking Routes",
+    "title": "Banco",
     "loading": "Carregando status da conta bancária…",
     "returnBanner": "Bem-vindo de volta — estamos verificando seu status de verificação.",
     "returnBannerDismiss": "Dispensar",
-    "returnBannerApprovedHint": "Verification is complete. Add routing accounts for any remaining currencies.",
+    "returnBannerApprovedHint": "A verificação está concluída. Adicione contas de roteamento para as moedas restantes.",
     "errorLoad": "Não foi possível carregar o status da conta bancária.",
     "errorFetchStatus": "Houve um problema ao recuperar suas informações bancárias. Por favor, tente novamente mais tarde.",
     "sections": {
       "transfers": {
-        "title": "One-time Transfer Routes",
-        "description": "Single-use bank transfer accounts that automatically route incoming funds to the space USDC or EURC wallets.",
-        "emptyTitle": "No one-time transfer routes yet",
-        "newTransferCta": "Add one-time route",
+        "title": "Rotas de transferência avulsas",
+        "description": "Contas de transferência bancária de uso único que roteiam automaticamente os fundos recebidos para as carteiras USDC ou EURC do space.",
+        "emptyTitle": "Nenhuma rota de transferência avulsa ainda",
+        "newTransferCta": "Adicionar rota avulsa",
         "loading": "Carregando transferências…"
       },
       "accounts": {
-        "title": "Deposit Routing Accounts",
-        "description": "Bank transfer accounts that automatically route incoming funds to the space USDC or EURC wallets.",
-        "emptyTitle": "No deposit routing accounts yet",
+        "title": "Contas de roteamento de depósito",
+        "description": "Contas de transferência bancária que roteiam automaticamente os fundos recebidos para as carteiras USDC ou EURC do space.",
+        "emptyTitle": "Nenhuma conta de roteamento de depósito ainda",
         "pendingTitle": "Verificação em andamento",
-        "pendingDescription": "Finish verification in Bridge to activate the currencies you selected. Your routing accounts will be set up automatically once approved.",
+        "pendingDescription": "Conclua a verificação no Bridge para ativar as moedas selecionadas. Suas contas de roteamento serão configuradas automaticamente após a aprovação.",
         "continueVerificationCta": "Continuar verificação",
         "loadingAccounts": "Carregando contas bancárias…",
-        "signInHint": "Sign in to manage banking routes."
+        "signInHint": "Faça login para gerenciar as rotas bancárias."
       }
     },
     "payouts": {
@@ -2889,14 +2889,14 @@
         "payouts": "Pagamentos"
       },
       "section": {
-        "title": "Payout Bank Accounts",
-        "description": "Register an external bank account to transfer funds from your USDC or EURC wallets through proposals."
+        "title": "Contas bancárias de pagamento",
+        "description": "Cadastre uma conta bancária externa para transferir fundos das suas carteiras USDC ou EURC por meio de propostas."
       },
       "addCta": "Adicionar conta de pagamento",
       "loading": "Carregando contas de pagamento…",
-      "emptyTitle": "No payout bank accounts yet",
+      "emptyTitle": "Nenhuma conta bancária de pagamento ainda",
       "cardBankFallback": "Conta bancária",
-      "liquidationAddressLabel": "Payout address",
+      "liquidationAddressLabel": "Endereço de pagamento",
       "payoutAddressLabel": "Endereço de pagamento",
       "detail": {
         "title": "Conta de pagamento",
@@ -2913,7 +2913,7 @@
       "addDialog": {
         "title": "Adicionar conta de pagamento",
         "stepOf": "Etapa {current} de {total}",
-        "step1Description": "Indicate the currency of the destination bank account.",
+        "step1Description": "Indique a moeda da conta bancária de destino.",
         "step2Description": "Informe os dados bancários da conta de destino.",
         "step3Description": "Insira o endereço do beneficiário e os detalhes da transferência.",
         "step4Description": "Revise e confirme os detalhes da sua conta de pagamento.",
@@ -2974,10 +2974,10 @@
         "submitting": "Criando…",
         "success": {
           "title": "Conta de pagamento registrada",
-          "subtitle": "The account is active. Copy the payout address to use in proposals.",
-          "liquidationAddressLabel": "Payout address",
+          "subtitle": "A conta está ativa. Copie o endereço de pagamento para usar em propostas.",
+          "liquidationAddressLabel": "Endereço de pagamento",
           "howToTitle": "Como realizar pagamentos",
-          "howToText": "Create a Funding or Expenses proposal pointing to this address as the payout destination. Funds will be converted and transferred to your registered bank.",
+          "howToText": "Crie uma proposta de Funding ou Expenses apontando para este endereço como destino do pagamento. Os fundos serão convertidos e transferidos para o banco cadastrado.",
           "done": "Concluído"
         },
         "swift": {
@@ -3013,22 +3013,22 @@
       }
     },
     "openAccount": {
-      "title": "Set up deposit routing accounts",
-      "titleAddCurrency": "Add a deposit routing account",
-      "description": "Tell us about your organization and which currencies you support. You'll verify your space once, and then be able to use deposit and payout banking routes.",
-      "descriptionAddCurrency": "Choose additional currencies to add deposit routing accounts for your space.",
-      "descriptionAddCurrencySingle": "Choose the deposit currency for this routing account. Additional verification from the provider may be required.",
+      "title": "Configurar contas de roteamento de depósito",
+      "titleAddCurrency": "Adicionar uma conta de roteamento de depósito",
+      "description": "Conte-nos sobre sua organização e quais moedas você utiliza. Você verificará seu space uma única vez e poderá usar rotas bancárias de depósito e pagamento.",
+      "descriptionAddCurrency": "Escolha moedas adicionais para adicionar contas de roteamento de depósito ao seu space.",
+      "descriptionAddCurrencySingle": "Crie instruções de depósito permanentes para transferências recebidas. Os fundos são convertidos automaticamente para USDC ou EURC e liquidados na sua carteira do tesouro.",
       "bankAccountDepositLabel": "Moeda de depósito",
-      "bankAccountDepositHint": "Currency this routing account will receive.",
+      "bankAccountDepositHint": "Moeda que esta conta de roteamento receberá.",
       "legalName": "Nome legal da entidade",
       "contactEmail": "E-mail de contato",
       "currenciesLabel": "Moedas",
-      "currenciesHint": "Select every currency you want to receive bank deposits in.",
-      "currenciesHintSingle": "Select a currency you want to receive bank deposits in.",
-      "submit": "Set up routing accounts",
-      "submitAddCurrency": "Add routing account",
+      "currenciesHint": "Selecione todas as moedas em que deseja receber depósitos bancários.",
+      "currenciesHintSingle": "Selecione uma moeda em que deseja receber depósitos bancários.",
+      "submit": "Configurar contas de roteamento",
+      "submitAddCurrency": "Adicionar conta de roteamento",
       "submitting": "Processando…",
-      "noCurrenciesAvailable": "All supported deposit routing accounts are already set up for this space.",
+      "noCurrenciesAvailable": "Todas as contas de roteamento de depósito compatíveis já estão configuradas para este space.",
       "railLabel": "Via de pagamento",
       "railPlaceholder": "Selecionar via",
       "requestRail": "Solicitar",
@@ -3039,7 +3039,7 @@
       "redirectPendingDescription": "Aceite os termos e conclua a verificação para ativar as moedas selecionadas."
     },
     "toolbar": {
-      "addCurrency": "Add routing account",
+      "addCurrency": "Adicionar conta de roteamento",
       "finishVerificationFirst": "Conclua primeiro a verificação em andamento",
       "allCurrenciesCovered": "Todas as moedas compatíveis já possuem contas",
       "loadingAccounts": "Carregando contas bancárias…",
@@ -3057,8 +3057,8 @@
       "openGearForVerification": "Clique para abrir detalhes da verificação e links do Bridge."
     },
     "minimums": {
-      "depositNote": "Minimum deposit:",
-      "payoutNote": "Minimum transfer:"
+      "depositNote": "Depósito mínimo:",
+      "payoutNote": "Transferência mínima:"
     },
     "advanced": {
       "gearLabel": "Configurações bancárias",
@@ -3259,7 +3259,7 @@
     },
     "createTransfer": {
       "title": "Nova transferência única",
-      "description": "Crie instruções de depósito para uma única transferência recebida. Os fundos são convertidos em uma stablecoin (USDC ou EURC) na sua tesouraria.",
+      "description": "Crie instruções de depósito para uma única transferência recebida. Os fundos são convertidos automaticamente para USDC ou EURC e liquidados na sua carteira do tesouro.",
       "corridorLabel": "Corredor",
       "corridorHint": "Selecione como o pagador enviará os fundos. Isso determina as instruções de depósito.",
       "fixedAmountLabel": "Exigir valor fixo",

--- a/packages/i18n/src/messages/pt.json
+++ b/packages/i18n/src/messages/pt.json
@@ -1349,7 +1349,7 @@
     "aiAgentsMobilizedCount": "Mobilizado {count, plural, one {# vez} other {# vezes}}"
   },
   "TreasuryTab": {
-    "bankAccounts": "Contas bancárias",
+    "bankingRoutes": "Banking",
     "balance": "Equilíbrio",
     "wallet": "Carteira",
     "searchTokens": "Tokens de pesquisa",
@@ -2857,35 +2857,30 @@
     "deleteFailed": "Não foi possível eliminar este sinal. Tente novamente."
   },
   "BankingTab": {
-    "title": "Transferências bancárias",
-    "subtitle": "Receba transferências bancárias na sua tesouraria e gerencie contas de depósito do space.",
+    "title": "Banking Routes",
     "loading": "Carregando status da conta bancária…",
     "returnBanner": "Bem-vindo de volta — estamos verificando seu status de verificação.",
     "returnBannerDismiss": "Dispensar",
-    "returnBannerApprovedHint": "A verificação está concluída. Abra uma conta do space para adicionar as moedas restantes.",
+    "returnBannerApprovedHint": "Verification is complete. Add routing accounts for any remaining currencies.",
     "errorLoad": "Não foi possível carregar o status da conta bancária.",
     "errorFetchStatus": "Houve um problema ao recuperar suas informações bancárias. Por favor, tente novamente mais tarde.",
     "sections": {
       "transfers": {
-        "title": "Transferências bancárias únicas",
-        "description": "Transferências recebidas pontuais.",
-        "emptyTitle": "Ainda não há transferências únicas",
-        "emptyDescription": "Crie uma transferência única quando precisar de um único pagamento recebido sem configurar uma conta de depósito completa.",
-        "newTransferCta": "Nova transferência única",
+        "title": "One-time Transfer Routes",
+        "description": "Single-use bank transfer accounts that automatically route incoming funds to the space USDC or EURC wallets.",
+        "emptyTitle": "No one-time transfer routes yet",
+        "newTransferCta": "Add one-time route",
         "loading": "Carregando transferências…"
       },
       "accounts": {
-        "title": "Contas bancárias",
-        "description": "Dados de depósito permanentes por moeda.",
-        "openAccountCta": "Abrir uma conta do space",
-        "addCurrencyCta": "Adicionar conta bancária",
-        "emptyTitle": "Ainda não há contas bancárias",
-        "emptyDescription": "Abra uma conta do space e escolha as moedas necessárias. Configuraremos os dados de depósito para cada uma.",
+        "title": "Deposit Routing Accounts",
+        "description": "Bank transfer accounts that automatically route incoming funds to the space USDC or EURC wallets.",
+        "emptyTitle": "No deposit routing accounts yet",
         "pendingTitle": "Verificação em andamento",
-        "pendingDescription": "Conclua a verificação no Bridge para ativar as moedas selecionadas. Suas contas serão criadas automaticamente após a aprovação.",
+        "pendingDescription": "Finish verification in Bridge to activate the currencies you selected. Your routing accounts will be set up automatically once approved.",
         "continueVerificationCta": "Continuar verificação",
         "loadingAccounts": "Carregando contas bancárias…",
-        "signInHint": "Entre para gerenciar contas bancárias."
+        "signInHint": "Sign in to manage banking routes."
       }
     },
     "payouts": {
@@ -2894,15 +2889,14 @@
         "payouts": "Pagamentos"
       },
       "section": {
-        "title": "Contas de pagamento",
-        "description": "Registre para onde o tesouro envia fiat após uma proposta aprovada. Cada conta recebe um endereço de liquidação para propostas de Financiamento ou Despesas."
+        "title": "Payout Bank Accounts",
+        "description": "Register an external bank account to transfer funds from your USDC or EURC wallets through proposals."
       },
       "addCta": "Adicionar conta de pagamento",
       "loading": "Carregando contas de pagamento…",
-      "emptyTitle": "Ainda não há contas de pagamento",
-      "emptyDescription": "Registre uma conta bancária para receber pagamentos do tesouro. USDC do tesouro → endereço de liquidação → votação → fiat no seu banco.",
+      "emptyTitle": "No payout bank accounts yet",
       "cardBankFallback": "Conta bancária",
-      "liquidationAddressLabel": "Endereço de liquidação",
+      "liquidationAddressLabel": "Payout address",
       "payoutAddressLabel": "Endereço de pagamento",
       "detail": {
         "title": "Conta de pagamento",
@@ -2919,7 +2913,7 @@
       "addDialog": {
         "title": "Adicionar conta de pagamento",
         "stepOf": "Etapa {current} de {total}",
-        "step1Description": "Escolha a moeda de destino desta conta de pagamento.",
+        "step1Description": "Indicate the currency of the destination bank account.",
         "step2Description": "Informe os dados bancários da conta de destino.",
         "step3Description": "Insira o endereço do beneficiário e os detalhes da transferência.",
         "step4Description": "Revise e confirme os detalhes da sua conta de pagamento.",
@@ -2980,10 +2974,10 @@
         "submitting": "Criando…",
         "success": {
           "title": "Conta de pagamento registrada",
-          "subtitle": "A conta está ativa. Copie o endereço de liquidação para usar em propostas.",
-          "liquidationAddressLabel": "Endereço de liquidação",
+          "subtitle": "The account is active. Copy the payout address to use in proposals.",
+          "liquidationAddressLabel": "Payout address",
           "howToTitle": "Como realizar pagamentos",
-          "howToText": "Crie uma proposta de Financiamento ou Despesas → cole este endereço como destinatário → selecione USDC ou EURC como token → vote e execute. A Bridge converte e transfere fiat para o banco registrado.",
+          "howToText": "Create a Funding or Expenses proposal pointing to this address as the payout destination. Funds will be converted and transferred to your registered bank.",
           "done": "Concluído"
         },
         "swift": {
@@ -3019,22 +3013,22 @@
       }
     },
     "openAccount": {
-      "title": "Abrir uma conta do space",
-      "titleAddCurrency": "Adicionar uma conta bancária",
-      "description": "Conte-nos sobre sua organização e quais moedas você precisa. Verificaremos seu space uma vez e criaremos contas para cada moeda.",
-      "descriptionAddCurrency": "Escolha moedas adicionais para adicionar contas de depósito ao seu space.",
-      "descriptionAddCurrencySingle": "Escolha a moeda de depósito para esta conta bancária. Verificação adicional do provedor pode ser necessária.",
+      "title": "Set up deposit routing accounts",
+      "titleAddCurrency": "Add a deposit routing account",
+      "description": "Tell us about your organization and which currencies you support. You'll verify your space once, and then be able to use deposit and payout banking routes.",
+      "descriptionAddCurrency": "Choose additional currencies to add deposit routing accounts for your space.",
+      "descriptionAddCurrencySingle": "Choose the deposit currency for this routing account. Additional verification from the provider may be required.",
       "bankAccountDepositLabel": "Moeda de depósito",
-      "bankAccountDepositHint": "Moeda que esta conta bancária receberá.",
+      "bankAccountDepositHint": "Currency this routing account will receive.",
       "legalName": "Nome legal da entidade",
       "contactEmail": "E-mail de contato",
       "currenciesLabel": "Moedas",
-      "currenciesHint": "Selecione todas as moedas nas quais deseja receber transferências bancárias.",
-      "currenciesHintSingle": "Selecione uma moeda na qual deseja receber transferências bancárias.",
-      "submit": "Abrir conta",
-      "submitAddCurrency": "Adicionar conta bancária",
+      "currenciesHint": "Select every currency you want to receive bank deposits in.",
+      "currenciesHintSingle": "Select a currency you want to receive bank deposits in.",
+      "submit": "Set up routing accounts",
+      "submitAddCurrency": "Add routing account",
       "submitting": "Processando…",
-      "noCurrenciesAvailable": "Todas as contas bancárias compatíveis já estão abertas para este space.",
+      "noCurrenciesAvailable": "All supported deposit routing accounts are already set up for this space.",
       "railLabel": "Via de pagamento",
       "railPlaceholder": "Selecionar via",
       "requestRail": "Solicitar",
@@ -3045,9 +3039,7 @@
       "redirectPendingDescription": "Aceite os termos e conclua a verificação para ativar as moedas selecionadas."
     },
     "toolbar": {
-      "add": "Adicionar",
-      "addCurrency": "Adicionar conta bancária",
-      "openSpaceAccount": "Abrir uma conta do space",
+      "addCurrency": "Add routing account",
       "finishVerificationFirst": "Conclua primeiro a verificação em andamento",
       "allCurrenciesCovered": "Todas as moedas compatíveis já possuem contas",
       "loadingAccounts": "Carregando contas bancárias…",
@@ -3063,6 +3055,10 @@
       "activating": "Ativando…",
       "activateFailed": "Não foi possível concluir a configuração. Tente novamente mais tarde. Se o problema persistir, entre em contato conosco.",
       "openGearForVerification": "Clique para abrir detalhes da verificação e links do Bridge."
+    },
+    "minimums": {
+      "depositNote": "Minimum deposit:",
+      "payoutNote": "Minimum transfer:"
     },
     "advanced": {
       "gearLabel": "Configurações bancárias",


### PR DESCRIPTION
## Summary

Closes #2338

Five cosmetic/copy improvements to the Banking tab UI — no functional changes.

- **Tab repositioned** to second position in the Treasury tab strip (Wallet → Banking → Transactions → Vaults)
- **Tab renamed** from "Bank Accounts" / "Banking Routes" to "Banking"
- **Section titles rewritten** to reflect forwarding-rail semantics:
  - Deposit accounts → "Deposit Routing Accounts"
  - One-time accounts → "One-time Transfer Routes"
  - Payouts → "Payout Bank Accounts"
- **Section descriptions rewritten** — forwarding-rail framing (funds automatically converted and settled in treasury wallet)
- **Minimum transfer notes** added as static informational text in all four entry points: deposit rail picker, one-time transfer dialog, payout add dialog (inside Treasury token box), and payout detail dialog
- **Empty state `emptyDescription` removed** from all three empty states (Deposit Routing Accounts, One-time Transfer Routes, Payout Bank Accounts)
- **Dead i18n keys removed**: `BankingTab.subtitle`, `toolbar.add`, `toolbar.openSpaceAccount`, `openAccount.openAccountCta`, `openAccount.addCurrencyCta`
- **Full i18n pass** for all 5 locales (en/de/es/fr/pt) including terminology audit (pt `balance` → "Saldo", es `balance` → "Saldo"), BOM fix in `de.json`, and all new/changed keys

## Test plan

- [ ] Banking tab appears second in Treasury tab strip
- [ ] Tab label reads "Banking" (previously "Bank Accounts" or "Banking Routes")
- [ ] Deposit Routing Accounts section: correct title, description, empty state (no subtitle)
- [ ] One-time Transfer Routes section: correct title, description, empty state (no subtitle)
- [ ] Payout Bank Accounts section: correct title, description, empty state (no subtitle)
- [ ] Minimum transfer note visible in deposit rail picker after selecting destination currency
- [ ] Minimum transfer note visible in one-time transfer dialog
- [ ] Minimum transfer note visible inside "Treasury token" box in payout add dialog
- [ ] Minimum transfer note visible in payout detail dialog "How to use" section
- [ ] Initial setup currencies description reads correctly
- [ ] Switch locale to de/es/fr/pt and verify no English placeholders remain

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new Banking/“banking routes” tab section in the Treasury interface.
  * Display payout and deposit minimum notes in relevant Banking/Treasury flows when applicable.

* **UI/UX Improvements**
  * Reorganized Treasury tab content for improved browsing flow.
  * Simplified empty-state messaging for deposits and payout accounts (title-only).
  * Refreshed Banking/Treasury terminology and labels across English, German, Spanish, French, and Portuguese for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->