### PR TITLE
fix(network): default network page to list view

### DIFF
--- a/apps/web/src/app/[lang]/network/page.tsx
+++ b/apps/web/src/app/[lang]/network/page.tsx
@@ -61,7 +61,7 @@ export default async function Index(props: PageProps) {
       query,
       category: searchParams?.category,
       order: orderRaw,
-      view: 'map',
+      view: 'list',
     });
     const queryString = nextParams.toString();
     redirect(`/${lang}/network${queryString ? `?${queryString}` : ''}`);

--- a/packages/epics/src/spaces/components/explore-spaces.tsx
+++ b/packages/epics/src/spaces/components/explore-spaces.tsx
@@ -169,7 +169,7 @@ export function ExploreSpaces({
   );
 
   const viewFromUrl = (params: URLSearchParams): NetworkMapView =>
-    params.get('view') === 'list' ? 'list' : 'map';
+    params.get('view') === 'map' ? 'map' : 'list';
 
   const [view, setViewState] = React.useState<NetworkMapView>(() =>
     enableNetworkMap ? viewFromUrl(searchParams) : 'list',


### PR DESCRIPTION
## Summary
- Default the network page to list view when the network map feature flag is enabled
- Update server-side redirect and client-side URL parsing so only `?view=map` opens the map

## Test plan
- [ ] With network map enabled, visit `/en/network` and confirm list view is shown by default
- [ ] Confirm `/en/network?view=map` still opens the map view
- [ ] Toggle between list and map using the view switcher and verify URL updates correctly

Made with [Cursor](https://cursor.com)