### PR TITLE
fix(chat): restore signal team member picker from space roster

### DIFF
--- a/packages/core/src/matrix/client/hooks/index.ts
+++ b/packages/core/src/matrix/client/hooks/index.ts
@@ -1,6 +1,7 @@
 export * from './use-matrix-token';
 export * from './use-user-privy-id-by-matrix-id';
 export * from './use-matrix-user-ids-by-privy-subs';
+export * from './use-matrix-user-ids-by-person-ids';
 export * from './use-space-group-call';
 export { shouldMirrorCallFeedVideoForDisplay } from './call-local-video-orientation';
 export {

--- a/packages/core/src/matrix/client/hooks/use-matrix-user-ids-by-person-ids.ts
+++ b/packages/core/src/matrix/client/hooks/use-matrix-user-ids-by-person-ids.ts
@@ -8,11 +8,6 @@ import { getMatrixUserIdsByPersonIdsAction } from '../../server/actions';
 
 /** Stable fallback — new object each render breaks referential equality downstream. */
 const EMPTY_PERSON_TO_MATRIX: Record<number, string> = {};
-const lastPersonToMatrixByKey = new Map<string, Record<number, string>>();
-
-function personIdsCacheKey(ids: number[]): string {
-  return ids.join('\u0000');
-}
 
 export interface UseMatrixUserIdsByPersonIdsInput {
   /** Hypha `Person.id` values from the space roster. */
@@ -55,19 +50,13 @@ export const useMatrixUserIdsByPersonIds = ({
       for (const row of rows) {
         map[row.personId] = row.matrixUserId;
       }
-      lastPersonToMatrixByKey.set(personIdsCacheKey(a.personIds), map);
       return map;
     },
     { keepPreviousData: true },
   );
 
-  const cachedMap =
-    uniqueSorted.length > 0
-      ? lastPersonToMatrixByKey.get(personIdsCacheKey(uniqueSorted))
-      : undefined;
-
   return {
-    personIdToMatrixUserId: data ?? cachedMap ?? EMPTY_PERSON_TO_MATRIX,
+    personIdToMatrixUserId: data ?? EMPTY_PERSON_TO_MATRIX,
     isLoading: isLoadingJwt || isLoading,
     error,
   };

--- a/packages/core/src/matrix/client/hooks/use-matrix-user-ids-by-person-ids.ts
+++ b/packages/core/src/matrix/client/hooks/use-matrix-user-ids-by-person-ids.ts
@@ -1,0 +1,74 @@
+'use client';
+
+import { determineEnvironment, useJwt } from '@hypha-platform/core/client';
+import React from 'react';
+import useSWR from 'swr';
+
+import { getMatrixUserIdsByPersonIdsAction } from '../../server/actions';
+
+/** Stable fallback — new object each render breaks referential equality downstream. */
+const EMPTY_PERSON_TO_MATRIX: Record<number, string> = {};
+const lastPersonToMatrixByKey = new Map<string, Record<number, string>>();
+
+function personIdsCacheKey(ids: number[]): string {
+  return ids.join('\u0000');
+}
+
+export interface UseMatrixUserIdsByPersonIdsInput {
+  /** Hypha `Person.id` values from the space roster. */
+  personIds?: number[];
+}
+
+/**
+ * Batch-resolve space roster person ids → Matrix MXIDs via `people.sub` +
+ * `matrix_user_links` (server-side; subs are not exposed on the public roster).
+ */
+export const useMatrixUserIdsByPersonIds = ({
+  personIds,
+}: UseMatrixUserIdsByPersonIdsInput) => {
+  const { jwt, isLoadingJwt } = useJwt();
+
+  const environment = React.useMemo(() => {
+    if (typeof window === 'undefined') return undefined;
+    return determineEnvironment(window.location.href);
+  }, []);
+
+  const uniqueSorted = React.useMemo(() => {
+    const raw = personIds ?? [];
+    return [...new Set(raw.filter((id) => Number.isFinite(id) && id > 0))].sort(
+      (a, b) => a - b,
+    );
+  }, [personIds]);
+
+  const arg =
+    isLoadingJwt || uniqueSorted.length === 0 || !environment || !jwt
+      ? null
+      : { personIds: uniqueSorted, environment };
+
+  const { data, error, isLoading } = useSWR(
+    arg ? [arg, 'matrixUserIdsByPersonIds'] : null,
+    async ([a]) => {
+      const rows = await getMatrixUserIdsByPersonIdsAction(a, {
+        authToken: jwt ?? undefined,
+      });
+      const map: Record<number, string> = {};
+      for (const row of rows) {
+        map[row.personId] = row.matrixUserId;
+      }
+      lastPersonToMatrixByKey.set(personIdsCacheKey(a.personIds), map);
+      return map;
+    },
+    { keepPreviousData: true },
+  );
+
+  const cachedMap =
+    uniqueSorted.length > 0
+      ? lastPersonToMatrixByKey.get(personIdsCacheKey(uniqueSorted))
+      : undefined;
+
+  return {
+    personIdToMatrixUserId: data ?? cachedMap ?? EMPTY_PERSON_TO_MATRIX,
+    isLoading: isLoadingJwt || isLoading,
+    error,
+  };
+};

--- a/packages/core/src/matrix/server/actions.ts
+++ b/packages/core/src/matrix/server/actions.ts
@@ -19,6 +19,7 @@ import { createMatrixUserLink, updateMatrixUserLink } from './mutations';
 import {
   findAdminUserName,
   findLinkByPrivyUserId,
+  findMatrixUserIdsByPersonIds,
   findMatrixUserIdsByPrivyUserIds,
 } from './queries';
 import { getLinkByMatrixUserId } from './web3/get-link-by-matrix-user-id';
@@ -81,6 +82,23 @@ export async function getMatrixUserIdsByPrivySubsAction(
     throw new Error('authToken is required for matrix user id batch lookup');
   }
   return findMatrixUserIdsByPrivyUserIds({ privyUserIds, environment }, { db });
+}
+
+/** Batch map space roster person ids → Matrix MXIDs without exposing Privy subs. */
+export async function getMatrixUserIdsByPersonIdsAction(
+  {
+    personIds,
+    environment,
+  }: {
+    personIds: number[];
+    environment: Environment;
+  },
+  { authToken }: { authToken?: string } = {},
+): Promise<Array<{ personId: number; matrixUserId: string }>> {
+  if (!authToken) {
+    throw new Error('authToken is required for matrix user id batch lookup');
+  }
+  return findMatrixUserIdsByPersonIds({ personIds, environment }, { db });
 }
 
 export async function getLinkByMatrixUserIdAction(

--- a/packages/core/src/matrix/server/queries.ts
+++ b/packages/core/src/matrix/server/queries.ts
@@ -1,8 +1,9 @@
 import {
   matrixUserLinks,
+  people,
   type MatrixUserLink,
 } from '@hypha-platform/storage-postgres';
-import { and, eq, inArray } from 'drizzle-orm';
+import { and, eq, inArray, isNotNull } from 'drizzle-orm';
 
 import { Environment } from '../../coherence/types';
 import { DbConfig } from '../../server';
@@ -88,6 +89,34 @@ export const findMatrixUserIdsByPrivyUserIds = async (
         inArray(matrixUserLinks.privyUserId, ids),
       ),
     );
+
+  return rows;
+};
+
+/** Batch lookup for mention picker: Hypha roster `person.id` → Matrix MXID (same env). */
+export const findMatrixUserIdsByPersonIds = async (
+  { personIds, environment }: { personIds: number[]; environment: Environment },
+  { db }: DbConfig,
+): Promise<Array<{ personId: number; matrixUserId: string }>> => {
+  const ids = [
+    ...new Set(personIds.filter((id) => Number.isFinite(id) && id > 0)),
+  ];
+  if (ids.length === 0) return [];
+
+  const rows = await db
+    .select({
+      personId: people.id,
+      matrixUserId: matrixUserLinks.matrixUserId,
+    })
+    .from(people)
+    .innerJoin(
+      matrixUserLinks,
+      and(
+        eq(matrixUserLinks.privyUserId, people.sub),
+        eq(matrixUserLinks.environment, environment),
+      ),
+    )
+    .where(and(inArray(people.id, ids), isNotNull(people.sub)));
 
   return rows;
 };

--- a/packages/core/src/space/client/hooks/index.ts
+++ b/packages/core/src/space/client/hooks/index.ts
@@ -14,6 +14,7 @@ export { useSpacesByWeb3Ids } from './useSpacesByWeb3Ids';
 export { useDelegateWeb3Rpc } from './useDelegate.web3.rpc';
 export { useUndelegateWeb3Rpc } from './useUndelegate.web3.rpc';
 export { useIsDelegate } from './useIsDelegate';
+export { useDelegatesForSpaces } from './useDelegatesForSpaces';
 export { useSpaceDelegate } from './useSpaceDelegate';
 export { useSpaceMinProposalDuration } from './useSpaceMinProposalDuration';
 export { useGetDelegators } from './useGetDelegators';

