### PR TITLE
fix(governance): link minter-deployed tokens and show their proposal info

### DIFF
--- a/apps/web/src/app/api/webhooks/proposal/executed/route.ts
+++ b/apps/web/src/app/api/webhooks/proposal/executed/route.ts
@@ -3,6 +3,7 @@ import {
   findDocumentsCreatorsForNotifications,
   findDocumentWithSpaceByIdRaw,
   findPeopleByWeb3Addresses,
+  linkDeployedTokenForProposal,
   web3Client,
 } from '@hypha-platform/core/server';
 import { getSpaceDetails } from '@hypha-platform/core/client';
@@ -184,6 +185,44 @@ export const POST = proposalExecutedSigningKey
           .forEach(({ reason }) =>
             console.error(
               'Failed to notify space members about proposal execution:',
+              reason,
+            ),
+          );
+      },
+      async (events) => {
+        // Server-side token-address backfill: deterministically links a
+        // deployed token's address to its DB row when a deploy proposal
+        // executes, independent of any browser being open. No-ops for
+        // non-token proposals.
+        const linking = events.map(async (event) => {
+          const proposalId = event.args.proposalId;
+          if (
+            proposalId > BigInt(Number.MAX_SAFE_INTEGER) ||
+            proposalId < BigInt(Number.MIN_SAFE_INTEGER)
+          ) {
+            return;
+          }
+
+          const result = await linkDeployedTokenForProposal(
+            {
+              proposalId: Number(proposalId),
+              transactionHash: event.transactionHash,
+            },
+            { db },
+          );
+
+          if (result.status === 'linked') {
+            console.info(
+              `Linked deployed token ${result.address} for proposal ${proposalId}.`,
+            );
+          }
+        });
+
+        (await Promise.allSettled(linking))
+          .filter((res) => res.status === 'rejected')
+          .forEach(({ reason }) =>
+            console.error(
+              'Failed to link deployed token for proposal:',
               reason,
             ),
           );

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -13,6 +13,14 @@ const CONNECT_SOURCES =
  * - object-src: `<object type="application/pdf">` fallback when canvas render fails
  */
 const UPLOADTHING_UFS_HOST = 'https://*.ufs.sh';
+/**
+ * UploadThing v7 uploads go to a region-prefixed ingest host
+ * (`<region>.ingest.uploadthing.com`), which is distinct from the `*.ufs.sh`
+ * serving CDN. Without it in `connect-src`, the upload PUT is blocked by CSP and
+ * the client hangs (e.g. "Uploading token icon..." never completes). Hardcoded
+ * (like `*.ufs.sh`) so uploads work regardless of per-env `NEXT_PUBLIC_CONNECT_SOURCES`.
+ */
+const UPLOADTHING_INGEST_HOST = 'https://*.ingest.uploadthing.com';
 
 /** OpenAI Realtime API (WebRTC / client secrets) — onboarding voice discovery Phase 2. */
 const OPENAI_REALTIME_CONNECT_SOURCES =
@@ -76,6 +84,7 @@ function applyCsp(response: NextResponse, request: NextRequest): NextResponse {
     'https://oauth2.googleapis.com',
     'https://content.googleapis.com',
     UPLOADTHING_UFS_HOST,
+    UPLOADTHING_INGEST_HOST,
     process.env.NEXT_PUBLIC_RPC_URL ?? '',
     process.env.NEXT_PUBLIC_MATRIX_HOMESERVER_URL ?? '',
     localChainRpc,

--- a/packages/core/src/assets/server/file-router.ts
+++ b/packages/core/src/assets/server/file-router.ts
@@ -27,23 +27,33 @@ const SVG_FALLBACK_MIME_TYPES = new Set([
 ]);
 
 export const fileRouter: FileRouter = {
-  attachmentUploader: f({
-    pdf: {
-      maxFileSize: UPLOADTHING_STANDARD_MAX_FILE_SIZE,
-      maxFileCount: UPLOADTHING_STANDARD_MAX_FILE_COUNT,
-      contentDisposition: 'attachment',
+  attachmentUploader: f(
+    {
+      pdf: {
+        maxFileSize: UPLOADTHING_STANDARD_MAX_FILE_SIZE,
+        maxFileCount: UPLOADTHING_STANDARD_MAX_FILE_COUNT,
+        contentDisposition: 'attachment',
+      },
+      image: {
+        maxFileSize: UPLOADTHING_STANDARD_MAX_FILE_SIZE,
+        maxFileCount: UPLOADTHING_STANDARD_MAX_FILE_COUNT,
+        contentDisposition: 'attachment',
+      },
+      blob: {
+        maxFileSize: UPLOADTHING_STANDARD_MAX_FILE_SIZE,
+        maxFileCount: UPLOADTHING_STANDARD_MAX_FILE_COUNT,
+        contentDisposition: 'attachment',
+      },
     },
-    image: {
-      maxFileSize: UPLOADTHING_STANDARD_MAX_FILE_SIZE,
-      maxFileCount: UPLOADTHING_STANDARD_MAX_FILE_COUNT,
-      contentDisposition: 'attachment',
-    },
-    blob: {
-      maxFileSize: UPLOADTHING_STANDARD_MAX_FILE_SIZE,
-      maxFileCount: UPLOADTHING_STANDARD_MAX_FILE_COUNT,
-      contentDisposition: 'attachment',
-    },
-  })
+    /**
+     * Do not block the browser on the server `onUploadComplete` webhook.
+     * Preview deployments sit behind Vercel Deployment Protection, so
+     * UploadThing's server-to-server callback to `/api/uploadthing` cannot
+     * authenticate; with the default `awaitServerData: true` the client polls
+     * forever after the ingest PUT succeeds.
+     */
+    { awaitServerData: false },
+  )
     .middleware(async ({ req }) => {
       const isValidAuthToken = await getAuthenticatedUser(req);
 
@@ -57,16 +67,19 @@ export const fileRouter: FileRouter = {
     .onUploadComplete(({ file }) =>
       console.debug(`Attachment "${file.key}" was successfully uploaded`),
     ),
-  imageUploader: f({
-    image: {
-      maxFileSize: UPLOADTHING_STANDARD_MAX_FILE_SIZE,
-      maxFileCount: 1,
+  imageUploader: f(
+    {
+      image: {
+        maxFileSize: UPLOADTHING_STANDARD_MAX_FILE_SIZE,
+        maxFileCount: 1,
+      },
+      blob: {
+        maxFileSize: UPLOADTHING_STANDARD_MAX_FILE_SIZE,
+        maxFileCount: 1,
+      },
     },
-    blob: {
-      maxFileSize: UPLOADTHING_STANDARD_MAX_FILE_SIZE,
-      maxFileCount: 1,
-    },
-  })
+    { awaitServerData: false },
+  )
     .middleware(async ({ req, files }) => {
       const isValidAuthToken = await getAuthenticatedUser(req);
 
@@ -98,18 +111,21 @@ export const fileRouter: FileRouter = {
       console.debug('ourFileRouter.onUploadComplete', { metadata, file });
       return;
     }),
-  callRecordingUploader: f({
-    video: {
-      maxFileSize: CALL_RECORDING_UPLOADTHING_MAX_FILE_SIZE,
-      maxFileCount: 1,
-      contentDisposition: 'inline',
+  callRecordingUploader: f(
+    {
+      video: {
+        maxFileSize: CALL_RECORDING_UPLOADTHING_MAX_FILE_SIZE,
+        maxFileCount: 1,
+        contentDisposition: 'inline',
+      },
+      blob: {
+        maxFileSize: CALL_RECORDING_UPLOADTHING_MAX_FILE_SIZE,
+        maxFileCount: 1,
+        contentDisposition: 'inline',
+      },
     },
-    blob: {
-      maxFileSize: CALL_RECORDING_UPLOADTHING_MAX_FILE_SIZE,
-      maxFileCount: 1,
-      contentDisposition: 'inline',
-    },
-  })
+    { awaitServerData: false },
+  )
     .middleware(async ({ req, files }) => {
       const isValidAuthToken = await getAuthenticatedUser(req);
       if (!isValidAuthToken) {

--- a/packages/core/src/common/server/webhooks/alchemy/middleware.ts
+++ b/packages/core/src/common/server/webhooks/alchemy/middleware.ts
@@ -19,6 +19,6 @@ export function newMiddleware(signingKey: string): Middleware {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
     if (!timingSafeEqual(theirSignature, ourSignature))
-      NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   };
 }

--- a/packages/core/src/governance/client/__tests__/decoders-with-minters.test.ts
+++ b/packages/core/src/governance/client/__tests__/decoders-with-minters.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from 'vitest';
+import { encodeFunctionData } from 'viem';
+import {
+  regularTokenFactoryAbi,
+  ownershipTokenFactoryAbi,
+  decayingTokenFactoryAbi,
+} from '@hypha-platform/core/generated';
+import { decodeTransaction } from '../hooks/decoders';
+import { decayBasisPointsToFormPercent } from '../../voice-decay-units';
+
+const ZERO = '0x0000000000000000000000000000000000000000' as const;
+
+const tx = (data: `0x${string}`) => ({
+  data,
+  target: ZERO,
+  value: 0n,
+});
+
+/** Common purchase/whitelist fields shared by every WithMinters struct. */
+const purchaseFields = {
+  tokenPrice: 0n,
+  priceCurrencyFeed: ZERO,
+  useTransferWhitelist: false,
+  useReceiveWhitelist: false,
+  initialTransferWhitelist: [],
+  initialReceiveWhitelist: [],
+  initialTransferWhitelistSpaceIds: [],
+  initialReceiveWhitelistSpaceIds: [],
+  paymentToken: ZERO,
+  paymentTokenPricePerToken: 0n,
+  tokensForSale: 0n,
+  purchaseEligibilityMode: 0,
+  initialPurchaseWhitelistSpaceIds: [],
+  initialAuthorizedMinters: [ZERO],
+} as const;
+
+describe('decodeTransaction — deploy*WithMinters variants', () => {
+  it('decodes deployTokenWithMinters as a regular token payload', () => {
+    const data = encodeFunctionData({
+      abi: regularTokenFactoryAbi,
+      functionName: 'deployTokenWithMinters',
+      args: [
+        {
+          spaceId: 1105n,
+          name: 'Local Impact Token',
+          symbol: 'LIT',
+          maxSupply: 1000n,
+          transferable: true,
+          fixedMaxSupply: false,
+          autoMinting: true,
+          defaultCreditLimit: 0n,
+          initialCreditWhitelistSpaceIds: [],
+          ...purchaseFields,
+        },
+      ],
+    });
+
+    const result = decodeTransaction(tx(data));
+
+    expect(result?.type).toBe('token');
+    expect(result?.data).toMatchObject({
+      tokenType: 'regular',
+      spaceId: 1105n,
+      name: 'Local Impact Token',
+      symbol: 'LIT',
+      maxSupply: 1000n,
+      transferable: true,
+      fixedMaxSupply: false,
+      autoMinting: true,
+    });
+  });
+
+  it('decodes deployOwnershipTokenWithMinters as an ownership token payload', () => {
+    const data = encodeFunctionData({
+      abi: ownershipTokenFactoryAbi,
+      functionName: 'deployOwnershipTokenWithMinters',
+      args: [
+        {
+          spaceId: 42n,
+          name: 'Ownership Token',
+          symbol: 'OWN',
+          maxSupply: 500n,
+          fixedMaxSupply: true,
+          autoMinting: false,
+          ...purchaseFields,
+        },
+      ],
+    });
+
+    const result = decodeTransaction(tx(data));
+
+    expect(result?.type).toBe('token');
+    expect(result?.data).toMatchObject({
+      tokenType: 'ownership',
+      spaceId: 42n,
+      name: 'Ownership Token',
+      symbol: 'OWN',
+      maxSupply: 500n,
+      fixedMaxSupply: true,
+      autoMinting: false,
+    });
+    // Ownership tokens have no `transferable` field in their struct.
+    expect(result?.data).not.toHaveProperty('transferable');
+  });
+
+  it('decodes deployDecayingTokenWithMinters as a voice token payload with decay', () => {
+    const decayBasisPoints = 500n;
+    const data = encodeFunctionData({
+      abi: decayingTokenFactoryAbi,
+      functionName: 'deployDecayingTokenWithMinters',
+      args: [
+        {
+          spaceId: 7n,
+          name: 'Voice Token',
+          symbol: 'VOICE',
+          maxSupply: 0n,
+          transferable: false,
+          fixedMaxSupply: false,
+          autoMinting: true,
+          decayPercentage: decayBasisPoints,
+          decayInterval: 86400n,
+          ...purchaseFields,
+        },
+      ],
+    });
+
+    const result = decodeTransaction(tx(data));
+
+    expect(result?.type).toBe('token');
+    expect(result?.data).toMatchObject({
+      tokenType: 'voice',
+      spaceId: 7n,
+      name: 'Voice Token',
+      symbol: 'VOICE',
+      transferable: false,
+      decayInterval: 86400n,
+      decayPercentage: BigInt(
+        decayBasisPointsToFormPercent(Number(decayBasisPoints)),
+      ),
+    });
+  });
+});

--- a/packages/core/src/governance/client/hooks/decoders.ts
+++ b/packages/core/src/governance/client/hooks/decoders.ts
@@ -522,6 +522,77 @@ function decodeDecayingSpaceTokenAdminProposal(
   }
 }
 
+/**
+ * Shape of the single `DeployParams` struct arg used by the `deploy*WithMinters`
+ * factory functions. Fields are a superset across regular/ownership/decaying:
+ * ownership has no `transferable`, only decaying carries decay fields, and only
+ * regular carries the mutual-credit fields. Optional members are simply absent
+ * for token types that don't define them.
+ */
+type DeployWithMintersParams = {
+  spaceId: bigint;
+  name: string;
+  symbol: string;
+  maxSupply: bigint;
+  transferable?: boolean;
+  fixedMaxSupply: boolean;
+  autoMinting: boolean;
+  tokenPrice: bigint;
+  priceCurrencyFeed: `0x${string}`;
+  useTransferWhitelist: boolean;
+  useReceiveWhitelist: boolean;
+  initialTransferWhitelist: readonly `0x${string}`[];
+  initialReceiveWhitelist: readonly `0x${string}`[];
+  initialTransferWhitelistSpaceIds: readonly bigint[];
+  initialReceiveWhitelistSpaceIds: readonly bigint[];
+  defaultCreditLimit?: bigint;
+  initialCreditWhitelistSpaceIds?: readonly bigint[];
+  decayPercentage?: bigint;
+  decayInterval?: bigint;
+};
+
+/**
+ * Maps a `deploy*WithMinters` struct arg to the same `token` payload the plain
+ * `deploy*Token` handlers produce, so the proposal card renders token info for
+ * minter-based deployments too.
+ */
+const tokenPayloadFromWithMintersParams = (
+  p: DeployWithMintersParams,
+  tokenType: 'regular' | 'ownership' | 'voice',
+): DecodedPayload => ({
+  type: 'token',
+  data: {
+    tokenType,
+    spaceId: p.spaceId,
+    name: p.name,
+    symbol: p.symbol,
+    maxSupply: p.maxSupply,
+    ...(p.transferable !== undefined && { transferable: p.transferable }),
+    fixedMaxSupply: p.fixedMaxSupply,
+    autoMinting: p.autoMinting,
+    priceInUSD: p.tokenPrice,
+    priceCurrencyFeed: p.priceCurrencyFeed,
+    useTransferWhitelist: p.useTransferWhitelist,
+    useReceiveWhitelist: p.useReceiveWhitelist,
+    initialTransferWhitelist: p.initialTransferWhitelist,
+    initialReceiveWhitelist: p.initialReceiveWhitelist,
+    initialTransferWhitelistSpaceIds: p.initialTransferWhitelistSpaceIds,
+    initialReceiveWhitelistSpaceIds: p.initialReceiveWhitelistSpaceIds,
+    ...(p.defaultCreditLimit !== undefined && {
+      defaultCreditLimit: p.defaultCreditLimit,
+    }),
+    ...(p.initialCreditWhitelistSpaceIds !== undefined && {
+      initialCreditWhitelistSpaceIds: p.initialCreditWhitelistSpaceIds,
+    }),
+    ...(p.decayPercentage !== undefined && {
+      decayPercentage: BigInt(
+        decayBasisPointsToFormPercent(Number(p.decayPercentage)),
+      ),
+    }),
+    ...(p.decayInterval !== undefined && { decayInterval: p.decayInterval }),
+  },
+});
+
 export function decodeTransaction(tx: Tx) {
   const decoders: TransactionDecoder[] = [
     {
@@ -676,6 +747,41 @@ export function decodeTransaction(tx: Tx) {
                 decayInterval: decoded.args[16],
               },
             }
+          : null,
+    },
+    /**
+     * `deploy*WithMinters` variants take a single `DeployParams` struct arg.
+     * They live on the same generated factory ABIs, so the plain `deploy*Token`
+     * handlers above return null for them and decoding falls through to here.
+     */
+    {
+      abi: regularTokenFactoryAbi,
+      handler: (decoded) =>
+        decoded.functionName === 'deployTokenWithMinters'
+          ? tokenPayloadFromWithMintersParams(
+              decoded.args[0] as DeployWithMintersParams,
+              'regular',
+            )
+          : null,
+    },
+    {
+      abi: ownershipTokenFactoryAbi,
+      handler: (decoded) =>
+        decoded.functionName === 'deployOwnershipTokenWithMinters'
+          ? tokenPayloadFromWithMintersParams(
+              decoded.args[0] as DeployWithMintersParams,
+              'ownership',
+            )
+          : null,
+    },
+    {
+      abi: decayingTokenFactoryAbi,
+      handler: (decoded) =>
+        decoded.functionName === 'deployDecayingTokenWithMinters'
+          ? tokenPayloadFromWithMintersParams(
+              decoded.args[0] as DeployWithMintersParams,
+              'voice',
+            )
           : null,
     },
     /**

--- a/packages/core/src/governance/client/hooks/useProposalActions.ts
+++ b/packages/core/src/governance/client/hooks/useProposalActions.ts
@@ -22,8 +22,11 @@ export const useProposalActions = () => {
             abi: regularTokenFactoryAbi,
             data: tx.data,
           });
-          if (decodedRegular.functionName === 'deployToken') {
-            actions.push('deployToken');
+          if (
+            decodedRegular.functionName === 'deployToken' ||
+            decodedRegular.functionName === 'deployTokenWithMinters'
+          ) {
+            actions.push(decodedRegular.functionName);
             return;
           }
         } catch {}
@@ -33,8 +36,11 @@ export const useProposalActions = () => {
             abi: ownershipTokenFactoryAbi,
             data: tx.data,
           });
-          if (decodedOwnership.functionName === 'deployOwnershipToken') {
-            actions.push('deployOwnershipToken');
+          if (
+            decodedOwnership.functionName === 'deployOwnershipToken' ||
+            decodedOwnership.functionName === 'deployOwnershipTokenWithMinters'
+          ) {
+            actions.push(decodedOwnership.functionName);
             return;
           }
         } catch {}
@@ -44,8 +50,11 @@ export const useProposalActions = () => {
             abi: decayingTokenFactoryAbi,
             data: tx.data,
           });
-          if (decodedDecaying.functionName === 'deployDecayingToken') {
-            actions.push('deployDecayingToken');
+          if (
+            decodedDecaying.functionName === 'deployDecayingToken' ||
+            decodedDecaying.functionName === 'deployDecayingTokenWithMinters'
+          ) {
+            actions.push(decodedDecaying.functionName);
             return;
           }
         } catch {}
@@ -63,6 +72,9 @@ export const useProposalActions = () => {
       'deployToken',
       'deployOwnershipToken',
       'deployDecayingToken',
+      'deployTokenWithMinters',
+      'deployOwnershipTokenWithMinters',
+      'deployDecayingTokenWithMinters',
     ];
     return (
       actions.length > 0 &&

--- a/packages/core/src/governance/server/extract-deployed-token-from-receipt.ts
+++ b/packages/core/src/governance/server/extract-deployed-token-from-receipt.ts
@@ -1,0 +1,61 @@
+import 'server-only';
+
+import { parseEventLogs } from 'viem';
+import {
+  regularTokenFactoryAbi,
+  ownershipTokenFactoryAbi,
+  decayingTokenFactoryAbi,
+} from '@hypha-platform/core/generated';
+
+import { web3Client } from '../../common/server/web3-rpc/client';
+
+export type DeployedTokenInfo = {
+  tokenAddress: `0x${string}`;
+  spaceId: bigint;
+  name: string;
+  symbol: string;
+};
+
+/**
+ * Server-side counterpart of the client `extractTokenAddressFromReceipt`.
+ * Reads a proposal-execution receipt and pulls the deployed token address from
+ * the factory `TokenDeployed` event. Works for both the plain `deploy*Token`
+ * and `deploy*WithMinters` paths since they emit the same event.
+ *
+ * Returns `null` when the receipt has no `TokenDeployed` log (e.g. the executed
+ * proposal didn't deploy a token).
+ */
+export const extractDeployedTokenFromReceipt = async (
+  transactionHash: `0x${string}`,
+): Promise<DeployedTokenInfo | null> => {
+  const receipt = await web3Client.getTransactionReceipt({
+    hash: transactionHash,
+  });
+
+  const logs = parseEventLogs({
+    abi: [
+      ...regularTokenFactoryAbi,
+      ...ownershipTokenFactoryAbi,
+      ...decayingTokenFactoryAbi,
+    ],
+    logs: receipt.logs,
+    strict: false,
+  });
+
+  const deployLog = logs.find((log) => log.eventName === 'TokenDeployed');
+  if (!deployLog) return null;
+
+  const args = deployLog.args as {
+    tokenAddress: `0x${string}`;
+    spaceId: bigint;
+    name: string;
+    symbol: string;
+  };
+
+  return {
+    tokenAddress: args.tokenAddress,
+    spaceId: args.spaceId,
+    name: args.name,
+    symbol: args.symbol,
+  };
+};

--- a/packages/core/src/governance/server/index.ts
+++ b/packages/core/src/governance/server/index.ts
@@ -6,4 +6,6 @@ export * from './get-token-holdings-by-space-slug';
 export * from './fetch-org-memory-asset';
 export * from './resolve-document-proposal-status';
 export * from './call-artifacts';
+export * from './extract-deployed-token-from-receipt';
+export * from './link-deployed-token';
 export * from './send-human-chat-message';

--- a/packages/core/src/governance/server/link-deployed-token.ts
+++ b/packages/core/src/governance/server/link-deployed-token.ts
@@ -1,6 +1,6 @@
 import 'server-only';
 
-import { DatabaseInstance } from '../../server';
+import type { DatabaseInstance } from '../../common/server/types';
 import { findTokenByAgreementWeb3Id } from './queries';
 import { updateToken } from './mutations';
 import { extractDeployedTokenFromReceipt } from './extract-deployed-token-from-receipt';

--- a/packages/core/src/governance/server/link-deployed-token.ts
+++ b/packages/core/src/governance/server/link-deployed-token.ts
@@ -1,0 +1,66 @@
+import 'server-only';
+
+import { DatabaseInstance } from '../../server';
+import { findTokenByAgreementWeb3Id } from './queries';
+import { updateToken } from './mutations';
+import { extractDeployedTokenFromReceipt } from './extract-deployed-token-from-receipt';
+
+export type LinkDeployedTokenInput = {
+  /** On-chain proposal id (matches `tokens.agreementWeb3Id`). */
+  proposalId: number;
+  /** Execution transaction hash from the `ProposalExecuted` event. */
+  transactionHash?: `0x${string}` | null;
+};
+
+export type LinkDeployedTokenResult =
+  | { status: 'linked'; address: `0x${string}` }
+  | {
+      status: 'skipped';
+      reason:
+        | 'no-db-token'
+        | 'already-linked'
+        | 'no-transaction-hash'
+        | 'no-token-deployed-event';
+      address?: string;
+    };
+
+/**
+ * Deterministically backfills `tokens.address` for a deploy proposal once it
+ * executes — the server-side replacement for the browser-only linking in
+ * `useProposalEvents`. Safe to call for any executed proposal: it no-ops unless
+ * a matching DB token exists with a still-empty address.
+ */
+export const linkDeployedTokenForProposal = async (
+  { proposalId, transactionHash }: LinkDeployedTokenInput,
+  { db }: { db: DatabaseInstance },
+): Promise<LinkDeployedTokenResult> => {
+  const token = await findTokenByAgreementWeb3Id(
+    { agreementWeb3Id: proposalId },
+    { db },
+  );
+  if (!token) {
+    return { status: 'skipped', reason: 'no-db-token' };
+  }
+  if (token.address) {
+    return {
+      status: 'skipped',
+      reason: 'already-linked',
+      address: token.address,
+    };
+  }
+  if (!transactionHash) {
+    return { status: 'skipped', reason: 'no-transaction-hash' };
+  }
+
+  const deployed = await extractDeployedTokenFromReceipt(transactionHash);
+  if (!deployed) {
+    return { status: 'skipped', reason: 'no-token-deployed-event' };
+  }
+
+  await updateToken(
+    { agreementWeb3Id: proposalId, address: deployed.tokenAddress },
+    { db },
+  );
+
+  return { status: 'linked', address: deployed.tokenAddress };
+};

--- a/packages/core/src/governance/server/mutations.ts
+++ b/packages/core/src/governance/server/mutations.ts
@@ -16,7 +16,8 @@ import {
   TokenUpdateData,
   isTokenUpdateData,
 } from '../types';
-import { DatabaseInstance, findTokenUpdateByDocumentId } from '../../server';
+import type { DatabaseInstance } from '../../common/server/types';
+import { findTokenUpdateByDocumentId } from './queries';
 import { CreateTokenInput, DeleteTokenInput } from '../types';
 import {
   buildUpdateTokenInputPatchFromTokenUpdateData,

--- a/packages/core/src/governance/server/queries.ts
+++ b/packages/core/src/governance/server/queries.ts
@@ -434,12 +434,22 @@ export const findTokenByAgreementWeb3Id = async (
   { agreementWeb3Id }: { agreementWeb3Id: number },
   { db }: DbConfig,
 ) => {
-  const [token] = await db
+  const matches = await db
     .select()
     .from(tokens)
     .where(eq(tokens.agreementWeb3Id, agreementWeb3Id))
-    .limit(1);
-  return token ?? null;
+    .limit(2);
+
+  if (matches.length === 0) {
+    return null;
+  }
+  if (matches.length > 1) {
+    throw new Error(
+      `Multiple tokens found with agreementWeb3Id: ${agreementWeb3Id}; refusing ambiguous lookup`,
+    );
+  }
+
+  return matches[0] ?? null;
 };
 
 export const findTokenUpdateByDocumentId = async (

--- a/packages/core/src/governance/server/queries.ts
+++ b/packages/core/src/governance/server/queries.ts
@@ -424,6 +424,24 @@ export const findAllDocumentsBySpaceSlugWithoutPagination = async (
   );
 };
 
+/**
+ * Find the single token row linked to an on-chain proposal id
+ * (`agreementWeb3Id`). Used by the server-side token-linking webhook to
+ * backfill `tokens.address` after a deploy proposal executes — independent of
+ * any browser being open.
+ */
+export const findTokenByAgreementWeb3Id = async (
+  { agreementWeb3Id }: { agreementWeb3Id: number },
+  { db }: DbConfig,
+) => {
+  const [token] = await db
+    .select()
+    .from(tokens)
+    .where(eq(tokens.agreementWeb3Id, agreementWeb3Id))
+    .limit(1);
+  return token ?? null;
+};
+
 export const findTokenUpdateByDocumentId = async (
   documentId: number,
   { db }: DbConfig,

--- a/packages/core/src/governance/server/queries.ts
+++ b/packages/core/src/governance/server/queries.ts
@@ -1,4 +1,4 @@
-import { DbConfig } from '@hypha-platform/core/server';
+import type { DbConfig } from '../../common/server/types';
 import { eq, sql, and, asc, desc, SQL } from 'drizzle-orm';
 
 import {

--- a/packages/storage-postgres/scripts/fix-lit-token-address.mjs
+++ b/packages/storage-postgres/scripts/fix-lit-token-address.mjs
@@ -1,0 +1,160 @@
+/**
+ * One-off, idempotent fix for the "LIT" (Local Impact Token) in space
+ * "Biorégion du Grand Paris" (web3SpaceId 1105).
+ *
+ * Context: the token WAS deployed on-chain (RegularTokenFactory) at
+ *   0x472320f5f22C133349d60373DeF05d8acA0cF827
+ * (verified on Base mainnet: getSpaceToken(1105) returns it, symbol() = "LIT",
+ *  name() = "Local Impact Token", totalSupply = 0).
+ * But its Postgres `tokens.address` was never written back (the address link is
+ * normally done client-side by the open proposal page at execution time), so the
+ * Treasury card renders "bare" (no type badge / created date / space / icon).
+ *
+ * This script backfills `tokens.address` for that row. It is SAFE:
+ *   - dry-run by default (prints what it would do); pass --apply to write.
+ *   - only updates rows whose address IS NULL and symbol matches.
+ *   - refuses to act if the target address is already linked to another row.
+ *
+ * Usage (read-only inspection):
+ *   DEFAULT_DB_URL=postgres://... node scripts/fix-lit-token-address.mjs
+ * Apply:
+ *   DEFAULT_DB_URL=postgres://... node scripts/fix-lit-token-address.mjs --apply
+ */
+import { neonConfig, Pool } from '@neondatabase/serverless';
+import { WebSocket } from 'ws';
+
+const WEB3_SPACE_ID = Number(process.env.WEB3_SPACE_ID || 1105);
+const TOKEN_SYMBOL = process.env.TOKEN_SYMBOL || 'LIT';
+const TOKEN_ADDRESS =
+  process.env.TOKEN_ADDRESS || '0x472320f5f22C133349d60373DeF05d8acA0cF827';
+const APPLY = process.argv.includes('--apply');
+
+const connectionString =
+  process.env.BRANCH_DB_URL || process.env.DEFAULT_DB_URL;
+
+if (!connectionString) {
+  console.error(
+    'Missing DB connection string. Set BRANCH_DB_URL or DEFAULT_DB_URL.',
+  );
+  process.exit(1);
+}
+
+if (connectionString.includes('localhost')) {
+  neonConfig.wsProxy = (host) => `${host}:5433/v1`;
+  neonConfig.useSecureWebSocket = false;
+  neonConfig.pipelineTLS = false;
+  neonConfig.pipelineConnect = false;
+} else {
+  neonConfig.webSocketConstructor = WebSocket;
+  neonConfig.poolQueryViaFetch = true;
+}
+
+const pool = new Pool({ connectionString });
+
+async function main() {
+  console.log(`Mode: ${APPLY ? 'APPLY (will write)' : 'DRY RUN (read-only)'}`);
+  console.log(
+    `Target: web3SpaceId=${WEB3_SPACE_ID} symbol=${TOKEN_SYMBOL} address=${TOKEN_ADDRESS}\n`,
+  );
+
+  const { rows: spaces } = await pool.query(
+    `SELECT id, slug, title, web3_space_id FROM spaces WHERE web3_space_id = $1`,
+    [WEB3_SPACE_ID],
+  );
+  if (spaces.length === 0) {
+    console.error(`No space found with web3_space_id = ${WEB3_SPACE_ID}.`);
+    return;
+  }
+  const space = spaces[0];
+  console.log(
+    `Space: id=${space.id} slug="${space.slug}" title="${space.title}"`,
+  );
+
+  // Show all tokens in this space for context.
+  const { rows: spaceTokens } = await pool.query(
+    `SELECT id, name, symbol, address, type, agreement_id, agreement_web3_id, created_at
+       FROM tokens WHERE space_id = $1 ORDER BY id`,
+    [space.id],
+  );
+  console.log(`\nTokens in space ${space.id}:`);
+  for (const t of spaceTokens) {
+    console.log(
+      `  #${t.id} ${t.symbol} "${t.name}" type=${t.type} address=${
+        t.address ?? 'NULL'
+      } agreementWeb3Id=${t.agreement_web3_id ?? 'NULL'} created=${t.created_at}`,
+    );
+  }
+
+  // Guard: is the target address already linked anywhere?
+  const { rows: existingByAddr } = await pool.query(
+    `SELECT id, symbol, space_id FROM tokens WHERE lower(address) = lower($1)`,
+    [TOKEN_ADDRESS],
+  );
+  if (existingByAddr.length > 0) {
+    console.log(
+      `\nAddress ${TOKEN_ADDRESS} is already linked to token(s): ${existingByAddr
+        .map((r) => `#${r.id}(${r.symbol})`)
+        .join(', ')}. Nothing to do.`,
+    );
+    return;
+  }
+
+  // Find the LIT row to fix.
+  const candidates = spaceTokens.filter(
+    (t) => (t.symbol || '').toUpperCase() === TOKEN_SYMBOL.toUpperCase(),
+  );
+  if (candidates.length === 0) {
+    console.log(
+      `\nNo DB token row found for symbol ${TOKEN_SYMBOL} in space ${space.id}. ` +
+        `A row may need to be created instead of updated — stopping (no insert performed).`,
+    );
+    return;
+  }
+  const nullAddr = candidates.filter((t) => t.address == null);
+  if (nullAddr.length === 0) {
+    console.log(
+      `\n${TOKEN_SYMBOL} row(s) already have an address set. Nothing to do.`,
+    );
+    return;
+  }
+  if (nullAddr.length > 1) {
+    console.log(
+      `\nFound ${nullAddr.length} ${TOKEN_SYMBOL} rows with NULL address ` +
+        `(ids: ${nullAddr.map((t) => t.id).join(', ')}). Refusing ambiguous update.`,
+    );
+    return;
+  }
+
+  const target = nullAddr[0];
+  console.log(
+    `\nWill set tokens.address = ${TOKEN_ADDRESS} on token #${target.id} (${target.symbol} "${target.name}").`,
+  );
+
+  if (!APPLY) {
+    console.log('\nDRY RUN — no changes written. Re-run with --apply to write.');
+    return;
+  }
+
+  const { rows: updated } = await pool.query(
+    `UPDATE tokens SET address = $1
+       WHERE id = $2 AND address IS NULL
+       RETURNING id, symbol, address`,
+    [TOKEN_ADDRESS, target.id],
+  );
+  if (updated.length === 0) {
+    console.log('No row updated (address was set concurrently?).');
+  } else {
+    console.log(
+      `Updated token #${updated[0].id} (${updated[0].symbol}) -> address=${updated[0].address}`,
+    );
+  }
+}
+
+main()
+  .then(() => pool.end())
+  .then(() => process.exit(0))
+  .catch(async (e) => {
+    console.error(e);
+    await pool.end().catch(() => {});
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary

Token deploy proposals created **with authorized minters** use the `*WithMinters` factory variants (a single `DeployParams` struct arg), which the client decoders and action recognizers never handled. Two visible bugs shared this one root cause:

1. **Empty proposal card** — the deploy transaction couldn't be decoded, so no token info rendered (reproduced on a fresh "On Voting" minters proposal, before any execution).
2. **Missing token metadata in Treasury** — `tokens.address` was never linked, because linking only ran client-side in an open browser. This is what made LIT appear with no data.

### Changes

- **Proposal card:** decode `deployTokenWithMinters` / `deployOwnershipTokenWithMinters` / `deployDecayingTokenWithMinters` in `decoders.ts` (shared helper for the struct arg; reuses the generated factory ABIs).
- **Client auto-link:** recognize the `*WithMinters` variants in `useProposalActions`.
- **Server-side linking (the durable fix):** new `extract-deployed-token-from-receipt.ts` + `linkDeployedTokenForProposal` + `findTokenByAgreementWeb3Id`, wired as a callback on the `ProposalExecuted` Alchemy webhook. Address backfill is now deterministic and independent of any browser being open. No-ops for non-token proposals.
- **Security hardening:** add the missing `return` in the Alchemy HMAC middleware — invalid signatures were previously falling through and getting processed.
- **Ops:** idempotent, dry-run-by-default backfill script (`fix-lit-token-address.mjs`) for tokens already affected before this fix.

## Test plan

- [x] `vitest` unit tests for all three `*WithMinters` decoders pass
- [x] ESLint clean on changed files (only pre-existing warnings)
- [x] `tsc` shows no new errors from these changes
- [x] LIT token already backfilled in the DB
- [ ] Verify a new minters proposal renders token info in the card
- [ ] Verify `tokens.address` is populated server-side after the `ProposalExecuted` webhook fires

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Token deployment proposals now correctly decode and display for newer “with minters” contract calls, including updated action extraction/validation.
  * After proposal execution, deployed token addresses are automatically linked back to their proposals using on-chain receipt data.
* **Bug Fixes**
  * Webhook signature verification now properly returns HTTP 401 on invalid signatures.
  * Updated CSP and upload ingest handling to prevent client upload requests from being blocked.
* **Chores**
  * Added a maintenance script to backfill missing token addresses for a specific token/space.
* **Tests**
  * Added coverage for “with minters” token deployment decoding scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->