### PR TITLE
perf: page loading speed + fix proposal modal flicker/refetch

### DIFF
--- a/apps/web/src/app/[lang]/dho/[id]/@aside/agreements/proposal/[documentSlug]/page.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@aside/agreements/proposal/[documentSlug]/page.tsx
@@ -56,7 +56,7 @@ export default function Agreements() {
   const {
     proposalDetails,
     isLoading: isLoadingProposal,
-    mutate: proposalDetailsMutate,
+    refreshUntilVoteApplied,
   } = useProposalDetailsWeb3Rpc({
     proposalId: document?.web3ProposalId as number,
   });
@@ -113,8 +113,10 @@ export default function Agreements() {
       setVoteMessage(tAgreementFlow('proposalLoader.gettingUpdatedData'));
       // Refresh the on-chain proposal details alongside the voters list so the
       // quorum/unity bars reflect the new vote the instant the loading overlay
-      // closes, instead of waiting up to 10s for the next background poll.
-      await Promise.all([votersMutate(), proposalDetailsMutate()]);
+      // closes, instead of waiting up to 10s for the next background poll. The
+      // RPC read can briefly lag the just-mined vote, so retry until the tally
+      // actually changes rather than trusting a single (possibly stale) read.
+      await Promise.all([votersMutate(), refreshUntilVoteApplied()]);
       setProgress(100);
       setVoteMessage(tAgreementFlow('proposalLoader.voteProcessed'));
     } catch (err: any) {

--- a/apps/web/src/app/[lang]/dho/[id]/@aside/agreements/proposal/[documentSlug]/page.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@aside/agreements/proposal/[documentSlug]/page.tsx
@@ -53,10 +53,13 @@ export default function Agreements() {
   const { id, lang } = useParams();
   const documentSlug = useDocumentSlug();
   const { document, isLoading } = useDocumentBySlug(documentSlug);
-  const { proposalDetails, isLoading: isLoadingProposal } =
-    useProposalDetailsWeb3Rpc({
-      proposalId: document?.web3ProposalId as number,
-    });
+  const {
+    proposalDetails,
+    isLoading: isLoadingProposal,
+    mutate: proposalDetailsMutate,
+  } = useProposalDetailsWeb3Rpc({
+    proposalId: document?.web3ProposalId as number,
+  });
   // While the document says this is a proposal (has a web3ProposalId) but the
   // on-chain details haven't arrived yet, keep the detail view in its loading
   // state. Otherwise quorum/unity/vote bars briefly render as 0 and then jump
@@ -108,7 +111,10 @@ export default function Agreements() {
       await update();
       setProgress(70);
       setVoteMessage(tAgreementFlow('proposalLoader.gettingUpdatedData'));
-      await votersMutate();
+      // Refresh the on-chain proposal details alongside the voters list so the
+      // quorum/unity bars reflect the new vote the instant the loading overlay
+      // closes, instead of waiting up to 10s for the next background poll.
+      await Promise.all([votersMutate(), proposalDetailsMutate()]);
       setProgress(100);
       setVoteMessage(tAgreementFlow('proposalLoader.voteProcessed'));
     } catch (err: any) {

--- a/apps/web/src/app/[lang]/dho/[id]/@aside/agreements/proposal/[documentSlug]/page.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@aside/agreements/proposal/[documentSlug]/page.tsx
@@ -56,6 +56,7 @@ export default function Agreements() {
   const {
     proposalDetails,
     isLoading: isLoadingProposal,
+    error: proposalError,
     refreshUntilVoteApplied,
   } = useProposalDetailsWeb3Rpc({
     proposalId: document?.web3ProposalId as number,
@@ -63,9 +64,11 @@ export default function Agreements() {
   // While the document says this is a proposal (has a web3ProposalId) but the
   // on-chain details haven't arrived yet, keep the detail view in its loading
   // state. Otherwise quorum/unity/vote bars briefly render as 0 and then jump
-  // to their real values - the visible "flicker" when opening the modal.
+  // to their real values - the visible "flicker" when opening the modal. Stop
+  // waiting once the RPC read errors, otherwise the skeleton would be stuck
+  // forever (proposalDetails never arrives) instead of surfacing the failure.
   const isProposalDataPending =
-    document?.web3ProposalId != null && !proposalDetails;
+    document?.web3ProposalId != null && !proposalDetails && !proposalError;
   const { mutate: votersMutate, myVote } = useMyVote(documentSlug);
   const {
     handleAccept,

--- a/apps/web/src/app/[lang]/dho/[id]/@aside/agreements/proposal/[documentSlug]/page.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@aside/agreements/proposal/[documentSlug]/page.tsx
@@ -151,7 +151,7 @@ export default function Agreements() {
     <ProposalOverlayShell>
       <LoadingBackdrop
         progress={progress}
-        isLoading={isLoading || isVoting || !!voteError}
+        isLoading={isVoting || !!voteError}
         message={
           voteError ? (
             <div className="text-center space-y-2">
@@ -202,6 +202,7 @@ export default function Agreements() {
           leadImage={document?.leadImage}
           attachments={document?.attachments}
           proposalId={document?.web3ProposalId}
+          web3SpaceId={space?.web3SpaceId ?? undefined}
           spaceSlug={space?.slug || ''}
           label={document?.label || ''}
           documentSlug={documentSlug}

--- a/apps/web/src/app/[lang]/dho/[id]/@aside/agreements/proposal/[documentSlug]/page.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@aside/agreements/proposal/[documentSlug]/page.tsx
@@ -4,6 +4,7 @@ import {
   ProposalDetail,
   ProposalOverlayShell,
   useSpaceDocumentsWithStatuses,
+  PROPOSAL_DOCUMENTS_DEFAULT_ORDER,
   useDbTokens,
 } from '@hypha-platform/epics';
 import { useParams } from 'next/navigation';
@@ -56,6 +57,12 @@ export default function Agreements() {
     useProposalDetailsWeb3Rpc({
       proposalId: document?.web3ProposalId as number,
     });
+  // While the document says this is a proposal (has a web3ProposalId) but the
+  // on-chain details haven't arrived yet, keep the detail view in its loading
+  // state. Otherwise quorum/unity/vote bars briefly render as 0 and then jump
+  // to their real values - the visible "flicker" when opening the modal.
+  const isProposalDataPending =
+    document?.web3ProposalId != null && !proposalDetails;
   const { mutate: votersMutate, myVote } = useMyVote(documentSlug);
   const {
     handleAccept,
@@ -76,6 +83,7 @@ export default function Agreements() {
   const { update } = useSpaceDocumentsWithStatuses({
     spaceSlug: space?.slug as string,
     spaceId: space?.web3SpaceId as number,
+    order: PROPOSAL_DOCUMENTS_DEFAULT_ORDER,
   });
   const { tokens } = useDbTokens();
   const [isVoting, setIsVoting] = useState(false);
@@ -190,7 +198,7 @@ export default function Agreements() {
           }}
           title={document?.title}
           status={document?.state}
-          isLoading={isLoading}
+          isLoading={isLoading || isProposalDataPending}
           leadImage={document?.leadImage}
           attachments={document?.attachments}
           proposalId={document?.web3ProposalId}

--- a/apps/web/src/app/[lang]/dho/[id]/@tab/_components/tab-loading-skeleton.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@tab/_components/tab-loading-skeleton.tsx
@@ -1,0 +1,37 @@
+import { Skeleton } from '@hypha-platform/ui';
+
+type TabLoadingSkeletonProps = {
+  cards?: number;
+  showTitle?: boolean;
+};
+
+/**
+ * Shared Suspense fallback for the space-detail `@tab` slots. Rendering a
+ * skeleton via each tab's `loading.tsx` gives instant visual feedback on tab
+ * switch instead of leaving the previous tab's content frozen until the RSC
+ * resolves.
+ */
+export function TabLoadingSkeleton({
+  cards = 6,
+  showTitle = true,
+}: TabLoadingSkeletonProps) {
+  return (
+    <div className="flex flex-col gap-4 py-4">
+      {showTitle ? (
+        <div className="flex flex-col gap-3">
+          <Skeleton loading width={180} height={28} className="rounded-md" />
+        </div>
+      ) : null}
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: cards }).map((_, index) => (
+          <Skeleton
+            key={index}
+            loading
+            height={140}
+            className="w-full rounded-lg"
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/[lang]/dho/[id]/@tab/agreements/loading.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@tab/agreements/loading.tsx
@@ -1,0 +1,5 @@
+import { TabLoadingSkeleton } from '../_components/tab-loading-skeleton';
+
+export default function Loading() {
+  return <TabLoadingSkeleton />;
+}

--- a/apps/web/src/app/[lang]/dho/[id]/@tab/coherence/loading.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@tab/coherence/loading.tsx
@@ -1,0 +1,5 @@
+import { TabLoadingSkeleton } from '../_components/tab-loading-skeleton';
+
+export default function Loading() {
+  return <TabLoadingSkeleton />;
+}

--- a/apps/web/src/app/[lang]/dho/[id]/@tab/members/loading.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@tab/members/loading.tsx
@@ -1,0 +1,5 @@
+import { TabLoadingSkeleton } from '../_components/tab-loading-skeleton';
+
+export default function Loading() {
+  return <TabLoadingSkeleton />;
+}

--- a/apps/web/src/app/[lang]/dho/[id]/@tab/members/page.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@tab/members/page.tsx
@@ -35,7 +35,7 @@ export default async function MembershipPage(props: PageProps) {
           basePath={`${basePath}/person`}
           useMembers={useMembers}
           spaceSlug={id}
-          refreshInterval={2000}
+          refreshInterval={5000}
         />
       </div>
     </SpaceTabAccessWrapper>

--- a/apps/web/src/app/[lang]/dho/[id]/@tab/overview/_components/home-token-holdings-dashboard-lazy.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@tab/overview/_components/home-token-holdings-dashboard-lazy.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+import { TabLoadingSkeleton } from '../../_components/tab-loading-skeleton';
+
+/**
+ * The overview dashboard pulls in d3 (a large dependency) and only ever renders
+ * client-side (SWR fetches gated on the Privy access token). Lazy-loading it via
+ * `next/dynamic` keeps the d3 chunk off the initial hydration path and shows a
+ * skeleton while it streams in.
+ */
+const HomeTokenHoldingsDashboard = dynamic(
+  () =>
+    import('./home-token-holdings-dashboard').then(
+      (mod) => mod.HomeTokenHoldingsDashboard,
+    ),
+  {
+    ssr: false,
+    loading: () => <TabLoadingSkeleton showTitle={false} />,
+  },
+);
+
+export function HomeTokenHoldingsDashboardLazy({
+  spaceSlug,
+}: {
+  spaceSlug: string;
+}) {
+  return <HomeTokenHoldingsDashboard spaceSlug={spaceSlug} />;
+}

--- a/apps/web/src/app/[lang]/dho/[id]/@tab/overview/loading.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@tab/overview/loading.tsx
@@ -1,0 +1,5 @@
+import { TabLoadingSkeleton } from '../_components/tab-loading-skeleton';
+
+export default function Loading() {
+  return <TabLoadingSkeleton showTitle={false} />;
+}

--- a/apps/web/src/app/[lang]/dho/[id]/@tab/overview/page.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@tab/overview/page.tsx
@@ -1,6 +1,6 @@
 import { Locale } from '@hypha-platform/i18n';
 import { SpaceTabAccessWrapper } from '@hypha-platform/epics';
-import { HomeTokenHoldingsDashboard } from './_components/home-token-holdings-dashboard';
+import { HomeTokenHoldingsDashboardLazy } from './_components/home-token-holdings-dashboard-lazy';
 
 type PageProps = {
   params: Promise<{ lang: Locale; id: string }>;
@@ -13,7 +13,7 @@ export default async function OrganisationPage(props: PageProps) {
 
   return (
     <SpaceTabAccessWrapper spaceSlug={id}>
-      <HomeTokenHoldingsDashboard spaceSlug={id} />
+      <HomeTokenHoldingsDashboardLazy spaceSlug={id} />
     </SpaceTabAccessWrapper>
   );
 }

--- a/apps/web/src/app/[lang]/dho/[id]/@tab/rewards/loading.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@tab/rewards/loading.tsx
@@ -1,0 +1,5 @@
+import { TabLoadingSkeleton } from '../_components/tab-loading-skeleton';
+
+export default function Loading() {
+  return <TabLoadingSkeleton />;
+}

--- a/apps/web/src/app/[lang]/dho/[id]/@tab/treasury/loading.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@tab/treasury/loading.tsx
@@ -1,0 +1,5 @@
+import { TabLoadingSkeleton } from '../_components/tab-loading-skeleton';
+
+export default function Loading() {
+  return <TabLoadingSkeleton />;
+}

--- a/apps/web/src/app/[lang]/network/page.tsx
+++ b/apps/web/src/app/[lang]/network/page.tsx
@@ -4,6 +4,7 @@ import {
   extractUniqueCategoryGroups,
   getAllSpaces,
   parseCategoryGroupFilterParam,
+  sortSpacesByOrder,
   SPACE_ORDERS,
   Space,
   SpaceOrder,
@@ -80,12 +81,17 @@ export default async function Index(props: PageProps) {
 
   const uniqueCategoryGroups = extractUniqueCategoryGroups(spaces);
 
+  // Pre-sort on the server so the first paint already matches the order the
+  // client applies after hydration. Without this the cards visibly reorder
+  // (DB order -> sorted order) on first load.
+  const sortedSpaces = sortSpacesByOrder(spaces, order);
+
   return (
     <Container className="flex flex-col gap-9 py-9">
       <ExploreSpaces
         lang={lang}
         query={query}
-        spaces={spaces}
+        spaces={sortedSpaces}
         categoryGroups={categoryGroups.length > 0 ? categoryGroups : undefined}
         order={order}
         uniqueCategoryGroups={uniqueCategoryGroups}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -45,6 +45,7 @@ import { ThemeStorageNormalize } from '@web/components/theme-storage-normalize';
 import { AppNavigationSessionCounter } from '@web/components/app-navigation-session-counter';
 import { ConnectedMenuTop } from '@web/components/connected-menu-top';
 import { LocalizedIntlProvider } from '@web/components/localized-intl-provider';
+import { SwrProvider } from '@web/components/swr-provider';
 import '@web/utils/initialize-proxy';
 
 const lato = Lato({
@@ -238,151 +239,153 @@ export default async function RootLayout({
           appId: process.env.NEXT_PUBLIC_PRIVY_APP_ID!,
         }}
       >
-        <ThemeProvider
-          attribute="class"
-          defaultTheme="dark"
-          enableSystem={false}
-          storageKey="theme"
-          disableTransitionOnChange
-        >
-          <ThemeStorageNormalize />
-          <AppNavigationSessionCounter />
-          <LocalizedIntlProvider locale={locale} messages={messages}>
-            <TooltipProvider>
-              <NotificationSubscriber
-                appId={notificationAppId}
-                safariWebId={safariWebId}
-                serviceWorkerPath={serviceWorkerPath}
-              >
-                <ConditionalMatrixProvider enabled={humanChatEnabled}>
-                  <PanelProviders>
-                    <GlobalCallDockProvider>
-                      <PanelWrapLayout
-                        left={
-                          aiChatEnabled
-                            ? {
-                                content: (
-                                  <AiLeftPanel
-                                    enableSpaceMemory={spaceMemoryEnabled}
-                                  />
-                                ),
-                              }
-                            : undefined
-                        }
-                        right={
-                          humanChatEnabled
-                            ? { content: <ConnectedHumanRightPanel /> }
-                            : undefined
-                        }
-                      >
-                        {/* Fixed menu bar — clamped to center column by SidebarInset */}
-                        <div className="sticky top-0 z-30 shrink-0">
-                          <ConnectedMenuTop
-                            aiChatEnabled={aiChatEnabled}
-                            logoHref={ROOT_URL}
-                            openMenuLabel={navOpenMenuLabel}
-                            closeMenuLabel={navCloseMenuLabel}
-                            leadingAction={
-                              aiChatEnabled ? (
-                                <div className="flex items-center gap-2">
-                                  <div className="md:hidden">
-                                    <AiSidebarTrigger />
+        <SwrProvider>
+          <ThemeProvider
+            attribute="class"
+            defaultTheme="dark"
+            enableSystem={false}
+            storageKey="theme"
+            disableTransitionOnChange
+          >
+            <ThemeStorageNormalize />
+            <AppNavigationSessionCounter />
+            <LocalizedIntlProvider locale={locale} messages={messages}>
+              <TooltipProvider>
+                <NotificationSubscriber
+                  appId={notificationAppId}
+                  safariWebId={safariWebId}
+                  serviceWorkerPath={serviceWorkerPath}
+                >
+                  <ConditionalMatrixProvider enabled={humanChatEnabled}>
+                    <PanelProviders>
+                      <GlobalCallDockProvider>
+                        <PanelWrapLayout
+                          left={
+                            aiChatEnabled
+                              ? {
+                                  content: (
+                                    <AiLeftPanel
+                                      enableSpaceMemory={spaceMemoryEnabled}
+                                    />
+                                  ),
+                                }
+                              : undefined
+                          }
+                          right={
+                            humanChatEnabled
+                              ? { content: <ConnectedHumanRightPanel /> }
+                              : undefined
+                          }
+                        >
+                          {/* Fixed menu bar — clamped to center column by SidebarInset */}
+                          <div className="sticky top-0 z-30 shrink-0">
+                            <ConnectedMenuTop
+                              aiChatEnabled={aiChatEnabled}
+                              logoHref={ROOT_URL}
+                              openMenuLabel={navOpenMenuLabel}
+                              closeMenuLabel={navCloseMenuLabel}
+                              leadingAction={
+                                aiChatEnabled ? (
+                                  <div className="flex items-center gap-2">
+                                    <div className="md:hidden">
+                                      <AiSidebarTrigger />
+                                    </div>
+                                    <AiPanelTrigger />
                                   </div>
-                                  <AiPanelTrigger />
-                                </div>
-                              ) : undefined
-                            }
-                            trailingAction={
-                              humanChatEnabled ? (
-                                <HumanSidebarTrigger />
-                              ) : undefined
-                            }
-                            mobileAction={
-                              <ConnectedButtonProfile
-                                newUserRedirectPath="/profile/signup"
-                                baseRedirectPath="/my-spaces"
-                                navItems={[
-                                  {
-                                    label: navMySpacesLabel,
-                                    href: `/${locale}/my-spaces`,
-                                  },
-                                  {
-                                    label: navNetworkLabel,
-                                    href: `/${locale}/network`,
-                                  },
-                                ]}
-                                trailingBeforeProfile={
-                                  isLanguageSelectVisible ? (
-                                    <ConnectedLanguageSelect
-                                      selectLanguageLabel={
-                                        navSelectLanguageLabel
-                                      }
-                                    />
-                                  ) : undefined
-                                }
-                                compact
-                              />
-                            }
-                          >
-                            <div className="hidden md:flex">
-                              <ConnectedButtonProfile
-                                newUserRedirectPath="/profile/signup"
-                                baseRedirectPath="/my-spaces"
-                                navItems={[
-                                  {
-                                    label: navMySpacesLabel,
-                                    href: `/${locale}/my-spaces`,
-                                  },
-                                  {
-                                    label: navNetworkLabel,
-                                    href: `/${locale}/network`,
-                                  },
-                                ]}
-                                trailingBeforeProfile={
-                                  isLanguageSelectVisible ? (
-                                    <ConnectedLanguageSelect
-                                      selectLanguageLabel={
-                                        navSelectLanguageLabel
-                                      }
-                                    />
-                                  ) : undefined
-                                }
-                              />
-                            </div>
-                          </ConnectedMenuTop>
-                        </div>
-                        {/* Scrollable content area */}
-                        <NextSSRPlugin
-                          routerConfig={extractRouterConfig(fileRouter)}
-                        />
-                        <div className="mb-auto pb-8">
-                          <div className="flex h-full justify-normal pt-4 md:pt-5">
-                            <div className="w-full h-full">{children}</div>
+                                ) : undefined
+                              }
+                              trailingAction={
+                                humanChatEnabled ? (
+                                  <HumanSidebarTrigger />
+                                ) : undefined
+                              }
+                              mobileAction={
+                                <ConnectedButtonProfile
+                                  newUserRedirectPath="/profile/signup"
+                                  baseRedirectPath="/my-spaces"
+                                  navItems={[
+                                    {
+                                      label: navMySpacesLabel,
+                                      href: `/${locale}/my-spaces`,
+                                    },
+                                    {
+                                      label: navNetworkLabel,
+                                      href: `/${locale}/network`,
+                                    },
+                                  ]}
+                                  trailingBeforeProfile={
+                                    isLanguageSelectVisible ? (
+                                      <ConnectedLanguageSelect
+                                        selectLanguageLabel={
+                                          navSelectLanguageLabel
+                                        }
+                                      />
+                                    ) : undefined
+                                  }
+                                  compact
+                                />
+                              }
+                            >
+                              <div className="hidden md:flex">
+                                <ConnectedButtonProfile
+                                  newUserRedirectPath="/profile/signup"
+                                  baseRedirectPath="/my-spaces"
+                                  navItems={[
+                                    {
+                                      label: navMySpacesLabel,
+                                      href: `/${locale}/my-spaces`,
+                                    },
+                                    {
+                                      label: navNetworkLabel,
+                                      href: `/${locale}/network`,
+                                    },
+                                  ]}
+                                  trailingBeforeProfile={
+                                    isLanguageSelectVisible ? (
+                                      <ConnectedLanguageSelect
+                                        selectLanguageLabel={
+                                          navSelectLanguageLabel
+                                        }
+                                      />
+                                    ) : undefined
+                                  }
+                                />
+                              </div>
+                            </ConnectedMenuTop>
                           </div>
-                        </div>
-                        <Suspense fallback={null}>
-                          <DeferredFooter
-                            networkLabel={footerNetworkLabel}
-                            legalLabel={footerLegalLabel}
-                            hyphaServicesLabel={footerHyphaServicesLabel}
-                            hyphaTokenomicsLabel={footerHyphaTokenomicsLabel}
-                            licensingPolicyLabel={footerLicensingPolicyLabel}
-                            termsAndConditionsLabel={
-                              footerTermsAndConditionsLabel
-                            }
-                            privacyPolicyLabel={footerPrivacyPolicyLabel}
+                          {/* Scrollable content area */}
+                          <NextSSRPlugin
+                            routerConfig={extractRouterConfig(fileRouter)}
                           />
-                        </Suspense>
-                      </PanelWrapLayout>
-                      {/* Outside capture root so tab screen share excludes the floating dock. */}
-                      {humanChatEnabled && <ConnectedGlobalCallDock />}
-                    </GlobalCallDockProvider>
-                  </PanelProviders>
-                </ConditionalMatrixProvider>
-              </NotificationSubscriber>
-            </TooltipProvider>
-          </LocalizedIntlProvider>
-        </ThemeProvider>
+                          <div className="mb-auto pb-8">
+                            <div className="flex h-full justify-normal pt-4 md:pt-5">
+                              <div className="w-full h-full">{children}</div>
+                            </div>
+                          </div>
+                          <Suspense fallback={null}>
+                            <DeferredFooter
+                              networkLabel={footerNetworkLabel}
+                              legalLabel={footerLegalLabel}
+                              hyphaServicesLabel={footerHyphaServicesLabel}
+                              hyphaTokenomicsLabel={footerHyphaTokenomicsLabel}
+                              licensingPolicyLabel={footerLicensingPolicyLabel}
+                              termsAndConditionsLabel={
+                                footerTermsAndConditionsLabel
+                              }
+                              privacyPolicyLabel={footerPrivacyPolicyLabel}
+                            />
+                          </Suspense>
+                        </PanelWrapLayout>
+                        {/* Outside capture root so tab screen share excludes the floating dock. */}
+                        {humanChatEnabled && <ConnectedGlobalCallDock />}
+                      </GlobalCallDockProvider>
+                    </PanelProviders>
+                  </ConditionalMatrixProvider>
+                </NotificationSubscriber>
+              </TooltipProvider>
+            </LocalizedIntlProvider>
+          </ThemeProvider>
+        </SwrProvider>
       </AuthProvider>
       {shouldInjectToolbar && <VercelToolbar />}
     </Html>

--- a/apps/web/src/components/swr-provider.tsx
+++ b/apps/web/src/components/swr-provider.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { SWRConfig } from 'swr';
+import type { ReactNode } from 'react';
+
+/**
+ * App-wide SWR defaults.
+ *
+ * The app had no global `SWRConfig`, so every hook fell back to SWR's built-in
+ * defaults (2s dedupe, unbounded error retries). Centralizing here lets us:
+ *  - collapse the many duplicate `/api/v1/spaces/{slug}`, `/me`, documents
+ *    requests that fire from the layout, the top menu, access wrappers and tab
+ *    components as the page hydrates (`dedupingInterval`);
+ *  - bound error-retry storms so a transiently failing/invalid request can't
+ *    hammer the network (`errorRetryCount`).
+ *
+ * Deliberately NOT set globally:
+ *  - `refreshInterval`: polling stays opt-in per hook.
+ *  - `keepPreviousData`: kept per-hook so navigating between different
+ *    resources (e.g. two spaces) doesn't briefly show the previous one's data.
+ */
+export function SwrProvider({ children }: { children: ReactNode }) {
+  return (
+    <SWRConfig
+      value={{
+        dedupingInterval: 5000,
+        revalidateOnFocus: true,
+        revalidateOnReconnect: true,
+        errorRetryCount: 3,
+      }}
+    >
+      {children}
+    </SWRConfig>
+  );
+}

--- a/packages/core/src/governance/client/hooks/useAgreementMutations.web2.rsc.ts
+++ b/packages/core/src/governance/client/hooks/useAgreementMutations.web2.rsc.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import useSWRMutation from 'swr/mutation';
+import { mutate as globalMutate } from 'swr';
 
 import { CreateAgreementInput, UpdateAgreementBySlugInput } from '../../types';
 import {
@@ -8,6 +9,25 @@ import {
   updateAgreementBySlugAction,
   deleteAgreementBySlugAction,
 } from '@hypha-platform/core/governance/server/actions';
+
+/**
+ * Revalidate every mounted space documents list (`/api/v1/spaces/.../documents/all`).
+ * Called after a document is created/updated (e.g. once an orchestrator links the
+ * new `web3ProposalId`) so the proposal card shows up in the agreements list as
+ * soon as the create overlay closes instead of waiting for the next poll. Fired
+ * twice (immediate + short delay) to absorb brief DB read propagation.
+ */
+const revalidateSpaceDocuments = () => {
+  const matchDocumentsAllKey = (key: unknown) =>
+    Array.isArray(key) &&
+    typeof key[0] === 'string' &&
+    key[0].includes('/documents/all');
+  void globalMutate(matchDocumentsAllKey, undefined, { revalidate: true });
+  setTimeout(() => {
+    void globalMutate(matchDocumentsAllKey, undefined, { revalidate: true });
+  }, 1500);
+};
+
 export const useAgreementMutationsWeb2Rsc = (authToken?: string | null) => {
   const {
     trigger: createAgreementMutation,
@@ -29,8 +49,11 @@ export const useAgreementMutationsWeb2Rsc = (authToken?: string | null) => {
     data: updatedAgreement,
   } = useSWRMutation(
     authToken ? [authToken, 'updateAgreement'] : null,
-    async ([authToken], { arg }: { arg: UpdateAgreementBySlugInput }) =>
-      updateAgreementBySlugAction(arg, { authToken }),
+    async ([authToken], { arg }: { arg: UpdateAgreementBySlugInput }) => {
+      const result = await updateAgreementBySlugAction(arg, { authToken });
+      revalidateSpaceDocuments();
+      return result;
+    },
   );
 
   const {

--- a/packages/core/src/governance/client/hooks/useAgreementMutations.web2.rsc.ts
+++ b/packages/core/src/governance/client/hooks/useAgreementMutations.web2.rsc.ts
@@ -16,15 +16,19 @@ import {
  * new `web3ProposalId`) so the proposal card shows up in the agreements list as
  * soon as the create overlay closes instead of waiting for the next poll. Fired
  * twice (immediate + short delay) to absorb brief DB read propagation.
+ *
+ * We revalidate *without* passing new data so SWR keeps the current list on
+ * screen while it refetches - passing `undefined` here would wipe the cache
+ * first, making every proposal disappear for a moment before reappearing.
  */
 const revalidateSpaceDocuments = () => {
   const matchDocumentsAllKey = (key: unknown) =>
     Array.isArray(key) &&
     typeof key[0] === 'string' &&
     key[0].includes('/documents/all');
-  void globalMutate(matchDocumentsAllKey, undefined, { revalidate: true });
+  void globalMutate(matchDocumentsAllKey);
   setTimeout(() => {
-    void globalMutate(matchDocumentsAllKey, undefined, { revalidate: true });
+    void globalMutate(matchDocumentsAllKey);
   }, 1500);
 };
 

--- a/packages/core/src/governance/client/hooks/useCreateAgreementOrchestrator.ts
+++ b/packages/core/src/governance/client/hooks/useCreateAgreementOrchestrator.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import useSWR, { mutate as globalMutate } from 'swr';
+import useSWR from 'swr';
 import { Config } from '@wagmi/core';
 import { z } from 'zod';
 import { produce } from 'immer';
@@ -269,18 +269,6 @@ export const useCreateAgreementOrchestrator = ({
           web3ProposalId: web3ProposalId ? Number(web3ProposalId) : undefined,
         });
         completeTask('LINK_WEB2_AND_WEB3_AGREEMENT');
-        // The new document now has its web3ProposalId, so it will show up in the
-        // agreements list. Revalidate the (already mounted, behind the overlay)
-        // `/documents/all` caches immediately so the proposal card appears as
-        // soon as the create overlay closes, instead of after the next poll.
-        void globalMutate(
-          (key) =>
-            Array.isArray(key) &&
-            typeof key[0] === 'string' &&
-            key[0].includes('/documents/all'),
-          undefined,
-          { revalidate: true },
-        );
         return result;
       } catch (error) {
         if (error instanceof Error) {

--- a/packages/core/src/governance/client/hooks/useCreateAgreementOrchestrator.ts
+++ b/packages/core/src/governance/client/hooks/useCreateAgreementOrchestrator.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import useSWR from 'swr';
+import useSWR, { mutate as globalMutate } from 'swr';
 import { Config } from '@wagmi/core';
 import { z } from 'zod';
 import { produce } from 'immer';
@@ -269,6 +269,18 @@ export const useCreateAgreementOrchestrator = ({
           web3ProposalId: web3ProposalId ? Number(web3ProposalId) : undefined,
         });
         completeTask('LINK_WEB2_AND_WEB3_AGREEMENT');
+        // The new document now has its web3ProposalId, so it will show up in the
+        // agreements list. Revalidate the (already mounted, behind the overlay)
+        // `/documents/all` caches immediately so the proposal card appears as
+        // soon as the create overlay closes, instead of after the next poll.
+        void globalMutate(
+          (key) =>
+            Array.isArray(key) &&
+            typeof key[0] === 'string' &&
+            key[0].includes('/documents/all'),
+          undefined,
+          { revalidate: true },
+        );
         return result;
       } catch (error) {
         if (error instanceof Error) {

--- a/packages/core/src/governance/client/hooks/useProposalDetails.web3.rpc.ts
+++ b/packages/core/src/governance/client/hooks/useProposalDetails.web3.rpc.ts
@@ -49,7 +49,11 @@ export const useProposalDetailsWeb3Rpc = ({
       ),
     {
       revalidateOnFocus: true,
-      refreshInterval: 10000,
+      // Only poll while the proposal is still live. Once it is executed
+      // (index 3) or expired (index 4) its on-chain state is immutable, so
+      // there is nothing to poll for - stop hitting the RPC every 10s.
+      refreshInterval: (latest) =>
+        latest && (latest[3] || latest[4]) ? 0 : 10000,
     },
   );
 

--- a/packages/core/src/governance/client/hooks/useProposalDetails.web3.rpc.ts
+++ b/packages/core/src/governance/client/hooks/useProposalDetails.web3.rpc.ts
@@ -41,7 +41,7 @@ export const useProposalDetailsWeb3Rpc = ({
 }) => {
   const hasValidProposalId =
     proposalId != null && Number.isFinite(Number(proposalId));
-  const { data, isLoading, error } = useSWR(
+  const { data, isLoading, error, mutate } = useSWR(
     hasValidProposalId ? [Number(proposalId), 'proposalDetails'] : null,
     async ([proposalId]) =>
       publicClient.readContract(
@@ -921,5 +921,6 @@ export const useProposalDetailsWeb3Rpc = ({
     proposalDetails: parsedProposal,
     isLoading,
     error,
+    mutate,
   };
 };

--- a/packages/core/src/governance/client/hooks/useProposalDetails.web3.rpc.ts
+++ b/packages/core/src/governance/client/hooks/useProposalDetails.web3.rpc.ts
@@ -57,6 +57,37 @@ export const useProposalDetailsWeb3Rpc = ({
     },
   );
 
+  // Keep the latest raw tuple in a ref so `refreshUntilVoteApplied` can compare
+  // pre/post-vote tallies without being recreated on every data change.
+  const dataRef = React.useRef(data);
+  dataRef.current = data;
+
+  /**
+   * After a vote we want the quorum/unity bars to update immediately, but the
+   * RPC node the read hits can briefly lag the just-mined vote transaction, so a
+   * single refetch sometimes returns stale tallies (the bars then only correct
+   * on the next 10s poll - the "sometimes not quick" behaviour). Refetch a few
+   * times until the yes+no tally changes (or we run out of attempts). Each
+   * refetch updates the SWR cache regardless, so the bars still reflect whatever
+   * the latest read returns.
+   */
+  const refreshUntilVoteApplied = React.useCallback(async () => {
+    const baseline = dataRef.current
+      ? Number(dataRef.current[5]) + Number(dataRef.current[6])
+      : null;
+    for (let attempt = 0; attempt < 6; attempt += 1) {
+      const updated = await mutate();
+      if (
+        !updated ||
+        baseline === null ||
+        Number(updated[5]) + Number(updated[6]) !== baseline
+      ) {
+        return;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 800));
+    }
+  }, [mutate]);
+
   const parsedProposal = React.useMemo(() => {
     if (!data) return null;
 
@@ -922,5 +953,6 @@ export const useProposalDetailsWeb3Rpc = ({
     isLoading,
     error,
     mutate,
+    refreshUntilVoteApplied,
   };
 };

--- a/packages/core/src/governance/client/hooks/useProposalDetails.web3.rpc.ts
+++ b/packages/core/src/governance/client/hooks/useProposalDetails.web3.rpc.ts
@@ -37,10 +37,12 @@ type ProposalTransaction = Parameters<typeof decodeTransaction>[0];
 export const useProposalDetailsWeb3Rpc = ({
   proposalId,
 }: {
-  proposalId: number;
+  proposalId: number | undefined | null;
 }) => {
+  const hasValidProposalId =
+    proposalId != null && Number.isFinite(Number(proposalId));
   const { data, isLoading, error } = useSWR(
-    [proposalId, 'proposalDetails'],
+    hasValidProposalId ? [Number(proposalId), 'proposalDetails'] : null,
     async ([proposalId]) =>
       publicClient.readContract(
         getProposalDetails({ proposalId: BigInt(proposalId) }),

--- a/packages/core/src/governance/client/hooks/useProposalVoters.ts
+++ b/packages/core/src/governance/client/hooks/useProposalVoters.ts
@@ -17,7 +17,10 @@ export const useProposalVoters = (documentSlug?: string) => {
         .then((res) => res.json())
         .then((data) => data.voters as Voter[]),
     {
-      refreshInterval: 10000,
+      // The voter's own vote is reflected immediately via `mutate()` after
+      // voting; this background poll only needs to pick up other members'
+      // votes, so a slightly slower cadence is fine.
+      refreshInterval: 15000,
     },
   );
 

--- a/packages/core/src/people/client/hooks/useJwt.ts
+++ b/packages/core/src/people/client/hooks/useJwt.ts
@@ -8,7 +8,15 @@ export const useJwt = () => {
   const { data: jwt, isLoading: isLoadingJwt } = useSWR(
     user?.id ? [user.id, 'jwt'] : null,
     () => getAccessToken(),
-    { refreshInterval: 1000 },
+    {
+      // Privy returns a cached token and only refreshes it when it is close to
+      // expiry, so there is no need to poll every second. Refreshing every few
+      // minutes keeps the token fresh without causing every `useJwt` consumer
+      // to re-render (and dependent SWR keys to churn) once per second.
+      refreshInterval: 5 * 60 * 1000,
+      revalidateOnFocus: true,
+      dedupingInterval: 60 * 1000,
+    },
   );
 
   return { jwt, isLoadingJwt };

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -8,6 +8,7 @@ export * from './people/server';
 export * from './people/types';
 export * from './space/server';
 export * from './space/types';
+export * from './space/utils';
 export {
   spaceSlugSchema,
   spaceMembersHttpPaginationQuerySchema,

--- a/packages/core/src/space/client/hooks/useSpaceProposals.web3.rpc.ts
+++ b/packages/core/src/space/client/hooks/useSpaceProposals.web3.rpc.ts
@@ -5,9 +5,14 @@ import useSWR from 'swr';
 import { getSpaceProposals } from '../web3';
 import React from 'react';
 
-export const useSpaceProposalsWeb3Rpc = ({ spaceId }: { spaceId: number }) => {
+export const useSpaceProposalsWeb3Rpc = ({
+  spaceId,
+}: {
+  spaceId: number | undefined | null;
+}) => {
+  const hasValidSpaceId = spaceId != null && Number.isFinite(Number(spaceId));
   const { data, isLoading, error, mutate } = useSWR(
-    [spaceId, 'spaceProposals'],
+    hasValidSpaceId ? [Number(spaceId), 'spaceProposals'] : null,
     async ([spaceId]) =>
       publicClient.readContract(
         getSpaceProposals({ spaceId: BigInt(spaceId) }),

--- a/packages/core/src/space/client/hooks/useWithdrawnProposals.web3.rpc.ts
+++ b/packages/core/src/space/client/hooks/useWithdrawnProposals.web3.rpc.ts
@@ -8,10 +8,11 @@ import React from 'react';
 export const useWithdrawnProposalsWeb3Rpc = ({
   spaceId,
 }: {
-  spaceId: number;
+  spaceId: number | undefined | null;
 }) => {
+  const hasValidSpaceId = spaceId != null && Number.isFinite(Number(spaceId));
   const { data, isLoading, error, mutate } = useSWR(
-    [spaceId, 'withdrawnProposals'],
+    hasValidSpaceId ? [Number(spaceId), 'withdrawnProposals'] : null,
     async ([spaceId]) =>
       publicClient.readContract(
         getWithdrawnProposalsBySpace({ spaceId: BigInt(spaceId) }),

--- a/packages/core/src/space/utils.ts
+++ b/packages/core/src/space/utils.ts
@@ -1,3 +1,5 @@
+import type { SpaceOrder } from '../categories/types';
+
 /**
  * True when the space carries the explicit archived flag in the database.
  */
@@ -5,6 +7,51 @@ export function isSpaceExplicitlyArchived(space: {
   flags?: string[];
 }): boolean {
   return space.flags?.includes('archived') === true;
+}
+
+/**
+ * Fields required to rank spaces. Kept structural so this can be shared between
+ * the server (RSC first paint) and the client without importing the full Space
+ * type in either direction.
+ */
+type SpaceSortFields = {
+  id: number;
+  memberAddresses?: readonly unknown[] | null;
+  memberCount?: number;
+  documentCount?: number;
+};
+
+/**
+ * Deterministically orders spaces by the given {@link SpaceOrder}.
+ *
+ * Used both on the server (so the initial HTML is already sorted) and on the
+ * client (after category / discoverability filtering). Sharing one comparator
+ * guarantees the server first paint and the client hydration agree, which
+ * prevents the network cards from visibly reordering on first load.
+ */
+export function sortSpacesByOrder<T extends SpaceSortFields>(
+  spaces: T[],
+  order: SpaceOrder,
+): T[] {
+  const compareMembers = (a: T, b: T) =>
+    (b.memberAddresses?.length ?? b.memberCount ?? 0) -
+    (a.memberAddresses?.length ?? a.memberCount ?? 0);
+  const compareAgreements = (a: T, b: T) =>
+    (b.documentCount ?? 0) - (a.documentCount ?? 0);
+  const compareRecent = (a: T, b: T) => b.id - a.id;
+
+  return [...spaces].sort((a, b) => {
+    switch (order) {
+      case 'mostmembers':
+        return compareMembers(a, b);
+      case 'mostagreements':
+        return compareAgreements(a, b);
+      case 'mostrecent':
+        return compareRecent(a, b);
+      default:
+        return 0;
+    }
+  });
 }
 
 /**

--- a/packages/epics/src/governance/hooks/use-space-documents-with-statuses.ts
+++ b/packages/epics/src/governance/hooks/use-space-documents-with-statuses.ts
@@ -136,7 +136,11 @@ export const useSpaceDocumentsWithStatuses = ({
     },
     {
       revalidateOnFocus: true,
-      refreshInterval: 10000,
+      // The `/documents/all` endpoint returns the full (unpaginated) document
+      // set, so polling it every 10s is expensive. New documents are rare and
+      // user-driven changes (create/vote/withdraw) call `update()` for instant
+      // reflection, so a slower background poll is enough.
+      refreshInterval: 30000,
       refreshWhenHidden: false,
       refreshWhenOffline: false,
     },

--- a/packages/epics/src/governance/hooks/use-space-documents-with-statuses.ts
+++ b/packages/epics/src/governance/hooks/use-space-documents-with-statuses.ts
@@ -18,6 +18,16 @@ import {
   normalizeProposalDocumentLabel,
 } from '@hypha-platform/core/client';
 
+/**
+ * Shared default ordering for the space documents list. Exported so every
+ * consumer (proposal aside page, `ProposalDetail`, agreements tab) uses the
+ * exact same SWR key and the `/documents/all` request is deduped instead of
+ * fetched once per component instance.
+ */
+export const PROPOSAL_DOCUMENTS_DEFAULT_ORDER: Order<Document> = [
+  { name: 'createdAt', dir: DirectionType.DESC },
+];
+
 const getDocumentBadges = (document: Document, t: (key: string) => string) => {
   const badges = [];
   const canonicalLabel = normalizeProposalDocumentLabel(document.label);
@@ -68,7 +78,7 @@ export const useSpaceDocumentsWithStatuses = ({
   order,
 }: {
   spaceSlug: string;
-  spaceId: number;
+  spaceId: number | undefined | null;
   order?: Order<Document>;
 }) => {
   const tAgreementFlow = useTranslations('AgreementFlow');

--- a/packages/epics/src/proposals/components/proposal-detail.tsx
+++ b/packages/epics/src/proposals/components/proposal-detail.tsx
@@ -12,10 +12,8 @@ import {
   Attachment,
   useSpaceDetailsWeb3Rpc,
   SpaceDetails,
-  DirectionType,
   Document,
   useSpaceMinProposalDuration,
-  useVote,
   bigIntToPercentageString,
   getTokenDecimals,
   CURRENCY_FEEDS,
@@ -52,9 +50,12 @@ import { MarkdownSuspense } from '@hypha-platform/ui/server';
 import { ButtonClose, ExpireProposalBanner } from '@hypha-platform/epics';
 import { useAuthentication } from '@hypha-platform/authentication';
 import { ProposalActivateSpacesData } from '../../governance/components/proposal-activate-spaces-data';
-import { useSpaceDocumentsWithStatuses } from '../../governance';
+import {
+  useSpaceDocumentsWithStatuses,
+  PROPOSAL_DOCUMENTS_DEFAULT_ORDER,
+} from '../../governance';
 import { isPast } from 'date-fns';
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useCallback } from 'react';
 import { TransparencyLevel } from '../../spaces/components/transparency-level';
 import { useTranslations } from 'next-intl';
 import { formatUnits } from 'viem';
@@ -472,18 +473,13 @@ export const ProposalDetail = ({
     proposalId: proposalId as number,
   });
   const { spaceDetails } = useSpaceDetailsWeb3Rpc({
-    spaceId: Number(proposalDetails?.spaceId),
+    spaceId: proposalDetails?.spaceId ?? null,
   });
   const { isAuthenticated } = useAuthentication();
   const { documents: documentsArrays } = useSpaceDocumentsWithStatuses({
-    spaceId: Number(proposalDetails?.spaceId),
+    spaceId: proposalDetails?.spaceId,
     spaceSlug,
-    order: [
-      {
-        name: 'createdAt',
-        dir: DirectionType.DESC,
-      },
-    ],
+    order: PROPOSAL_DOCUMENTS_DEFAULT_ORDER,
   });
   const { spaces: dbSpaces } = useDbSpaces({ parentOnly: false });
 
@@ -530,8 +526,6 @@ export const ProposalDetail = ({
     proposalDetails?.updateTokenData?.initialTransferWhitelistSpaceIds,
     proposalDetails?.updateTokenData?.initialReceiveWhitelistSpaceIds,
   ]);
-
-  const tokenSymbol = proposalDetails?.tokens?.[0]?.symbol;
 
   const redeemChainDataForResubmit = useMemo(() => {
     if (label !== 'Redeem Tokens') return null;
@@ -592,31 +586,27 @@ export const ProposalDetail = ({
     };
   }, [redeemChainDataForResubmit]);
 
-  const {
-    handleAccept: internalHandleAccept,
-    handleReject: internalHandleReject,
-    handleCheckProposalExpiration: internalHandleCheckProposalExpiration,
-    isCheckingExpiration: internalIsCheckingExpiration,
-    isVoting: internalIsVoting,
-    isDeletingToken,
-    isUpdatingToken,
-  } = useVote({
-    documentId,
-    proposalId,
-    tokenSymbol,
-    authToken,
-  });
-
-  const handleAccept = onAccept || internalHandleAccept;
-  const handleReject = onReject || internalHandleReject;
+  // Voting handlers and state come from the parent (the proposal aside page),
+  // which owns the single `useVote` instance. Previously `ProposalDetail` also
+  // called `useVote`, spinning up a second set of contract-event watchers for
+  // the same proposal. The fallbacks below keep the component usable on its own.
+  const noopVoteHandler = useCallback(async () => {}, []);
+  const handleAccept = onAccept ?? noopVoteHandler;
+  const handleReject = onReject ?? noopVoteHandler;
   const handleCheckProposalExpiration =
-    onCheckProposalExpiration || internalHandleCheckProposalExpiration;
-  const isCheckingExpiration =
-    externalIsCheckingExpiration !== undefined
-      ? externalIsCheckingExpiration
-      : internalIsCheckingExpiration;
-  const isVoting =
-    externalIsVoting !== undefined ? externalIsVoting : internalIsVoting;
+    onCheckProposalExpiration ?? noopVoteHandler;
+  const isCheckingExpiration = externalIsCheckingExpiration ?? false;
+  const isVoting = externalIsVoting ?? false;
+
+  // Stable ISO end time. The previous inline `new Date()` fallback produced a
+  // brand-new value on every render, which re-triggered downstream effects and
+  // width transitions on each 10s poll. Memoizing keeps the reference stable
+  // between polls (the fallback is only used while data is still loading, and
+  // is hidden behind the FormVoting skeleton).
+  const formattedEndTime = useMemo(
+    () => formatISO(new Date(proposalDetails?.endTime ?? new Date())),
+    [proposalDetails?.endTime],
+  );
 
   const findDocumentStatus = (
     documentsArrays: DocumentsArrays,
@@ -663,6 +653,7 @@ export const ProposalDetail = ({
 
   const { duration } = useSpaceMinProposalDuration({
     spaceId: spaceIdBigInt as bigint,
+    enabled: spaceIdBigInt != null,
   });
 
   const [displayExpireProposalBanner, setDisplayExpireProposalBanner] =
@@ -720,7 +711,20 @@ export const ProposalDetail = ({
     }
 
     setDisplayExpireProposalBanner(shouldShowBanner);
-  }, [duration, proposalDetails, spaceDetails]);
+    // Depend on the scalar fields we actually read rather than the whole
+    // `proposalDetails`/`spaceDetails` objects, which get a fresh reference on
+    // every 10s poll even when nothing changed - that was causing needless
+    // setState cascades (and animated vote-bar re-renders) on each poll.
+  }, [
+    duration,
+    proposalDetails?.endTime,
+    proposalDetails?.executed,
+    proposalDetails?.expired,
+    proposalDetails?.quorumPercentage,
+    proposalDetails?.unityPercentage,
+    spaceDetails?.quorum,
+    spaceDetails?.unity,
+  ]);
 
   useEffect(() => {
     if (proposalDetails?.executed || proposalDetails?.expired) {
@@ -1421,7 +1425,7 @@ export const ProposalDetail = ({
       <FormVoting
         unity={proposalDetails?.unityPercentage || 0}
         quorum={proposalDetails?.quorumPercentage || 0}
-        endTime={formatISO(new Date(proposalDetails?.endTime || new Date()))}
+        endTime={formattedEndTime}
         executed={proposalDetails?.executed}
         expired={proposalDetails?.expired}
         onAccept={handleAccept}

--- a/packages/epics/src/proposals/components/proposal-detail.tsx
+++ b/packages/epics/src/proposals/components/proposal-detail.tsx
@@ -608,6 +608,25 @@ export const ProposalDetail = ({
     [proposalDetails?.endTime],
   );
 
+  // The description is rendered through MarkdownSuspense, which compiles MDX
+  // asynchronously and therefore re-suspends (flashing its "Loading..."
+  // fallback) whenever this subtree re-renders. After voting, unrelated state
+  // (vote counts, voters, isVoting) changes and would otherwise re-render the
+  // markdown and reload the description. Memoizing the element by its actual
+  // inputs keeps the reference stable so React skips re-rendering it.
+  const descriptionMarkdown = useMemo(
+    () => (
+      <MarkdownSuspense>
+        {label === 'Investment'
+          ? stripHyphaInvestmentFormMarker(content ?? '')
+          : label === 'Exchange'
+          ? stripExchangeDetailsBlock(content ?? '')
+          : content}
+      </MarkdownSuspense>
+    ),
+    [content, label],
+  );
+
   const findDocumentStatus = (
     documentsArrays: DocumentsArrays,
     proposalId: number | null | undefined,
@@ -1178,13 +1197,7 @@ export const ProposalDetail = ({
         isExpiring={isExpiring}
         web3SpaceId={proposalDetails?.spaceId}
       />
-      <MarkdownSuspense>
-        {label === 'Investment'
-          ? stripHyphaInvestmentFormMarker(content ?? '')
-          : label === 'Exchange'
-          ? stripExchangeDetailsBlock(content ?? '')
-          : content}
-      </MarkdownSuspense>
+      {descriptionMarkdown}
       <AttachmentList attachments={attachments || []} />
       {label === 'Investment' ? (
         <ProposalAcceptInvestmentData

--- a/packages/epics/src/proposals/components/proposal-detail.tsx
+++ b/packages/epics/src/proposals/components/proposal-detail.tsx
@@ -420,6 +420,13 @@ type ProposalDetailProps = ProposalHeadProps & {
   leadImage?: string;
   attachments?: (string | Attachment)[];
   proposalId?: number | null | undefined;
+  /**
+   * The space's on-chain id, known immediately from the URL slug. Passing it
+   * lets space-scoped reads (space details, membership, delegate, min duration,
+   * documents) start in parallel instead of waiting for `proposalDetails` to
+   * resolve first - which removed the cold-open loading waterfall.
+   */
+  web3SpaceId?: number;
   spaceSlug: string;
   label?: string;
   documentSlug: string;
@@ -454,6 +461,7 @@ export const ProposalDetail = ({
   leadImage,
   attachments,
   proposalId,
+  web3SpaceId,
   spaceSlug,
   label,
   documentSlug,
@@ -472,12 +480,16 @@ export const ProposalDetail = ({
   const { proposalDetails } = useProposalDetailsWeb3Rpc({
     proposalId: proposalId as number,
   });
+  // Prefer the space id from the URL (available immediately) so space-scoped
+  // reads don't wait on the on-chain proposal fetch. Fall back to the proposal
+  // once it resolves for any consumer opened without the prop.
+  const effectiveWeb3SpaceId = web3SpaceId ?? proposalDetails?.spaceId ?? null;
   const { spaceDetails } = useSpaceDetailsWeb3Rpc({
-    spaceId: proposalDetails?.spaceId ?? null,
+    spaceId: effectiveWeb3SpaceId,
   });
   const { isAuthenticated } = useAuthentication();
   const { documents: documentsArrays } = useSpaceDocumentsWithStatuses({
-    spaceId: proposalDetails?.spaceId,
+    spaceId: effectiveWeb3SpaceId,
     spaceSlug,
     order: PROPOSAL_DOCUMENTS_DEFAULT_ORDER,
   });
@@ -666,9 +678,8 @@ export const ProposalDetail = ({
     );
   };
 
-  const spaceIdBigInt = proposalDetails?.spaceId
-    ? BigInt(proposalDetails?.spaceId)
-    : null;
+  const spaceIdBigInt =
+    effectiveWeb3SpaceId != null ? BigInt(effectiveWeb3SpaceId) : null;
 
   const { duration } = useSpaceMinProposalDuration({
     spaceId: spaceIdBigInt as bigint,
@@ -1444,11 +1455,11 @@ export const ProposalDetail = ({
         onAccept={handleAccept}
         onReject={handleReject}
         isCheckingExpiration={isCheckingExpiration}
-        isLoading={isLoading}
+        isLoading={isLoading || !spaceDetails}
         isVoting={isVoting}
         documentSlug={documentSlug}
         isAuthenticated={isAuthenticated}
-        web3SpaceId={proposalDetails?.spaceId}
+        web3SpaceId={effectiveWeb3SpaceId ?? undefined}
         spaceDetails={spaceDetails as unknown as SpaceDetails}
         proposalStatus={proposalStatus}
         hideDurationData={hideDurationData()}

--- a/packages/epics/src/spaces/components/explore-spaces.tsx
+++ b/packages/epics/src/spaces/components/explore-spaces.tsx
@@ -8,6 +8,7 @@ import {
   getCategoryGroupLabel,
   hasSpaceMapLocation,
   isSpaceArchived,
+  sortSpacesByOrder,
   spaceMatchesCategoryGroups,
 } from '@hypha-platform/core/client';
 import {
@@ -228,32 +229,10 @@ export function ExploreSpaces({
     },
   );
 
-  const compareMembers = (a: Space, b: Space) => {
-    const aCount = a.memberAddresses?.length ?? a.memberCount ?? 0;
-    const bCount = b.memberAddresses?.length ?? b.memberCount ?? 0;
-    return bCount - aCount;
-  };
-  const compareAgreements = (a: Space, b: Space) => {
-    return (b.documentCount ?? 0) - (a.documentCount ?? 0);
-  };
-  const compareRecent = (a: Space, b: Space) => {
-    return b.id - a.id;
-  };
-
-  const sortedSpaces = React.useMemo(() => {
-    return [...selectedSpaces].sort((a, b) => {
-      switch (order) {
-        case 'mostmembers':
-          return compareMembers(a, b);
-        case 'mostagreements':
-          return compareAgreements(a, b);
-        case 'mostrecent':
-          return compareRecent(a, b);
-        default:
-          return 0;
-      }
-    });
-  }, [selectedSpaces, order]);
+  const sortedSpaces = React.useMemo(
+    () => sortSpacesByOrder(selectedSpaces, order ?? 'mostmembers'),
+    [selectedSpaces, order],
+  );
 
   const mapSpaces = React.useMemo(
     () => selectedSpaces.filter(hasSpaceMapLocation),

--- a/packages/epics/src/spaces/components/explore-spaces.tsx
+++ b/packages/epics/src/spaces/components/explore-spaces.tsx
@@ -96,13 +96,19 @@ const CategoryLabel = ({
             </Text>
           ))}{' '}
           <Text className="text-4 ml-1 mr-1">|</Text>
-          <CountValue value={selectedSpaces?.length ?? 0} isLoading={isLoading} />
+          <CountValue
+            value={selectedSpaces?.length ?? 0}
+            isLoading={isLoading}
+          />
         </Text>
       ) : (
         <Text className="text-4 text-left">
           <Text className="text-4 ml-1 capitalize">{allLabel}</Text>
           <Text className="text-4 ml-1 mr-1">|</Text>
-          <CountValue value={selectedSpaces?.length ?? 0} isLoading={isLoading} />
+          <CountValue
+            value={selectedSpaces?.length ?? 0}
+            isLoading={isLoading}
+          />
         </Text>
       )}
     </Text>

--- a/packages/epics/src/spaces/components/explore-spaces.tsx
+++ b/packages/epics/src/spaces/components/explore-spaces.tsx
@@ -20,6 +20,7 @@ import {
   type NetworkMapView,
 } from '../../network-map';
 import { CreateSpaceButton } from './create-space-button';
+import { NetworkLoadingGrid } from './network-loading-grid';
 import { SpaceCardList } from './space-card-list';
 import { SpaceSearch } from './space-search';
 import { SpaceOrderCombobox } from './space-order-combobox';
@@ -285,16 +286,7 @@ export function ExploreSpaces({
 
   const cardGridClassName = 'sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4';
   const spacesListContent = showSpacesSkeleton ? (
-    <div className={cn('grid w-full grid-cols-1 gap-4', cardGridClassName)}>
-      {Array.from({ length: 12 }).map((_, index) => (
-        <Skeleton
-          key={index}
-          loading
-          height={228}
-          className="w-full rounded-lg"
-        />
-      ))}
-    </div>
+    <NetworkLoadingGrid count={12} cardGridClassName={cardGridClassName} />
   ) : (
     <SpaceCardList
       lang={lang}

--- a/packages/epics/src/spaces/components/explore-spaces.tsx
+++ b/packages/epics/src/spaces/components/explore-spaces.tsx
@@ -27,7 +27,7 @@ import { spaceToolbarPrimaryButtonClassName } from './space-toolbar-styles';
 import { Locale } from '@hypha-platform/i18n';
 import { useTranslations } from 'next-intl';
 import { Text } from '@radix-ui/themes';
-import { Badge, Heading, Separator } from '@hypha-platform/ui';
+import { Badge, Heading, Separator, Skeleton } from '@hypha-platform/ui';
 import React from 'react';
 import { cn } from '@hypha-platform/ui-utils';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
@@ -50,16 +50,40 @@ function toLowerHex<A extends `0x${string}`>(a: A): Lowercase<A> {
   return a.toLowerCase() as Lowercase<A>;
 }
 
+const CountValue = ({
+  value,
+  isLoading,
+  width = 24,
+}: {
+  value: number;
+  isLoading?: boolean;
+  width?: number;
+}) => {
+  if (isLoading) {
+    return (
+      <Skeleton
+        loading
+        width={width}
+        height={16}
+        className="inline-block align-middle"
+      />
+    );
+  }
+  return <>{value}</>;
+};
+
 const CategoryLabel = ({
   selectedSpaces,
   categoryGroups,
   allLabel,
   className,
+  isLoading,
 }: {
   selectedSpaces: Space[];
   categoryGroups?: CategoryGroupId[];
   allLabel: string;
   className?: string | undefined;
+  isLoading?: boolean;
 }) => {
   return (
     <Text className={cn('text-4 text-left', className)}>
@@ -72,13 +96,13 @@ const CategoryLabel = ({
             </Text>
           ))}{' '}
           <Text className="text-4 ml-1 mr-1">|</Text>
-          {selectedSpaces?.length}
+          <CountValue value={selectedSpaces?.length ?? 0} isLoading={isLoading} />
         </Text>
       ) : (
         <Text className="text-4 text-left">
           <Text className="text-4 ml-1 capitalize">{allLabel}</Text>
           <Text className="text-4 ml-1 mr-1">|</Text>
-          {selectedSpaces?.length}
+          <CountValue value={selectedSpaces?.length ?? 0} isLoading={isLoading} />
         </Text>
       )}
     </Text>
@@ -123,11 +147,25 @@ export function ExploreSpaces({
     [nonArchivedSpaces, categoryGroups],
   );
 
-  const { filteredSpaces: selectedSpaces } =
+  const { filteredSpaces: selectedSpaces, isLoading: isFilterLoading } =
     useFilterSpacesListWithDiscoverability({
       spaces: categoryFilteredSpaces,
       useGeneralState: true,
     });
+
+  // Discoverability is resolved on-chain, so the filtered set (and therefore the
+  // total count) starts as "all spaces" and shrinks as the batch resolves, which
+  // made the list visibly reorder and the counts flicker on first load. Gate the
+  // list + counts on a settle-once flag so we show a stable skeleton until the
+  // filter has resolved a single time, then keep the final set. Rendering the
+  // skeleton on the server too avoids an SSR -> skeleton flash.
+  const [hasSettledFilter, setHasSettledFilter] = React.useState(false);
+  React.useEffect(() => {
+    if (!isFilterLoading) {
+      setHasSettledFilter(true);
+    }
+  }, [isFilterLoading]);
+  const showSpacesSkeleton = !hasSettledFilter;
 
   const agreementCount = React.useMemo(() => {
     return selectedSpaces.reduce(
@@ -239,6 +277,27 @@ export function ExploreSpaces({
     [selectedSpaces],
   );
 
+  const cardGridClassName = 'sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4';
+  const spacesListContent = showSpacesSkeleton ? (
+    <div className={cn('grid w-full grid-cols-1 gap-4', cardGridClassName)}>
+      {Array.from({ length: 12 }).map((_, index) => (
+        <Skeleton
+          key={index}
+          loading
+          height={228}
+          className="w-full rounded-lg"
+        />
+      ))}
+    </div>
+  ) : (
+    <SpaceCardList
+      lang={lang}
+      spaces={sortedSpaces}
+      pageSize={12}
+      cardGridClassName={cardGridClassName}
+    />
+  );
+
   const { isAuthenticated } = useAuthentication();
 
   const renderMapToolbar = React.useCallback(
@@ -335,6 +394,7 @@ export function ExploreSpaces({
         selectedSpaces={selectedSpaces}
         categoryGroups={categoryGroups}
         allLabel={t('all')}
+        isLoading={showSpacesSkeleton}
       />
       {showSortControl ? <SpaceOrderCombobox order={order} /> : null}
     </div>
@@ -344,7 +404,11 @@ export function ExploreSpaces({
     <div className="flex items-stretch justify-center gap-0">
       <div className="flex min-w-[7rem] flex-col px-6 sm:min-w-[9rem] sm:px-10">
         <div className="flex justify-center text-7 font-medium">
-          {selectedSpaces.length}
+          <CountValue
+            value={selectedSpaces.length}
+            isLoading={showSpacesSkeleton}
+            width={40}
+          />
         </div>
         <div className="mt-2 flex justify-center text-1 text-neutral-500">
           {tCommon('Spaces')}
@@ -356,7 +420,11 @@ export function ExploreSpaces({
       />
       <div className="flex min-w-[7rem] flex-col px-6 sm:min-w-[9rem] sm:px-10">
         <div className="flex justify-center text-7 font-medium">
-          {uniqueMemberAddresses.size}
+          <CountValue
+            value={uniqueMemberAddresses.size}
+            isLoading={showSpacesSkeleton}
+            width={40}
+          />
         </div>
         <div className="mt-2 flex justify-center text-1 text-neutral-500">
           {tCommon('Members')}
@@ -368,7 +436,11 @@ export function ExploreSpaces({
       />
       <div className="flex min-w-[7rem] flex-col px-6 sm:min-w-[9rem] sm:px-10">
         <div className="flex justify-center text-7 font-medium">
-          {agreementCount}
+          <CountValue
+            value={agreementCount}
+            isLoading={showSpacesSkeleton}
+            width={40}
+          />
         </div>
         <div className="mt-2 flex justify-center text-1 text-neutral-500">
           {tCommon('Agreements')}
@@ -405,12 +477,7 @@ export function ExploreSpaces({
           </div>
           <div className={cn(view !== 'list' && 'hidden')}>
             {listMetaRow}
-            <SpaceCardList
-              lang={lang}
-              spaces={sortedSpaces}
-              pageSize={12}
-              cardGridClassName="sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4"
-            />
+            {spacesListContent}
           </div>
           <div className={cn('mt-8', deferBelowMapContent && 'hidden')}>
             {metricsSection}
@@ -419,12 +486,7 @@ export function ExploreSpaces({
       ) : (
         <>
           {listMetaRow}
-          <SpaceCardList
-            lang={lang}
-            spaces={sortedSpaces}
-            pageSize={12}
-            cardGridClassName="sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4"
-          />
+          {spacesListContent}
         </>
       )}
     </div>

--- a/packages/epics/src/spaces/components/network-loading-grid.tsx
+++ b/packages/epics/src/spaces/components/network-loading-grid.tsx
@@ -66,12 +66,6 @@ export function NetworkLoadingGrid({
               </React.Fragment>
             ))}
           </div>
-
-          {/* Footer stat pills */}
-          <div className="absolute inset-x-5 bottom-5 flex items-center justify-between">
-            <div className="h-6 w-16 rounded-full bg-neutral-3" />
-            <div className="h-6 w-6 rounded-full bg-neutral-3" />
-          </div>
         </div>
       ))}
     </div>

--- a/packages/epics/src/spaces/components/network-loading-grid.tsx
+++ b/packages/epics/src/spaces/components/network-loading-grid.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import React from 'react';
+import { cn } from '@hypha-platform/ui-utils';
+
+type NetworkLoadingGridProps = {
+  count?: number;
+  cardGridClassName?: string;
+};
+
+/**
+ * Loading state for the network spaces grid. Instead of plain pulsing blocks it
+ * renders placeholder "space" cards that assemble themselves (staggered rise-in)
+ * with a light sweep across each card and a small animated node constellation -
+ * a nod to the "one vibrant network" theme - so the wait feels intentional. All
+ * motion is disabled under `prefers-reduced-motion`.
+ */
+export function NetworkLoadingGrid({
+  count = 12,
+  cardGridClassName,
+}: NetworkLoadingGridProps) {
+  return (
+    <div
+      className={cn('grid w-full grid-cols-1 gap-4', cardGridClassName)}
+      aria-hidden="true"
+    >
+      {Array.from({ length: count }).map((_, index) => (
+        <div
+          key={index}
+          className="relative h-[228px] overflow-hidden rounded-lg border border-neutral-4 bg-neutral-2 p-5 animate-network-rise motion-reduce:animate-none"
+          style={{ animationDelay: `${Math.min(index, 8) * 70}ms` }}
+        >
+          {/* Diagonal light sweep */}
+          <div className="pointer-events-none absolute inset-0 -translate-x-full animate-shimmer bg-gradient-to-r from-transparent via-neutral-5/40 to-transparent motion-reduce:hidden" />
+
+          {/* Header: avatar node + title lines */}
+          <div className="flex items-center gap-3">
+            <div className="relative h-10 w-10 shrink-0">
+              <span className="absolute inset-0 rounded-full bg-accent-6/50 animate-ping motion-reduce:hidden" />
+              <span className="absolute inset-0 rounded-full bg-neutral-4" />
+            </div>
+            <div className="flex flex-1 flex-col gap-2">
+              <div className="h-3 w-2/3 rounded-full bg-neutral-4" />
+              <div className="h-2.5 w-2/5 rounded-full bg-neutral-3" />
+            </div>
+          </div>
+
+          {/* Body lines */}
+          <div className="mt-5 flex flex-col gap-2">
+            <div className="h-2.5 w-full rounded-full bg-neutral-3" />
+            <div className="h-2.5 w-11/12 rounded-full bg-neutral-3" />
+            <div className="h-2.5 w-3/4 rounded-full bg-neutral-3" />
+          </div>
+
+          {/* Animated node constellation */}
+          <div className="mt-6 flex items-center gap-2">
+            {Array.from({ length: 4 }).map((__, node) => (
+              <React.Fragment key={node}>
+                <span
+                  className="h-2.5 w-2.5 rounded-full bg-accent-7 animate-pulse motion-reduce:animate-none"
+                  style={{ animationDelay: `${node * 180}ms` }}
+                />
+                {node < 3 ? (
+                  <span className="h-px flex-1 bg-gradient-to-r from-accent-6/60 to-neutral-4" />
+                ) : null}
+              </React.Fragment>
+            ))}
+          </div>
+
+          {/* Footer stat pills */}
+          <div className="absolute inset-x-5 bottom-5 flex items-center justify-between">
+            <div className="h-6 w-16 rounded-full bg-neutral-3" />
+            <div className="h-6 w-6 rounded-full bg-neutral-3" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/epics/src/spaces/hooks/use-spaces-discoverability-batch.ts
+++ b/packages/epics/src/spaces/hooks/use-spaces-discoverability-batch.ts
@@ -106,7 +106,11 @@ export function useFilterSpacesListWithDiscoverability({
   const { discoverabilityMap, isLoading: isDiscoverabilityLoading } =
     useSpacesDiscoverabilityBatch({ spaces });
 
-  const { user } = useAuthentication();
+  const {
+    user,
+    isAuthenticated,
+    isLoading: isAuthLoading,
+  } = useAuthentication();
   const { web3SpaceIds: userMemberSpaceIds, isLoading: isMemberSpacesLoading } =
     useMemberWeb3SpaceIds({
       personAddress: user?.wallet?.address,
@@ -200,10 +204,26 @@ export function useFilterSpacesListWithDiscoverability({
     userMemberSpaceIdsSet,
   ]);
 
+  // For the network (general) list the filtered set depends on three async
+  // inputs: on-chain discoverability, whether the viewer is logged in, and which
+  // spaces they are a member of. On a hard refresh Privy isn't ready yet, so the
+  // viewer looks logged-out and their member-space fetch hasn't started -
+  // discoverability resolves first and the list would "settle" showing only
+  // public spaces, then jump as auth + membership resolve (the 76 -> 132 -> 182
+  // count climb). Treat the list as loading until Privy is ready AND, when the
+  // viewer is authenticated, until their member spaces have actually resolved.
+  const isGeneralStateLoading =
+    isAuthLoading ||
+    isDiscoverabilityLoading ||
+    isMemberSpacesLoading ||
+    (isAuthenticated &&
+      user?.wallet?.address != null &&
+      userMemberSpaceIds === undefined);
+
   return {
     filteredSpaces,
     isLoading: useGeneralState
-      ? isDiscoverabilityLoading || isMemberSpacesLoading
+      ? isGeneralStateLoading
       : isUserStateLoading || isDiscoverabilityLoading,
   };
 }

--- a/packages/ui-utils/src/global.css
+++ b/packages/ui-utils/src/global.css
@@ -278,6 +278,8 @@
   /* Animations */
   --animate-accordion-down: accordion-down 0.2s ease-out;
   --animate-accordion-up: accordion-up 0.2s ease-out;
+  --animate-shimmer: shimmer 1.8s ease-in-out infinite;
+  --animate-network-rise: network-rise 0.5s cubic-bezier(0.22, 1, 0.36, 1) both;
 }
 
 /* Keyframes */
@@ -296,6 +298,28 @@
   }
   to {
     height: 0;
+  }
+}
+
+/* Diagonal light sweep used by loading skeletons (e.g. the network grid). */
+@keyframes shimmer {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+/* Staggered entrance for loading cards so the grid "assembles" itself. */
+@keyframes network-rise {
+  from {
+    opacity: 0;
+    transform: translateY(10px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
   }
 }
 


### PR DESCRIPTION
## Summary

Draft PR seeding the phased work to improve Hypha page-loading performance and fix the proposal modal flickering/refetching bug. No implementation yet — branch scaffolding only.

Plan (phased):

- **Phase 1 — Proposal modal flicker/refetch fix**
  - Guard SWR keys against missing/invalid IDs (`useProposalDetails`, `useSpaceProposals`, `useWithdrawnProposals`, `use-space-documents-with-statuses`) to stop `BigInt(undefined)` error-retry loops.
  - Remove duplicate hook trees in `proposal-detail.tsx` (single `useProposalDetailsWeb3Rpc`, single `useVote`, single `useSpaceDocumentsWithStatuses`).
  - Fix loading/derived state so quorum/unity don't flash 0 → real; stabilize `endTime`; narrow `useEffect` deps.
  - Tame the 1s `useJwt` refresh.
- **Phase 2 — High-impact perf pass**
  - Global `SWRConfig` (dedupingInterval, keepPreviousData, opt-in refreshInterval).
  - Rationalize polling; stop polling finalized proposals; ensure every mutation triggers immediate `mutate`/optimistic update so user actions reflect in the UI instantly.
  - De-duplicate space/document/on-chain fetches; gate eager hook mounting.
- **Phase 3 — Broader UX / structural**
  - Per-tab `loading.tsx` skeletons; pagination for documents/members/coherences/spaces; dynamic-import heavy overview dashboard + Suspense streaming.

## Test plan

- [ ] Proposal modal: no invalid-key RPC retry loop, no 1s `getAccessToken`, no 0 → value flash, vote bars stop animating on every poll.
- [ ] User actions (vote, join, create, withdraw, edit) reflect in UI immediately.
- [ ] Tab switches show skeletons; duplicate `/api/v1/spaces/{slug}` + `/documents/all` requests collapse.
- [ ] `pnpm --filter @hypha-platform/core test`, `pnpm lint`, `pnpm build` green.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added smoother loading states across proposal, overview, members, rewards, coherence, and treasury views.
  * Introduced a more polished network spaces loading screen and improved skeleton placeholders.
  * Token holdings on the overview tab now load more efficiently in the browser for a faster initial experience.

* **Bug Fixes**
  * Reduced flicker and stale data when viewing proposal details or submitting votes.
  * Improved list ordering and counts so spaces and proposals appear more consistently while data loads.
  * Slowed some background refreshes to reduce unnecessary updates and re-renders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->