### PR TITLE
debug(matrix): call stability debug instrumentation + TypeError guards (#2322)

### DIFF
--- a/packages/core/src/matrix/client/hooks/use-space-group-call.ts
+++ b/packages/core/src/matrix/client/hooks/use-space-group-call.ts
@@ -1830,6 +1830,21 @@ export function useSpaceGroupCall(
       (id) => !remoteIdsWithFeed.has(id),
     ).length;
 
+    // DEBUG-TEMP(#2322): verbose stall-check — revert after investigation
+    if (isMatrixCallDebugEnabled() && othersInCall.length > 0) {
+      console.debug('[hypha.group_call] stall-check', {
+        othersInCall,
+        remoteIdsWithFeed: [...remoteIdsWithFeed],
+        missingRemoteFeedCount,
+        allFeedUserIds: gc.userMediaFeeds.map((f) => ({
+          userId: f.userId,
+          local: f.isLocal(),
+          audioMuted: f.isAudioMuted?.(),
+        })),
+        participantMapSize: gc.participants.size,
+      });
+    }
+
     const now = Date.now();
     if (missingRemoteFeedCount > 0 && othersInCall.length > 0) {
       if (remoteMediaRepairNudgeIntervalRef.current == null) {

--- a/packages/core/src/matrix/client/hooks/use-space-group-call.ts
+++ b/packages/core/src/matrix/client/hooks/use-space-group-call.ts
@@ -287,8 +287,13 @@ function nudgeGroupCallPlaceOutgoing(gc: MatrixSdk.GroupCall): void {
   if (typeof fn !== 'function') return;
   try {
     fn.call(gc);
-  } catch {
-    /* ignore */
+  } catch (err) {
+    if (isMatrixCallDebugEnabled()) {
+      console.warn(
+        '[hypha.group_call] nudgeGroupCallPlaceOutgoing failed',
+        err,
+      );
+    }
   }
 }
 
@@ -2074,6 +2079,9 @@ export function useSpaceGroupCall(
         /** Local/remote feeds can appear after getUserMedia — re-publish and nudge peers. */
         nudgeGroupCallPlaceOutgoing(gc);
         scheduleLocalMediaBootstrap(gc);
+        if (isMatrixCallDebugEnabled()) {
+          logDevMediaSnapshot();
+        }
       };
       gc.on(GroupCallEvent.UserMediaFeedsChanged, onFeedsMaybeParticipants);
       gc.on(GroupCallEvent.ScreenshareFeedsChanged, onFeedsMaybeParticipants);
@@ -2131,6 +2139,7 @@ export function useSpaceGroupCall(
       evalRemoteMediaStall,
       syncLocalScreenshareState,
       reconcileLocalScreenshareStop,
+      logDevMediaSnapshot,
     ],
   );
 

--- a/packages/core/src/matrix/client/hooks/use-space-group-call.ts
+++ b/packages/core/src/matrix/client/hooks/use-space-group-call.ts
@@ -361,7 +361,7 @@ async function waitForPublishableLocalVideoTrack(
 
 /** Matrix SDK can leave a stale or missing track after camera off→on. */
 async function recoverLocalCameraFeed(gc: MatrixSdk.GroupCall): Promise<void> {
-  if (gc.isLocalVideoMuted()) return;
+  if (gc.isLocalVideoMuted?.() ?? true) return;
   if (getPublishableLocalVideoTrack(gc)) return;
   if (getLocalVideoTrackPresence(gc)) {
     if (await waitForPublishableLocalVideoTrack(gc, 1200)) return;
@@ -452,7 +452,7 @@ async function waitForLiveLocalAudioTrack(
 async function recoverLocalMicrophoneFeed(
   gc: MatrixSdk.GroupCall,
 ): Promise<void> {
-  if (gc.isMicrophoneMuted()) return;
+  if (gc.isMicrophoneMuted?.() ?? true) return;
   if (getLiveLocalAudioTrack(gc)) return;
 
   await gc.setMicrophoneMuted(true);
@@ -469,10 +469,10 @@ async function ensureLocalCallMediaPublished(
   kind: 'audio' | 'video',
 ): Promise<void> {
   try {
-    if (!gc.isMicrophoneMuted()) {
+    if (!(gc.isMicrophoneMuted?.() ?? true)) {
       await recoverLocalMicrophoneFeed(gc);
     }
-    if (kind === 'video' && !gc.isLocalVideoMuted()) {
+    if (kind === 'video' && !(gc.isLocalVideoMuted?.() ?? true)) {
       await recoverLocalCameraFeed(gc);
     }
   } catch {


### PR DESCRIPTION
## Summary

Phase A investigation work for #2322 (Matrix/WebRTC call instability). This PR sets up observability and adds a targeted defensive fix — no deep behaviour changes.

- **Surfaces `placeOutgoingCalls` errors** via `console.warn` under `isMatrixCallDebugEnabled` (was silently swallowed)
- **Feed-change snapshot** on every `UserMediaFeedsChanged` event (gated by debug mode), giving per-event visibility instead of only the 12-second periodic tick
- **Verbose stall-check log** ⚠️ `commit 0c06f722b` — prints full participant-map vs feed-list on every stall evaluation. **Revert this commit before final merge** (`git revert 0c06f722b`) once the debug session is complete
- **Optional-chain guards** on `gc.isLocalVideoMuted?.()` and `gc.isMicrophoneMuted?.()` in `recoverLocalCameraFeed`, `recoverLocalMicrophoneFeed`, and `ensureLocalCallMediaPublished` — prevents TypeError crash if the SDK returns a GC object missing these methods (observed in production logs)

## How to activate debug logging

```js
// Browser DevTools console (works in production):
localStorage.setItem('hypha.callDebug', '1')
// then reload and join a call
// filter console: [hypha.group_call]
```

See `progress/members/gerroza/tickets/2322-matrix-call-stability/debug-plan.md` in hypha-context for the full debug session checklist.

## Build note

`hypha-api` TS build failure (`web3-abi.ts`) is pre-existing on `main` — confirmed unrelated to these changes.

## Test plan

- [ ] Join a 2+ person call with `hypha.callDebug=1` set in localStorage
- [ ] Confirm `[hypha.group_call] stall-check` entries appear in console showing participant vs feed state
- [ ] Confirm `[hypha.group_call] media_snapshot` fires on feed changes (not just on 12s tick)
- [ ] Trigger a video mute/unmute cycle — confirm no TypeError in console
- [ ] After investigation: `git revert 0c06f722b` to drop the verbose stall-check before merging

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved group call reliability by handling media recovery more safely when mute-state checks aren’t available.
  * Added better handling for outgoing call placement errors so issues are surfaced in debug mode instead of being ignored.
  * Enhanced remote media stall diagnostics with additional debug details to help identify missing feeds.
  * Added more consistent debug snapshots when call participant feeds change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->