### PR TITLE
fix(build): bake Google Drive env vars into production bundles

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -153,10 +153,11 @@ jobs:
         env:
           BRANCH_DB_URL: ${{ steps.create-branch.outputs.db_url_with_pooler }}
         run: |
-          vercel env pull --environment=preview --token=${{ env.VERCEL_TOKEN }}
+          # Next.js loads env from apps/web — root .env.local is not picked up by the web build.
+          vercel env pull apps/web/.env.local --environment=preview --token=${{ env.VERCEL_TOKEN }}
           # Build-time feature flags; enable on preview deploys for PR testing.
-          echo "NEXT_PUBLIC_ENABLE_NETWORK_MAP=true" >> .env.local
-          echo "NEXT_PUBLIC_ENABLE_ONBOARDING_VOICE_REALTIME=true" >> .env.local
+          echo "NEXT_PUBLIC_ENABLE_NETWORK_MAP=true" >> apps/web/.env.local
+          echo "NEXT_PUBLIC_ENABLE_ONBOARDING_VOICE_REALTIME=true" >> apps/web/.env.local
           vercel build --token=${{ env.VERCEL_TOKEN }}
 
       - name: Deploy Preview to Vercel

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -42,7 +42,9 @@ jobs:
         run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Build Project Artifacts
-        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+        run: |
+          vercel env pull --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+          vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
         env:
           PRIVATE_KEY: ${{ secrets.EVM_SC_OWNER_PRIVATE_KEY }}
           DEFAULT_DB_URL: ${{ secrets.POSTGRES_URL }}

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -43,7 +43,8 @@ jobs:
 
       - name: Build Project Artifacts
         run: |
-          vercel env pull --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+          # Next.js loads env from apps/web — root .env.local is not picked up by the web build.
+          vercel env pull apps/web/.env.local --environment=production --token=${{ secrets.VERCEL_TOKEN }}
           vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
         env:
           PRIVATE_KEY: ${{ secrets.EVM_SC_OWNER_PRIVATE_KEY }}

--- a/turbo.json
+++ b/turbo.json
@@ -1,11 +1,11 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "ui": "tui",
-  "globalDependencies": [".env"],
+  "globalDependencies": [".env", "apps/web/.env*"],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "inputs": ["$TURBO_DEFAULT$", ".env*"],
+      "inputs": ["$TURBO_DEFAULT$", ".env*", "apps/web/.env*"],
       "env": [
         "NEON_DATABASE_USERNAME",
         "NEON_DATABASE_NAME",

--- a/turbo.json
+++ b/turbo.json
@@ -15,7 +15,10 @@
         "DEFAULT_DB_URL",
         "PRIVATE_KEY",
         "DEFAULT_DB_AUTHENTICATED_URL",
-        "DEFAULT_DB_ANONYMOUS_URL"
+        "DEFAULT_DB_ANONYMOUS_URL",
+        "NEXT_PUBLIC_GOOGLE_DRIVE_CLIENT_ID",
+        "NEXT_PUBLIC_GOOGLE_DRIVE_API_KEY",
+        "NEXT_PUBLIC_GOOGLE_DRIVE_APP_ID"
       ],
       "outputs": [".next/**", "!.next/cache/**"]
     },


### PR DESCRIPTION
## Summary
- Pull production env vars with `vercel env pull` before `vercel build --prod`, matching the preview deploy workflow.
- Add `NEXT_PUBLIC_GOOGLE_DRIVE_*` to Turbo `build.env` so cache invalidates when Drive credentials change.

Fixes Google Drive appearing greyed out on production even when the three Vercel env vars are set — `NEXT_PUBLIC_*` values were not reliably baked into client bundles.

## Test plan
- [ ] Merge and deploy to production
- [ ] On `app.hypha.earth/en/onboarding`, open DevTools → Sources → search `apps.googleusercontent.com` — client ID should appear in a chunk
- [ ] Click **+ → Google Drive** — item should be enabled (not greyed out)
- [ ] Pick a file from Drive and confirm it attaches to the composer


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved production builds by pulling the latest environment settings before creating release artifacts, helping ensure builds use the correct deployment configuration.
  * Updated build tracking so additional app environment values are included during builds, reducing the chance of missing configuration in production.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->