--- a/packages/epics/src/coherence/components/signal-team-member-picker.tsx
+++ b/packages/epics/src/coherence/components/signal-team-member-picker.tsx
@@ -113,7 +113,11 @@ export function SignalTeamMemberPicker({
 }: SignalTeamMemberPickerProps) {
   const t = useTranslations('CoherenceTab');
   const { space } = useSpaceBySlug(spaceSlug);
-  const { persons, isLoading: isLoadingMembers } = useSpaceMembersAndDelegates({
+  const {
+    persons,
+    isLoading: isLoadingMembers,
+    error: membersError,
+  } = useSpaceMembersAndDelegates({
     spaceSlug,
     web3SpaceId: space?.web3SpaceId,
     useMembers,
@@ -193,7 +197,7 @@ export function SignalTeamMemberPicker({
       </p>
       {isLoading ? (
         <p className="text-sm text-muted-foreground">{t('loading')}</p>
-      ) : matrixIdsError && rosterMembers.length === 0 ? (
+      ) : (matrixIdsError || membersError) && rosterMembers.length === 0 ? (
         <p role="alert" className="text-sm text-destructive">
           {t('signalTeamMembersLoadFailed')}
         </p>

--- a/packages/epics/src/coherence/components/signal-team-member-picker.tsx
+++ b/packages/epics/src/coherence/components/signal-team-member-picker.tsx
@@ -2,10 +2,7 @@
 
 import React from 'react';
 import { Check, Plus } from 'lucide-react';
-import {
-  Person,
-  useMatrixUserIdsByPrivySubs,
-} from '@hypha-platform/core/client';
+import { useMatrixUserIdsByPersonIds } from '@hypha-platform/core/client';
 import { useTranslations } from 'next-intl';
 import { PersonAvatar } from '../../people/components/person-avatar';
 import { UseMembers } from '../../spaces';
@@ -111,26 +108,25 @@ export function SignalTeamMemberPicker({
     paginationDisabled: true,
   });
   const spaceMembers = persons.data;
-  const privySubs = React.useMemo(
+  const rosterPersonIds = React.useMemo(
     () =>
       spaceMembers
-        .map((member) => member.sub?.trim())
-        .filter((sub): sub is string => Boolean(sub)),
+        .map((member) => member.id)
+        .filter((id): id is number => Number.isFinite(id) && id > 0),
     [spaceMembers],
   );
-  const { subToMatrixUserId, isLoading: isLoadingMatrixIds } =
-    useMatrixUserIdsByPrivySubs({ privySubs });
+  const { personIdToMatrixUserId, isLoading: isLoadingMatrixIds } =
+    useMatrixUserIdsByPersonIds({ personIds: rosterPersonIds });
 
   const ownerPerson = React.useMemo(() => {
     if (!ownerMatrixUserId) return null;
     return (
       spaceMembers.find(
         (member) =>
-          member.sub?.trim() &&
-          subToMatrixUserId[member.sub.trim()] === ownerMatrixUserId,
+          personIdToMatrixUserId[member.id]?.trim() === ownerMatrixUserId,
       ) ?? null
     );
-  }, [ownerMatrixUserId, spaceMembers, subToMatrixUserId]);
+  }, [ownerMatrixUserId, spaceMembers, personIdToMatrixUserId]);
 
   const selectableMembers = React.useMemo(() => {
     const extraCandidates = ownerMatrixUserId
@@ -140,27 +136,25 @@ export function SignalTeamMemberPicker({
             displayLabel: ownerPerson
               ? personRosterDisplayLabel(ownerPerson, t('unknownMember'))
               : t('createSignalTeamOwner'),
-            privySub: ownerPerson?.sub?.trim(),
             avatarUrl: ownerPerson?.avatarUrl ?? undefined,
           },
         ]
       : [];
 
     const rosterSpaceMembers = ownerMatrixUserId
-      ? spaceMembers.filter((member) => {
-          const sub = member.sub?.trim();
-          if (!sub) return true;
-          return subToMatrixUserId[sub] !== ownerMatrixUserId;
-        })
+      ? spaceMembers.filter(
+          (member) =>
+            personIdToMatrixUserId[member.id]?.trim() !== ownerMatrixUserId,
+        )
       : spaceMembers;
 
     return buildSpaceRosterMentionCandidates({
       spaceMembers: rosterSpaceMembers,
-      subToMatrixUserId,
+      personIdToMatrixUserId,
       unknownLabel: t('unknownMember'),
       extraCandidates,
     });
-  }, [ownerMatrixUserId, ownerPerson, spaceMembers, subToMatrixUserId, t]);
+  }, [ownerMatrixUserId, ownerPerson, spaceMembers, personIdToMatrixUserId, t]);
 
   const effectiveSelectedIds = React.useMemo(() => {
     const base = normalizeMatrixUserIds(selectedMemberIds);

--- a/packages/epics/src/coherence/components/signal-team-member-picker.tsx
+++ b/packages/epics/src/coherence/components/signal-team-member-picker.tsx
@@ -2,10 +2,14 @@
 
 import React from 'react';
 import { Check, Plus } from 'lucide-react';
-import { useMatrixUserIdsByPersonIds } from '@hypha-platform/core/client';
+import {
+  useMatrixUserIdsByPersonIds,
+  useSpaceBySlug,
+} from '@hypha-platform/core/client';
 import { useTranslations } from 'next-intl';
 import { PersonAvatar } from '../../people/components/person-avatar';
 import { UseMembers } from '../../spaces';
+import { useSpaceMembersAndDelegates } from '../../spaces/hooks/use-space-members-and-delegates';
 import { useResolvedMentionCandidateLabel } from '../../common/human-chat-panel/use-resolved-mention-candidate-label';
 import {
   buildSpaceRosterMentionCandidates,
@@ -103,11 +107,13 @@ export function SignalTeamMemberPicker({
   disabled,
 }: SignalTeamMemberPickerProps) {
   const t = useTranslations('CoherenceTab');
-  const { persons, isLoading: isLoadingMembers } = useMembers({
+  const { space } = useSpaceBySlug(spaceSlug);
+  const { persons, isLoading: isLoadingMembers } = useSpaceMembersAndDelegates({
     spaceSlug,
-    paginationDisabled: true,
+    web3SpaceId: space?.web3SpaceId,
+    useMembers,
   });
-  const spaceMembers = persons.data;
+  const spaceMembers = persons;
   const rosterPersonIds = React.useMemo(
     () =>
       spaceMembers

--- a/packages/epics/src/coherence/components/signal-team-member-picker.tsx
+++ b/packages/epics/src/coherence/components/signal-team-member-picker.tsx
@@ -12,7 +12,7 @@ import { UseMembers } from '../../spaces';
 import { useSpaceMembersAndDelegates } from '../../spaces/hooks/use-space-members-and-delegates';
 import { useResolvedMentionCandidateLabel } from '../../common/human-chat-panel/use-resolved-mention-candidate-label';
 import {
-  buildSpaceRosterMentionCandidates,
+  buildSpaceRosterSignalTeamMembers,
   personRosterDisplayLabel,
 } from '../../common/human-chat-panel/build-space-roster-mention-candidates';
 
@@ -36,6 +36,7 @@ function SignalTeamPickerRow({
   selected,
   disabled,
   isOwner,
+  noChatAccountLabel,
   onToggle,
 }: {
   matrixUserId: string;
@@ -45,6 +46,7 @@ function SignalTeamPickerRow({
   selected: boolean;
   disabled?: boolean;
   isOwner?: boolean;
+  noChatAccountLabel?: string;
   onToggle: () => void;
 }) {
   const t = useTranslations('CoherenceTab');
@@ -54,6 +56,7 @@ function SignalTeamPickerRow({
     privySub,
   });
   const label = resolvedLabel?.trim() || displayLabel;
+  const canToggle = Boolean(matrixUserId.trim());
 
   return (
     <button
@@ -62,7 +65,7 @@ function SignalTeamPickerRow({
         selected
           ? 'border border-accent-8/55 bg-accent-3/28 ring-1 ring-accent-8/35'
           : 'border border-transparent hover:bg-muted/70'
-      }`}
+      } ${!canToggle ? 'opacity-60' : ''}`}
       disabled={disabled || (isOwner && selected)}
       onClick={onToggle}
     >
@@ -78,11 +81,13 @@ function SignalTeamPickerRow({
             <Check className="h-3.5 w-3.5 text-accent-11" />
             {t('signalTeamRemoveMember')}
           </>
-        ) : (
+        ) : canToggle ? (
           <>
             <Plus className="h-3.5 w-3.5" />
             {t('signalTeamAddMember')}
           </>
+        ) : (
+          noChatAccountLabel
         )}
       </span>
     </button>
@@ -121,8 +126,11 @@ export function SignalTeamMemberPicker({
         .filter((id): id is number => Number.isFinite(id) && id > 0),
     [spaceMembers],
   );
-  const { personIdToMatrixUserId, isLoading: isLoadingMatrixIds } =
-    useMatrixUserIdsByPersonIds({ personIds: rosterPersonIds });
+  const {
+    personIdToMatrixUserId,
+    isLoading: isLoadingMatrixIds,
+    error: matrixIdsError,
+  } = useMatrixUserIdsByPersonIds({ personIds: rosterPersonIds });
 
   const ownerPerson = React.useMemo(() => {
     if (!ownerMatrixUserId) return null;
@@ -134,32 +142,38 @@ export function SignalTeamMemberPicker({
     );
   }, [ownerMatrixUserId, spaceMembers, personIdToMatrixUserId]);
 
-  const selectableMembers = React.useMemo(() => {
-    const extraCandidates = ownerMatrixUserId
-      ? [
-          {
-            userId: ownerMatrixUserId,
-            displayLabel: ownerPerson
-              ? personRosterDisplayLabel(ownerPerson, t('unknownMember'))
-              : t('createSignalTeamOwner'),
-            avatarUrl: ownerPerson?.avatarUrl ?? undefined,
-          },
-        ]
-      : [];
-
-    const rosterSpaceMembers = ownerMatrixUserId
-      ? spaceMembers.filter(
-          (member) =>
-            personIdToMatrixUserId[member.id]?.trim() !== ownerMatrixUserId,
-        )
-      : spaceMembers;
-
-    return buildSpaceRosterMentionCandidates({
-      spaceMembers: rosterSpaceMembers,
+  const rosterMembers = React.useMemo(() => {
+    const rows = buildSpaceRosterSignalTeamMembers({
+      spaceMembers: ownerMatrixUserId
+        ? spaceMembers.filter(
+            (member) =>
+              personIdToMatrixUserId[member.id]?.trim() !== ownerMatrixUserId,
+          )
+        : spaceMembers,
       personIdToMatrixUserId,
       unknownLabel: t('unknownMember'),
-      extraCandidates,
     });
+
+    if (!ownerMatrixUserId) return rows;
+
+    const ownerRow = ownerPerson
+      ? {
+          personId: ownerPerson.id,
+          matrixUserId: ownerMatrixUserId,
+          displayLabel: personRosterDisplayLabel(
+            ownerPerson,
+            t('unknownMember'),
+          ),
+          avatarUrl: ownerPerson.avatarUrl ?? undefined,
+        }
+      : {
+          personId: -1,
+          matrixUserId: ownerMatrixUserId,
+          displayLabel: t('createSignalTeamOwner'),
+          avatarUrl: undefined,
+        };
+
+    return [ownerRow, ...rows];
   }, [ownerMatrixUserId, ownerPerson, spaceMembers, personIdToMatrixUserId, t]);
 
   const effectiveSelectedIds = React.useMemo(() => {
@@ -179,33 +193,43 @@ export function SignalTeamMemberPicker({
       </p>
       {isLoading ? (
         <p className="text-sm text-muted-foreground">{t('loading')}</p>
-      ) : selectableMembers.length === 0 ? (
+      ) : matrixIdsError && rosterMembers.length === 0 ? (
+        <p role="alert" className="text-sm text-destructive">
+          {t('signalTeamMembersLoadFailed')}
+        </p>
+      ) : rosterMembers.length === 0 ? (
         <p className="text-sm text-muted-foreground">
           {t('createSignalTeamNoMembers')}
         </p>
       ) : (
-        <div className="grid gap-1">
-          {selectableMembers.map((member) => {
-            const isOwner = member.userId === ownerMatrixUserId;
-            const selected = effectiveSelectedIds.includes(member.userId);
+        <div className="narrow-scrollbar grid max-h-60 gap-1 overflow-y-auto">
+          {rosterMembers.map((member) => {
+            const matrixUserId = member.matrixUserId;
+            const isOwner = matrixUserId === ownerMatrixUserId;
+            const selected = matrixUserId
+              ? effectiveSelectedIds.includes(matrixUserId)
+              : false;
+            const canToggle = Boolean(matrixUserId);
             return (
               <SignalTeamPickerRow
-                key={member.userId}
-                matrixUserId={member.userId}
+                key={member.personId}
+                matrixUserId={matrixUserId ?? ''}
                 displayLabel={member.displayLabel}
-                privySub={member.privySub}
+                privySub={undefined}
                 avatarUrl={member.avatarUrl}
                 selected={selected}
-                disabled={disabled}
+                disabled={disabled || !canToggle}
                 isOwner={isOwner}
+                noChatAccountLabel={t('signalTeamNoChatAccount')}
                 onToggle={() => {
+                  if (!matrixUserId) return;
                   if (isOwner && selected) return;
                   const memberIdsOnly = effectiveSelectedIds.filter(
                     (id) => id !== ownerMatrixUserId,
                   );
                   const next = selected
-                    ? memberIdsOnly.filter((id) => id !== member.userId)
-                    : [...memberIdsOnly, member.userId];
+                    ? memberIdsOnly.filter((id) => id !== matrixUserId)
+                    : [...memberIdsOnly, matrixUserId];
                   onSelectedMemberIdsChange(normalizeMatrixUserIds(next));
                 }}
               />

--- a/packages/epics/src/common/human-chat-panel/build-space-roster-mention-candidates.ts
+++ b/packages/epics/src/common/human-chat-panel/build-space-roster-mention-candidates.ts
@@ -15,12 +15,12 @@ export function personRosterDisplayLabel(
 /** Space members with a linked Matrix id — same source as the Members tab roster. */
 export function buildSpaceRosterMentionCandidates({
   spaceMembers,
-  subToMatrixUserId,
+  personIdToMatrixUserId,
   unknownLabel,
   extraCandidates = [],
 }: {
   spaceMembers: Person[];
-  subToMatrixUserId: Record<string, string>;
+  personIdToMatrixUserId: Record<number, string>;
   unknownLabel: string;
   extraCandidates?: ChatMentionCandidate[];
 }): ChatMentionCandidate[] {
@@ -33,15 +33,12 @@ export function buildSpaceRosterMentionCandidates({
   }
 
   for (const member of spaceMembers) {
-    const sub = member.sub?.trim();
-    if (!sub) continue;
-    const userId = subToMatrixUserId[sub]?.trim();
+    const userId = personIdToMatrixUserId[member.id]?.trim();
     if (!userId) continue;
     byUserId.set(userId, {
       userId,
       displayLabel: personRosterDisplayLabel(member, unknownLabel),
       avatarUrl: member.avatarUrl ?? undefined,
-      privySub: sub,
     });
   }
 

--- a/packages/epics/src/common/human-chat-panel/build-space-roster-mention-candidates.ts
+++ b/packages/epics/src/common/human-chat-panel/build-space-roster-mention-candidates.ts
@@ -48,3 +48,34 @@ export function buildSpaceRosterMentionCandidates({
     }),
   );
 }
+
+export type SignalTeamRosterMember = {
+  personId: number;
+  matrixUserId: string | null;
+  displayLabel: string;
+  avatarUrl?: string;
+};
+
+/** Full space roster for Signal Team manage UI — includes members without a Matrix link. */
+export function buildSpaceRosterSignalTeamMembers({
+  spaceMembers,
+  personIdToMatrixUserId,
+  unknownLabel,
+}: {
+  spaceMembers: Person[];
+  personIdToMatrixUserId: Record<number, string>;
+  unknownLabel: string;
+}): SignalTeamRosterMember[] {
+  return spaceMembers
+    .map((member) => ({
+      personId: member.id,
+      matrixUserId: personIdToMatrixUserId[member.id]?.trim() || null,
+      displayLabel: personRosterDisplayLabel(member, unknownLabel),
+      avatarUrl: member.avatarUrl ?? undefined,
+    }))
+    .sort((a, b) =>
+      a.displayLabel.localeCompare(b.displayLabel, undefined, {
+        sensitivity: 'base',
+      }),
+    );
+}

--- a/packages/epics/src/common/human-chat-panel/human-chat-panel-members.tsx
+++ b/packages/epics/src/common/human-chat-panel/human-chat-panel-members.tsx
@@ -3,10 +3,11 @@
 import { useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { Skeleton } from '@hypha-platform/ui';
-import { useMatrix } from '@hypha-platform/core/client';
+import { useMatrix, useSpaceBySlug } from '@hypha-platform/core/client';
 import { PersonAvatar } from '../../people/components/person-avatar';
 import { APP_CHROME_SUBTLE_SQUARE_RADIUS } from '../../spaces/components/compact-space-banner';
 import { UseMembers } from '../../spaces';
+import { useSpaceMembersAndDelegates } from '../../spaces/hooks/use-space-members-and-delegates';
 import { shortenMatrixIdForDisplay } from './matrix-room-member-display';
 
 type HumanChatPanelMembersProps = {
@@ -32,14 +33,13 @@ export function HumanChatPanelMembers({
   const t = useTranslations('HumanChatPanel');
   const { getRoomMembers, isMatrixAvailable, isAuthenticated } = useMatrix();
   const [onlineCount, setOnlineCount] = useState(0);
-
-  const { persons, isLoading } = useMembers({
+  const { space } = useSpaceBySlug(spaceSlug ?? '');
+  const { persons: members, isLoading } = useSpaceMembersAndDelegates({
     spaceSlug,
-    paginationDisabled: true,
+    web3SpaceId: space?.web3SpaceId,
+    useMembers,
   });
-
-  const members = persons?.data ?? [];
-  const totalCount = persons?.pagination?.total ?? members.length;
+  const totalCount = members.length;
 
   useEffect(() => {
     if (!roomId || !isMatrixAvailable || !isAuthenticated) {

--- a/packages/epics/src/common/human-chat-panel/human-chat-panel-members.tsx
+++ b/packages/epics/src/common/human-chat-panel/human-chat-panel-members.tsx
@@ -34,7 +34,11 @@ export function HumanChatPanelMembers({
   const { getRoomMembers, isMatrixAvailable, isAuthenticated } = useMatrix();
   const [onlineCount, setOnlineCount] = useState(0);
   const { space } = useSpaceBySlug(spaceSlug ?? '');
-  const { persons: members, isLoading } = useSpaceMembersAndDelegates({
+  const {
+    persons: members,
+    isLoading,
+    error,
+  } = useSpaceMembersAndDelegates({
     spaceSlug,
     web3SpaceId: space?.web3SpaceId,
     useMembers,
@@ -115,7 +119,15 @@ export function HumanChatPanelMembers({
           ))}
         </div>
       )}
-      {!isLoading && members.length === 0 && (
+      {!isLoading && error && members.length === 0 && (
+        <div
+          role="alert"
+          className="px-2 py-4 text-center text-sm text-destructive"
+        >
+          {t('signalTeamMembersLoadFailed')}
+        </div>
+      )}
+      {!isLoading && !error && members.length === 0 && (
         <div className="px-2 py-4 text-center text-sm text-muted-foreground">
           {t('noMembers')}
         </div>

--- a/packages/epics/src/common/human-right-panel.tsx
+++ b/packages/epics/src/common/human-right-panel.tsx
@@ -135,7 +135,10 @@ import {
 } from './human-chat-panel/human-chat-message-link';
 import { useGlobalCallDock } from './global-call-dock-context';
 import { useScreenshareTabAudioPrompt } from './human-chat-panel/use-screenshare-tab-audio-prompt';
-import { buildSpaceRosterMentionCandidates } from './human-chat-panel/build-space-roster-mention-candidates';
+import {
+  buildSpaceRosterMentionCandidates,
+  buildSpaceRosterSignalTeamMembers,
+} from './human-chat-panel/build-space-roster-mention-candidates';
 
 function personRosterLabel(p: Person, unknownLabel: string): string {
   const full = [p.name, p.surname].filter(Boolean).join(' ').trim();
@@ -1000,11 +1003,12 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
   const { person: me } = useMe();
   const { space, isLoading: isSpaceLoading } = useSpaceBySlug(spaceSlug ?? '');
   const effectiveSpaceWeb3Id = space?.web3SpaceId ?? undefined;
-  const { persons: spaceMembersResult } = useSpaceMembersAndDelegates({
-    spaceSlug,
-    web3SpaceId: effectiveSpaceWeb3Id,
-    useMembers,
-  });
+  const { persons: spaceMembersResult, isLoading: isLoadingSpaceMembers } =
+    useSpaceMembersAndDelegates({
+      spaceSlug,
+      web3SpaceId: effectiveSpaceWeb3Id,
+      useMembers,
+    });
   const spaceMembers = useMemo(
     () => spaceMembersResult ?? [],
     [spaceMembersResult],
@@ -1589,7 +1593,11 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
   const { subToMatrixUserId } = useMatrixUserIdsByPrivySubs({
     privySubs: rosterSubs,
   });
-  const { personIdToMatrixUserId } = useMatrixUserIdsByPersonIds({
+  const {
+    personIdToMatrixUserId,
+    isLoading: isLoadingMatrixUserIds,
+    error: matrixUserIdsError,
+  } = useMatrixUserIdsByPersonIds({
     personIds: rosterPersonIds,
   });
 
@@ -2033,6 +2041,15 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
     canInteractWithSignalThread &&
     !isChatFollowerTab &&
     mentionCandidates.length > 0;
+  const signalTeamRosterMembers = useMemo(
+    () =>
+      buildSpaceRosterSignalTeamMembers({
+        spaceMembers,
+        personIdToMatrixUserId,
+        unknownLabel: t('unknownMember'),
+      }),
+    [spaceMembers, personIdToMatrixUserId, t],
+  );
   const signalTeamSelectableMembers = useMemo((): ChatMentionCandidate[] => {
     const extraCandidates: ChatMentionCandidate[] = [];
     if (currentUserId) {
@@ -4520,41 +4537,56 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
                         <p className="text-xs text-muted-foreground">
                           {t('signalTeamMemberListHint')}
                         </p>
-                        {signalTeamSelectableMembers.length === 0 ? (
+                        {isLoadingSpaceMembers || isLoadingMatrixUserIds ? (
+                          <p className="text-sm text-muted-foreground">
+                            {t('loading')}
+                          </p>
+                        ) : matrixUserIdsError &&
+                          signalTeamRosterMembers.length === 0 ? (
+                          <p role="alert" className="text-sm text-destructive">
+                            {t('signalTeamMembersLoadFailed')}
+                          </p>
+                        ) : signalTeamRosterMembers.length === 0 ? (
                           <p className="text-sm text-muted-foreground">
                             {t('noMembers')}
                           </p>
                         ) : (
-                          <div className="grid gap-1">
-                            {signalTeamSelectableMembers.map((member) => {
-                              const selected =
-                                signalTeamEditorMemberIds.includes(
-                                  member.userId,
-                                );
+                          <div className="narrow-scrollbar grid max-h-60 gap-1 overflow-y-auto">
+                            {signalTeamRosterMembers.map((member) => {
+                              const matrixUserId = member.matrixUserId;
+                              const selected = matrixUserId
+                                ? signalTeamEditorMemberIds.includes(
+                                    matrixUserId,
+                                  )
+                                : false;
                               const isCurrentUser =
-                                member.userId === currentUserId;
+                                matrixUserId != null &&
+                                matrixUserId === currentUserId;
                               const isOwner =
-                                member.userId === signalTeamOwnerId;
+                                matrixUserId != null &&
+                                matrixUserId === signalTeamOwnerId;
+                              const canToggle = Boolean(matrixUserId);
                               return (
                                 <button
-                                  key={member.userId}
+                                  key={member.personId}
                                   type="button"
                                   className={`flex items-center justify-between rounded-md px-2 py-1 text-left text-sm ${
                                     selected
                                       ? 'border border-accent-8/55 bg-accent-3/28 ring-1 ring-accent-8/35'
                                       : 'border border-transparent hover:bg-muted/70'
-                                  }`}
-                                  disabled={signalTeamBusy}
+                                  } ${!canToggle ? 'opacity-60' : ''}`}
+                                  disabled={signalTeamBusy || !canToggle}
                                   onClick={() => {
+                                    if (!matrixUserId) return;
                                     if (isCurrentUser && selected) return;
                                     if (isOwner && selected) return;
                                     const next = selected
                                       ? signalTeamEditorMemberIds.filter(
-                                          (id) => id !== member.userId,
+                                          (id) => id !== matrixUserId,
                                         )
                                       : [
                                           ...signalTeamEditorMemberIds,
-                                          member.userId,
+                                          matrixUserId,
                                         ];
                                     setSignalTeamDraftMemberIds(
                                       normalizeMatrixUserIds(next),
@@ -4563,9 +4595,8 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
                                 >
                                   <SignalTeamResolvedMemberLabel
                                     candidate={{
-                                      userId: member.userId,
+                                      userId: matrixUserId ?? '',
                                       displayLabel: member.displayLabel,
-                                      privySub: member.privySub,
                                     }}
                                     fallbackLabel={member.displayLabel}
                                     isOwner={isOwner}
@@ -4574,11 +4605,13 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
                                   <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
                                     {isOwner ? null : selected ? (
                                       <Check className="h-3.5 w-3.5 text-accent-11" />
-                                    ) : (
+                                    ) : canToggle ? (
                                       <Plus className="h-3.5 w-3.5" />
-                                    )}
+                                    ) : null}
                                     {isOwner
-                                      ? 'Owner'
+                                      ? t('signalTeamOwner')
+                                      : !canToggle
+                                      ? t('signalTeamNoChatAccount')
                                       : selected
                                       ? t('signalTeamRemoveMember')
                                       : t('signalTeamAddMember')}

--- a/packages/epics/src/common/human-right-panel.tsx
+++ b/packages/epics/src/common/human-right-panel.tsx
@@ -34,6 +34,7 @@ import {
   useHookRegistry,
   useJwt,
   useMatrixUserIdsByPrivySubs,
+  useMatrixUserIdsByPersonIds,
   useMe,
   useSpaceBySlug,
   useSpaceMutationsWeb2Rsc,
@@ -131,9 +132,9 @@ import {
   buildHyphaChatMentionDeepLinkUrl,
   setSignalSearchParam,
 } from './human-chat-panel/human-chat-message-link';
-import { buildSpaceRosterMentionCandidates } from './human-chat-panel/build-space-roster-mention-candidates';
 import { useGlobalCallDock } from './global-call-dock-context';
 import { useScreenshareTabAudioPrompt } from './human-chat-panel/use-screenshare-tab-audio-prompt';
+import { buildSpaceRosterMentionCandidates } from './human-chat-panel/build-space-roster-mention-candidates';
 
 function personRosterLabel(p: Person, unknownLabel: string): string {
   const full = [p.name, p.surname].filter(Boolean).join(' ').trim();
@@ -1575,23 +1576,35 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
         .filter((s): s is string => Boolean(s)),
     [spaceMembers],
   );
+  const rosterPersonIds = useMemo(
+    () =>
+      spaceMembers
+        .map((p) => p.id)
+        .filter((id): id is number => Number.isFinite(id) && id > 0),
+    [spaceMembers],
+  );
 
   const { subToMatrixUserId } = useMatrixUserIdsByPrivySubs({
     privySubs: rosterSubs,
+  });
+  const { personIdToMatrixUserId } = useMatrixUserIdsByPersonIds({
+    personIds: rosterPersonIds,
   });
 
   /** Same source as `@` mention labels: Hypha roster wins over Matrix bridge displaynames. */
   const matrixUserIdToPersonLabel = useMemo(() => {
     const m = new Map<string, string>();
     for (const p of spaceMembers) {
-      const sub = p.sub?.trim();
-      if (!sub) continue;
-      const mxid = subToMatrixUserId[sub]?.trim();
+      let mxid = personIdToMatrixUserId[p.id]?.trim();
+      if (!mxid) {
+        const sub = p.sub?.trim();
+        if (sub) mxid = subToMatrixUserId[sub]?.trim();
+      }
       if (!mxid) continue;
       m.set(mxid, personRosterLabel(p, t('unknownMember')));
     }
     return m;
-  }, [spaceMembers, subToMatrixUserId, t]);
+  }, [spaceMembers, personIdToMatrixUserId, subToMatrixUserId, t]);
 
   /** Fallback roster lookup using Matrix localpart == Privy sub (same `useMembers` roster source as chat Members tab). */
   const personLabelByPrivySub = useMemo(() => {
@@ -1698,10 +1711,12 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
 
     /** Same names as Members tab — overrides Matrix-only technical displaynames. */
     for (const p of spaceMembers) {
+      let mxid = personIdToMatrixUserId[p.id]?.trim();
       const sub = p.sub?.trim();
-      if (!sub) continue;
-      let mxid = subToMatrixUserId[sub];
-      if (!mxid) {
+      if (!mxid && sub) {
+        mxid = subToMatrixUserId[sub]?.trim();
+      }
+      if (!mxid && sub) {
         for (const userId of byUserId.keys()) {
           if (matrixUserIdToCanonicalPrivySub(userId) === sub) {
             mxid = userId;
@@ -1715,7 +1730,7 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
       byUserId.set(mxid, {
         displayLabel: personRosterLabel(p, t('unknownMember')),
         avatarUrl: p.avatarUrl ?? prev?.avatarUrl,
-        privySub: sub,
+        ...(sub ? { privySub: sub } : {}),
       });
     }
 
@@ -1741,6 +1756,7 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
     currentUserId,
     spaceMembers,
     subToMatrixUserId,
+    personIdToMatrixUserId,
     t,
     mentionMembershipEpoch,
   ]);
@@ -2087,44 +2103,35 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
   const signalTeamSelectableMembers = useMemo((): ChatMentionCandidate[] => {
     const extraCandidates: ChatMentionCandidate[] = [];
     if (currentUserId) {
-      const alreadyListed = spaceMembers.some((member) => {
-        const sub = member.sub?.trim();
-        return sub && subToMatrixUserId[sub]?.trim() === currentUserId;
-      });
+      const alreadyListed = spaceMembers.some(
+        (member) => personIdToMatrixUserId[member.id]?.trim() === currentUserId,
+      );
       if (!alreadyListed) {
-        const selfSub = me?.sub?.trim();
-        const isOnSpaceRoster = selfSub
-          ? spaceMembers.some((member) => member.sub?.trim() === selfSub)
-          : false;
-        if (isOnSpaceRoster) {
-          extraCandidates.push({
-            userId: currentUserId,
-            displayLabel:
-              [me?.name, me?.surname].filter(Boolean).join(' ').trim() ||
-              me?.nickname?.trim() ||
-              t('you'),
-            avatarUrl: me?.avatarUrl,
-            ...(selfSub ? { privySub: selfSub } : {}),
-          });
-        }
+        extraCandidates.push({
+          userId: currentUserId,
+          displayLabel:
+            [me?.name, me?.surname].filter(Boolean).join(' ').trim() ||
+            me?.nickname?.trim() ||
+            t('you'),
+          avatarUrl: me?.avatarUrl,
+        });
       }
     }
 
     return buildSpaceRosterMentionCandidates({
       spaceMembers,
-      subToMatrixUserId,
+      personIdToMatrixUserId,
       unknownLabel: t('unknownMember'),
       extraCandidates,
     });
   }, [
     spaceMembers,
-    subToMatrixUserId,
+    personIdToMatrixUserId,
     currentUserId,
     me?.name,
     me?.surname,
     me?.nickname,
     me?.avatarUrl,
-    me?.sub,
     t,
   ]);
   const effectiveSignalTeamMemberIds = useMemo(
@@ -4580,66 +4587,74 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
                         <p className="text-xs text-muted-foreground">
                           {t('signalTeamMemberListHint')}
                         </p>
-                        <div className="grid gap-1">
-                          {signalTeamSelectableMembers.map((member) => {
-                            const selected = signalTeamEditorMemberIds.includes(
-                              member.userId,
-                            );
-                            const isCurrentUser =
-                              member.userId === currentUserId;
-                            const isOwner = member.userId === signalTeamOwnerId;
-                            return (
-                              <button
-                                key={member.userId}
-                                type="button"
-                                className={`flex items-center justify-between rounded-md px-2 py-1 text-left text-sm ${
-                                  selected
-                                    ? 'border border-accent-8/55 bg-accent-3/28 ring-1 ring-accent-8/35'
-                                    : 'border border-transparent hover:bg-muted/70'
-                                }`}
-                                disabled={signalTeamBusy}
-                                onClick={() => {
-                                  if (isCurrentUser && selected) return;
-                                  if (isOwner && selected) return;
-                                  const next = selected
-                                    ? signalTeamEditorMemberIds.filter(
-                                        (id) => id !== member.userId,
-                                      )
-                                    : [
-                                        ...signalTeamEditorMemberIds,
-                                        member.userId,
-                                      ];
-                                  setSignalTeamDraftMemberIds(
-                                    normalizeMatrixUserIds(next),
-                                  );
-                                }}
-                              >
-                                <SignalTeamResolvedMemberLabel
-                                  candidate={{
-                                    userId: member.userId,
-                                    displayLabel: member.displayLabel,
-                                    privySub: member.privySub,
+                        {signalTeamSelectableMembers.length === 0 ? (
+                          <p className="text-sm text-muted-foreground">
+                            {t('noMembers')}
+                          </p>
+                        ) : (
+                          <div className="grid gap-1">
+                            {signalTeamSelectableMembers.map((member) => {
+                              const selected =
+                                signalTeamEditorMemberIds.includes(
+                                  member.userId,
+                                );
+                              const isCurrentUser =
+                                member.userId === currentUserId;
+                              const isOwner =
+                                member.userId === signalTeamOwnerId;
+                              return (
+                                <button
+                                  key={member.userId}
+                                  type="button"
+                                  className={`flex items-center justify-between rounded-md px-2 py-1 text-left text-sm ${
+                                    selected
+                                      ? 'border border-accent-8/55 bg-accent-3/28 ring-1 ring-accent-8/35'
+                                      : 'border border-transparent hover:bg-muted/70'
+                                  }`}
+                                  disabled={signalTeamBusy}
+                                  onClick={() => {
+                                    if (isCurrentUser && selected) return;
+                                    if (isOwner && selected) return;
+                                    const next = selected
+                                      ? signalTeamEditorMemberIds.filter(
+                                          (id) => id !== member.userId,
+                                        )
+                                      : [
+                                          ...signalTeamEditorMemberIds,
+                                          member.userId,
+                                        ];
+                                    setSignalTeamDraftMemberIds(
+                                      normalizeMatrixUserIds(next),
+                                    );
                                   }}
-                                  fallbackLabel={member.displayLabel}
-                                  isOwner={isOwner}
-                                  unknownMemberLabel={t('unknownMember')}
-                                />
-                                <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
-                                  {isOwner ? null : selected ? (
-                                    <Check className="h-3.5 w-3.5 text-accent-11" />
-                                  ) : (
-                                    <Plus className="h-3.5 w-3.5" />
-                                  )}
-                                  {isOwner
-                                    ? 'Owner'
-                                    : selected
-                                    ? t('signalTeamRemoveMember')
-                                    : t('signalTeamAddMember')}
-                                </span>
-                              </button>
-                            );
-                          })}
-                        </div>
+                                >
+                                  <SignalTeamResolvedMemberLabel
+                                    candidate={{
+                                      userId: member.userId,
+                                      displayLabel: member.displayLabel,
+                                      privySub: member.privySub,
+                                    }}
+                                    fallbackLabel={member.displayLabel}
+                                    isOwner={isOwner}
+                                    unknownMemberLabel={t('unknownMember')}
+                                  />
+                                  <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
+                                    {isOwner ? null : selected ? (
+                                      <Check className="h-3.5 w-3.5 text-accent-11" />
+                                    ) : (
+                                      <Plus className="h-3.5 w-3.5" />
+                                    )}
+                                    {isOwner
+                                      ? 'Owner'
+                                      : selected
+                                      ? t('signalTeamRemoveMember')
+                                      : t('signalTeamAddMember')}
+                                  </span>
+                                </button>
+                              );
+                            })}
+                          </div>
+                        )}
                       </div>
                     )}
                   </div>

--- a/packages/epics/src/common/human-right-panel.tsx
+++ b/packages/epics/src/common/human-right-panel.tsx
@@ -61,6 +61,7 @@ import {
   isChatPanelVideoFile,
 } from './human-chat-panel/chat-panel-media-types';
 import { UseMembers } from '../spaces';
+import { useSpaceMembersAndDelegates } from '../spaces/hooks/use-space-members-and-delegates';
 import {
   UserSpaceState,
   useUserSpaceState,
@@ -997,16 +998,17 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
     authToken,
   });
   const { person: me } = useMe();
-  const { persons: spaceMembersResult } = useMembers({
-    spaceSlug,
-    paginationDisabled: true,
-  });
-  const spaceMembers = useMemo(
-    () => spaceMembersResult?.data ?? [],
-    [spaceMembersResult?.data],
-  );
   const { space, isLoading: isSpaceLoading } = useSpaceBySlug(spaceSlug ?? '');
   const effectiveSpaceWeb3Id = space?.web3SpaceId ?? undefined;
+  const { persons: spaceMembersResult } = useSpaceMembersAndDelegates({
+    spaceSlug,
+    web3SpaceId: effectiveSpaceWeb3Id,
+    useMembers,
+  });
+  const spaceMembers = useMemo(
+    () => spaceMembersResult ?? [],
+    [spaceMembersResult],
+  );
   const { access: spaceActivityAccess, isLoading: isDiscoverabilityLoading } =
     useSpaceDiscoverability({
       spaceId: effectiveSpaceWeb3Id ? BigInt(effectiveSpaceWeb3Id) : undefined,
@@ -1683,83 +1685,14 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
   }, [roomId, mode, space?.chatRoomId]);
 
   const rawMentionCandidates = useMemo((): ChatMentionCandidate[] => {
-    if (!client || mentionCandidateRoomIds.length === 0) return [];
-
-    const byUserId = new Map<
-      string,
-      { displayLabel: string; avatarUrl?: string; privySub?: string }
-    >();
-
-    for (const candidateRoomId of mentionCandidateRoomIds) {
-      const room = client.getRoom(candidateRoomId);
-      if (!room) continue;
-      for (const member of room.getJoinedMembers()) {
-        const userId = member.userId;
-        if (!userId) continue;
-        if (currentUserId && userId === currentUserId) continue;
-        byUserId.set(userId, {
-          displayLabel: matrixMemberDisplayLabel(member, userId),
-          avatarUrl: matrixMemberAvatarSquare(
-            client,
-            candidateRoomId,
-            userId,
-            64,
-          ),
-        });
-      }
-    }
-
-    /** Same names as Members tab — overrides Matrix-only technical displaynames. */
-    for (const p of spaceMembers) {
-      let mxid = personIdToMatrixUserId[p.id]?.trim();
-      const sub = p.sub?.trim();
-      if (!mxid && sub) {
-        mxid = subToMatrixUserId[sub]?.trim();
-      }
-      if (!mxid && sub) {
-        for (const userId of byUserId.keys()) {
-          if (matrixUserIdToCanonicalPrivySub(userId) === sub) {
-            mxid = userId;
-            break;
-          }
-        }
-      }
-      if (!mxid) continue;
-      if (currentUserId && mxid === currentUserId) continue;
-      const prev = byUserId.get(mxid);
-      byUserId.set(mxid, {
-        displayLabel: personRosterLabel(p, t('unknownMember')),
-        avatarUrl: p.avatarUrl ?? prev?.avatarUrl,
-        ...(sub ? { privySub: sub } : {}),
-      });
-    }
-
-    const list: ChatMentionCandidate[] = [];
-    for (const [userId, v] of byUserId) {
-      list.push({
-        userId,
-        displayLabel: v.displayLabel,
-        avatarUrl: v.avatarUrl,
-        ...(v.privySub ? { privySub: v.privySub } : {}),
-      });
-    }
-
-    list.sort((a, b) =>
-      a.displayLabel.localeCompare(b.displayLabel, undefined, {
-        sensitivity: 'base',
-      }),
-    );
-    return list;
-  }, [
-    client,
-    mentionCandidateRoomIds,
-    currentUserId,
-    spaceMembers,
-    subToMatrixUserId,
-    personIdToMatrixUserId,
-    t,
-    mentionMembershipEpoch,
-  ]);
+    const candidates = buildSpaceRosterMentionCandidates({
+      spaceMembers,
+      personIdToMatrixUserId,
+      unknownLabel: t('unknownMember'),
+    });
+    if (!currentUserId) return candidates;
+    return candidates.filter((candidate) => candidate.userId !== currentUserId);
+  }, [spaceMembers, personIdToMatrixUserId, currentUserId, t]);
 
   useEffect(() => {
     if (!client || rawMentionCandidates.length === 0) return;

--- a/packages/epics/src/common/human-right-panel.tsx
+++ b/packages/epics/src/common/human-right-panel.tsx
@@ -1003,12 +1003,15 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
   const { person: me } = useMe();
   const { space, isLoading: isSpaceLoading } = useSpaceBySlug(spaceSlug ?? '');
   const effectiveSpaceWeb3Id = space?.web3SpaceId ?? undefined;
-  const { persons: spaceMembersResult, isLoading: isLoadingSpaceMembers } =
-    useSpaceMembersAndDelegates({
-      spaceSlug,
-      web3SpaceId: effectiveSpaceWeb3Id,
-      useMembers,
-    });
+  const {
+    persons: spaceMembersResult,
+    isLoading: isLoadingSpaceMembers,
+    error: spaceMembersError,
+  } = useSpaceMembersAndDelegates({
+    spaceSlug,
+    web3SpaceId: effectiveSpaceWeb3Id,
+    useMembers,
+  });
   const spaceMembers = useMemo(
     () => spaceMembersResult ?? [],
     [spaceMembersResult],
@@ -4542,7 +4545,7 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
                           <p className="text-sm text-muted-foreground">
                             {t('loading')}
                           </p>
-                        ) : matrixUserIdsError &&
+                        ) : (matrixUserIdsError || spaceMembersError) &&
                           signalTeamRosterMembers.length === 0 ? (
                           <p role="alert" className="text-sm text-destructive">
                             {t('signalTeamMembersLoadFailed')}

--- a/packages/epics/src/common/human-right-panel.tsx
+++ b/packages/epics/src/common/human-right-panel.tsx
@@ -1439,6 +1439,29 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
   >(null);
   const signalDeepLinkEpochRef = useRef(0);
 
+  /** Leave signal/coherence chat without the deep-link effect re-opening from `?signal=`. */
+  const exitCoherenceChat = useCallback(() => {
+    signalDeepLinkEpochRef.current += 1;
+    setSignalDeepLinkNotice(null);
+
+    const hasSignalDeepLink =
+      Boolean(searchParams?.get('signal')?.trim()) ||
+      Boolean(searchParams?.get('msg')?.trim());
+    if (hasSignalDeepLink) {
+      const next = new URLSearchParams(searchParams?.toString() ?? '');
+      next.delete('signal');
+      next.delete('msg');
+      const qs = next.toString();
+      const cleaned = qs ? `${pathname}?${qs}` : pathname;
+      if (typeof window !== 'undefined') {
+        window.history.replaceState(window.history.state, '', cleaned);
+      }
+      router.replace(cleaned, { scroll: false });
+    }
+
+    closeCoherenceChat();
+  }, [closeCoherenceChat, pathname, router, searchParams]);
+
   const pendingCallStartNotifyRef = useRef(false);
   const callStartedNotifyRoomRef = useRef<string | null>(null);
 
@@ -2444,10 +2467,10 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
   const hasLoadedCoherenceMessagesRef = useRef(false);
   useEffect(() => {
     if (prevSidebarOpenRef.current && !sidebarOpen && mode === 'coherence') {
-      closeCoherenceChat();
+      exitCoherenceChat();
     }
     prevSidebarOpenRef.current = sidebarOpen;
-  }, [sidebarOpen, mode, closeCoherenceChat]);
+  }, [sidebarOpen, mode, exitCoherenceChat]);
 
   // Reset human chat when navigating to a different space (picker, recently visited, etc.)
   useEffect(() => {
@@ -2457,31 +2480,9 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
     lastHumanChatSpaceSlugRef.current = nextSlug;
     if (!prevSlug) return;
 
-    closeCoherenceChat();
-    setSignalDeepLinkNotice(null);
-    signalDeepLinkEpochRef.current += 1;
-
-    if (searchParams?.get('signal')?.trim()) {
-      const cleaned = setSignalSearchParam(
-        pathname,
-        searchParams?.toString() ?? '',
-        null,
-      );
-      if (typeof window !== 'undefined') {
-        window.history.replaceState(window.history.state, '', cleaned);
-      }
-      router.replace(cleaned, { scroll: false });
-    }
-
+    exitCoherenceChat();
     resetChatStateOnAuthDrop();
-  }, [
-    spaceSlug,
-    closeCoherenceChat,
-    pathname,
-    router,
-    searchParams,
-    resetChatStateOnAuthDrop,
-  ]);
+  }, [spaceSlug, exitCoherenceChat, resetChatStateOnAuthDrop]);
 
   useEffect(() => {
     hasLoadedCoherenceMessagesRef.current = false;
@@ -3088,7 +3089,7 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
         pathSlug === spaceSlug
       ) {
         if (mode === 'coherence') {
-          closeCoherenceChat();
+          exitCoherenceChat();
         }
         openHumanChatPanel();
         setActiveTab('chat');
@@ -3199,7 +3200,7 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
       router,
       openCoherenceChat,
       openHumanChatPanel,
-      closeCoherenceChat,
+      exitCoherenceChat,
       mode,
       space?.chatRoomId,
       spaceSlug,
@@ -4129,7 +4130,7 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
       <SidebarHeader className="bg-background-2 gap-0 p-0">
         <HumanChatPanelHeader
           title={mode === 'coherence' ? coherenceTitle ?? undefined : ''}
-          onBack={mode === 'coherence' ? closeCoherenceChat : undefined}
+          onBack={mode === 'coherence' ? exitCoherenceChat : undefined}
           notificationSettingsHref={notificationCentreHref}
           trailingStart={
             showAuthedUi && roomId ? (

--- a/packages/epics/src/spaces/hooks/index.ts
+++ b/packages/epics/src/spaces/hooks/index.ts
@@ -10,6 +10,7 @@ export * from './use-space-member';
 export * from './use-action-gating';
 export * from './use-space-discoverability';
 export * from './use-user-space-state.web3.rpc';
+export * from './use-space-members-and-delegates';
 export * from './use-can-mutate-in-space.web3.rpc';
 export * from './use-spaces-discoverability-batch';
 export {

--- a/packages/epics/src/spaces/hooks/use-space-members-and-delegates.ts
+++ b/packages/epics/src/spaces/hooks/use-space-members-and-delegates.ts
@@ -1,0 +1,189 @@
+'use client';
+
+import {
+  getDelegators,
+  Person,
+  publicClient,
+  useDelegatesForSpaces,
+  useSpaceDetailsWeb3Rpc,
+} from '@hypha-platform/core/client';
+import { useMemo } from 'react';
+import useSWR from 'swr';
+
+import type { UseMembers } from './types';
+
+function normalizeAddress(address: string | undefined | null): string | null {
+  const trimmed = address?.trim();
+  return trimmed ? trimmed.toLowerCase() : null;
+}
+
+async function fetchPersonByWeb3Address(
+  address: string,
+): Promise<Person | null> {
+  const res = await fetch(
+    `/api/v1/people/by-web3-address/${encodeURIComponent(address)}`,
+  );
+  if (!res.ok) return null;
+  const person = (await res.json()) as Person;
+  return person?.id ? person : null;
+}
+
+/**
+ * On-chain space members plus valid delegates (delegator is an on-chain member).
+ * Same population allowed to interact in space chat — excludes Matrix room joiners
+ * who are not members or delegates.
+ */
+export function useSpaceMembersAndDelegates({
+  spaceSlug,
+  web3SpaceId,
+  useMembers,
+  refreshInterval,
+}: {
+  spaceSlug?: string;
+  web3SpaceId?: number | null;
+  useMembers: UseMembers;
+  refreshInterval?: number;
+}) {
+  const { persons, isLoading: isLoadingMembers } = useMembers({
+    spaceSlug,
+    paginationDisabled: true,
+    refreshInterval,
+  });
+
+  const memberPersons = persons?.data ?? [];
+
+  const effectiveWeb3SpaceId =
+    typeof web3SpaceId === 'number' &&
+    Number.isFinite(web3SpaceId) &&
+    web3SpaceId > 0
+      ? web3SpaceId
+      : undefined;
+
+  const { data: delegateAddresses, isLoading: isLoadingDelegateAddresses } =
+    useDelegatesForSpaces({
+      spaceId: effectiveWeb3SpaceId ? BigInt(effectiveWeb3SpaceId) : undefined,
+    });
+
+  const { spaceDetails, isLoading: isLoadingSpaceDetails } =
+    useSpaceDetailsWeb3Rpc({
+      spaceId: effectiveWeb3SpaceId,
+    });
+
+  const onChainMemberAddressSet = useMemo(() => {
+    const set = new Set<string>();
+    for (const member of spaceDetails?.members ?? []) {
+      const normalized = normalizeAddress(member);
+      if (normalized) set.add(normalized);
+    }
+    return set;
+  }, [spaceDetails?.members]);
+
+  const memberPersonIds = useMemo(
+    () => new Set(memberPersons.map((person) => person.id)),
+    [memberPersons],
+  );
+
+  const memberAddressSet = useMemo(() => {
+    const set = new Set<string>();
+    for (const person of memberPersons) {
+      const normalized = normalizeAddress(person.address);
+      if (normalized) set.add(normalized);
+    }
+    return set;
+  }, [memberPersons]);
+
+  const extraDelegateAddresses = useMemo(() => {
+    if (!delegateAddresses?.length) return [];
+    const out: string[] = [];
+    for (const delegate of delegateAddresses) {
+      const normalized = normalizeAddress(delegate);
+      if (!normalized || memberAddressSet.has(normalized)) continue;
+      out.push(normalized);
+    }
+    return out;
+  }, [delegateAddresses, memberAddressSet]);
+
+  const delegatePersonsKey =
+    effectiveWeb3SpaceId && extraDelegateAddresses.length > 0
+      ? [
+          'spaceDelegatePersons',
+          effectiveWeb3SpaceId,
+          extraDelegateAddresses.join('\u0000'),
+        ]
+      : null;
+
+  const { data: delegatePersons, isLoading: isLoadingDelegatePersons } = useSWR(
+    delegatePersonsKey,
+    async () => {
+      if (!effectiveWeb3SpaceId) return [];
+      const spaceId = BigInt(effectiveWeb3SpaceId);
+      const resolved: Person[] = [];
+
+      await Promise.all(
+        extraDelegateAddresses.map(async (address) => {
+          try {
+            const delegators = await publicClient.readContract(
+              getDelegators({
+                user: address as `0x${string}`,
+                spaceId,
+              }),
+            );
+            const isValidDelegate = delegators.some((delegator) => {
+              const normalized = normalizeAddress(delegator);
+              return normalized
+                ? onChainMemberAddressSet.has(normalized)
+                : false;
+            });
+            if (!isValidDelegate) return;
+
+            const person = await fetchPersonByWeb3Address(address);
+            if (person && !memberPersonIds.has(person.id)) {
+              resolved.push(person);
+            }
+          } catch (error) {
+            console.warn(
+              '[useSpaceMembersAndDelegates] delegate lookup failed',
+              address,
+              error,
+            );
+          }
+        }),
+      );
+
+      return resolved;
+    },
+    { revalidateOnFocus: true },
+  );
+
+  const personsList = useMemo(() => {
+    const byId = new Map<number, Person>();
+    for (const person of memberPersons) {
+      byId.set(person.id, person);
+    }
+    for (const person of delegatePersons ?? []) {
+      if (!byId.has(person.id)) {
+        byId.set(person.id, person);
+      }
+    }
+    return [...byId.values()].sort((a, b) => {
+      const labelA =
+        [a.name, a.surname].filter(Boolean).join(' ').trim() ||
+        a.nickname?.trim() ||
+        '';
+      const labelB =
+        [b.name, b.surname].filter(Boolean).join(' ').trim() ||
+        b.nickname?.trim() ||
+        '';
+      return labelA.localeCompare(labelB, undefined, { sensitivity: 'base' });
+    });
+  }, [memberPersons, delegatePersons]);
+
+  return {
+    persons: personsList,
+    isLoading:
+      isLoadingMembers ||
+      isLoadingDelegateAddresses ||
+      isLoadingSpaceDetails ||
+      isLoadingDelegatePersons,
+  };
+}

--- a/packages/epics/src/spaces/hooks/use-space-members-and-delegates.ts
+++ b/packages/epics/src/spaces/hooks/use-space-members-and-delegates.ts
@@ -10,6 +10,7 @@ import {
 import { useMemo } from 'react';
 import useSWR from 'swr';
 
+import { personRosterDisplayLabel } from '../../common/human-chat-panel/build-space-roster-mention-candidates';
 import type { UseMembers } from './types';
 
 function normalizeAddress(address: string | undefined | null): string | null {
@@ -59,15 +60,21 @@ export function useSpaceMembersAndDelegates({
       ? web3SpaceId
       : undefined;
 
-  const { data: delegateAddresses, isLoading: isLoadingDelegateAddresses } =
-    useDelegatesForSpaces({
-      spaceId: effectiveWeb3SpaceId ? BigInt(effectiveWeb3SpaceId) : undefined,
-    });
+  const {
+    data: delegateAddresses,
+    isLoading: isLoadingDelegateAddresses,
+    error: delegateAddressesError,
+  } = useDelegatesForSpaces({
+    spaceId: effectiveWeb3SpaceId ? BigInt(effectiveWeb3SpaceId) : undefined,
+  });
 
-  const { spaceDetails, isLoading: isLoadingSpaceDetails } =
-    useSpaceDetailsWeb3Rpc({
-      spaceId: effectiveWeb3SpaceId,
-    });
+  const {
+    spaceDetails,
+    isLoading: isLoadingSpaceDetails,
+    error: spaceDetailsError,
+  } = useSpaceDetailsWeb3Rpc({
+    spaceId: effectiveWeb3SpaceId,
+  });
 
   const onChainMemberAddressSet = useMemo(() => {
     const set = new Set<string>();
@@ -78,9 +85,19 @@ export function useSpaceMembersAndDelegates({
     return set;
   }, [spaceDetails?.members]);
 
+  const onChainMembersCacheKey = useMemo(
+    () => [...onChainMemberAddressSet].sort().join('\u0000'),
+    [onChainMemberAddressSet],
+  );
+
   const memberPersonIds = useMemo(
     () => new Set(memberPersons.map((person) => person.id)),
     [memberPersons],
+  );
+
+  const memberPersonIdsCacheKey = useMemo(
+    () => [...memberPersonIds].sort((a, b) => a - b).join(','),
+    [memberPersonIds],
   );
 
   const memberAddressSet = useMemo(() => {
@@ -109,10 +126,16 @@ export function useSpaceMembersAndDelegates({
           'spaceDelegatePersons',
           effectiveWeb3SpaceId,
           extraDelegateAddresses.join('\u0000'),
+          onChainMembersCacheKey,
+          memberPersonIdsCacheKey,
         ]
       : null;
 
-  const { data: delegatePersons, isLoading: isLoadingDelegatePersons } = useSWR(
+  const {
+    data: delegatePersons,
+    isLoading: isLoadingDelegatePersons,
+    error: delegatePersonsError,
+  } = useSWR(
     delegatePersonsKey,
     async () => {
       if (!effectiveWeb3SpaceId) return [];
@@ -165,18 +188,17 @@ export function useSpaceMembersAndDelegates({
         byId.set(person.id, person);
       }
     }
-    return [...byId.values()].sort((a, b) => {
-      const labelA =
-        [a.name, a.surname].filter(Boolean).join(' ').trim() ||
-        a.nickname?.trim() ||
-        '';
-      const labelB =
-        [b.name, b.surname].filter(Boolean).join(' ').trim() ||
-        b.nickname?.trim() ||
-        '';
-      return labelA.localeCompare(labelB, undefined, { sensitivity: 'base' });
-    });
+    return [...byId.values()].sort((a, b) =>
+      personRosterDisplayLabel(a, '').localeCompare(
+        personRosterDisplayLabel(b, ''),
+        undefined,
+        { sensitivity: 'base' },
+      ),
+    );
   }, [memberPersons, delegatePersons]);
+
+  const error =
+    delegateAddressesError ?? spaceDetailsError ?? delegatePersonsError;
 
   return {
     persons: personsList,
@@ -185,5 +207,6 @@ export function useSpaceMembersAndDelegates({
       isLoadingDelegateAddresses ||
       isLoadingSpaceDetails ||
       isLoadingDelegatePersons,
+    error,
   };
 }

--- a/packages/i18n/src/messages/de.json
+++ b/packages/i18n/src/messages/de.json
@@ -3134,6 +3134,9 @@
     "signalTeamMemberListHint": "Wähle Mitglieder aus, die Nachrichten senden, erwähnen und an Thread-Anrufen teilnehmen können.",
     "signalTeamAddMember": "Hinzufügen",
     "signalTeamRemoveMember": "Entfernen",
+    "signalTeamOwner": "Inhaber",
+    "signalTeamMembersLoadFailed": "Mitgliederliste konnte nicht geladen werden. Bitte erneut versuchen.",
+    "signalTeamNoChatAccount": "Kein Chat-Konto",
     "signalTeamPendingRequests": "Ausstehende Anfragen",
     "signalTeamApproveRequester": "Zum Team hinzufügen",
     "signalTeamUpdated": "Signal-Team aktualisiert",
@@ -3545,7 +3548,9 @@
     "resizeBottomLeftLabel": "Anruffenster über die untere linke Ecke skalieren",
     "resizeBottomRightLabel": "Anruffenster über die untere rechte Ecke skalieren",
     "openFloatingWindowLabel": "Schwebendes Anruffenster öffnen",
-    "closeFloatingWindowLabel": "Schwebendes Anruffenster schließen"
+    "closeFloatingWindowLabel": "Schwebendes Anruffenster schließen",
+    "signalTeamMembersLoadFailed": "Mitgliederliste konnte nicht geladen werden. Bitte erneut versuchen.",
+    "signalTeamNoChatAccount": "Kein Chat-Konto"
   },
   "SpaceLocation": {
     "sectionTitle": "Standort auf der Karte",

--- a/packages/i18n/src/messages/en.json
+++ b/packages/i18n/src/messages/en.json
@@ -3173,6 +3173,9 @@
     "signalTeamMemberListHint": "Select members who can message, mention, and join thread calls.",
     "signalTeamAddMember": "Add",
     "signalTeamRemoveMember": "Remove",
+    "signalTeamOwner": "Owner",
+    "signalTeamMembersLoadFailed": "Could not load member list. Try again.",
+    "signalTeamNoChatAccount": "No chat account",
     "signalTeamPendingRequests": "Pending requests",
     "signalTeamApproveRequester": "Add to team",
     "signalTeamUpdated": "Signal team updated",
@@ -3588,7 +3591,9 @@
     "resizeBottomLabel": "Resize call window from bottom edge",
     "resizeLeftLabel": "Resize call window from left edge",
     "openFloatingWindowLabel": "Open floating call window",
-    "closeFloatingWindowLabel": "Close floating call window"
+    "closeFloatingWindowLabel": "Close floating call window",
+    "signalTeamMembersLoadFailed": "Could not load member list. Try again.",
+    "signalTeamNoChatAccount": "No chat account"
   },
   "SpaceLocation": {
     "sectionTitle": "Location on map",

--- a/packages/i18n/src/messages/es.json
+++ b/packages/i18n/src/messages/es.json
@@ -2610,6 +2610,9 @@
     "signalTeamMemberListHint": "Selecciona los miembros que pueden enviar mensajes, mencionar y unirse a llamadas del hilo.",
     "signalTeamAddMember": "Añadir",
     "signalTeamRemoveMember": "Quitar",
+    "signalTeamOwner": "Propietario",
+    "signalTeamMembersLoadFailed": "No se pudo cargar la lista de miembros. Inténtalo de nuevo.",
+    "signalTeamNoChatAccount": "Sin cuenta de chat",
     "signalTeamPendingRequests": "Solicitudes pendientes",
     "signalTeamApproveRequester": "Añadir al equipo",
     "signalTeamUpdated": "Equipo Signal actualizado",
@@ -3021,7 +3024,9 @@
     "resizeBottomLeftLabel": "Redimensionar la llamada desde la esquina inferior izquierda",
     "resizeBottomRightLabel": "Redimensionar la llamada desde la esquina inferior derecha",
     "openFloatingWindowLabel": "Abrir ventana flotante de llamada",
-    "closeFloatingWindowLabel": "Cerrar ventana flotante de llamada"
+    "closeFloatingWindowLabel": "Cerrar ventana flotante de llamada",
+    "signalTeamMembersLoadFailed": "No se pudo cargar la lista de miembros. Inténtalo de nuevo.",
+    "signalTeamNoChatAccount": "Sin cuenta de chat"
   },
   "SpaceLocation": {
     "sectionTitle": "Ubicación en el mapa",

--- a/packages/i18n/src/messages/fr.json
+++ b/packages/i18n/src/messages/fr.json
@@ -2608,6 +2608,9 @@
     "signalTeamMemberListHint": "Sélectionnez les membres qui peuvent envoyer des messages, mentionner et rejoindre les appels du fil.",
     "signalTeamAddMember": "Ajouter",
     "signalTeamRemoveMember": "Retirer",
+    "signalTeamOwner": "Propriétaire",
+    "signalTeamMembersLoadFailed": "Impossible de charger la liste des membres. Réessayez.",
+    "signalTeamNoChatAccount": "Pas de compte chat",
     "signalTeamPendingRequests": "Demandes en attente",
     "signalTeamApproveRequester": "Ajouter à l’équipe",
     "signalTeamUpdated": "Équipe Signal mise à jour",
@@ -3017,7 +3020,9 @@
     "resizeBottomLeftLabel": "Redimensionner l'appel depuis le coin inférieur gauche",
     "resizeBottomRightLabel": "Redimensionner l'appel depuis le coin inférieur droit",
     "openFloatingWindowLabel": "Ouvrir la fenêtre d'appel flottante",
-    "closeFloatingWindowLabel": "Fermer la fenêtre d'appel flottante"
+    "closeFloatingWindowLabel": "Fermer la fenêtre d'appel flottante",
+    "signalTeamMembersLoadFailed": "Impossible de charger la liste des membres. Réessayez.",
+    "signalTeamNoChatAccount": "Pas de compte chat"
   },
   "SpaceLocation": {
     "sectionTitle": "Emplacement sur la carte",

--- a/packages/i18n/src/messages/pt.json
+++ b/packages/i18n/src/messages/pt.json
@@ -2610,6 +2610,9 @@
     "signalTeamMemberListHint": "Selecione os membros que podem enviar mensagens, mencionar e participar de chamadas da thread.",
     "signalTeamAddMember": "Adicionar",
     "signalTeamRemoveMember": "Remover",
+    "signalTeamOwner": "Proprietário",
+    "signalTeamMembersLoadFailed": "Não foi possível carregar a lista de membros. Tente novamente.",
+    "signalTeamNoChatAccount": "Sem conta de chat",
     "signalTeamPendingRequests": "Solicitações pendentes",
     "signalTeamApproveRequester": "Adicionar à equipe",
     "signalTeamUpdated": "Equipe Signal atualizada",
@@ -3019,7 +3022,9 @@
     "resizeBottomLeftLabel": "Redimensionar chamada pelo canto inferior esquerdo",
     "resizeBottomRightLabel": "Redimensionar chamada pelo canto inferior direito",
     "openFloatingWindowLabel": "Abrir janela flutuante da chamada",
-    "closeFloatingWindowLabel": "Fechar janela flutuante da chamada"
+    "closeFloatingWindowLabel": "Fechar janela flutuante da chamada",
+    "signalTeamMembersLoadFailed": "Não foi possível carregar a lista de membros. Tente novamente.",
+    "signalTeamNoChatAccount": "Sem conta de chat"
   },
   "SpaceLocation": {
     "sectionTitle": "Localização no mapa",


### PR DESCRIPTION
## Summary
- Add server-side batch lookup to map space roster person ids to Matrix user ids without exposing Privy subs on the public members API
- Build Signal Team picker and mention candidates from the full space roster instead of Matrix joined-room members only
- Show an empty-state message when no roster members can be linked to Matrix accounts

## Test plan
- [ ] Open a signal thread chat and click **Manage** under Signal Team
- [ ] Confirm space members appear in the picker and can be added/removed
- [ ] Save changes and verify `@` mentions work for signal team members
- [ ] Confirm the Members tab still lists the same roster names


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Signal team member selection and chat mentions now resolve Matrix identities using space roster person IDs, improving matching accuracy.
  * Roster and delegate handling for Signal team pickers is now roster-backed for more consistent member lists.
* **Bug Fixes**
  * Owner detection/selection toggling is more reliable with normalized Matrix IDs and clearer handling when mappings are missing.
  * Added explicit loading/failure/empty states for the Signal team member editor.
  * Consolidated Signal deep-link exit behavior during navigation.
* **Documentation**
  * Added/updated Signal team UI strings (owner label and error states) across multiple languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->