### PR TITLE
fix(coherence): enable signal creation for delegates and member-space participants

### DIFF
--- a/packages/epics/src/coherence/components/signal-section.tsx
+++ b/packages/epics/src/coherence/components/signal-section.tsx
@@ -41,7 +41,7 @@ import Link from 'next/link';
 import React from 'react';
 import { useTranslations } from 'next-intl';
 import { Archive, Pencil, SearchIcon } from 'lucide-react';
-import { useSpaceMember } from '../../spaces/hooks/use-space-member';
+import { useCanMutateInSpace } from '../../spaces/hooks/use-can-mutate-in-space.web3.rpc';
 import {
   SIGNAL_PROVISIONING_NOTICE_EVENT,
   SIGNAL_PROVISIONING_NOTICE_STORAGE_KEY,
@@ -243,8 +243,9 @@ export const SignalSection: FC<SignalSectionProps> = ({
   }, [provisioningNoticeLines]);
 
   const createSignalHref = `/${lang}/dho/${id}/coherence/new-signal`;
-  const { isMember, isMemberLoading } = useSpaceMember({
+  const { canMutate, isLoading: isMutateLoading } = useCanMutateInSpace({
     spaceId: web3SpaceId,
+    spaceSlug: id,
   });
   const boardStorageKey = React.useMemo(
     () => `${SIGNAL_BOARDS_STORAGE_KEY_PREFIX}${id}`,
@@ -686,16 +687,16 @@ export const SignalSection: FC<SignalSectionProps> = ({
               variant="outline"
               colorVariant="accent"
               className="w-auto"
-              disabled={isMemberLoading || !isMember}
+              disabled={isMutateLoading || !canMutate}
               onClick={() => {
-                if (isMemberLoading || !isMember) return;
+                if (isMutateLoading || !canMutate) return;
                 resetBoardForm();
                 setCreateBoardOpen(true);
               }}
             >
               {t('createBoard')}
             </Button>
-            {!isMemberLoading && isMember ? (
+            {!isMutateLoading && canMutate ? (
               <Button
                 asChild
                 variant="default"

--- a/packages/epics/src/common/ai-left-panel.tsx
+++ b/packages/epics/src/common/ai-left-panel.tsx
@@ -73,7 +73,7 @@ import { resolveSpaceDisplayLogoUrl } from '../spaces/utils/resolve-space-displa
 import {
   UserSpaceState,
   useUserSpaceState,
-} from '../spaces/hooks/use-user-space-state';
+} from '../spaces/hooks/use-user-space-state.web3.rpc';
 import { useSpaceDiscoverability } from '../spaces/hooks/use-space-discoverability';
 import {
   checkAccess,

--- a/packages/epics/src/common/human-right-panel.tsx
+++ b/packages/epics/src/common/human-right-panel.tsx
@@ -63,7 +63,7 @@ import { UseMembers } from '../spaces';
 import {
   UserSpaceState,
   useUserSpaceState,
-} from '../spaces/hooks/use-user-space-state';
+} from '../spaces/hooks/use-user-space-state.web3.rpc';
 import { useSpaceDiscoverability } from '../spaces/hooks/use-space-discoverability';
 import {
   checkAccess,

--- a/packages/epics/src/governance/components/documents-sections.tsx
+++ b/packages/epics/src/governance/components/documents-sections.tsx
@@ -11,7 +11,7 @@ import { Button } from '@hypha-platform/ui';
 import {
   UserSpaceState,
   useUserSpaceState,
-} from '../../spaces/hooks/use-user-space-state';
+} from '../../spaces/hooks/use-user-space-state.web3.rpc';
 
 type DocumentsSectionsProps = {
   lang: string;

--- a/packages/epics/src/spaces/components/space-access-denied.tsx
+++ b/packages/epics/src/spaces/components/space-access-denied.tsx
@@ -2,7 +2,7 @@
 
 import { Button } from '@hypha-platform/ui';
 import { Empty } from '../../common/empty';
-import { UserSpaceState } from '../hooks/use-user-space-state';
+import { UserSpaceState } from '../hooks/use-user-space-state.web3.rpc';
 import { useAuthentication } from '@hypha-platform/authentication';
 import {
   useSpaceDetailsWeb3Rpc,

--- a/packages/epics/src/spaces/components/space-call-join-hero-banner.tsx
+++ b/packages/epics/src/spaces/components/space-call-join-hero-banner.tsx
@@ -8,7 +8,7 @@ import { useGlobalCallDock } from '../../common/global-call-dock-context';
 import {
   UserSpaceState,
   useUserSpaceState,
-} from '../hooks/use-user-space-state';
+} from '../hooks/use-user-space-state.web3.rpc';
 
 type SpaceCallJoinHeroBannerProps = {
   spaceSlug: string;

--- a/packages/epics/src/spaces/components/space-discoverability-filter.tsx
+++ b/packages/epics/src/spaces/components/space-discoverability-filter.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Space } from '@hypha-platform/core/client';
-import { useUserSpaceState } from '../hooks/use-user-space-state';
+import { useUserSpaceState } from '../hooks/use-user-space-state.web3.rpc';
 import { shouldShowSpace } from '../hooks/use-filter-spaces-by-discoverability';
 import { useMemo } from 'react';
 

--- a/packages/epics/src/spaces/components/space-tab-access-wrapper.tsx
+++ b/packages/epics/src/spaces/components/space-tab-access-wrapper.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useSpaceDiscoverability } from '../hooks/use-space-discoverability';
-import { useUserSpaceState } from '../hooks/use-user-space-state';
+import { useUserSpaceState } from '../hooks/use-user-space-state.web3.rpc';
 import { checkAccess } from '../utils/transparency-access';
 import { SpaceAccessDenied } from './space-access-denied';
 import { useSpaceBySlug } from '@hypha-platform/core/client';

--- a/packages/epics/src/spaces/hooks/index.ts
+++ b/packages/epics/src/spaces/hooks/index.ts
@@ -9,7 +9,7 @@ export * from './use-exit-space';
 export * from './use-space-member';
 export * from './use-action-gating';
 export * from './use-space-discoverability';
-export * from './use-user-space-state';
+export * from './use-user-space-state.web3.rpc';
 export * from './use-can-mutate-in-space.web3.rpc';
 export * from './use-spaces-discoverability-batch';
 export {

--- a/packages/epics/src/spaces/hooks/use-can-mutate-in-space.web3.rpc.ts
+++ b/packages/epics/src/spaces/hooks/use-can-mutate-in-space.web3.rpc.ts
@@ -1,7 +1,10 @@
 'use client';
 
 import { Space } from '@hypha-platform/core/client';
-import { UserSpaceState, useUserSpaceState } from './use-user-space-state';
+import {
+  UserSpaceState,
+  useUserSpaceState,
+} from './use-user-space-state.web3.rpc';
 
 export function useCanMutateInSpace({
   spaceId,

--- a/packages/epics/src/spaces/hooks/use-filter-spaces-by-discoverability.ts
+++ b/packages/epics/src/spaces/hooks/use-filter-spaces-by-discoverability.ts
@@ -2,7 +2,7 @@
 
 import { Space } from '@hypha-platform/core/client';
 import { TransparencyLevel } from '../components/transparency-level';
-import { UserSpaceState } from './use-user-space-state';
+import { UserSpaceState } from './use-user-space-state.web3.rpc';
 import { checkDiscoverability } from '../utils/transparency-access';
 
 export function shouldShowSpace(

--- a/packages/epics/src/spaces/hooks/use-filter-spaces-list.ts
+++ b/packages/epics/src/spaces/hooks/use-filter-spaces-list.ts
@@ -2,7 +2,10 @@
 
 import { Space } from '@hypha-platform/core/client';
 import { useSpaceDiscoverability } from './use-space-discoverability';
-import { useUserSpaceState, UserSpaceState } from './use-user-space-state';
+import {
+  useUserSpaceState,
+  UserSpaceState,
+} from './use-user-space-state.web3.rpc';
 import { shouldShowSpace } from './use-filter-spaces-by-discoverability';
 import { useMemo } from 'react';
 

--- a/packages/epics/src/spaces/hooks/use-spaces-discoverability-batch.ts
+++ b/packages/epics/src/spaces/hooks/use-spaces-discoverability-batch.ts
@@ -1,10 +1,10 @@
 'use client';
 
 import { Space } from '@hypha-platform/core/client';
-import { useUserSpaceState } from './use-user-space-state';
+import { useUserSpaceState } from './use-user-space-state.web3.rpc';
 import { shouldShowSpace } from './use-filter-spaces-by-discoverability';
 import { TransparencyLevel } from '../components/transparency-level';
-import { UserSpaceState } from './use-user-space-state';
+import { UserSpaceState } from './use-user-space-state.web3.rpc';
 import { useMemo } from 'react';
 import useSWR from 'swr';
 import { publicClient, getSpaceVisibility } from '@hypha-platform/core/client';

--- a/packages/epics/src/spaces/hooks/use-user-space-state.ts
+++ b/packages/epics/src/spaces/hooks/use-user-space-state.ts
@@ -2,7 +2,11 @@
 
 import { useAuthentication } from '@hypha-platform/authentication';
 import { useSpaceMember } from './use-space-member';
-import { useIsDelegate } from '@hypha-platform/core/client';
+import { useMemberWeb3SpaceIds } from './use-member-web3-space-ids';
+import {
+  useIsDelegate,
+  useSpaceDetailsWeb3Rpc,
+} from '@hypha-platform/core/client';
 import {
   useSpaceBySlug,
   Space,
@@ -48,6 +52,81 @@ export function useUserSpaceState({
     spaceId: effectiveSpaceId as number,
     userAddress: user?.wallet?.address,
   });
+
+  const {
+    web3SpaceIds: userMemberWeb3SpaceIds,
+    isLoading: isUserMemberWeb3SpaceIdsLoading,
+  } = useMemberWeb3SpaceIds({ personAddress: user?.wallet?.address });
+
+  const {
+    spaceDetails: hostSpaceDetails,
+    isLoading: isHostSpaceDetailsLoading,
+  } = useSpaceDetailsWeb3Rpc({
+    spaceId: effectiveSpaceId ?? undefined,
+  });
+
+  const hostMemberAddressesKey = useMemo(() => {
+    const members = hostSpaceDetails?.members;
+    if (!members?.length) return '';
+    return members
+      .map((member: string) => member.toLowerCase())
+      .sort()
+      .join(',');
+  }, [hostSpaceDetails?.members]);
+
+  const userMemberSpaceIdsKey = useMemo(() => {
+    if (!userMemberWeb3SpaceIds?.length) return '';
+    return userMemberWeb3SpaceIds
+      .map((id) => id.toString())
+      .sort()
+      .join(',');
+  }, [userMemberWeb3SpaceIds]);
+
+  const {
+    data: isMemberSpaceParticipant,
+    isLoading: isMemberSpaceParticipantLoading,
+  } = useSWR(
+    isAuthenticated &&
+      user?.wallet?.address &&
+      effectiveSpaceId &&
+      hostMemberAddressesKey &&
+      userMemberSpaceIdsKey
+      ? [
+          'memberSpaceParticipant',
+          effectiveSpaceId,
+          hostMemberAddressesKey,
+          userMemberSpaceIdsKey,
+        ]
+      : null,
+    async () => {
+      const hostMembersLower = new Set(
+        hostSpaceDetails!.members.map((member: string) => member.toLowerCase()),
+      );
+
+      const checks = await Promise.all(
+        userMemberWeb3SpaceIds!.map(async (spaceId) => {
+          try {
+            const details = await publicClient.readContract(
+              getSpaceDetails({ spaceId }),
+            );
+            const executor = details[9] as string | undefined;
+            return (
+              typeof executor === 'string' &&
+              hostMembersLower.has(executor.toLowerCase())
+            );
+          } catch (error) {
+            console.error(
+              `Error checking member-space access for space ${spaceId}:`,
+              error,
+            );
+            return false;
+          }
+        }),
+      );
+
+      return checks.some(Boolean);
+    },
+  );
 
   const effectiveSpaceSlug = spaceSlug || effectiveSpace?.slug || '';
   const { spaces: organisationSpaces, isLoading: isOrganisationSpacesLoading } =
@@ -150,7 +229,7 @@ export function useUserSpaceState({
       return UserSpaceState.NOT_LOGGED_IN;
     }
 
-    if (isMember || isDelegate) {
+    if (isMember || isDelegate || isMemberSpaceParticipant) {
       return UserSpaceState.LOGGED_IN_SPACE;
     }
 
@@ -159,11 +238,22 @@ export function useUserSpaceState({
     }
 
     return UserSpaceState.LOGGED_IN;
-  }, [isAuthenticated, user, isMember, isDelegate, isOrgMember, isOrgDelegate]);
+  }, [
+    isAuthenticated,
+    user,
+    isMember,
+    isDelegate,
+    isMemberSpaceParticipant,
+    isOrgMember,
+    isOrgDelegate,
+  ]);
 
   const isLoading =
     isMemberLoading ||
     isDelegateLoading ||
+    isUserMemberWeb3SpaceIdsLoading ||
+    isHostSpaceDetailsLoading ||
+    isMemberSpaceParticipantLoading ||
     isOrganisationSpacesLoading ||
     isOrgMembershipLoading ||
     spaceFromHook.isLoading;

--- a/packages/epics/src/spaces/hooks/use-user-space-state.web3.rpc.ts
+++ b/packages/epics/src/spaces/hooks/use-user-space-state.web3.rpc.ts
@@ -53,16 +53,29 @@ export function useUserSpaceState({
     userAddress: user?.wallet?.address,
   });
 
+  const shouldCheckMemberSpaceParticipant =
+    isAuthenticated &&
+    !!user?.wallet?.address &&
+    !!effectiveSpaceId &&
+    !isMemberLoading &&
+    !isDelegateLoading &&
+    !isMember &&
+    !isDelegate;
+
   const {
     web3SpaceIds: userMemberWeb3SpaceIds,
     isLoading: isUserMemberWeb3SpaceIdsLoading,
-  } = useMemberWeb3SpaceIds({ personAddress: user?.wallet?.address });
+  } = useMemberWeb3SpaceIds({
+    personAddress: shouldCheckMemberSpaceParticipant
+      ? user?.wallet?.address
+      : undefined,
+  });
 
   const {
     spaceDetails: hostSpaceDetails,
     isLoading: isHostSpaceDetailsLoading,
   } = useSpaceDetailsWeb3Rpc({
-    spaceId: effectiveSpaceId ?? undefined,
+    spaceId: shouldCheckMemberSpaceParticipant ? effectiveSpaceId : undefined,
   });
 
   const hostMemberAddressesKey = useMemo(() => {
@@ -86,9 +99,7 @@ export function useUserSpaceState({
     data: isMemberSpaceParticipant,
     isLoading: isMemberSpaceParticipantLoading,
   } = useSWR(
-    isAuthenticated &&
-      user?.wallet?.address &&
-      effectiveSpaceId &&
+    shouldCheckMemberSpaceParticipant &&
       hostMemberAddressesKey &&
       userMemberSpaceIdsKey
       ? [
@@ -103,28 +114,27 @@ export function useUserSpaceState({
         hostSpaceDetails!.members.map((member: string) => member.toLowerCase()),
       );
 
-      const checks = await Promise.all(
-        userMemberWeb3SpaceIds!.map(async (spaceId) => {
-          try {
-            const details = await publicClient.readContract(
-              getSpaceDetails({ spaceId }),
-            );
-            const executor = details[9] as string | undefined;
-            return (
-              typeof executor === 'string' &&
-              hostMembersLower.has(executor.toLowerCase())
-            );
-          } catch (error) {
-            console.error(
-              `Error checking member-space access for space ${spaceId}:`,
-              error,
-            );
-            return false;
+      for (const spaceId of userMemberWeb3SpaceIds!) {
+        try {
+          const details = await publicClient.readContract(
+            getSpaceDetails({ spaceId }),
+          );
+          const executor = details[9] as string | undefined;
+          if (
+            typeof executor === 'string' &&
+            hostMembersLower.has(executor.toLowerCase())
+          ) {
+            return true;
           }
-        }),
-      );
+        } catch (error) {
+          console.error(
+            `Error checking member-space access for space ${spaceId}:`,
+            error,
+          );
+        }
+      }
 
-      return checks.some(Boolean);
+      return false;
     },
   );
 
@@ -248,12 +258,16 @@ export function useUserSpaceState({
     isOrgDelegate,
   ]);
 
+  const isMemberSpaceParticipantPathLoading =
+    shouldCheckMemberSpaceParticipant &&
+    (isUserMemberWeb3SpaceIdsLoading ||
+      isHostSpaceDetailsLoading ||
+      isMemberSpaceParticipantLoading);
+
   const isLoading =
     isMemberLoading ||
     isDelegateLoading ||
-    isUserMemberWeb3SpaceIdsLoading ||
-    isHostSpaceDetailsLoading ||
-    isMemberSpaceParticipantLoading ||
+    isMemberSpaceParticipantPathLoading ||
     isOrganisationSpacesLoading ||
     isOrgMembershipLoading ||
     spaceFromHook.isLoading;

--- a/packages/epics/src/spaces/utils/transparency-access.ts
+++ b/packages/epics/src/spaces/utils/transparency-access.ts
@@ -1,5 +1,5 @@
 import { TransparencyLevel } from '../components/transparency-level';
-import { UserSpaceState } from '../hooks/use-user-space-state';
+import { UserSpaceState } from '../hooks/use-user-space-state.web3.rpc';
 
 export function checkDiscoverability(
   discoverabilityLevel: TransparencyLevel | undefined,


### PR DESCRIPTION
## Summary
- Fix the disabled **New Signal** and **Create Board** buttons for users who are delegates or members of a space that is an on-chain member of the host space.
- Extend `useUserSpaceState` to grant `LOGGED_IN_SPACE` when any of the user's member/delegate spaces has its executor listed in the host space's on-chain member roster.
- Switch `SignalSection` from direct `useSpaceMember` checks to `useCanMutateInSpace`, matching other coherence write actions (e.g. space memory).

## Test plan
- [ ] As a direct member of a space, confirm **New Signal** and **Create Board** are enabled.
- [ ] As a delegate of a space (not a direct member), confirm both buttons are enabled.
- [ ] As a member/delegate of a child space that is listed as a member space of the host, confirm both buttons are enabled.
- [ ] As a logged-in non-member with no delegate/member-space path, confirm both buttons stay disabled.
- [ ] Click **New Signal** and verify the aside form opens (not access denied).


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved space membership detection so the app can recognize more valid logged-in space participants.
  * Updated board creation controls to enable/disable correctly based on the latest permission checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->