### PR TITLE
fix(matrix): repair GroupCall reconnect crash and glare lockstep (#2322)

### DIFF
--- a/packages/core/src/matrix/client/hooks/use-space-group-call.ts
+++ b/packages/core/src/matrix/client/hooks/use-space-group-call.ts
@@ -282,6 +282,11 @@ async function tryRepairRoomCallPermissions(
 }
 
 function nudgeGroupCallPlaceOutgoing(gc: MatrixSdk.GroupCall): void {
+  // Don't call placeOutgoingCalls before the GroupCall has entered — localCallFeed
+  // isn't initialized yet (set inside enter() after initLocalCallFeed completes) and
+  // the SDK's onCallStateChanged will crash reading it. enter() calls placeOutgoingCalls
+  // itself at the end, so nothing is lost by skipping the nudge here.
+  if (gc.state !== GroupCallState.Entered) return;
   const fn = (gc as unknown as { placeOutgoingCalls?: () => void })
     .placeOutgoingCalls;
   if (typeof fn !== 'function') return;

--- a/packages/core/src/matrix/client/hooks/use-space-group-call.ts
+++ b/packages/core/src/matrix/client/hooks/use-space-group-call.ts
@@ -1875,10 +1875,17 @@ export function useSpaceGroupCall(
     const now = Date.now();
     if (missingRemoteFeedCount > 0 && othersInCall.length > 0) {
       if (remoteMediaRepairNudgeIntervalRef.current == null) {
+        // Randomise the interval period so peers that detected the missing feed
+        // simultaneously (e.g. two people joining at the same time) don't fire
+        // repair nudges in lockstep — persistent lockstep causes every retry to
+        // glare and the B↔C pairwise call never establishes.
+        const jitteredMs =
+          REMOTE_MEDIA_REPAIR_NUDGE_MS +
+          Math.floor(Math.random() * REMOTE_MEDIA_REPAIR_NUDGE_MS);
         remoteMediaRepairNudgeIntervalRef.current = setInterval(() => {
           if (groupCallRef.current !== gc) return;
           nudgeGroupCallPlaceOutgoing(gc);
-        }, REMOTE_MEDIA_REPAIR_NUDGE_MS);
+        }, jitteredMs);
       }
       /**
        * The SDK can know the remote participant from group-call member state

--- a/packages/core/src/matrix/client/hooks/use-space-group-call.ts
+++ b/packages/core/src/matrix/client/hooks/use-space-group-call.ts
@@ -1848,6 +1848,28 @@ export function useSpaceGroupCall(
         })),
         participantMapSize: gc.participants.size,
       });
+      // TEMP-DEBUG #2322 Bug#3: detect call-glare (ringing-state race).
+      // activePairwiseCallCount > 0 but missingRemoteFeedCount > 0 → calls placed but
+      // ICE/glare blocked them. activePairwiseCallCount === 0 but participants present →
+      // call invite was dropped (classic glare: both sides placed outgoing simultaneously).
+      if (missingRemoteFeedCount > 0) {
+        const gcAny = gc as unknown as Record<string, unknown>;
+        const callsMap = gcAny['calls'] as
+          | Map<string, Map<string, unknown>>
+          | undefined;
+        let activePairwiseCallCount = 0;
+        if (callsMap) {
+          for (const [, deviceCalls] of callsMap) {
+            activePairwiseCallCount += deviceCalls.size;
+          }
+        }
+        console.warn('[hypha.group_call] stall-missing-feeds', {
+          missingRemoteFeedCount,
+          activePairwiseCallCount,
+          participantDeviceCount: countGroupCallParticipantDevices(gc),
+          gcState: gc.state,
+        });
+      }
     }
 
     const now = Date.now();

--- a/packages/core/src/matrix/client/providers/matrix-provider.tsx
+++ b/packages/core/src/matrix/client/providers/matrix-provider.tsx
@@ -1920,8 +1920,9 @@ export const MatrixProvider: React.FC<MatrixProviderProps> = ({ children }) => {
         const resolvedId = joined.roomId;
         await ensureRoomCallPowerLevels(client, resolvedId);
         // `joinRoom` resolves before the lazy room store always exposes `getRoom`
-        // (race with sync / canonical id). Wait briefly for `getRoom` parity with listeners.
-        for (let i = 0; i < 40; i++) {
+        // (race with sync / canonical id). On hard page reload the SDK must re-sync
+        // all room state from scratch, which can take several seconds — wait up to 10s.
+        for (let i = 0; i < 200; i++) {
           if (client.getRoom(resolvedId)) {
             return resolvedId;
           }


### PR DESCRIPTION
## Summary

Fixes the primary WebRTC call instability reported in #2322 — the TypeError loop that permanently blocked reconnects after a real ICE drop, and a glare-lockstep issue that prevented B↔C pairwise connections from recovering automatically.

### Bug #1 + Bug #2 fix — state guard in `nudgeGroupCallPlaceOutgoing`

Root cause: `attachGroupCallListeners(gc)` (line 2435 in `enterWithKind`) registered `ParticipantsChanged → nudgeGroupCallPlaceOutgoing` **before** `await gc.enter()` (line 2498). When the stall recovery triggered a leave/rejoin on L1, and L2's `m.call.member` room state arrived during the re-enter window, `placeOutgoingCalls()` was called while `localCallFeed === undefined` (not yet set by `initLocalCallFeed` inside `enter()`). The SDK's `onCallStateChanged` then crashed reading `localCallFeed.isAudioMuted()`, entering an infinite TypeError loop on every subsequent nudge attempt.

Fix: one guard at the top of `nudgeGroupCallPlaceOutgoing` — skip the nudge if the GroupCall hasn't reached `GroupCallState.Entered`. The SDK itself calls `placeOutgoingCalls()` at the end of `enter()` after `initLocalCallFeed` completes, so no participants are missed.

Bug #2 (stale feed registry persisting) was a direct consequence — the repair nudge crashed before it could re-place any calls. Fixed by this same guard.

### Bug #3 fix — jitter on repair nudge interval

When B and C detect each other's missing feeds at the same time (e.g. joining simultaneously), their `setInterval` repair nudges start in lockstep and fire together every 1500ms. Each synchronized fire causes both sides to place outgoing calls to each other simultaneously — persistent glare — so the B↔C pairwise call never establishes.

Fix: randomise the repair interval between 1500ms and 3000ms so B and C drift out of phase within a couple of cycles.

### N1 fix — `joinRoom` room-availability poll window

Extended from 2s (40 × 50ms) to 10s (200 × 50ms). On hard page reload the Matrix SDK must re-sync all room state from scratch, which can take several seconds and exceed the previous 2-second window, producing a spurious `Room not available in Matrix client after join` error.

---

### Commits

| Commit | Type | Keep? |
|---|---|---|
| `fix(matrix): guard placeOutgoingCalls on GroupCallState.Entered` | Real fix | **KEEP** |
| `debug-temp(matrix): log pairwise call count for glare detection` | Temp logging | **REVERT after live debug call** — adds `stall-missing-feeds` warn to distinguish glare from ICE failure |
| `fix(matrix): jitter repair nudge interval to break glare lockstep` | Real fix | **KEEP** |

## Test plan

- [ ] Join a 2-person call — audio/video connects normally, no console errors
- [ ] Join a 3-person call — all three pairs connect (B↔C in particular)
- [ ] WiFi disconnect scenario: L2 loses WiFi, gets error page, refreshes; L1 waits for stall (~48s), stall recovery runs; **expect no TypeError in L1's console, expect B to reconnect after L2 rejoins**
- [ ] B↔C glare: A joins first, B and C join simultaneously; verify B and C connect within ~10s
- [ ] Mute/unmute, video toggle — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved group call reliability by preventing call actions from running too early during call setup.
  * Reduced issues with remote media recovery by making retries more resilient and less likely to stall.
  * Increased the wait time after joining a room so rooms are more likely to appear correctly after a hard refresh or sync delay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->