### PR TITLE
fix(governance): allow reissuing tokens after rejected proposals

### DIFF
--- a/apps/web/src/app/api/webhooks/proposal/rejected/route.ts
+++ b/apps/web/src/app/api/webhooks/proposal/rejected/route.ts
@@ -59,6 +59,7 @@ export const POST = proposalRejectedSigningKey
             'Failed to delete undeployed draft tokens for rejected proposals:',
             error,
           );
+          throw error;
         }
 
         const creatorsToNotify = await findDocumentsCreatorsForNotifications(

--- a/apps/web/src/app/api/webhooks/proposal/rejected/route.ts
+++ b/apps/web/src/app/api/webhooks/proposal/rejected/route.ts
@@ -1,5 +1,6 @@
 import {
   Alchemy,
+  deleteUndeployedTokensByAgreementWeb3Ids,
   findDocumentsCreatorsForNotifications,
   findDocumentWithSpaceByIdRaw,
   findPeopleByWeb3Addresses,
@@ -36,6 +37,29 @@ export const POST = proposalRejectedSigningKey
               args.proposalId >= BigInt(Number.MIN_SAFE_INTEGER),
           )
           .map(({ args }) => Number(args.proposalId));
+
+        try {
+          const deletedTokens = await deleteUndeployedTokensByAgreementWeb3Ids(
+            proposalIds,
+            { db },
+          );
+          if (deletedTokens.length > 0) {
+            console.log(
+              'Deleted undeployed draft tokens for rejected proposals:',
+              deletedTokens.map((token) => ({
+                id: token.id,
+                agreementWeb3Id: token.agreementWeb3Id,
+                name: token.name,
+                symbol: token.symbol,
+              })),
+            );
+          }
+        } catch (error) {
+          console.error(
+            'Failed to delete undeployed draft tokens for rejected proposals:',
+            error,
+          );
+        }
 
         const creatorsToNotify = await findDocumentsCreatorsForNotifications(
           { proposalIds },

--- a/packages/core/src/governance/__tests__/issue-token-duplicate.test.ts
+++ b/packages/core/src/governance/__tests__/issue-token-duplicate.test.ts
@@ -81,9 +81,7 @@ describe('findBlockingDuplicateIssueToken', () => {
       baseToken({ address: '0xabc' }),
     ];
 
-    expect(findBlockingDuplicateIssueToken(tokens, options)).toEqual(
-      tokens[1],
-    );
+    expect(findBlockingDuplicateIssueToken(tokens, options)).toEqual(tokens[1]);
   });
 
   it('returns undefined when only rejected drafts match', () => {

--- a/packages/core/src/governance/__tests__/issue-token-duplicate.test.ts
+++ b/packages/core/src/governance/__tests__/issue-token-duplicate.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+import type { DbToken } from '../../common/types';
+import {
+  findBlockingDuplicateIssueToken,
+  isBlockingDuplicateIssueToken,
+} from '../issue-token-duplicate';
+
+const baseToken = (overrides: Partial<DbToken> = {}): DbToken => ({
+  name: 'Local Impact Token',
+  symbol: 'LIT',
+  maxSupply: 0,
+  type: 'impact',
+  transferable: true,
+  isVotingToken: false,
+  spaceId: 42,
+  ...overrides,
+});
+
+const options = {
+  spaceId: 42,
+  name: 'Local Impact Token',
+  symbol: 'LIT',
+  rejectedProposalIds: new Set<number>([1001]),
+  withdrawnProposalIds: new Set<number>([1002]),
+};
+
+describe('isBlockingDuplicateIssueToken', () => {
+  it('blocks deployed tokens with matching name and symbol in the same space', () => {
+    expect(
+      isBlockingDuplicateIssueToken(
+        baseToken({ address: '0xabc', agreementWeb3Id: 999 }),
+        options,
+      ),
+    ).toBe(true);
+  });
+
+  it('does not block undeployed tokens from rejected proposals', () => {
+    expect(
+      isBlockingDuplicateIssueToken(
+        baseToken({ agreementWeb3Id: 1001 }),
+        options,
+      ),
+    ).toBe(false);
+  });
+
+  it('does not block undeployed tokens from withdrawn proposals', () => {
+    expect(
+      isBlockingDuplicateIssueToken(
+        baseToken({ agreementWeb3Id: 1002 }),
+        options,
+      ),
+    ).toBe(false);
+  });
+
+  it('blocks undeployed tokens tied to active proposals', () => {
+    expect(
+      isBlockingDuplicateIssueToken(
+        baseToken({ agreementWeb3Id: 2000 }),
+        options,
+      ),
+    ).toBe(true);
+  });
+
+  it('ignores tokens in other spaces or with different name/symbol', () => {
+    expect(
+      isBlockingDuplicateIssueToken(baseToken({ spaceId: 99 }), options),
+    ).toBe(false);
+    expect(
+      isBlockingDuplicateIssueToken(
+        baseToken({ name: 'Other Token' }),
+        options,
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('findBlockingDuplicateIssueToken', () => {
+  it('returns the first blocking token when one exists', () => {
+    const tokens = [
+      baseToken({ agreementWeb3Id: 1001 }),
+      baseToken({ address: '0xabc' }),
+    ];
+
+    expect(findBlockingDuplicateIssueToken(tokens, options)).toEqual(
+      tokens[1],
+    );
+  });
+
+  it('returns undefined when only rejected drafts match', () => {
+    const tokens = [baseToken({ agreementWeb3Id: 1001 })];
+
+    expect(findBlockingDuplicateIssueToken(tokens, options)).toBeUndefined();
+  });
+});

--- a/packages/core/src/governance/index.ts
+++ b/packages/core/src/governance/index.ts
@@ -6,3 +6,4 @@ export * from './exchange-deposit-marker';
 export * from './types';
 export * from './validation';
 export * from './voice-decay-units';
+export * from './issue-token-duplicate';

--- a/packages/core/src/governance/issue-token-duplicate.ts
+++ b/packages/core/src/governance/issue-token-duplicate.ts
@@ -26,8 +26,7 @@ const isRejectedOrWithdrawnDraft = (
     return false;
   }
   return (
-    rejectedProposalIds.has(proposalId) ||
-    withdrawnProposalIds.has(proposalId)
+    rejectedProposalIds.has(proposalId) || withdrawnProposalIds.has(proposalId)
   );
 };
 
@@ -58,11 +57,7 @@ export const isBlockingDuplicateIssueToken = (
     return true;
   }
   if (
-    isRejectedOrWithdrawnDraft(
-      token,
-      rejectedProposalIds,
-      withdrawnProposalIds,
-    )
+    isRejectedOrWithdrawnDraft(token, rejectedProposalIds, withdrawnProposalIds)
   ) {
     return false;
   }

--- a/packages/core/src/governance/issue-token-duplicate.ts
+++ b/packages/core/src/governance/issue-token-duplicate.ts
@@ -1,0 +1,76 @@
+import type { DbToken } from '../common/types';
+
+export type IssueTokenDuplicateCheckOptions = {
+  spaceId: number;
+  name: string;
+  symbol: string;
+  rejectedProposalIds: ReadonlySet<number>;
+  withdrawnProposalIds: ReadonlySet<number>;
+};
+
+const matchesNameAndSymbol = (
+  token: DbToken,
+  name: string,
+  symbol: string,
+): boolean =>
+  token.name?.toLowerCase() === name.toLowerCase() &&
+  token.symbol?.toLowerCase() === symbol.toLowerCase();
+
+const isRejectedOrWithdrawnDraft = (
+  token: DbToken,
+  rejectedProposalIds: ReadonlySet<number>,
+  withdrawnProposalIds: ReadonlySet<number>,
+): boolean => {
+  const proposalId = token.agreementWeb3Id;
+  if (proposalId == null) {
+    return false;
+  }
+  return (
+    rejectedProposalIds.has(proposalId) ||
+    withdrawnProposalIds.has(proposalId)
+  );
+};
+
+/**
+ * Returns true when an existing DB token should block creating another issue-token
+ * proposal with the same name and symbol in the same space.
+ *
+ * Deployed tokens always block. Undeployed draft rows from rejected or withdrawn
+ * proposals do not — those records can remain after client-side cleanup misses.
+ */
+export const isBlockingDuplicateIssueToken = (
+  token: DbToken,
+  {
+    spaceId,
+    name,
+    symbol,
+    rejectedProposalIds,
+    withdrawnProposalIds,
+  }: IssueTokenDuplicateCheckOptions,
+): boolean => {
+  if (token.spaceId !== spaceId) {
+    return false;
+  }
+  if (!matchesNameAndSymbol(token, name, symbol)) {
+    return false;
+  }
+  if (token.address) {
+    return true;
+  }
+  if (
+    isRejectedOrWithdrawnDraft(
+      token,
+      rejectedProposalIds,
+      withdrawnProposalIds,
+    )
+  ) {
+    return false;
+  }
+  return true;
+};
+
+export const findBlockingDuplicateIssueToken = (
+  tokens: DbToken[] | undefined,
+  options: IssueTokenDuplicateCheckOptions,
+): DbToken | undefined =>
+  tokens?.find((token) => isBlockingDuplicateIssueToken(token, options));

--- a/packages/core/src/governance/server/mutations.ts
+++ b/packages/core/src/governance/server/mutations.ts
@@ -224,6 +224,28 @@ export const deleteUndeployedTokensByAgreementWeb3Ids = async (
     .returning();
 };
 
+/** Delete undeployed draft rows for a space, optionally scoped to one symbol. */
+export const deleteUndeployedDraftTokensForSpace = async (
+  {
+    spaceId,
+    symbol,
+  }: {
+    spaceId: number;
+    symbol?: string;
+  },
+  { db }: { db: DatabaseInstance },
+) => {
+  const conditions = [eq(tokens.spaceId, spaceId), isNull(tokens.address)];
+  if (symbol?.trim()) {
+    conditions.push(sql`lower(${tokens.symbol}) = lower(${symbol.trim()})`);
+  }
+
+  return db
+    .delete(tokens)
+    .where(and(...conditions))
+    .returning();
+};
+
 export const createTokenUpdate = async (
   input: CreateTokenUpdateInput,
   { db }: { db: DatabaseInstance },

--- a/packages/core/src/governance/server/mutations.ts
+++ b/packages/core/src/governance/server/mutations.ts
@@ -4,7 +4,7 @@ import {
   tokens,
   tokenUpdates,
 } from '@hypha-platform/storage-postgres';
-import { eq, sql } from 'drizzle-orm';
+import { eq, sql, and, inArray, isNull } from 'drizzle-orm';
 import type { InferInsertModel } from 'drizzle-orm';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -205,6 +205,26 @@ export const deleteToken = async (
     .where(eq(tokens.id, Number(input.id)))
     .returning();
   return deleted;
+};
+
+/** Remove draft token rows left behind when issue-token proposals fail on-chain. */
+export const deleteUndeployedTokensByAgreementWeb3Ids = async (
+  proposalIds: number[],
+  { db }: { db: DatabaseInstance },
+) => {
+  if (proposalIds.length === 0) {
+    return [];
+  }
+
+  return db
+    .delete(tokens)
+    .where(
+      and(
+        inArray(tokens.agreementWeb3Id, proposalIds),
+        isNull(tokens.address),
+      ),
+    )
+    .returning();
 };
 
 export const createTokenUpdate = async (

--- a/packages/core/src/governance/server/mutations.ts
+++ b/packages/core/src/governance/server/mutations.ts
@@ -219,10 +219,7 @@ export const deleteUndeployedTokensByAgreementWeb3Ids = async (
   return db
     .delete(tokens)
     .where(
-      and(
-        inArray(tokens.agreementWeb3Id, proposalIds),
-        isNull(tokens.address),
-      ),
+      and(inArray(tokens.agreementWeb3Id, proposalIds), isNull(tokens.address)),
     )
     .returning();
 };

--- a/packages/epics/src/governance/components/issue-new-token-form.tsx
+++ b/packages/epics/src/governance/components/issue-new-token-form.tsx
@@ -399,12 +399,40 @@ export const IssueNewTokenForm = ({
   useClearResubmitOnSuccess(progress === 100 && !isError);
 
   const { tokens: dbTokens, refetchDbTokens } = useDbTokens();
-  const { spaceProposalsIds } = useSpaceProposalsWeb3Rpc({
+  const {
+    spaceProposalsIds,
+    isLoading: isLoadingSpaceProposals,
+    error: spaceProposalsError,
+  } = useSpaceProposalsWeb3Rpc({
     spaceId: web3SpaceId ?? 0,
   });
-  const { withdrawnProposalsIds } = useWithdrawnProposalsWeb3Rpc({
+  const {
+    withdrawnProposalsIds,
+    isLoading: isLoadingWithdrawnProposals,
+    error: withdrawnProposalsError,
+  } = useWithdrawnProposalsWeb3Rpc({
     spaceId: web3SpaceId ?? 0,
   });
+
+  const needsProposalStatusForDuplicateCheck =
+    typeof web3SpaceId === 'number' &&
+    Number.isInteger(web3SpaceId) &&
+    web3SpaceId > 0;
+
+  const isProposalStatusLoading =
+    needsProposalStatusForDuplicateCheck &&
+    (isLoadingSpaceProposals || isLoadingWithdrawnProposals);
+
+  const hasProposalStatusError =
+    needsProposalStatusForDuplicateCheck &&
+    Boolean(spaceProposalsError || withdrawnProposalsError);
+
+  const isProposalStatusReady =
+    !needsProposalStatusForDuplicateCheck ||
+    (!isProposalStatusLoading &&
+      !hasProposalStatusError &&
+      spaceProposalsIds !== undefined &&
+      withdrawnProposalsIds !== undefined);
 
   const rejectedProposalIds = React.useMemo(
     () =>
@@ -434,6 +462,10 @@ export const IssueNewTokenForm = ({
 
   const handleCreate = async (data: FormValues) => {
     setFormError(null);
+
+    if (!isProposalStatusReady) {
+      return;
+    }
 
     const duplicateToken = findBlockingDuplicateIssueToken(dbTokens, {
       spaceId: spaceId as number,
@@ -538,7 +570,14 @@ export const IssueNewTokenForm = ({
               </div>
             )}
             <div className="flex justify-end w-full">
-              <Button type="submit">{tAgreementFlow('buttons.publish')}</Button>
+              <Button
+                type="submit"
+                disabled={
+                  isPending || isProposalStatusLoading || hasProposalStatusError
+                }
+              >
+                {tAgreementFlow('buttons.publish')}
+              </Button>
             </div>
           </div>
         </form>

--- a/packages/epics/src/governance/components/issue-new-token-form.tsx
+++ b/packages/epics/src/governance/components/issue-new-token-form.tsx
@@ -8,10 +8,12 @@ import {
   createAgreementFiles,
   useMe,
   useCreateIssueTokenOrchestrator,
-  DbToken,
   useJwt,
   WHITELIST_DUPLICATE_ENTRY_MESSAGE,
   type Space,
+  findBlockingDuplicateIssueToken,
+  useSpaceProposalsWeb3Rpc,
+  useWithdrawnProposalsWeb3Rpc,
 } from '@hypha-platform/core/client';
 import { z } from 'zod';
 import { Button, Form, Separator } from '@hypha-platform/ui';
@@ -397,6 +399,25 @@ export const IssueNewTokenForm = ({
   useClearResubmitOnSuccess(progress === 100 && !isError);
 
   const { tokens: dbTokens, refetchDbTokens } = useDbTokens();
+  const { spaceProposalsIds } = useSpaceProposalsWeb3Rpc({
+    spaceId: web3SpaceId ?? 0,
+  });
+  const { withdrawnProposalsIds } = useWithdrawnProposalsWeb3Rpc({
+    spaceId: web3SpaceId ?? 0,
+  });
+
+  const rejectedProposalIds = React.useMemo(
+    () =>
+      new Set(
+        Array.from(spaceProposalsIds?.rejected ?? []).map((id) => Number(id)),
+      ),
+    [spaceProposalsIds?.rejected],
+  );
+  const withdrawnProposalIds = React.useMemo(
+    () =>
+      new Set(Array.from(withdrawnProposalsIds ?? []).map((id) => Number(id))),
+    [withdrawnProposalsIds],
+  );
 
   const tokenType = form.watch('type');
 
@@ -414,16 +435,15 @@ export const IssueNewTokenForm = ({
   const handleCreate = async (data: FormValues) => {
     setFormError(null);
 
-    const duplicateToken = dbTokens?.find((token: DbToken) => {
-      const isNameEqual =
-        token.name?.toLowerCase() === data.name?.toLowerCase();
-      const isSymbolEqual =
-        token.symbol?.toLowerCase() === data.symbol?.toLowerCase();
-      const isSpaceEqual = token.spaceId === spaceId;
-      return isNameEqual && isSymbolEqual && isSpaceEqual;
+    const duplicateToken = findBlockingDuplicateIssueToken(dbTokens, {
+      spaceId: spaceId as number,
+      name: data.name,
+      symbol: data.symbol,
+      rejectedProposalIds,
+      withdrawnProposalIds,
     });
 
-    if (dbTokens?.length && duplicateToken) {
+    if (duplicateToken) {
       setFormError(tAgreementFlow('issueNewTokenForm.duplicateToken'));
       return;
     }

--- a/packages/epics/src/hooks/use-db-tokens.ts
+++ b/packages/epics/src/hooks/use-db-tokens.ts
@@ -25,6 +25,7 @@ type Token = {
   createdAt: Date;
   documentCount: number;
   address?: string;
+  agreementWeb3Id?: number;
   referenceCurrency?: string | null;
   referencePrice?: number | null;
   archived: boolean;

--- a/packages/storage-postgres/package.json
+++ b/packages/storage-postgres/package.json
@@ -7,7 +7,8 @@
     "push": "drizzle-kit push",
     "migrate": "drizzle-kit migrate",
     "seed": "tsx src/seed.ts",
-    "studio": "drizzle-kit studio"
+    "studio": "drizzle-kit studio",
+    "cleanup:undeployed-tokens": "tsx scripts/cleanup-undeployed-space-tokens.ts"
   },
   "devDependencies": {
     "@hypha-platform/config-typescript": "workspace:*",

--- a/packages/storage-postgres/scripts/cleanup-undeployed-space-tokens.ts
+++ b/packages/storage-postgres/scripts/cleanup-undeployed-space-tokens.ts
@@ -1,0 +1,96 @@
+/**
+ * Remove undeployed draft token rows left behind by failed issue-token proposals.
+ *
+ * Usage (dry run — lists rows only):
+ *   SPACE_SLUG=bioregion-saintonge TOKEN_SYMBOL=LIT pnpm exec tsx scripts/cleanup-undeployed-space-tokens.ts
+ *
+ * Usage (delete):
+ *   SPACE_SLUG=bioregion-saintonge TOKEN_SYMBOL=LIT pnpm exec tsx scripts/cleanup-undeployed-space-tokens.ts --confirm
+ *
+ * Requires BRANCH_DB_URL or DEFAULT_DB_URL (same as the app DB).
+ */
+import { and, eq, isNull, sql } from 'drizzle-orm';
+
+import { db } from '../src/db';
+import { spaces, tokens } from '../src/schema';
+
+const spaceSlug = process.env.SPACE_SLUG?.trim();
+const tokenSymbol = process.env.TOKEN_SYMBOL?.trim();
+const confirm = process.argv.includes('--confirm');
+
+async function main() {
+  if (!spaceSlug) {
+    throw new Error('SPACE_SLUG is required (e.g. bioregion-saintonge)');
+  }
+
+  const [space] = await db
+    .select({ id: spaces.id, slug: spaces.slug, title: spaces.title })
+    .from(spaces)
+    .where(eq(spaces.slug, spaceSlug))
+    .limit(1);
+
+  if (!space) {
+    throw new Error(`Space not found for slug: ${spaceSlug}`);
+  }
+
+  const conditions = [eq(tokens.spaceId, space.id), isNull(tokens.address)];
+  if (tokenSymbol) {
+    conditions.push(sql`lower(${tokens.symbol}) = lower(${tokenSymbol})`);
+  }
+
+  const matches = await db
+    .select({
+      id: tokens.id,
+      name: tokens.name,
+      symbol: tokens.symbol,
+      agreementId: tokens.agreementId,
+      agreementWeb3Id: tokens.agreementWeb3Id,
+      createdAt: tokens.createdAt,
+    })
+    .from(tokens)
+    .where(and(...conditions));
+
+  console.log(
+    JSON.stringify(
+      {
+        space: { id: space.id, slug: space.slug, title: space.title },
+        tokenSymbolFilter: tokenSymbol ?? null,
+        matchCount: matches.length,
+        matches,
+        confirm,
+      },
+      null,
+      2,
+    ),
+  );
+
+  if (matches.length === 0) {
+    return;
+  }
+
+  if (!confirm) {
+    console.log(
+      '\nDry run only. Re-run with --confirm to delete these undeployed draft rows.',
+    );
+    return;
+  }
+
+  const deleted = await db
+    .delete(tokens)
+    .where(and(...conditions))
+    .returning({
+      id: tokens.id,
+      name: tokens.name,
+      symbol: tokens.symbol,
+      agreementWeb3Id: tokens.agreementWeb3Id,
+    });
+
+  console.log('\nDeleted:', JSON.stringify(deleted, null, 2));
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary
- Confirms a bug: issue-token proposals create a draft `tokens` DB row immediately, but when the on-chain proposal is rejected the row is only deleted if someone has the proposal page open (`useProposalEvents`). The issue-new-token form then blocks recreation with "A token with the same name and symbol already exists in your space."
- Adds `isBlockingDuplicateIssueToken` / `findBlockingDuplicateIssueToken` so duplicate checks ignore undeployed draft rows tied to rejected or withdrawn proposals, while still blocking deployed tokens and active pending proposals.
- Deletes undeployed draft tokens in the `ProposalRejected` webhook so orphans are cleaned up server-side even when no client is watching.

## Root cause
For bioregion-saintonge's failed LIT (Local Impact Token) proposal, a draft token row with name/symbol but no on-chain `address` remained in the database and matched the frontend duplicate guard.

## Test plan
- [x] Unit tests for duplicate helper (`issue-token-duplicate.test.ts`)
- [ ] Reproduce on bioregion-saintonge: submit issue-token proposal with LIT, let it fail/reject, then recreate with same name/symbol — should proceed
- [ ] Verify an active on-voting proposal with the same name/symbol is still blocked
- [ ] Verify a deployed token with matching name/symbol is still blocked


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added smarter duplicate checks when creating a new token, including support for rejected or withdrawn proposals.
  * Added a cleanup utility for removing undeployed draft tokens, with a dry-run mode and optional confirmation.

* **Bug Fixes**
  * Rejected proposals now also clear related undeployed draft tokens.
  * Duplicate-token detection now avoids blocking valid drafts tied to rejected or withdrawn proposals.

* **Tests**
  * Added coverage for duplicate-token detection edge cases and matching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->