### PR TITLE
fix(epics): show all pins on flat map projection

### DIFF
--- a/packages/epics/src/network-map/components/network-globe-map.tsx
+++ b/packages/epics/src/network-map/components/network-globe-map.tsx
@@ -118,7 +118,8 @@ function isPinVisibleOnProjection(
   latitude: number,
 ): boolean {
   const clipAngle = projection.clipAngle?.();
-  if (clipAngle == null || clipAngle >= 180) {
+  // Equirectangular uses clipAngle(0) for antimeridian cuts, not back-face culling.
+  if (clipAngle == null || clipAngle >= 180 || clipAngle <= 0) {
     return true;
   }
 


### PR DESCRIPTION
## Summary
- Fix flat map pin visibility so every located space is shown, not only pins within ~90° of (0°, 0°)
- Skip globe back-face culling when D3 equirectangular reports `clipAngle(0)` (antimeridian cuts, not hemisphere hiding)
- Globe view behavior is unchanged: orthographic still hides pins on the far side of the sphere

## Test plan
- [ ] Open network map in globe view and rotate to show Australia/Pacific pins
- [ ] Switch to flat view and confirm the same pins appear worldwide (including Australia and Pacific clusters)
- [ ] Confirm globe view still hides pins on the back hemisphere when rotated


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved globe pin visibility handling for certain map projections, including cases where the projection uses a zero clip angle.
  * Prevented pins from being incorrectly hidden when rendering maps with antimeridian cuts or similar full-visibility settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->