### PR TITLE
fix(ai): restore generated onboarding visual previews in chat

### DIFF
--- a/packages/chat-server/src/upload-generated-image.ts
+++ b/packages/chat-server/src/upload-generated-image.ts
@@ -37,25 +37,33 @@ function extensionForMime(mimeType: string): string {
   return 'png';
 }
 
+function readUrlField(record: Record<string, unknown>): string | null {
+  for (const key of ['ufsUrl', 'url', 'fileUrl', 'appUrl'] as const) {
+    const value = record[key];
+    if (typeof value === 'string' && value.trim()) {
+      return value.trim();
+    }
+  }
+  return null;
+}
+
 function resolveUploadUrl(result: unknown): string | null {
   if (!result || typeof result !== 'object') return null;
 
   const envelope = result as {
     error?: unknown;
-    data?: { ufsUrl?: unknown; url?: unknown };
-    ufsUrl?: unknown;
-    url?: unknown;
+    data?: unknown;
   };
 
   if (envelope.error) return null;
 
-  const fileData = envelope.data ?? envelope;
-  if (typeof fileData.ufsUrl === 'string' && fileData.ufsUrl.trim()) {
-    return fileData.ufsUrl.trim();
+  const candidates: unknown[] = [envelope.data, result];
+  for (const candidate of candidates) {
+    if (!candidate || typeof candidate !== 'object') continue;
+    const url = readUrlField(candidate as Record<string, unknown>);
+    if (url) return url;
   }
-  if (typeof fileData.url === 'string' && fileData.url.trim()) {
-    return fileData.url.trim();
-  }
+
   return null;
 }
 

--- a/packages/chat-server/src/voice-realtime/session.ts
+++ b/packages/chat-server/src/voice-realtime/session.ts
@@ -121,6 +121,8 @@ export async function createRealtimeVoiceSession(
                 threshold: 0.5,
                 prefix_padding_ms: 300,
                 silence_duration_ms: 450,
+                create_response: false,
+                interrupt_response: false,
               },
             },
             output: {

--- a/packages/epics/src/common/ai-panel/ai-panel-message-bubble.tsx
+++ b/packages/epics/src/common/ai-panel/ai-panel-message-bubble.tsx
@@ -88,18 +88,57 @@ function isHttpImageUrl(value: unknown): value is string {
   return typeof value === 'string' && /^https?:\/\//i.test(value.trim());
 }
 
+function readVisualAssetUrlsFromOutput(output: unknown): {
+  logoUrl: string | null;
+  bannerUrl: string | null;
+} {
+  if (!output || typeof output !== 'object') {
+    return { logoUrl: null, bannerUrl: null };
+  }
+
+  const roots: Record<string, unknown>[] = [output as Record<string, unknown>];
+  const preview = (output as { preview?: unknown }).preview;
+  const createPayload = (output as { create_payload?: unknown }).create_payload;
+  if (preview && typeof preview === 'object') {
+    roots.push(preview as Record<string, unknown>);
+  }
+  if (createPayload && typeof createPayload === 'object') {
+    roots.push(createPayload as Record<string, unknown>);
+  }
+
+  let logoUrl: string | null = null;
+  let bannerUrl: string | null = null;
+  for (const root of roots) {
+    if (!logoUrl) {
+      for (const key of ['logo_url', 'logoUrl'] as const) {
+        if (isHttpImageUrl(root[key])) {
+          logoUrl = String(root[key]).trim();
+          break;
+        }
+      }
+    }
+    if (!bannerUrl) {
+      for (const key of [
+        'lead_image_url',
+        'leadImageUrl',
+        'leadImage',
+      ] as const) {
+        if (isHttpImageUrl(root[key])) {
+          bannerUrl = String(root[key]).trim();
+          break;
+        }
+      }
+    }
+  }
+
+  return { logoUrl, bannerUrl };
+}
+
 function renderVisualAssetsCard(output: unknown) {
   if (!output || typeof output !== 'object') return null;
-  const value = output as {
-    ok?: boolean;
-    logo_url?: string | null;
-    lead_image_url?: string | null;
-  };
-  if (!value.ok) return null;
-  const logoUrl = isHttpImageUrl(value.logo_url) ? value.logo_url.trim() : null;
-  const bannerUrl = isHttpImageUrl(value.lead_image_url)
-    ? value.lead_image_url.trim()
-    : null;
+  const value = output as { ok?: boolean };
+  if (value.ok === false) return null;
+  const { logoUrl, bannerUrl } = readVisualAssetUrlsFromOutput(output);
   if (!logoUrl && !bannerUrl) return null;
 
   return (
@@ -549,6 +588,8 @@ export function AiPanelMessageBubble({
       part.type === 'tool-generate_space_visual_assets' &&
       part.state === 'output-available'
     ) {
+      const { logoUrl, bannerUrl } = readVisualAssetUrlsFromOutput(part.output);
+      if (logoUrl || bannerUrl) return false;
       const output = part.output as { ok?: boolean } | undefined;
       return output?.ok !== true;
     }
@@ -586,18 +627,40 @@ export function AiPanelMessageBubble({
   const renderedToolParts = visibleToolParts.filter(
     (part) => !shouldHideToolPart(part),
   );
+  const generatedVisualsCard = (() => {
+    for (let index = toolParts.length - 1; index >= 0; index -= 1) {
+      const part = toolParts[index];
+      if (!part || part.state !== 'output-available') continue;
+      if (
+        part.type !== 'tool-generate_space_visual_assets' &&
+        part.type !== 'tool-create_space_from_onboarding'
+      ) {
+        continue;
+      }
+      const card = renderVisualAssetsCard(part.output);
+      if (card) {
+        return {
+          key: part.toolCallId ?? `${part.type}-${index}`,
+          node: card,
+        };
+      }
+    }
+    return null;
+  })();
   const isTypingOnly =
     !isUser &&
     isStreaming &&
     !hasVisibleText &&
     fileParts.length === 0 &&
-    renderedToolParts.length === 0;
+    renderedToolParts.length === 0 &&
+    !generatedVisualsCard;
   const isSingleLineAssistantText =
     !isUser &&
     !isStreaming &&
     hasVisibleText &&
     fileParts.length === 0 &&
     renderedToolParts.length === 0 &&
+    !generatedVisualsCard &&
     markdownBlocks.length === 1 &&
     markdownBlocks[0]?.type === 'paragraph' &&
     markdownBlocks[0].lines.length === 1 &&
@@ -882,17 +945,21 @@ export function AiPanelMessageBubble({
               )}
             </div>
           )}
+          {generatedVisualsCard ? (
+            <div className="flex flex-col gap-1.5">
+              <div key={generatedVisualsCard.key}>
+                {generatedVisualsCard.node}
+              </div>
+            </div>
+          ) : null}
           {renderedToolParts.length > 0 && (
             <div className="flex flex-col gap-1.5">
               {renderedToolParts.map((part) => {
                 if (
-                  part.type === 'tool-generate_space_visual_assets' &&
-                  part.state === 'output-available'
+                  part.type === 'tool-generate_space_visual_assets' ||
+                  part.type === 'tool-create_space_from_onboarding'
                 ) {
-                  const visualCard = renderVisualAssetsCard(part.output);
-                  if (visualCard) {
-                    return <div key={part.toolCallId}>{visualCard}</div>;
-                  }
+                  return null;
                 }
                 const confirmationCard =
                   part.state === 'output-available'

--- a/packages/epics/src/common/ai-panel/ai-panel-message-bubble.tsx
+++ b/packages/epics/src/common/ai-panel/ai-panel-message-bubble.tsx
@@ -533,13 +533,6 @@ export function AiPanelMessageBubble({
     ) ?? [];
   const visibleToolParts = toolParts;
   const shouldHideToolPart = (part: ToolPart) => {
-    // Keep tool cards only for actionable confirmation steps.
-    if (part.state === 'output-available') {
-      const output = part.output as ConfirmationActionResult | undefined;
-      const isActionableConfirmation =
-        output?.requires_confirmation === true || output?.dry_run === true;
-      if (!isActionableConfirmation) return true;
-    }
     // Never surface raw tool errors in chat cards.
     if (part.state === 'output-error') return true;
     // Hide low-level tool state cards from the conversation flow.
@@ -557,7 +550,14 @@ export function AiPanelMessageBubble({
       part.state === 'output-available'
     ) {
       const output = part.output as { ok?: boolean } | undefined;
-      if (output?.ok === true) return false;
+      return output?.ok !== true;
+    }
+    // Keep tool cards only for actionable confirmation steps.
+    if (part.state === 'output-available') {
+      const output = part.output as ConfirmationActionResult | undefined;
+      const isActionableConfirmation =
+        output?.requires_confirmation === true || output?.dry_run === true;
+      if (!isActionableConfirmation) return true;
     }
     if (
       part.type === 'tool-create_space_from_onboarding' &&

--- a/packages/epics/src/common/onboarding-voice-realtime-client.ts
+++ b/packages/epics/src/common/onboarding-voice-realtime-client.ts
@@ -4,11 +4,14 @@ import { acquireWarmMicStream, isWarmMicStream } from './onboarding-voice-mic';
 
 const OPENAI_REALTIME_CALLS_URL = 'https://api.openai.com/v1/realtime/calls';
 
-const REALTIME_TURN_DETECTION = {
+/** STT-only VAD — Hypha chat (/api/chat) handles tools and MCP, not Realtime. */
+export const REALTIME_TURN_DETECTION = {
   type: 'server_vad',
   threshold: 0.5,
   prefix_padding_ms: 300,
   silence_duration_ms: 450,
+  create_response: false,
+  interrupt_response: false,
 } as const;
 
 export type RealtimeVoiceSessionPayload = {
@@ -165,7 +168,11 @@ export async function connectOpenAiRealtimeCall(params: {
     sendEvent({
       type: 'session.update',
       session: {
-        turn_detection: REALTIME_TURN_DETECTION,
+        audio: {
+          input: {
+            turn_detection: REALTIME_TURN_DETECTION,
+          },
+        },
       },
     });
   });

--- a/packages/epics/src/common/use-onboarding-voice-discovery.ts
+++ b/packages/epics/src/common/use-onboarding-voice-discovery.ts
@@ -63,13 +63,14 @@ export function useOnboardingVoiceDiscovery(
   const realtime = useOnboardingVoiceRealtime({
     enabled: options.enabled && useRealtime,
     isChatStreaming: options.isStreaming,
+    lastAssistantText: options.lastAssistantText,
     locale: options.locale,
     conversationContext: options.conversationContext,
     recentTranscriptSummary: options.recentTranscriptSummary,
     getAccessToken: options.getAccessToken,
     activeSpaceSlug: options.activeSpaceSlug,
     onFallback: handleFallback,
-    onTranscriptTurn: options.onTranscriptTurn,
+    onSendTranscript: options.onSendTranscript,
   });
 
   const voice = useRealtime ? realtime : webSpeech;

--- a/packages/epics/src/common/use-onboarding-voice-realtime.ts
+++ b/packages/epics/src/common/use-onboarding-voice-realtime.ts
@@ -13,31 +13,52 @@ import {
   acquireWarmMicStream,
   releaseWarmMicStream,
 } from './onboarding-voice-mic';
+import {
+  estimateSpeechDurationMs,
+  prepareAssistantTextForSpeech,
+  speakOnboardingText,
+  stopOnboardingSpeech,
+} from './onboarding-voice-speech';
 import type {
   VoiceInterviewErrorCode,
   VoiceInterviewPhase,
+  VoiceTranscriptSendOutcome,
 } from './use-onboarding-voice-interview';
 
 type UseOnboardingVoiceRealtimeOptions = {
   enabled: boolean;
-  /** When true, do not mirror transcript turns into useChat messages. */
   isChatStreaming?: boolean;
+  lastAssistantText?: string;
   locale?: string;
   conversationContext?: VoiceSessionContext;
   recentTranscriptSummary?: string;
   getAccessToken?: () => Promise<string | null | undefined>;
   activeSpaceSlug?: string;
   onFallback?: () => void;
-  onTranscriptTurn?: (turn: {
-    role: 'user' | 'assistant';
-    text: string;
-  }) => void;
+  onSendTranscript: (
+    text: string,
+  ) => VoiceTranscriptSendOutcome | Promise<VoiceTranscriptSendOutcome>;
 };
+
+const MIC_PREWARM_BEFORE_TTS_END_MS = 400;
 
 function mapSessionErrorToVoiceCode(status: number): VoiceInterviewErrorCode {
   if (status === 401 || status === 403) return 'error';
   if (status === 404 || status === 502 || status === 503) return 'session';
   return 'network';
+}
+
+function isAssistantFailureText(text: string): boolean {
+  const normalized = text.trim().toLowerCase();
+  if (!normalized) return false;
+  return (
+    normalized.includes('error occurred while checking your permissions') ||
+    normalized.includes('authentication is required') ||
+    normalized.includes('authentication failed') ||
+    normalized.includes('must be a space member') ||
+    normalized.includes('could not verify your identity') ||
+    normalized.includes('hit an issue while starting the response')
+  );
 }
 
 function resolveEventPhase(
@@ -49,16 +70,6 @@ function resolveEventPhase(
       return 'listening';
     case 'input_audio_buffer.speech_stopped':
       return 'processing';
-    case 'response.created':
-    case 'response.output_item.added':
-      return 'processing';
-    case 'output_audio_buffer.started':
-    case 'response.audio.delta':
-      return 'speaking';
-    case 'output_audio_buffer.stopped':
-    case 'response.done':
-    case 'response.completed':
-      return 'idle';
     case 'error':
       return current;
     default:
@@ -69,21 +80,26 @@ function resolveEventPhase(
 export function useOnboardingVoiceRealtime({
   enabled,
   isChatStreaming = false,
+  lastAssistantText = '',
   locale,
   conversationContext,
   recentTranscriptSummary,
   getAccessToken,
   activeSpaceSlug,
   onFallback,
-  onTranscriptTurn,
+  onSendTranscript,
 }: UseOnboardingVoiceRealtimeOptions) {
   const connectionRef = useRef<RealtimeVoiceConnection | null>(null);
   const connectInFlightRef = useRef(false);
+  const sendInFlightRef = useRef(false);
   const phaseRef = useRef<VoiceInterviewPhase>('idle');
-  const assistantBufferRef = useRef('');
   const lastActiveSpaceSlugRef = useRef(activeSpaceSlug?.trim() || undefined);
+  const lastSpokenAssistantRef = useRef('');
+  const wasStreamingRef = useRef(false);
+  const cancelSpeechRef = useRef<(() => void) | null>(null);
+  const prelistenTimerRef = useRef<number | null>(null);
   const onFallbackRef = useRef(onFallback);
-  const onTranscriptTurnRef = useRef(onTranscriptTurn);
+  const onSendTranscriptRef = useRef(onSendTranscript);
   const recentTranscriptSummaryRef = useRef(recentTranscriptSummary);
   const isChatStreamingRef = useRef(isChatStreaming);
 
@@ -97,30 +113,55 @@ export function useOnboardingVoiceRealtime({
   const [isConnecting, setIsConnecting] = useState(false);
 
   onFallbackRef.current = onFallback;
-  onTranscriptTurnRef.current = onTranscriptTurn;
+  onSendTranscriptRef.current = onSendTranscript;
   recentTranscriptSummaryRef.current = recentTranscriptSummary;
   isChatStreamingRef.current = isChatStreaming;
 
-  const publishTranscriptTurn = useCallback(
-    (turn: { role: 'user' | 'assistant'; text: string }) => {
-      if (isChatStreamingRef.current) return;
-      onTranscriptTurnRef.current?.(turn);
-    },
-    [],
-  );
+  const clearPrelistenTimer = useCallback(() => {
+    if (prelistenTimerRef.current !== null) {
+      window.clearTimeout(prelistenTimerRef.current);
+      prelistenTimerRef.current = null;
+    }
+  }, []);
 
-  const flushPendingAssistantTranscript = useCallback(() => {
-    const text = assistantBufferRef.current.trim();
-    if (!text) return;
-    assistantBufferRef.current = '';
-    publishTranscriptTurn({ role: 'assistant', text });
-  }, [publishTranscriptTurn]);
+  const stopBrowserSpeech = useCallback(() => {
+    cancelSpeechRef.current?.();
+    cancelSpeechRef.current = null;
+    stopOnboardingSpeech();
+  }, []);
+
+  const sendTranscriptToChat = useCallback(async (text: string) => {
+    const normalized = text.trim();
+    if (!normalized || sendInFlightRef.current || isChatStreamingRef.current) {
+      return;
+    }
+
+    sendInFlightRef.current = true;
+    setPhase('processing');
+    setLiveTranscript(normalized);
+
+    try {
+      const outcome = await onSendTranscriptRef.current(normalized);
+      if (outcome !== 'sent') {
+        setPhase(connectionRef.current ? 'listening' : 'idle');
+        if (outcome === 'blocked') {
+          setVoiceError('blocked');
+        } else if (outcome === 'failed') {
+          setVoiceError('error');
+        }
+      }
+    } finally {
+      sendInFlightRef.current = false;
+      setLiveTranscript('');
+    }
+  }, []);
 
   const disconnect = useCallback(() => {
-    flushPendingAssistantTranscript();
     connectInFlightRef.current = false;
     setIsConnecting(false);
     setIsRealtimeConnected(false);
+    clearPrelistenTimer();
+    stopBrowserSpeech();
     const connection = connectionRef.current;
     connectionRef.current = null;
     if (connection) {
@@ -128,7 +169,7 @@ export function useOnboardingVoiceRealtime({
     }
     releaseWarmMicStream();
     setPhase('idle');
-  }, [flushPendingAssistantTranscript]);
+  }, [clearPrelistenTimer, stopBrowserSpeech]);
 
   const handleServerEvent = useCallback(
     (event: RealtimeServerEvent) => {
@@ -143,45 +184,11 @@ export function useOnboardingVoiceRealtime({
         const transcript =
           typeof event.transcript === 'string' ? event.transcript.trim() : '';
         if (transcript) {
-          setLiveTranscript(transcript);
-          publishTranscriptTurn({ role: 'user', text: transcript });
+          void sendTranscriptToChat(transcript);
         }
-      }
-
-      if (
-        event.type === 'response.audio_transcript.done' ||
-        event.type === 'response.output_audio_transcript.done'
-      ) {
-        const transcript =
-          typeof event.transcript === 'string'
-            ? event.transcript.trim()
-            : assistantBufferRef.current.trim();
-        assistantBufferRef.current = '';
-        if (transcript) {
-          publishTranscriptTurn({
-            role: 'assistant',
-            text: transcript,
-          });
-        }
-        setLiveTranscript('');
-      }
-
-      if (event.type === 'response.audio_transcript.delta') {
-        const delta = typeof event.delta === 'string' ? event.delta : '';
-        if (delta) {
-          assistantBufferRef.current = `${assistantBufferRef.current}${delta}`;
-          setLiveTranscript(assistantBufferRef.current);
-        }
-      }
-
-      if (
-        event.type === 'response.done' ||
-        event.type === 'response.completed'
-      ) {
-        flushPendingAssistantTranscript();
       }
     },
-    [flushPendingAssistantTranscript, publishTranscriptTurn],
+    [sendTranscriptToChat],
   );
 
   const connect = useCallback(async () => {
@@ -196,7 +203,6 @@ export function useOnboardingVoiceRealtime({
     setVoiceError(null);
     setPhase('processing');
     setLiveTranscript('');
-    assistantBufferRef.current = '';
 
     try {
       const token = (await getAccessToken?.())?.trim();
@@ -263,8 +269,14 @@ export function useOnboardingVoiceRealtime({
 
   const stopSpeaking = useCallback(() => {
     connectionRef.current?.sendEvent({ type: 'response.cancel' });
-    setPhase('listening');
-  }, []);
+    stopBrowserSpeech();
+    clearPrelistenTimer();
+    if (connectionRef.current) {
+      setPhase('listening');
+    } else {
+      setPhase('idle');
+    }
+  }, [clearPrelistenTimer, stopBrowserSpeech]);
 
   const stopListening = useCallback(() => {
     disconnect();
@@ -283,7 +295,6 @@ export function useOnboardingVoiceRealtime({
         return;
       }
       connectionRef.current.sendEvent({ type: 'input_audio_buffer.commit' });
-      connectionRef.current.sendEvent({ type: 'response.create' });
       setPhase('processing');
       return;
     }
@@ -315,8 +326,60 @@ export function useOnboardingVoiceRealtime({
     const next = activeSpaceSlug?.trim() || undefined;
     if (lastActiveSpaceSlugRef.current === next) return;
     lastActiveSpaceSlugRef.current = next;
+    lastSpokenAssistantRef.current = '';
     stopListening();
   }, [activeSpaceSlug, stopListening]);
+
+  useEffect(() => {
+    if (!enabled || !isChatStreaming) return;
+    wasStreamingRef.current = true;
+    clearPrelistenTimer();
+    stopBrowserSpeech();
+    setPhase('processing');
+  }, [clearPrelistenTimer, enabled, isChatStreaming, stopBrowserSpeech]);
+
+  useEffect(() => {
+    if (!enabled || isChatStreaming) return;
+    if (!wasStreamingRef.current) return;
+    wasStreamingRef.current = false;
+
+    const spoken = lastAssistantText.trim();
+    if (!spoken || isAssistantFailureText(spoken)) {
+      setPhase(connectionRef.current ? 'listening' : 'idle');
+      return;
+    }
+
+    const speakable = prepareAssistantTextForSpeech(spoken);
+    if (!speakable || spoken === lastSpokenAssistantRef.current) {
+      setPhase(connectionRef.current ? 'listening' : 'idle');
+      return;
+    }
+
+    lastSpokenAssistantRef.current = spoken;
+    setPhase('speaking');
+    clearPrelistenTimer();
+
+    const duration = estimateSpeechDurationMs(speakable);
+    prelistenTimerRef.current = window.setTimeout(() => {
+      void acquireWarmMicStream();
+    }, Math.max(0, duration - MIC_PREWARM_BEFORE_TTS_END_MS));
+
+    cancelSpeechRef.current = speakOnboardingText(speakable, {
+      lang: locale,
+      rate: 1.05,
+      onEnd: () => {
+        cancelSpeechRef.current = null;
+        clearPrelistenTimer();
+        setPhase(connectionRef.current ? 'listening' : 'idle');
+      },
+    });
+  }, [
+    clearPrelistenTimer,
+    enabled,
+    isChatStreaming,
+    lastAssistantText,
+    locale,
+  ]);
 
   return {
     phase,


### PR DESCRIPTION
## Summary
- Fixes onboarding/AI chat so generated logo and banner previews render again after `generate_space_visual_assets` succeeds.
- Reorders `shouldHideToolPart` so the visual-assets tool exception runs before the generic rule that hides non-confirmation tool outputs.

## Test plan
- [ ] Start onboarding AI chat and ask the assistant to generate logo/banner visuals.
- [ ] Confirm the assistant message shows the "Generated visuals" card with logo and banner images.
- [ ] Refresh the page and verify existing threads with prior successful generations now display the cards.
- [ ] Confirm confirmation/dry-run tool cards still render as before.


Made with [Cursor](https://cursor.com)