### PR TITLE
fix(matrix): best-effort cleanMemberState on tab/browser close (#2322)

### DIFF
--- a/packages/core/src/matrix/client/hooks/use-space-group-call.ts
+++ b/packages/core/src/matrix/client/hooks/use-space-group-call.ts
@@ -3700,6 +3700,27 @@ export function useSpaceGroupCall(
     };
   }, [emitCallSessionEnd]);
 
+  // Best-effort member-state cleanup on tab/browser close. The normal leave
+  // and unmount paths already call runCleanup(); this only fires when the page
+  // is torn down before React cleanup runs (e.g. closing the tab mid-call).
+  // cleanMemberState() removes our device entry from m.call.member room state
+  // so other participants don't see a ghost "device connected" indicator.
+  // Limitation: if the network is already down at close time the HTTP call
+  // will fail silently — a LiveKit/MatrixRTC-level fix is needed for that case.
+  useEffect(() => {
+    const handleBeforeUnload = (): void => {
+      const gc = groupCallRef.current;
+      if (!gc) return;
+      void (
+        gc as MatrixSdk.GroupCall & { cleanMemberState?: () => void }
+      ).cleanMemberState?.();
+    };
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  }, []);
+
   useEffect(() => {
     if (!remoteMediaRecoverRequestedRef.current) return;
     if (callState !== 'connected' && callState !== 'awaiting_media') return;


### PR DESCRIPTION
Closes: #2322

## Summary

- Adds a `beforeunload` listener in `use-space-group-call.ts` that fires `cleanMemberState()` when the page is torn down before React cleanup runs (e.g. closing the tab mid-call)
- Prevents ghost `m.call.member` room-state entries that leave other participants seeing a phantom "device connected" / perpetual "Connecting…" indicator after someone closes without pressing Leave
- Listener is removed on component unmount so normal leave and SPA-navigation paths (which already call `runCleanup`) are unaffected

**Known limitation:** if the network is already down at close time the HTTP write will fail silently. A LiveKit/MatrixRTC-level fix is required for that case — documented and deferred.

Related to #2322.

## Test plan

- [ ] Join a space call with two participants
- [ ] Close the tab of one participant without pressing Leave
- [ ] Verify the remaining participant's UI no longer shows the closed participant as "device connected" or stuck at "Connecting…"
- [ ] Verify normal Leave button still works correctly for both participants
- [ ] Verify SPA navigation away from the space also cleans up correctly (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup when a page or tab is closed, helping ensure group call participant state is cleared more reliably.
  * Added a fallback cleanup path for unexpected unloads, reducing the chance of stale call state after leaving a session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->