### PR TITLE
fix(spaces): use border-only selection for activation mode cards

### DIFF
--- a/packages/epics/src/spaces/components/create-space-form.tsx
+++ b/packages/epics/src/spaces/components/create-space-form.tsx
@@ -920,10 +920,13 @@ export const SpaceForm = ({
         <FormLabel>{tSpaces('activationMode')}</FormLabel>
         <div className="flex flex-col gap-2">
           <Card
-            className={clsx('flex p-6 cursor-pointer space-x-4 items-center', {
-              'border-accent-9 bg-accent-3 ring-1 ring-accent-9/30': isSandbox,
-              'hover:border-accent-5': !isSandbox,
-            })}
+            className={clsx(
+              'flex p-6 cursor-pointer space-x-4 items-center border-2',
+              {
+                'border-accent-9': isSandbox,
+                'hover:border-accent-5': !isSandbox,
+              },
+            )}
             onClick={toggleSandbox}
           >
             <div className="flex flex-col">
@@ -936,10 +939,13 @@ export const SpaceForm = ({
             </div>
           </Card>
           <Card
-            className={clsx('flex p-6 cursor-pointer space-x-4 items-center', {
-              'border-accent-9 bg-accent-3 ring-1 ring-accent-9/30': isDemo,
-              'hover:border-accent-5': !isDemo,
-            })}
+            className={clsx(
+              'flex p-6 cursor-pointer space-x-4 items-center border-2',
+              {
+                'border-accent-9': isDemo,
+                'hover:border-accent-5': !isDemo,
+              },
+            )}
             onClick={toggleDemo}
           >
             <div className="flex flex-col">
@@ -950,10 +956,13 @@ export const SpaceForm = ({
             </div>
           </Card>
           <Card
-            className={clsx('flex p-6 cursor-pointer space-x-4 items-center', {
-              'border-accent-9 bg-accent-3 ring-1 ring-accent-9/30': isLive,
-              'hover:border-accent-5': !isLive,
-            })}
+            className={clsx(
+              'flex p-6 cursor-pointer space-x-4 items-center border-2',
+              {
+                'border-accent-9': isLive,
+                'hover:border-accent-5': !isLive,
+              },
+            )}
             onClick={toggleLive}
           >
             <div className="flex flex-col">
@@ -966,10 +975,9 @@ export const SpaceForm = ({
           {label === 'configure' && (
             <Card
               className={clsx(
-                'flex p-6 cursor-pointer space-x-4 items-center',
+                'flex p-6 cursor-pointer space-x-4 items-center border-2',
                 {
-                  'border-accent-9 bg-accent-3 ring-1 ring-accent-9/30':
-                    isArchived,
+                  'border-accent-9': isArchived,
                   'hover:border-accent-5': !isArchived,
                 },
               )}


### PR DESCRIPTION
## Summary
- Remove filled accent background (`bg-accent-3`) and ring from activation mode cards in space configuration
- Match the border-only selected state used by Space Discoverability / transparency pickers (`border-accent-9` with `border-2`)

## Test plan
- [ ] Open Space Configuration for an existing space
- [ ] Select Pilot Mode, Live Mode, and Archive Mode — each should show a purple border highlight with readable text (no solid fill)
- [ ] Confirm selected state matches Space Discoverability picker styling in transparency settings


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the visual styling of activation mode cards for a cleaner selected state and hover behavior.
  * Selected cards now use a clearer border highlight, with a lighter hover border on unselected cards.
  * Removed the previous background and ring-based selection effects for these options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->