### PR TITLE
feat(signals): voting-power-weighted upvotes on the signals board

### DIFF
--- a/apps/web/.env.template
+++ b/apps/web/.env.template
@@ -10,6 +10,9 @@ DAO_SPACE_FACTORY_ADDRESS=0xff6006c67803a380Db25230F1aEc605790C405a1
 # Mutual credit whitelist API (server-only; set real values in Vercel env vars)
 MUTUAL_CREDIT_WHITELIST_API_KEY=
 MUTUAL_CREDIT_WHITELIST_SIGNER_PRIVATE_KEY=
+# On-chain mirror of signal upvotes (optional; off when unset)
+SIGNALS_CONTRACT_ADDRESS=
+SIGNALS_RELAYER_PRIVATE_KEY=
 
 # Escrow proxy (EscrowImplementation) for Accept Investment — optional override (defaults to Base mainnet address in code, same batch as DAO proposals).
 # Set only if you deploy a different proxy: cd packages/storage-evm && npx hardhat run scripts/escrow-proxy.deploy.ts --network <network>

--- a/apps/web/src/app/[lang]/dho/[id]/@tab/coherence/page.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@tab/coherence/page.tsx
@@ -37,7 +37,7 @@ export default async function CoherencePage(props: PageProps) {
   const order: CoherenceOrder =
     orderRaw && COHERENCE_ORDERS.includes(orderRaw as CoherenceOrder)
       ? (orderRaw as CoherenceOrder)
-      : 'mostrecent';
+      : 'mostupvoted';
   const priorityRaw = searchParams?.priority;
   const priorityFilter =
     priorityRaw === 'critical' ||

--- a/apps/web/src/app/api/v1/spaces/[spaceSlug]/coherences/route.ts
+++ b/apps/web/src/app/api/v1/spaces/[spaceSlug]/coherences/route.ts
@@ -4,7 +4,10 @@ import type { PaginatedResponse } from '@hypha-platform/core/client';
 import {
   COHERENCE_TAGS,
   COHERENCE_TYPES,
+  findCoherenceUpvoteSummaries,
+  findSelf,
   findSpaceBySlug,
+  getDb,
   type Coherence,
   type CoherenceTag,
   type CoherenceType,
@@ -53,11 +56,38 @@ function paginateCoherences(
 
 function parseOrderBy(
   raw: string | null,
-): 'mostrecent' | 'mostmessages' | 'mostviews' | undefined {
-  if (raw === 'mostrecent' || raw === 'mostmessages' || raw === 'mostviews') {
+): 'mostrecent' | 'mostmessages' | 'mostviews' | 'mostupvoted' | undefined {
+  if (
+    raw === 'mostrecent' ||
+    raw === 'mostmessages' ||
+    raw === 'mostviews' ||
+    raw === 'mostupvoted'
+  ) {
     return raw;
   }
   return undefined;
+}
+
+/** Resolve the authenticated viewer's person id (if any) for `myUpvote`. */
+async function resolveViewerPersonId(
+  request: NextRequest,
+): Promise<number | null> {
+  const authToken = request.headers.get('Authorization')?.split(' ')[1];
+  if (!authToken) return null;
+  try {
+    const viewer = await findSelf({ db: getDb({ authToken }) });
+    return viewer?.id ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function toBigIntOrZero(value: string | undefined): bigint {
+  try {
+    return BigInt(value ?? '0');
+  } catch {
+    return 0n;
+  }
 }
 
 function parseType(raw: string | null): CoherenceType | undefined {
@@ -119,6 +149,8 @@ export async function GET(
       includeArchivedRaw === 'true' ||
       includeArchivedRaw === 'yes';
 
+    const orderBy = parseOrderBy(url.searchParams.get('orderBy'));
+
     const coherences = await getAllCoherences({
       spaceId: space.id,
       search: url.searchParams.get('search')?.trim() || undefined,
@@ -126,13 +158,39 @@ export async function GET(
       tags: parseTags(url),
       priority: parsePriority(url.searchParams.get('priority')),
       includeArchived,
-      orderBy: parseOrderBy(url.searchParams.get('orderBy')),
+      orderBy,
     });
+
+    const viewerPersonId = await resolveViewerPersonId(request);
+    const upvoteSummaries = await findCoherenceUpvoteSummaries(
+      {
+        coherenceIds: coherences.map((coherence) => coherence.id),
+        viewerPersonId,
+      },
+      { db },
+    );
+
+    let enriched: Coherence[] = coherences.map((coherence) => ({
+      ...coherence,
+      upvotes: upvoteSummaries[coherence.id],
+    }));
+
+    if (orderBy === 'mostupvoted') {
+      enriched = [...enriched].sort((a, b) => {
+        const diff =
+          toBigIntOrZero(b.upvotes?.totalVotingPower) -
+          toBigIntOrZero(a.upvotes?.totalVotingPower);
+        if (diff !== 0n) return diff > 0n ? 1 : -1;
+        return (
+          new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+        );
+      });
+    }
 
     const page = parsePositiveInt(url.searchParams.get('page'), 1);
     const pageSize = parsePositiveInt(url.searchParams.get('pageSize'), 100);
 
-    return NextResponse.json(paginateCoherences(coherences, page, pageSize));
+    return NextResponse.json(paginateCoherences(enriched, page, pageSize));
   } catch (error) {
     console.error('Failed to fetch coherences:', error);
     return NextResponse.json(

--- a/packages/core/src/coherence/client/hooks/index.ts
+++ b/packages/core/src/coherence/client/hooks/index.ts
@@ -1,4 +1,5 @@
 export * from './useCoherenceMutations.web2.rsc';
+export * from './useCoherenceUpvotes.web2.rsc';
 export * from './useFindCoherences';
 export * from './useSignalWorkflow.web2.rsc';
 export * from './useUpdateSignalWorkflow.web2.rsc';

--- a/packages/core/src/coherence/client/hooks/useCoherenceUpvotes.web2.rsc.ts
+++ b/packages/core/src/coherence/client/hooks/useCoherenceUpvotes.web2.rsc.ts
@@ -1,0 +1,45 @@
+'use client';
+
+import useSWRMutation from 'swr/mutation';
+import {
+  removeCoherenceUpvoteAction,
+  upvoteCoherenceAction,
+} from '../../server/actions';
+
+/**
+ * Upvote mutations for signals. Voting power is resolved server-side from the
+ * space's on-chain voting power source; `votingPowerPercent` (default 100)
+ * scales the caller's max power.
+ */
+export const useCoherenceUpvoteMutations = (authToken?: string | null) => {
+  const {
+    trigger: upvote,
+    isMutating: isUpvoting,
+    error: upvoteError,
+  } = useSWRMutation(
+    authToken ? [authToken, 'upvoteCoherence'] : null,
+    async (
+      [authToken],
+      { arg }: { arg: { slug: string; votingPowerPercent?: number } },
+    ) => upvoteCoherenceAction(arg, { authToken }),
+  );
+
+  const {
+    trigger: removeUpvote,
+    isMutating: isRemovingUpvote,
+    error: removeUpvoteError,
+  } = useSWRMutation(
+    authToken ? [authToken, 'removeCoherenceUpvote'] : null,
+    async ([authToken], { arg }: { arg: { slug: string } }) =>
+      removeCoherenceUpvoteAction(arg, { authToken }),
+  );
+
+  return {
+    upvote,
+    isUpvoting,
+    upvoteError,
+    removeUpvote,
+    isRemovingUpvote,
+    removeUpvoteError,
+  };
+};

--- a/packages/core/src/coherence/client/hooks/useFindCoherences.ts
+++ b/packages/core/src/coherence/client/hooks/useFindCoherences.ts
@@ -16,7 +16,7 @@ export interface CoherenceQuery {
   tags?: CoherenceTag[];
   priority?: CoherencePriority;
   includeArchived?: boolean;
-  orderBy?: 'mostrecent' | 'mostmessages' | 'mostviews';
+  orderBy?: 'mostrecent' | 'mostmessages' | 'mostviews' | 'mostupvoted';
 }
 
 const COHERENCES_REFRESH_MS = 60_000;

--- a/packages/core/src/coherence/server/actions.ts
+++ b/packages/core/src/coherence/server/actions.ts
@@ -247,9 +247,12 @@ export async function upvoteCoherenceAction(
     requesterPersonId: self.id,
   });
 
+  // Default to 100 only for missing/non-numeric input; an explicit 0 falls
+  // through to the Math.max(1, ...) clamp below.
+  const rawPercent = Number(votingPowerPercent);
   const percent = Math.min(
     100,
-    Math.max(1, Math.trunc(Number(votingPowerPercent) || 100)),
+    Math.max(1, Number.isFinite(rawPercent) ? Math.trunc(rawPercent) : 100),
   );
 
   const { votingPower: maxVotingPower, tokenDecimals } =
@@ -307,12 +310,14 @@ export async function removeCoherenceUpvoteAction(
     slug,
     authToken,
   });
-  await removeCoherenceUpvote(
+  const removed = await removeCoherenceUpvote(
     { coherenceId: coherence.id, personId: self.id },
     { db },
   );
 
-  if (coherence.web3SpaceId != null && self.address) {
+  // Only mirror on-chain when a row was actually deleted; a no-op removal
+  // (e.g. double click) should not emit a removal event.
+  if (removed && coherence.web3SpaceId != null && self.address) {
     const web3SpaceId = coherence.web3SpaceId;
     const voter = self.address as `0x${string}`;
     after(() =>

--- a/packages/core/src/coherence/server/actions.ts
+++ b/packages/core/src/coherence/server/actions.ts
@@ -310,6 +310,13 @@ export async function removeCoherenceUpvoteAction(
     slug,
     authToken,
   });
+  // Same membership rules as the upvote path — otherwise any authenticated
+  // user could read arbitrary signals' upvote summaries via this action.
+  await assertCoherenceSpacePanelAuth({
+    slug,
+    authToken: authToken as string,
+    requesterPersonId: self.id,
+  });
   const removed = await removeCoherenceUpvote(
     { coherenceId: coherence.id, personId: self.id },
     { db },

--- a/packages/core/src/coherence/server/actions.ts
+++ b/packages/core/src/coherence/server/actions.ts
@@ -39,6 +39,8 @@ import {
   upsertCoherenceUpvote,
 } from './coherence-upvotes';
 import { getMemberVotingPower } from './web3/get-member-voting-power';
+import { recordSignalUpvoteOnChain } from './web3/record-signal-upvote-onchain';
+import { after } from 'next/server';
 import type { CoherenceUpvoteSummary } from '../types';
 
 async function assertSignalWorkflowAccess({
@@ -275,6 +277,21 @@ export async function upvoteCoherenceAction(
     { db },
   );
 
+  // Mirror the upvote to the Signals contract after the response is sent;
+  // best-effort and invisible to the user.
+  const web3SpaceId = coherence.web3SpaceId;
+  const voter = self.address as `0x${string}`;
+  const amount = votingPower;
+  after(() =>
+    recordSignalUpvoteOnChain({
+      web3SpaceId,
+      signalId: coherence.id,
+      voter,
+      amount,
+      kind: 'upvote',
+    }),
+  );
+
   return getCoherenceUpvoteSummary({
     coherenceId: coherence.id,
     viewerPersonId: self.id,
@@ -294,6 +311,20 @@ export async function removeCoherenceUpvoteAction(
     { coherenceId: coherence.id, personId: self.id },
     { db },
   );
+
+  if (coherence.web3SpaceId != null && self.address) {
+    const web3SpaceId = coherence.web3SpaceId;
+    const voter = self.address as `0x${string}`;
+    after(() =>
+      recordSignalUpvoteOnChain({
+        web3SpaceId,
+        signalId: coherence.id,
+        voter,
+        kind: 'removal',
+      }),
+    );
+  }
+
   return getCoherenceUpvoteSummary({
     coherenceId: coherence.id,
     viewerPersonId: self.id,

--- a/packages/core/src/coherence/server/actions.ts
+++ b/packages/core/src/coherence/server/actions.ts
@@ -31,6 +31,15 @@ import {
 import type { SignalWorkflowConfig } from '../signal-workflow';
 import { assertCoherenceSpacePanelAuth } from './assert-coherence-space-panel-auth';
 import { normalizeCoherence } from './web3/normalize-coherence';
+import {
+  EMPTY_COHERENCE_UPVOTE_SUMMARY,
+  findCoherenceForUpvote,
+  findCoherenceUpvoteSummaries,
+  removeCoherenceUpvote,
+  upsertCoherenceUpvote,
+} from './coherence-upvotes';
+import { getMemberVotingPower } from './web3/get-member-voting-power';
+import type { CoherenceUpvoteSummary } from '../types';
 
 async function assertSignalWorkflowAccess({
   spaceId,
@@ -165,6 +174,127 @@ export async function patchCoherenceTaskBySlugAction(
     { ...validated, requesterPersonId: self.id },
     { db },
   );
+}
+
+async function resolveCoherenceUpvoteContext({
+  slug,
+  authToken,
+}: {
+  slug: string;
+  authToken?: string;
+}) {
+  if (!authToken) {
+    throw new Error('authToken is required to vote on a signal');
+  }
+  const authDb = getDb({ authToken });
+  const self = await findSelf({ db: authDb });
+  if (!self?.id) {
+    throw new Error('Could not resolve authenticated user for signal upvote');
+  }
+  const coherence = await findCoherenceForUpvote({ slug }, { db });
+  if (!coherence) {
+    throw new Error(`Signal not found for slug="${slug}"`);
+  }
+  return { self, coherence };
+}
+
+async function getCoherenceUpvoteSummary({
+  coherenceId,
+  viewerPersonId,
+}: {
+  coherenceId: number;
+  viewerPersonId: number;
+}): Promise<CoherenceUpvoteSummary> {
+  const summaries = await findCoherenceUpvoteSummaries(
+    { coherenceIds: [coherenceId], viewerPersonId },
+    { db },
+  );
+  return summaries[coherenceId] ?? EMPTY_COHERENCE_UPVOTE_SUMMARY;
+}
+
+/**
+ * Upvote a signal with a share of the caller's proposal voting power.
+ * Voting power is read from the space's on-chain voting power source and
+ * snapshotted; `votingPowerPercent` (1..100, default 100 = max) scales it.
+ */
+export async function upvoteCoherenceAction(
+  {
+    slug,
+    votingPowerPercent = 100,
+  }: { slug: string; votingPowerPercent?: number },
+  { authToken }: { authToken?: string },
+): Promise<CoherenceUpvoteSummary> {
+  const { self, coherence } = await resolveCoherenceUpvoteContext({
+    slug,
+    authToken,
+  });
+  if (coherence.archived) {
+    throw new Error('Cannot vote on an archived signal');
+  }
+  if (coherence.spaceId == null || coherence.web3SpaceId == null) {
+    throw new Error('Signal space is not linked to an on-chain space');
+  }
+  if (!self.address) {
+    throw new Error('A linked wallet is required to vote on signals');
+  }
+  await assertSignalWorkflowAccess({
+    spaceId: coherence.spaceId,
+    requesterPersonId: self.id,
+  });
+
+  const percent = Math.min(
+    100,
+    Math.max(1, Math.trunc(Number(votingPowerPercent) || 100)),
+  );
+
+  const { votingPower: maxVotingPower, tokenDecimals } =
+    await getMemberVotingPower({
+      memberAddress: self.address as `0x${string}`,
+      web3SpaceId: coherence.web3SpaceId,
+    });
+  if (maxVotingPower <= 0n) {
+    throw new Error('You have no voting power in this space');
+  }
+
+  let votingPower = (maxVotingPower * BigInt(percent)) / 100n;
+  if (votingPower <= 0n) {
+    votingPower = 1n;
+  }
+
+  await upsertCoherenceUpvote(
+    {
+      coherenceId: coherence.id,
+      personId: self.id,
+      votingPower: votingPower.toString(),
+      maxVotingPower: maxVotingPower.toString(),
+      tokenDecimals,
+    },
+    { db },
+  );
+
+  return getCoherenceUpvoteSummary({
+    coherenceId: coherence.id,
+    viewerPersonId: self.id,
+  });
+}
+
+/** Remove the caller's own upvote from a signal. */
+export async function removeCoherenceUpvoteAction(
+  { slug }: { slug: string },
+  { authToken }: { authToken?: string },
+): Promise<CoherenceUpvoteSummary> {
+  const { self, coherence } = await resolveCoherenceUpvoteContext({
+    slug,
+    authToken,
+  });
+  await removeCoherenceUpvote(
+    { coherenceId: coherence.id, personId: self.id },
+    { db },
+  );
+  return getCoherenceUpvoteSummary({
+    coherenceId: coherence.id,
+    viewerPersonId: self.id,
+  });
 }
 
 export async function getSignalWorkflowConfigAction(

--- a/packages/core/src/coherence/server/actions.ts
+++ b/packages/core/src/coherence/server/actions.ts
@@ -237,8 +237,11 @@ export async function upvoteCoherenceAction(
   if (!self.address) {
     throw new Error('A linked wallet is required to vote on signals');
   }
-  await assertSignalWorkflowAccess({
-    spaceId: coherence.spaceId,
+  // Same membership rules as other signal interactions: Postgres membership
+  // with an on-chain member/delegate fallback.
+  await assertCoherenceSpacePanelAuth({
+    slug,
+    authToken: authToken as string,
     requesterPersonId: self.id,
   });
 

--- a/packages/core/src/coherence/server/coherence-upvotes.ts
+++ b/packages/core/src/coherence/server/coherence-upvotes.ts
@@ -1,0 +1,162 @@
+import {
+  coherenceUpvotes,
+  coherences,
+  people,
+  spaces,
+} from '@hypha-platform/storage-postgres';
+import { and, eq, inArray } from 'drizzle-orm';
+import { DbConfig } from '../../server';
+import type { CoherenceUpvoteSummary, CoherenceUpvoter } from '../types';
+
+const MAX_VOTERS_PER_SUMMARY = 12;
+
+export const EMPTY_COHERENCE_UPVOTE_SUMMARY: CoherenceUpvoteSummary = {
+  totalVotingPower: '0',
+  upvoteCount: 0,
+  tokenDecimals: 0,
+  voters: [],
+  myUpvote: null,
+};
+
+/** Coherence row with the space link needed to resolve on-chain voting power. */
+export const findCoherenceForUpvote = async (
+  { slug }: { slug: string },
+  { db }: DbConfig,
+) => {
+  const [row] = await db
+    .select({
+      id: coherences.id,
+      spaceId: coherences.spaceId,
+      archived: coherences.archived,
+      web3SpaceId: spaces.web3SpaceId,
+    })
+    .from(coherences)
+    .innerJoin(spaces, eq(coherences.spaceId, spaces.id))
+    .where(eq(coherences.slug, slug))
+    .limit(1);
+  return row ?? null;
+};
+
+/**
+ * Aggregates upvotes for a set of coherences: total voting power, voter list
+ * (highest power first) and, when a viewer is given, their own upvote.
+ */
+export const findCoherenceUpvoteSummaries = async (
+  {
+    coherenceIds,
+    viewerPersonId,
+  }: { coherenceIds: number[]; viewerPersonId?: number | null },
+  { db }: DbConfig,
+): Promise<Record<number, CoherenceUpvoteSummary>> => {
+  if (coherenceIds.length === 0) return {};
+
+  const rows = await db
+    .select({
+      coherenceId: coherenceUpvotes.coherenceId,
+      personId: coherenceUpvotes.personId,
+      votingPower: coherenceUpvotes.votingPower,
+      maxVotingPower: coherenceUpvotes.maxVotingPower,
+      tokenDecimals: coherenceUpvotes.tokenDecimals,
+      name: people.name,
+      surname: people.surname,
+      avatarUrl: people.avatarUrl,
+    })
+    .from(coherenceUpvotes)
+    .innerJoin(people, eq(coherenceUpvotes.personId, people.id))
+    .where(inArray(coherenceUpvotes.coherenceId, coherenceIds));
+
+  const summaries: Record<number, CoherenceUpvoteSummary> = {};
+  const totals = new Map<number, bigint>();
+
+  for (const row of rows) {
+    const summary = (summaries[row.coherenceId] ??= {
+      ...EMPTY_COHERENCE_UPVOTE_SUMMARY,
+      voters: [],
+    });
+    let power: bigint;
+    try {
+      power = BigInt(row.votingPower);
+    } catch {
+      power = 0n;
+    }
+    totals.set(row.coherenceId, (totals.get(row.coherenceId) ?? 0n) + power);
+    summary.upvoteCount += 1;
+    summary.tokenDecimals = Math.max(summary.tokenDecimals, row.tokenDecimals);
+    const voter: CoherenceUpvoter = {
+      personId: row.personId,
+      name: [row.name, row.surname].filter(Boolean).join(' ').trim() || null,
+      avatarUrl: row.avatarUrl,
+      votingPower: power.toString(),
+    };
+    summary.voters.push(voter);
+    if (viewerPersonId != null && row.personId === viewerPersonId) {
+      summary.myUpvote = {
+        votingPower: row.votingPower,
+        maxVotingPower: row.maxVotingPower,
+      };
+    }
+  }
+
+  for (const [coherenceId, summary] of Object.entries(summaries)) {
+    summary.totalVotingPower = (
+      totals.get(Number(coherenceId)) ?? 0n
+    ).toString();
+    summary.voters.sort((a, b) => {
+      const diff = BigInt(b.votingPower) - BigInt(a.votingPower);
+      return diff > 0n ? 1 : diff < 0n ? -1 : 0;
+    });
+    summary.voters = summary.voters.slice(0, MAX_VOTERS_PER_SUMMARY);
+  }
+
+  return summaries;
+};
+
+export const upsertCoherenceUpvote = async (
+  {
+    coherenceId,
+    personId,
+    votingPower,
+    maxVotingPower,
+    tokenDecimals,
+  }: {
+    coherenceId: number;
+    personId: number;
+    votingPower: string;
+    maxVotingPower: string;
+    tokenDecimals: number;
+  },
+  { db }: DbConfig,
+) => {
+  await db
+    .insert(coherenceUpvotes)
+    .values({
+      coherenceId,
+      personId,
+      votingPower,
+      maxVotingPower,
+      tokenDecimals,
+    })
+    .onConflictDoUpdate({
+      target: [coherenceUpvotes.coherenceId, coherenceUpvotes.personId],
+      set: {
+        votingPower,
+        maxVotingPower,
+        tokenDecimals,
+        updatedAt: new Date(),
+      },
+    });
+};
+
+export const removeCoherenceUpvote = async (
+  { coherenceId, personId }: { coherenceId: number; personId: number },
+  { db }: DbConfig,
+) => {
+  await db
+    .delete(coherenceUpvotes)
+    .where(
+      and(
+        eq(coherenceUpvotes.coherenceId, coherenceId),
+        eq(coherenceUpvotes.personId, personId),
+      ),
+    );
+};

--- a/packages/core/src/coherence/server/coherence-upvotes.ts
+++ b/packages/core/src/coherence/server/coherence-upvotes.ts
@@ -147,16 +147,19 @@ export const upsertCoherenceUpvote = async (
     });
 };
 
+/** @returns true when an upvote row was actually deleted. */
 export const removeCoherenceUpvote = async (
   { coherenceId, personId }: { coherenceId: number; personId: number },
   { db }: DbConfig,
-) => {
-  await db
+): Promise<boolean> => {
+  const deleted = await db
     .delete(coherenceUpvotes)
     .where(
       and(
         eq(coherenceUpvotes.coherenceId, coherenceId),
         eq(coherenceUpvotes.personId, personId),
       ),
-    );
+    )
+    .returning();
+  return deleted.length > 0;
 };

--- a/packages/core/src/coherence/server/index.ts
+++ b/packages/core/src/coherence/server/index.ts
@@ -1,6 +1,7 @@
 export * from '../lib';
 export * from './ai-signal-actions';
 export * from './actions';
+export * from './coherence-upvotes';
 export * from './mutations';
 export * from './queries';
 export * from './signal-orchestrator';

--- a/packages/core/src/coherence/server/queries.ts
+++ b/packages/core/src/coherence/server/queries.ts
@@ -25,7 +25,7 @@ type FindAllCoherencesInput = {
   tags?: CoherenceTag[];
   priority?: CoherencePriority;
   includeArchived?: boolean;
-  orderBy?: 'mostrecent' | 'mostmessages' | 'mostviews';
+  orderBy?: 'mostrecent' | 'mostmessages' | 'mostviews' | 'mostupvoted';
   progressStatus?: string;
   board?: string;
   assigneeId?: number;
@@ -59,6 +59,8 @@ export const findAllCoherences = async (
         return desc(coherences.messages);
       case 'mostviews':
         return desc(coherences.views);
+      // 'mostupvoted' is resolved by the caller after aggregating upvote
+      // summaries; recency is only the SQL-level pre-sort.
       default:
         return desc(coherences.createdAt);
     }

--- a/packages/core/src/coherence/server/web3/get-all-coherences.ts
+++ b/packages/core/src/coherence/server/web3/get-all-coherences.ts
@@ -15,7 +15,7 @@ type GetAllCoherencesInput = {
   tags?: CoherenceTag[];
   priority?: CoherencePriority;
   includeArchived?: boolean;
-  orderBy?: 'mostrecent' | 'mostmessages' | 'mostviews';
+  orderBy?: 'mostrecent' | 'mostmessages' | 'mostviews' | 'mostupvoted';
   progressStatus?: string;
   board?: string;
   assigneeId?: number;

--- a/packages/core/src/coherence/server/web3/get-member-voting-power.ts
+++ b/packages/core/src/coherence/server/web3/get-member-voting-power.ts
@@ -1,0 +1,91 @@
+import 'server-only';
+
+import {
+  tokenVotingPowerImplementationAddress,
+  voteDecayTokenVotingPowerImplementationAddress,
+} from '@hypha-platform/core/generated';
+import { publicClient } from '../../../common/web3/public-client';
+import { getSpaceDetails } from '../../../space/shared/web3/get-space-details';
+
+/**
+ * SpaceVotingPower (1 member = 1 vote) — voting power source id 2.
+ * Not part of the wagmi-generated bindings; address from
+ * packages/storage-evm/contracts/addresses.txt.
+ */
+const SPACE_VOTING_POWER_ADDRESS =
+  '0x87537f0B5B8f34D689d484E743e83F82636E14a7' as const;
+
+/** Shared `getVotingPower` view exposed by every voting power source contract. */
+const votingPowerSourceAbi = [
+  {
+    type: 'function',
+    name: 'getVotingPower',
+    stateMutability: 'view',
+    inputs: [
+      { name: '_user', type: 'address' },
+      { name: '_sourceSpaceId', type: 'uint256' },
+    ],
+    outputs: [{ type: 'uint256' }],
+  },
+] as const;
+
+const VOTING_POWER_SOURCE_CONTRACTS: Record<
+  number,
+  { address: `0x${string}`; tokenDecimals: number }
+> = {
+  // 1 token = 1 vote (TokenVotingPower)
+  1: {
+    address: tokenVotingPowerImplementationAddress[8453],
+    tokenDecimals: 18,
+  },
+  // 1 member = 1 vote (SpaceVotingPower)
+  2: { address: SPACE_VOTING_POWER_ADDRESS, tokenDecimals: 0 },
+  // 1 voice = 1 vote (VoteDecayTokenVotingPower)
+  3: {
+    address: voteDecayTokenVotingPowerImplementationAddress[8453],
+    tokenDecimals: 18,
+  },
+};
+
+export type MemberVotingPower = {
+  votingPower: bigint;
+  votingPowerSource: number;
+  tokenDecimals: number;
+};
+
+/**
+ * Reads a member's current voting power from the same on-chain voting power
+ * source contract the space uses for proposal voting.
+ */
+export async function getMemberVotingPower({
+  memberAddress,
+  web3SpaceId,
+}: {
+  memberAddress: `0x${string}`;
+  web3SpaceId: number;
+}): Promise<MemberVotingPower> {
+  const spaceDetails = await publicClient.readContract(
+    getSpaceDetails({ spaceId: BigInt(web3SpaceId) }),
+  );
+  const votingPowerSource = Number(spaceDetails[2]);
+
+  const source = VOTING_POWER_SOURCE_CONTRACTS[votingPowerSource];
+  if (!source) {
+    throw new Error(
+      `Unsupported voting power source ${votingPowerSource} for space ${web3SpaceId}`,
+    );
+  }
+
+  const votingPower = await publicClient.readContract({
+    address: source.address,
+    abi: votingPowerSourceAbi,
+    functionName: 'getVotingPower',
+    args: [memberAddress, BigInt(web3SpaceId)],
+  });
+
+  return {
+    votingPower,
+    votingPowerSource,
+    tokenDecimals: source.tokenDecimals,
+  };
+}

--- a/packages/core/src/coherence/server/web3/get-member-voting-power.ts
+++ b/packages/core/src/coherence/server/web3/get-member-voting-power.ts
@@ -1,19 +1,26 @@
 import 'server-only';
 
-import {
-  tokenVotingPowerImplementationAddress,
-  voteDecayTokenVotingPowerImplementationAddress,
-} from '@hypha-platform/core/generated';
-import { publicClient } from '../../../common/web3/public-client';
+import { web3Client } from '../../../common/server/web3-rpc/client';
 import { getSpaceDetails } from '../../../space/shared/web3/get-space-details';
 
 /**
- * SpaceVotingPower (1 member = 1 vote) — voting power source id 2.
+ * VotingPowerDirectory — resolves a voting power source id to its contract,
+ * exactly like DAOProposalsImplementation does when tallying proposal votes.
  * Not part of the wagmi-generated bindings; address from
  * packages/storage-evm/contracts/addresses.txt.
  */
-const SPACE_VOTING_POWER_ADDRESS =
-  '0x87537f0B5B8f34D689d484E743e83F82636E14a7' as const;
+const VOTING_POWER_DIRECTORY_ADDRESS =
+  '0x9780a96B4382bdd0Aa6fC41B6b6A68A04c5C5727' as const;
+
+const votingPowerDirectoryAbi = [
+  {
+    type: 'function',
+    name: 'getVotingPowerSourceContract',
+    stateMutability: 'view',
+    inputs: [{ name: '_id', type: 'uint256' }],
+    outputs: [{ type: 'address' }],
+  },
+] as const;
 
 /** Shared `getVotingPower` view exposed by every voting power source contract. */
 const votingPowerSourceAbi = [
@@ -29,23 +36,8 @@ const votingPowerSourceAbi = [
   },
 ] as const;
 
-const VOTING_POWER_SOURCE_CONTRACTS: Record<
-  number,
-  { address: `0x${string}`; tokenDecimals: number }
-> = {
-  // 1 token = 1 vote (TokenVotingPower)
-  1: {
-    address: tokenVotingPowerImplementationAddress[8453],
-    tokenDecimals: 18,
-  },
-  // 1 member = 1 vote (SpaceVotingPower)
-  2: { address: SPACE_VOTING_POWER_ADDRESS, tokenDecimals: 0 },
-  // 1 voice = 1 vote (VoteDecayTokenVotingPower)
-  3: {
-    address: voteDecayTokenVotingPowerImplementationAddress[8453],
-    tokenDecimals: 18,
-  },
-};
+/** Source 2 (SpaceVotingPower, 1 member = 1 vote) counts votes as plain integers. */
+const ONE_MEMBER_ONE_VOTE_SOURCE = 2;
 
 export type MemberVotingPower = {
   votingPower: bigint;
@@ -64,20 +56,20 @@ export async function getMemberVotingPower({
   memberAddress: `0x${string}`;
   web3SpaceId: number;
 }): Promise<MemberVotingPower> {
-  const spaceDetails = await publicClient.readContract(
+  const spaceDetails = await web3Client.readContract(
     getSpaceDetails({ spaceId: BigInt(web3SpaceId) }),
   );
   const votingPowerSource = Number(spaceDetails[2]);
 
-  const source = VOTING_POWER_SOURCE_CONTRACTS[votingPowerSource];
-  if (!source) {
-    throw new Error(
-      `Unsupported voting power source ${votingPowerSource} for space ${web3SpaceId}`,
-    );
-  }
+  const sourceAddress = await web3Client.readContract({
+    address: VOTING_POWER_DIRECTORY_ADDRESS,
+    abi: votingPowerDirectoryAbi,
+    functionName: 'getVotingPowerSourceContract',
+    args: [BigInt(votingPowerSource)],
+  });
 
-  const votingPower = await publicClient.readContract({
-    address: source.address,
+  const votingPower = await web3Client.readContract({
+    address: sourceAddress,
     abi: votingPowerSourceAbi,
     functionName: 'getVotingPower',
     args: [memberAddress, BigInt(web3SpaceId)],
@@ -86,6 +78,6 @@ export async function getMemberVotingPower({
   return {
     votingPower,
     votingPowerSource,
-    tokenDecimals: source.tokenDecimals,
+    tokenDecimals: votingPowerSource === ONE_MEMBER_ONE_VOTE_SOURCE ? 0 : 18,
   };
 }

--- a/packages/core/src/coherence/server/web3/record-signal-upvote-onchain.ts
+++ b/packages/core/src/coherence/server/web3/record-signal-upvote-onchain.ts
@@ -1,0 +1,118 @@
+import 'server-only';
+
+import { createPublicClient, createWalletClient, http } from 'viem';
+import { nonceManager, privateKeyToAccount } from 'viem/accounts';
+import { base } from 'viem/chains';
+
+/**
+ * Background mirror of signal upvotes to the Signals contract
+ * (packages/storage-evm/contracts/SignalsImplementation.sol). The off-chain
+ * Postgres record is the source of truth; this only emits an auditable
+ * on-chain event and must never affect the user-facing flow — errors are
+ * logged and swallowed, and the feature is off unless both env vars are set:
+ *
+ *   SIGNALS_CONTRACT_ADDRESS      — deployed Signals proxy address
+ *   SIGNALS_RELAYER_PRIVATE_KEY   — relayer wallet authorized via setRelayer
+ */
+const signalsAbi = [
+  {
+    type: 'function',
+    name: 'recordUpvote',
+    stateMutability: 'nonpayable',
+    inputs: [
+      { name: '_spaceId', type: 'uint256' },
+      { name: '_signalId', type: 'uint256' },
+      { name: '_voter', type: 'address' },
+      { name: '_amount', type: 'uint256' },
+    ],
+    outputs: [],
+  },
+  {
+    type: 'function',
+    name: 'recordUpvoteRemoval',
+    stateMutability: 'nonpayable',
+    inputs: [
+      { name: '_spaceId', type: 'uint256' },
+      { name: '_signalId', type: 'uint256' },
+      { name: '_voter', type: 'address' },
+    ],
+    outputs: [],
+  },
+] as const;
+
+type UpvoteEvent = {
+  web3SpaceId: number;
+  signalId: number;
+  voter: `0x${string}`;
+  /** Wei-scale voting power; required for upvotes, ignored for removals. */
+  amount?: bigint;
+  kind: 'upvote' | 'removal';
+};
+
+function getSignalsConfig() {
+  const address = process.env.SIGNALS_CONTRACT_ADDRESS;
+  const privateKey = process.env.SIGNALS_RELAYER_PRIVATE_KEY;
+  if (!address || !privateKey) return null;
+  return {
+    address: address as `0x${string}`,
+    privateKey: privateKey as `0x${string}`,
+  };
+}
+
+export async function recordSignalUpvoteOnChain(
+  event: UpvoteEvent,
+): Promise<void> {
+  const config = getSignalsConfig();
+  if (!config) {
+    console.debug(
+      '[signals-onchain] SIGNALS_CONTRACT_ADDRESS / SIGNALS_RELAYER_PRIVATE_KEY not set; skipping on-chain mirror',
+    );
+    return;
+  }
+
+  try {
+    const account = privateKeyToAccount(config.privateKey, { nonceManager });
+    const transport = http(process.env.RPC_URL || 'https://mainnet.base.org');
+    const publicClient = createPublicClient({ chain: base, transport });
+    const walletClient = createWalletClient({
+      account,
+      chain: base,
+      transport,
+    });
+
+    let hash: `0x${string}`;
+    if (event.kind === 'upvote') {
+      const { request } = await publicClient.simulateContract({
+        account,
+        address: config.address,
+        abi: signalsAbi,
+        functionName: 'recordUpvote',
+        args: [
+          BigInt(event.web3SpaceId),
+          BigInt(event.signalId),
+          event.voter,
+          event.amount ?? 0n,
+        ],
+      });
+      hash = await walletClient.writeContract(request);
+    } else {
+      const { request } = await publicClient.simulateContract({
+        account,
+        address: config.address,
+        abi: signalsAbi,
+        functionName: 'recordUpvoteRemoval',
+        args: [BigInt(event.web3SpaceId), BigInt(event.signalId), event.voter],
+      });
+      hash = await walletClient.writeContract(request);
+    }
+    console.log(
+      `[signals-onchain] mirrored ${event.kind} for signal ${event.signalId} in space ${event.web3SpaceId}: ${hash}`,
+    );
+  } catch (error) {
+    // Best-effort mirror: the vote is already stored off-chain.
+    console.error(
+      `[signals-onchain] failed to mirror ${event.kind} for signal ${event.signalId}:`,
+      error,
+    );
+  }
+}

--- a/packages/core/src/coherence/server/web3/record-signal-upvote-onchain.ts
+++ b/packages/core/src/coherence/server/web3/record-signal-upvote-onchain.ts
@@ -50,9 +50,22 @@ type UpvoteEvent = {
 };
 
 function getSignalsConfig() {
-  const address = process.env.SIGNALS_CONTRACT_ADDRESS;
-  const privateKey = process.env.SIGNALS_RELAYER_PRIVATE_KEY;
-  if (!address || !privateKey) return null;
+  const address = process.env.SIGNALS_CONTRACT_ADDRESS?.trim();
+  // Tolerate keys pasted without the 0x prefix or with stray quotes/spaces.
+  const rawKey = process.env.SIGNALS_RELAYER_PRIVATE_KEY?.trim().replace(
+    /^['"]|['"]$/g,
+    '',
+  );
+  if (!address || !rawKey) return null;
+
+  const privateKey = rawKey.startsWith('0x') ? rawKey : `0x${rawKey}`;
+  if (!/^0x[0-9a-fA-F]{64}$/.test(privateKey)) {
+    console.error(
+      '[signals-onchain] SIGNALS_RELAYER_PRIVATE_KEY is not a 32-byte hex key; skipping on-chain mirror',
+    );
+    return null;
+  }
+
   return {
     address: address as `0x${string}`,
     privateKey: privateKey as `0x${string}`,

--- a/packages/core/src/coherence/types.ts
+++ b/packages/core/src/coherence/types.ts
@@ -62,6 +62,26 @@ export type PatchCoherenceTaskBySlugInput = {
   slug: string;
 } & PatchCoherenceTaskInput;
 
+export type CoherenceUpvoter = {
+  personId: number;
+  name: string | null;
+  avatarUrl: string | null;
+  /** Raw voting power units (wei-scale for token sources, whole votes for 1m1v). */
+  votingPower: string;
+};
+
+export type CoherenceUpvoteSummary = {
+  /** Sum of all upvote voting power in raw units. */
+  totalVotingPower: string;
+  upvoteCount: number;
+  /** Display decimals of the voting power source (0 for 1m1v, 18 for token/voice). */
+  tokenDecimals: number;
+  /** Voters ordered by voting power, highest first (capped). */
+  voters: CoherenceUpvoter[];
+  /** The requesting user's own upvote, when authenticated. */
+  myUpvote: { votingPower: string; maxVotingPower: string } | null;
+};
+
 export type Coherence = {
   id: number;
   creatorId: number;
@@ -82,6 +102,8 @@ export type Coherence = {
   progressStatus: string | null;
   board: string | null;
   assigneeIds: number[];
+  /** Present on list/detail API responses; not stored on the row itself. */
+  upvotes?: CoherenceUpvoteSummary;
 };
 
 export enum Environment {

--- a/packages/epics/src/coherence/components/coherence-block.tsx
+++ b/packages/epics/src/coherence/components/coherence-block.tsx
@@ -111,7 +111,7 @@ export function CoherenceBlock({
   const [hideArchived, setHideArchived] = React.useState(true);
   const viewMode = React.useMemo(() => {
     const parsed = parseSignalViewMode(searchParams.get(SIGNAL_VIEW_QUERY_KEY));
-    return parsed ?? 'board';
+    return parsed ?? 'swimlane';
   }, [searchParams]);
   const hasAppliedMobileDefault = React.useRef(false);
 

--- a/packages/epics/src/coherence/components/create-signal-form.tsx
+++ b/packages/epics/src/coherence/components/create-signal-form.tsx
@@ -22,6 +22,7 @@ import {
   SelectTrigger,
   SelectValue,
   Separator,
+  Slider,
 } from '@hypha-platform/ui';
 import { Text } from '@radix-ui/themes';
 import { RefreshCw } from 'lucide-react';
@@ -39,6 +40,7 @@ import {
   schemaCreateCoherenceForm,
   revalidateCoherences,
   useCoherenceMutationsWeb2Rsc,
+  useCoherenceUpvoteMutations,
   useJwt,
   useMatrix,
   useMe,
@@ -153,6 +155,9 @@ export const CreateSignalForm = ({
     updateCoherenceSignalBySlug,
     isUpdatingCoherenceSignal,
   } = useCoherenceMutationsWeb2Rsc(authToken);
+  const { upvote: upvoteCoherence } = useCoherenceUpvoteMutations(authToken);
+  // Creator's initial upvote share of their proposal voting power (max by default).
+  const [creatorVotePercent, setCreatorVotePercent] = React.useState(100);
   const [isTogglingArchiveState, setIsTogglingArchiveState] =
     React.useState(false);
   const [isSignalArchived, setIsSignalArchived] = React.useState(
@@ -596,6 +601,20 @@ export const CreateSignalForm = ({
         const coherence = await createCoherence({ ...data });
         setSignalProvisioningNotice(null);
         const coherenceSlug = coherence.slug;
+        if (coherenceSlug) {
+          // Best-effort creator upvote; ranking still works without it.
+          try {
+            await upvoteCoherence({
+              slug: coherenceSlug,
+              votingPowerPercent: creatorVotePercent,
+            });
+          } catch (upvoteError) {
+            console.warn(
+              'Signal created but creator upvote failed:',
+              upvoteError,
+            );
+          }
+        }
         if (!isMatrixAvailable) {
           setSignalProvisioningNotice(t('provisioning.chatUnavailable'));
           console.warn('Matrix client is unavailable — skipping room creation');
@@ -670,6 +689,8 @@ export const CreateSignalForm = ({
       authToken,
       createCoherence,
       createRoom,
+      creatorVotePercent,
+      upvoteCoherence,
       isEditAuthorized,
       joinRoom,
       loadRoomHistory,
@@ -895,6 +916,29 @@ export const CreateSignalForm = ({
                 )}
               />
             </section>
+            {mode === 'create' ? (
+              <section className="rounded-xl border border-border/70 bg-muted/15 p-4 shadow-sm ring-1 ring-border/40 dark:bg-muted/10 lg:p-6">
+                <div className="flex w-full flex-col gap-3">
+                  <FormLabel className="text-foreground">
+                    {t('signalFormVotingPower')}
+                  </FormLabel>
+                  <Slider
+                    min={1}
+                    max={100}
+                    step={1}
+                    value={[creatorVotePercent]}
+                    onValueChange={(value) =>
+                      setCreatorVotePercent(value[0] ?? 100)
+                    }
+                    displayValue
+                    disabled={isMutating}
+                  />
+                  <FormDescription>
+                    {t('signalFormVotingPowerHint')}
+                  </FormDescription>
+                </div>
+              </section>
+            ) : null}
             <section className="rounded-xl border border-border/70 bg-muted/15 p-4 shadow-sm ring-1 ring-border/40 dark:bg-muted/10 lg:p-6">
               <div className="grid gap-6 md:grid-cols-2">
                 <FormField

--- a/packages/epics/src/coherence/components/create-signal-form.tsx
+++ b/packages/epics/src/coherence/components/create-signal-form.tsx
@@ -12,6 +12,7 @@ import {
   FormLabel,
   FormMessage,
   Input,
+  Label,
   LucideReactIcon,
   MultiSelect,
   RequirementMark,
@@ -918,10 +919,12 @@ export const CreateSignalForm = ({
             </section>
             {mode === 'create' ? (
               <section className="rounded-xl border border-border/70 bg-muted/15 p-4 shadow-sm ring-1 ring-border/40 dark:bg-muted/10 lg:p-6">
+                {/* creatorVotePercent is local state, not a form field, so
+                    avoid the FormField-context-bound components here. */}
                 <div className="flex w-full flex-col gap-3">
-                  <FormLabel className="text-foreground">
+                  <Label className="text-foreground">
                     {t('signalFormVotingPower')}
-                  </FormLabel>
+                  </Label>
                   <Slider
                     min={1}
                     max={100}
@@ -933,9 +936,9 @@ export const CreateSignalForm = ({
                     displayValue
                     disabled={isMutating}
                   />
-                  <FormDescription>
+                  <p className="text-sm text-muted-foreground">
                     {t('signalFormVotingPowerHint')}
-                  </FormDescription>
+                  </p>
                 </div>
               </section>
             ) : null}

--- a/packages/epics/src/coherence/components/index.ts
+++ b/packages/epics/src/coherence/components/index.ts
@@ -26,5 +26,6 @@ export * from './signal-task-card';
 export * from './signal-workflow-settings';
 export * from './signal-linked-calendar-events';
 export * from './signal-card-actions';
+export * from './signal-upvote-control';
 export * from './space-memory-section';
 export * from './space-memory-timeline-item';

--- a/packages/epics/src/coherence/components/signal-card.tsx
+++ b/packages/epics/src/coherence/components/signal-card.tsx
@@ -51,6 +51,7 @@ import { cn } from '@hypha-platform/ui-utils';
 import { useSpaceAccentPortalStyles } from '../../spaces/components/space-accent-portal-context';
 import { resolveDateFnsLocale } from '../../utils/date-fns-locale';
 import { SignalTagBadges } from './signal-tag-badges';
+import { SignalUpvoteControl } from './signal-upvote-control';
 import { priorityLeftBorderClass } from '../utils/signal-priority-styles';
 import { useParams, useRouter } from 'next/navigation';
 import { PersonAvatar } from '../../people/components/person-avatar';
@@ -98,6 +99,7 @@ export const SignalCard: React.FC<SignalCardProps & Coherence> = ({
   messages = 0,
   roomId,
   creatorId,
+  upvotes,
   refresh,
   onOpenConversation,
   className,
@@ -634,13 +636,19 @@ export const SignalCard: React.FC<SignalCardProps & Coherence> = ({
           </div>
         </div>
 
-        {onOpenConversation && !archived ? (
-          <div className="mt-auto flex min-h-[2.75rem] shrink-0 flex-col justify-center bg-muted/10 px-3 py-1.5">
+        <div className="mt-auto flex min-h-[2.75rem] shrink-0 items-center gap-2 bg-muted/10 px-3 py-1.5">
+          <SignalUpvoteControl
+            slug={slug}
+            upvotes={upvotes}
+            refresh={refresh}
+            disabled={isLoading || Boolean(archived)}
+          />
+          {onOpenConversation && !archived ? (
             <Button
               variant="outline"
               colorVariant="accent"
               size="sm"
-              className="h-8 w-full bg-transparent hover:bg-accent-3/30"
+              className="h-8 min-w-0 flex-1 bg-transparent hover:bg-accent-3/30"
               disabled={isLoading || !roomId}
               onClick={(e) => {
                 e.stopPropagation();
@@ -650,10 +658,10 @@ export const SignalCard: React.FC<SignalCardProps & Coherence> = ({
               title={!roomId ? tSignalCard('noConversationRoom') : undefined}
             >
               <ChatBubbleIcon />
-              {t('openConversation')}
+              <span className="truncate">{t('openConversation')}</span>
             </Button>
-          </div>
-        ) : null}
+          ) : null}
+        </div>
         <AlertDialog
           open={archiveDialogOpen}
           onOpenChange={(open) => {

--- a/packages/epics/src/coherence/components/signal-section-skeleton.tsx
+++ b/packages/epics/src/coherence/components/signal-section-skeleton.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import React from 'react';
+import { useTranslations } from 'next-intl';
+import { cn } from '@hypha-platform/ui-utils';
+import type { SignalViewMode } from './signal-section';
+
+function SkeletonBlock({
+  className,
+  delayMs = 0,
+}: {
+  className?: string;
+  delayMs?: number;
+}) {
+  return (
+    <div
+      className={cn('animate-pulse rounded-md bg-muted', className)}
+      style={delayMs ? { animationDelay: `${delayMs}ms` } : undefined}
+      aria-hidden
+    />
+  );
+}
+
+function SkeletonCard({ delayMs = 0 }: { delayMs?: number }) {
+  return (
+    <div
+      className="animate-pulse rounded-lg border border-border/60 bg-muted/30 p-3"
+      style={delayMs ? { animationDelay: `${delayMs}ms` } : undefined}
+      aria-hidden
+    >
+      <div className="h-3 w-3/4 rounded bg-muted" />
+      <div className="mt-2 h-3 w-1/2 rounded bg-muted/80" />
+      <div className="mt-4 flex items-center gap-2">
+        <div className="h-5 w-14 rounded-full bg-muted/80" />
+        <div className="h-5 w-9 rounded-full bg-muted/60" />
+        <div className="ml-auto h-5 w-5 rounded-full bg-muted/80" />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Pulsing placeholder shown while signals and the space workflow load,
+ * shaped to roughly match the active view so the reveal doesn't jump.
+ */
+export function SignalSectionSkeleton({
+  viewMode,
+}: {
+  viewMode: SignalViewMode;
+}) {
+  const t = useTranslations('CoherenceTab');
+
+  return (
+    <div role="status" aria-busy="true" className="w-full">
+      <span className="sr-only">{t('loadingSignals')}</span>
+      {viewMode === 'board' ? (
+        <div className="flex w-full gap-3 overflow-hidden">
+          {[0, 1, 2, 3].map((column) => (
+            <div
+              key={column}
+              className="flex min-w-0 flex-1 flex-col gap-2 rounded-xl border border-border/50 bg-muted/10 p-2"
+            >
+              <SkeletonBlock className="h-6 w-24" delayMs={column * 120} />
+              {Array.from({ length: 3 - (column % 2) }, (_, card) => (
+                <SkeletonCard key={card} delayMs={column * 120 + card * 150} />
+              ))}
+            </div>
+          ))}
+        </div>
+      ) : viewMode === 'swimlane' ? (
+        <div className="flex w-full flex-col gap-3">
+          {[0, 1, 2].map((lane) => (
+            <div
+              key={lane}
+              className="flex flex-col gap-2 rounded-xl border border-border/50 bg-muted/10 p-2"
+            >
+              <SkeletonBlock className="h-6 w-32" delayMs={lane * 140} />
+              <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-4">
+                {Array.from({ length: 4 - lane }, (_, card) => (
+                  <SkeletonCard key={card} delayMs={lane * 140 + card * 150} />
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : viewMode === 'list' ? (
+        <div className="flex w-full flex-col gap-2">
+          {Array.from({ length: 6 }, (_, row) => (
+            <SkeletonBlock
+              key={row}
+              className="h-12 w-full rounded-lg"
+              delayMs={row * 100}
+            />
+          ))}
+        </div>
+      ) : (
+        <div className="grid w-full grid-cols-1 gap-2 md:grid-cols-3 lg:grid-cols-4">
+          {Array.from({ length: 8 }, (_, card) => (
+            <SkeletonCard key={card} delayMs={card * 100} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/epics/src/coherence/components/signal-section.tsx
+++ b/packages/epics/src/coherence/components/signal-section.tsx
@@ -7,6 +7,7 @@ import { useParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { PlusIcon } from '@radix-ui/react-icons';
 import { SearchIcon } from 'lucide-react';
+import { useAuthentication } from '@hypha-platform/authentication';
 import { Button, ErrorAlert, Input } from '@hypha-platform/ui';
 import {
   Coherence,
@@ -31,6 +32,7 @@ import { SignalBoardView } from './signal-board-view';
 import { SignalSwimlaneView } from './signal-swimlane-view';
 import { SignalListView } from './signal-list-view';
 import { SignalGrid } from './signal-grid';
+import { SignalSectionSkeleton } from './signal-section-skeleton';
 
 const SIGNAL_PROVISIONING_NOTICE_AUTO_DISMISS_MS = 8000;
 
@@ -64,8 +66,8 @@ export const SignalSection: FC<SignalSectionProps> = ({
     string[]
   >([]);
 
-  const { workflow, isLoading: isWorkflowLoading } =
-    useSignalWorkflow(spaceSlug);
+  const { isAuthenticated, isLoading: isAuthLoading } = useAuthentication();
+  const { workflow, error: workflowError } = useSignalWorkflow(spaceSlug);
   const { patchTask } = usePatchCoherenceTask(spaceSlug);
   const { canMutate } = useCanMutateInSpace({
     spaceId: web3SpaceId || undefined,
@@ -193,9 +195,34 @@ export const SignalSection: FC<SignalSectionProps> = ({
   );
 
   const visibleSignals = filteredSignals;
+
+  // The workflow is only fetched once auth resolves and a jwt exists, so the
+  // auth → jwt → workflow chain has gaps where every isLoading flag is false.
+  // Gating on data/error instead of isLoading keeps the board from flashing
+  // in with the default workflow and disappearing again mid-load. Signed-out
+  // visitors never get a workflow and render the default one immediately.
+  const isWorkflowPending =
+    !workflow && !workflowError && (isAuthLoading || isAuthenticated);
+
+  // Safety valve: if auth or the workflow fetch silently stalls, reveal the
+  // board with the default workflow rather than pulsing forever.
+  const [workflowWaitExpired, setWorkflowWaitExpired] = React.useState(false);
+  React.useEffect(() => {
+    if (!isWorkflowPending) return;
+    const timer = window.setTimeout(() => setWorkflowWaitExpired(true), 8000);
+    return () => window.clearTimeout(timer);
+  }, [isWorkflowPending]);
+
+  // Once real content has been shown, never fall back to the skeleton —
+  // late revalidations must not blank the board.
+  const hasShownContentRef = React.useRef(false);
   const showInitialLoading =
-    (isLoading && visibleSignals.length === 0) ||
-    (isWorkflowLoading && !workflow);
+    !hasShownContentRef.current &&
+    ((isLoading && visibleSignals.length === 0) ||
+      (isWorkflowPending && !workflowWaitExpired));
+  if (!showInitialLoading) {
+    hasShownContentRef.current = true;
+  }
 
   return (
     <div className="flex w-full flex-col gap-4">
@@ -224,49 +251,55 @@ export const SignalSection: FC<SignalSectionProps> = ({
         <ErrorAlert lines={provisioningNoticeLines} bgColor="bg-yellow-600" />
       ) : null}
 
-      {showInitialLoading ? null : visibleSignals.length === 0 ? (
-        <Empty>
-          <p>{t('listIsEmpty')}</p>
-        </Empty>
-      ) : viewMode === 'board' ? (
-        <SignalBoardView
-          signals={visibleSignals}
-          workflow={resolvedWorkflow}
-          spaceSlug={spaceSlug}
-          onSignalClick={onSignalClick}
-          readOnly={!canUpdateTasks}
-          refresh={refresh}
-          onMoveStatus={(signal, progressStatus) =>
-            patchAndRefresh(signal, { progressStatus })
-          }
-        />
-      ) : viewMode === 'swimlane' ? (
-        <SignalSwimlaneView
-          signals={visibleSignals}
-          workflow={resolvedWorkflow}
-          onSignalClick={onSignalClick}
-          readOnly={!canUpdateTasks}
-          refresh={refresh}
-          onPatch={patchAndRefresh}
-        />
-      ) : viewMode === 'list' ? (
-        <SignalListView
-          signals={visibleSignals}
-          workflow={resolvedWorkflow}
-          onSignalClick={onSignalClick}
-          readOnly={!canUpdateTasks}
-          refresh={refresh}
-          onPatch={patchAndRefresh}
-        />
+      {showInitialLoading ? (
+        <SignalSectionSkeleton viewMode={viewMode} />
       ) : (
-        <SignalGrid
-          isLoading={false}
-          basePath={basePath}
-          leadImage={leadImage}
-          signals={visibleSignals}
-          refresh={refresh}
-          onSignalClick={onSignalClick}
-        />
+        <div className="animate-in fade-in duration-300">
+          {visibleSignals.length === 0 ? (
+            <Empty>
+              <p>{t('listIsEmpty')}</p>
+            </Empty>
+          ) : viewMode === 'board' ? (
+            <SignalBoardView
+              signals={visibleSignals}
+              workflow={resolvedWorkflow}
+              spaceSlug={spaceSlug}
+              onSignalClick={onSignalClick}
+              readOnly={!canUpdateTasks}
+              refresh={refresh}
+              onMoveStatus={(signal, progressStatus) =>
+                patchAndRefresh(signal, { progressStatus })
+              }
+            />
+          ) : viewMode === 'swimlane' ? (
+            <SignalSwimlaneView
+              signals={visibleSignals}
+              workflow={resolvedWorkflow}
+              onSignalClick={onSignalClick}
+              readOnly={!canUpdateTasks}
+              refresh={refresh}
+              onPatch={patchAndRefresh}
+            />
+          ) : viewMode === 'list' ? (
+            <SignalListView
+              signals={visibleSignals}
+              workflow={resolvedWorkflow}
+              onSignalClick={onSignalClick}
+              readOnly={!canUpdateTasks}
+              refresh={refresh}
+              onPatch={patchAndRefresh}
+            />
+          ) : (
+            <SignalGrid
+              isLoading={false}
+              basePath={basePath}
+              leadImage={leadImage}
+              signals={visibleSignals}
+              refresh={refresh}
+              onSignalClick={onSignalClick}
+            />
+          )}
+        </div>
       )}
     </div>
   );

--- a/packages/epics/src/coherence/components/signal-task-card.tsx
+++ b/packages/epics/src/coherence/components/signal-task-card.tsx
@@ -28,6 +28,7 @@ import {
   statusColorDotClass,
 } from '../utils/signal-priority-styles';
 import { SignalTagBadges } from './signal-tag-badges';
+import { SignalUpvoteControl } from './signal-upvote-control';
 import { isSignalDueOverdue } from '../utils/signal-due-date';
 
 type SignalTaskCardProps = {
@@ -247,6 +248,13 @@ export function SignalTaskCard({
 
         <div className="mt-2.5 flex items-end justify-between gap-2">
           <div className="flex min-w-0 flex-wrap items-center gap-1.5">
+            <SignalUpvoteControl
+              slug={signal.slug}
+              upvotes={signal.upvotes}
+              refresh={refresh}
+              disabled={Boolean(signal.archived)}
+              compact
+            />
             {hasValidDue ? (
               <span
                 className={cn(

--- a/packages/epics/src/coherence/components/signal-upvote-control.tsx
+++ b/packages/epics/src/coherence/components/signal-upvote-control.tsx
@@ -170,7 +170,9 @@ export function SignalUpvoteControl({
     [],
   );
 
-  const pillHeightClass = compact ? 'h-4' : 'h-5';
+  // Button size="sm" sets min-h-8; zero it so the compact heights apply.
+  const pillHeightClass = cn('min-h-0 py-0', compact ? 'h-5' : 'h-6');
+  const hasAnyVotes = summary.upvoteCount > 0;
 
   return (
     <div
@@ -185,7 +187,8 @@ export function SignalUpvoteControl({
         size="sm"
         className={cn(
           pillHeightClass,
-          'gap-1 rounded-r-none border-r-0 px-2 tabular-nums',
+          'gap-1 rounded-r-none border-r-0 tabular-nums',
+          hasAnyVotes ? 'px-2' : 'w-8 justify-center px-0',
           hasVoted
             ? 'bg-accent-3/40 text-accent-11 hover:bg-accent-3/60'
             : 'bg-transparent text-muted-foreground hover:text-foreground',
@@ -235,6 +238,7 @@ export function SignalUpvoteControl({
               pillHeightClass,
               'w-8 rounded-l-none px-0 text-muted-foreground hover:text-foreground',
             )}
+            aria-haspopup="dialog"
             aria-label={t('upvoteDetails')}
             title={t('upvoteDetails')}
             onClick={stopPropagation}

--- a/packages/epics/src/coherence/components/signal-upvote-control.tsx
+++ b/packages/epics/src/coherence/components/signal-upvote-control.tsx
@@ -76,6 +76,12 @@ export function SignalUpvoteControl({
   const [popoverOpen, setPopoverOpen] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
 
+  // Drop the optimistic overlay whenever the parent delivers fresh upvote
+  // data (refresh() or another member's vote), so the prop wins again.
+  React.useEffect(() => {
+    setLocalSummary(null);
+  }, [upvotes]);
+
   const summary = localSummary ?? upvotes ?? EMPTY_SUMMARY;
   const hasVoted = summary.myUpvote != null;
   const isMutating = isUpvoting || isRemovingUpvote;

--- a/packages/epics/src/coherence/components/signal-upvote-control.tsx
+++ b/packages/epics/src/coherence/components/signal-upvote-control.tsx
@@ -139,7 +139,10 @@ export function SignalUpvoteControl({
         slug: trimmedSlug,
         votingPowerPercent: percent,
       });
-      if (next) await applyResult(next);
+      if (next) {
+        setPopoverOpen(false);
+        await applyResult(next);
+      }
     } catch (err) {
       console.warn('Could not update signal upvote:', err);
       setError(t('upvoteFailed'));
@@ -152,7 +155,10 @@ export function SignalUpvoteControl({
     setError(null);
     try {
       const next = await removeUpvote({ slug: trimmedSlug });
-      if (next) await applyResult(next);
+      if (next) {
+        setPopoverOpen(false);
+        await applyResult(next);
+      }
     } catch (err) {
       console.warn('Could not remove signal upvote:', err);
       setError(t('upvoteFailed'));
@@ -164,7 +170,7 @@ export function SignalUpvoteControl({
     [],
   );
 
-  const pillHeightClass = compact ? 'h-5' : 'h-6';
+  const pillHeightClass = compact ? 'h-4' : 'h-5';
 
   return (
     <div
@@ -202,7 +208,7 @@ export function SignalUpvoteControl({
       >
         <ArrowBigUp
           className={cn(
-            compact ? 'h-3.5 w-3.5' : 'h-4 w-4',
+            compact ? 'h-3 w-3' : 'h-3.5 w-3.5',
             hasVoted && 'fill-current',
           )}
           aria-hidden
@@ -227,7 +233,7 @@ export function SignalUpvoteControl({
             size="sm"
             className={cn(
               pillHeightClass,
-              'w-5 rounded-l-none px-0 text-muted-foreground hover:text-foreground',
+              'w-8 rounded-l-none px-0 text-muted-foreground hover:text-foreground',
             )}
             aria-label={t('upvoteDetails')}
             title={t('upvoteDetails')}

--- a/packages/epics/src/coherence/components/signal-upvote-control.tsx
+++ b/packages/epics/src/coherence/components/signal-upvote-control.tsx
@@ -1,0 +1,350 @@
+'use client';
+
+import React from 'react';
+import { useLocale, useTranslations } from 'next-intl';
+import { ArrowBigUp, ChevronDown } from 'lucide-react';
+import {
+  useCoherenceUpvoteMutations,
+  useJwt,
+  type CoherenceUpvoteSummary,
+} from '@hypha-platform/core/client';
+import {
+  Button,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+  Slider,
+} from '@hypha-platform/ui';
+import { cn } from '@hypha-platform/ui-utils';
+import { PersonAvatar } from '../../people/components/person-avatar';
+import { useSpaceAccentPortalStyles } from '../../spaces/components/space-accent-portal-context';
+import { formatVotingPowerCompact } from '../utils/format-voting-power';
+
+const EMPTY_SUMMARY: CoherenceUpvoteSummary = {
+  totalVotingPower: '0',
+  upvoteCount: 0,
+  tokenDecimals: 0,
+  voters: [],
+  myUpvote: null,
+};
+
+function myUpvotePercent(summary: CoherenceUpvoteSummary): number {
+  const myUpvote = summary.myUpvote;
+  if (!myUpvote) return 100;
+  try {
+    const max = BigInt(myUpvote.maxVotingPower);
+    if (max <= 0n) return 100;
+    const percent = Number((BigInt(myUpvote.votingPower) * 100n) / max);
+    return Math.min(100, Math.max(1, percent));
+  } catch {
+    return 100;
+  }
+}
+
+type SignalUpvoteControlProps = {
+  slug?: string | null;
+  upvotes?: CoherenceUpvoteSummary;
+  refresh?: () => Promise<void>;
+  disabled?: boolean;
+  /** Smaller pill for dense task cards. */
+  compact?: boolean;
+  className?: string;
+};
+
+/**
+ * Upvote pill + details popover for a signal. The pill toggles an upvote at
+ * full voting power; the popover lets the user fine-tune the share of voting
+ * power, remove the upvote, and see who has voted.
+ */
+export function SignalUpvoteControl({
+  slug,
+  upvotes,
+  refresh,
+  disabled = false,
+  compact = false,
+  className,
+}: SignalUpvoteControlProps) {
+  const t = useTranslations('SignalCard');
+  const locale = useLocale();
+  const { jwt } = useJwt();
+  const spaceAccentPortalStyle = useSpaceAccentPortalStyles();
+  const { upvote, removeUpvote, isUpvoting, isRemovingUpvote } =
+    useCoherenceUpvoteMutations(jwt);
+
+  const [localSummary, setLocalSummary] =
+    React.useState<CoherenceUpvoteSummary | null>(null);
+  const [popoverOpen, setPopoverOpen] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  const summary = localSummary ?? upvotes ?? EMPTY_SUMMARY;
+  const hasVoted = summary.myUpvote != null;
+  const isMutating = isUpvoting || isRemovingUpvote;
+  const canVote = Boolean(slug?.trim()) && Boolean(jwt) && !disabled;
+
+  const [percent, setPercent] = React.useState(() => myUpvotePercent(summary));
+
+  const totalLabel = React.useMemo(
+    () =>
+      formatVotingPowerCompact(
+        summary.totalVotingPower,
+        summary.tokenDecimals,
+        locale,
+      ),
+    [summary.totalVotingPower, summary.tokenDecimals, locale],
+  );
+
+  const applyResult = React.useCallback(
+    async (next: CoherenceUpvoteSummary) => {
+      setLocalSummary(next);
+      setPercent(myUpvotePercent(next));
+      try {
+        await refresh?.();
+      } catch {
+        // Ranking refresh is best-effort; the local summary is already current.
+      }
+    },
+    [refresh],
+  );
+
+  const handleToggle = React.useCallback(async () => {
+    const trimmedSlug = slug?.trim();
+    if (!trimmedSlug || !canVote || isMutating) return;
+    setError(null);
+    try {
+      const next = hasVoted
+        ? await removeUpvote({ slug: trimmedSlug })
+        : await upvote({ slug: trimmedSlug });
+      if (next) await applyResult(next);
+    } catch (err) {
+      console.warn('Could not toggle signal upvote:', err);
+      setError(t('upvoteFailed'));
+    }
+  }, [
+    applyResult,
+    canVote,
+    hasVoted,
+    isMutating,
+    removeUpvote,
+    slug,
+    t,
+    upvote,
+  ]);
+
+  const handleApplyPercent = React.useCallback(async () => {
+    const trimmedSlug = slug?.trim();
+    if (!trimmedSlug || !canVote || isMutating) return;
+    setError(null);
+    try {
+      const next = await upvote({
+        slug: trimmedSlug,
+        votingPowerPercent: percent,
+      });
+      if (next) await applyResult(next);
+    } catch (err) {
+      console.warn('Could not update signal upvote:', err);
+      setError(t('upvoteFailed'));
+    }
+  }, [applyResult, canVote, isMutating, percent, slug, t, upvote]);
+
+  const handleRemove = React.useCallback(async () => {
+    const trimmedSlug = slug?.trim();
+    if (!trimmedSlug || !canVote || isMutating) return;
+    setError(null);
+    try {
+      const next = await removeUpvote({ slug: trimmedSlug });
+      if (next) await applyResult(next);
+    } catch (err) {
+      console.warn('Could not remove signal upvote:', err);
+      setError(t('upvoteFailed'));
+    }
+  }, [applyResult, canVote, isMutating, removeUpvote, slug, t]);
+
+  const stopPropagation = React.useCallback(
+    (e: React.SyntheticEvent) => e.stopPropagation(),
+    [],
+  );
+
+  const pillHeightClass = compact ? 'h-6' : 'h-8';
+
+  return (
+    <div
+      className={cn('flex shrink-0 items-center', className)}
+      onClick={stopPropagation}
+      onKeyDown={stopPropagation}
+    >
+      <Button
+        type="button"
+        variant="outline"
+        colorVariant={hasVoted ? 'accent' : 'neutral'}
+        size="sm"
+        className={cn(
+          pillHeightClass,
+          'gap-1 rounded-r-none border-r-0 px-2 tabular-nums',
+          hasVoted
+            ? 'bg-accent-3/40 text-accent-11 hover:bg-accent-3/60'
+            : 'bg-transparent text-muted-foreground hover:text-foreground',
+        )}
+        disabled={!canVote || isMutating}
+        aria-pressed={hasVoted}
+        aria-label={hasVoted ? t('removeUpvote') : t('upvote')}
+        title={
+          !jwt
+            ? t('signInToUpvote')
+            : hasVoted
+            ? t('removeUpvote')
+            : t('upvote')
+        }
+        onClick={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          void handleToggle();
+        }}
+      >
+        <ArrowBigUp
+          className={cn(
+            compact ? 'h-3.5 w-3.5' : 'h-4 w-4',
+            hasVoted && 'fill-current',
+          )}
+          aria-hidden
+        />
+        <span className={compact ? 'text-[11px]' : 'text-1'}>{totalLabel}</span>
+      </Button>
+      <Popover
+        open={popoverOpen}
+        onOpenChange={(open) => {
+          setPopoverOpen(open);
+          if (open) {
+            setPercent(myUpvotePercent(summary));
+            setError(null);
+          }
+        }}
+      >
+        <PopoverTrigger asChild>
+          <Button
+            type="button"
+            variant="outline"
+            colorVariant="neutral"
+            size="sm"
+            className={cn(
+              pillHeightClass,
+              'w-6 rounded-l-none px-0 text-muted-foreground hover:text-foreground',
+            )}
+            aria-label={t('upvoteDetails')}
+            title={t('upvoteDetails')}
+            onClick={stopPropagation}
+          >
+            <ChevronDown className="h-3.5 w-3.5" aria-hidden />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent
+          align="start"
+          className="w-72 p-4"
+          style={spaceAccentPortalStyle}
+          onClick={stopPropagation}
+        >
+          <div className="flex flex-col gap-3">
+            <div className="flex items-center justify-between gap-2">
+              <span className="text-1 font-medium text-muted-foreground">
+                {t('totalSupport')}
+              </span>
+              <span className="text-2 font-semibold tabular-nums">
+                {totalLabel}
+              </span>
+            </div>
+
+            {canVote ? (
+              <div className="flex flex-col gap-2">
+                <span className="text-1 text-muted-foreground">
+                  {t('yourVotingPowerShare')}
+                </span>
+                <Slider
+                  min={1}
+                  max={100}
+                  step={1}
+                  value={[percent]}
+                  onValueChange={(value) => setPercent(value[0] ?? 100)}
+                  displayValue
+                  disabled={isMutating}
+                />
+                <div className="flex items-center gap-2">
+                  <Button
+                    type="button"
+                    colorVariant="accent"
+                    size="sm"
+                    className="h-7 flex-1"
+                    disabled={isMutating}
+                    onClick={() => void handleApplyPercent()}
+                  >
+                    {hasVoted ? t('updateUpvote') : t('upvote')}
+                  </Button>
+                  {hasVoted ? (
+                    <Button
+                      type="button"
+                      variant="outline"
+                      colorVariant="neutral"
+                      size="sm"
+                      className="h-7"
+                      disabled={isMutating}
+                      onClick={() => void handleRemove()}
+                    >
+                      {t('removeUpvote')}
+                    </Button>
+                  ) : null}
+                </div>
+              </div>
+            ) : (
+              <p className="text-1 text-muted-foreground">
+                {t('signInToUpvote')}
+              </p>
+            )}
+
+            {error ? (
+              <p role="alert" className="text-1 text-error-11">
+                {error}
+              </p>
+            ) : null}
+
+            <div className="flex flex-col gap-1.5 border-t border-border/60 pt-2.5">
+              <span className="text-1 font-medium text-muted-foreground">
+                {t('supportersCount', { count: summary.upvoteCount })}
+              </span>
+              {summary.voters.length === 0 ? (
+                <p className="text-1 text-muted-foreground">
+                  {t('noSupportersYet')}
+                </p>
+              ) : (
+                <ul className="flex max-h-40 flex-col gap-1.5 overflow-y-auto">
+                  {summary.voters.map((voter) => (
+                    <li
+                      key={voter.personId}
+                      className="flex items-center justify-between gap-2"
+                    >
+                      <span className="flex min-w-0 items-center gap-1.5">
+                        <PersonAvatar
+                          size="sm"
+                          shape="circle"
+                          avatarSrc={voter.avatarUrl ?? ''}
+                          userName={voter.name ?? undefined}
+                        />
+                        <span className="truncate text-1">
+                          {voter.name || t('anonymousSupporter')}
+                        </span>
+                      </span>
+                      <span className="shrink-0 text-1 tabular-nums text-muted-foreground">
+                        {formatVotingPowerCompact(
+                          voter.votingPower,
+                          summary.tokenDecimals,
+                          locale,
+                        )}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </div>
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}

--- a/packages/epics/src/coherence/components/signal-upvote-control.tsx
+++ b/packages/epics/src/coherence/components/signal-upvote-control.tsx
@@ -164,7 +164,7 @@ export function SignalUpvoteControl({
     [],
   );
 
-  const pillHeightClass = compact ? 'h-6' : 'h-8';
+  const pillHeightClass = compact ? 'h-5' : 'h-6';
 
   return (
     <div
@@ -227,7 +227,7 @@ export function SignalUpvoteControl({
             size="sm"
             className={cn(
               pillHeightClass,
-              'w-6 rounded-l-none px-0 text-muted-foreground hover:text-foreground',
+              'w-5 rounded-l-none px-0 text-muted-foreground hover:text-foreground',
             )}
             aria-label={t('upvoteDetails')}
             title={t('upvoteDetails')}
@@ -308,11 +308,7 @@ export function SignalUpvoteControl({
               <span className="text-1 font-medium text-muted-foreground">
                 {t('supportersCount', { count: summary.upvoteCount })}
               </span>
-              {summary.voters.length === 0 ? (
-                <p className="text-1 text-muted-foreground">
-                  {t('noSupportersYet')}
-                </p>
-              ) : (
+              {summary.voters.length === 0 ? null : (
                 <ul className="flex max-h-40 flex-col gap-1.5 overflow-y-auto">
                   {summary.voters.map((voter) => (
                     <li

--- a/packages/epics/src/coherence/components/signal-view-controls.tsx
+++ b/packages/epics/src/coherence/components/signal-view-controls.tsx
@@ -69,11 +69,11 @@ export function SignalViewControls({
             className="shrink-0"
           >
             <TabsList triggerVariant="switch" className="w-fit">
-              <TabsTrigger value="board" variant="switch">
-                {t('signalViewBoard')}
-              </TabsTrigger>
               <TabsTrigger value="swimlane" variant="switch">
                 {t('signalViewSwimlane')}
+              </TabsTrigger>
+              <TabsTrigger value="board" variant="switch">
+                {t('signalViewBoard')}
               </TabsTrigger>
               <TabsTrigger value="list" variant="switch">
                 {t('signalViewList')}

--- a/packages/epics/src/coherence/lib/__tests__/signal-view-mode.test.ts
+++ b/packages/epics/src/coherence/lib/__tests__/signal-view-mode.test.ts
@@ -22,8 +22,9 @@ describe('parseSignalViewMode', () => {
 });
 
 describe('isDefaultSignalViewMode', () => {
-  it('treats board as default', () => {
-    expect(isDefaultSignalViewMode('board')).toBe(true);
+  it('treats swimlane as default', () => {
+    expect(isDefaultSignalViewMode('swimlane')).toBe(true);
+    expect(isDefaultSignalViewMode('board')).toBe(false);
     expect(isDefaultSignalViewMode('grid')).toBe(false);
   });
 });

--- a/packages/epics/src/coherence/lib/signal-view-mode.ts
+++ b/packages/epics/src/coherence/lib/signal-view-mode.ts
@@ -3,8 +3,8 @@ import type { SignalViewMode } from '../components/signal-section';
 export const SIGNAL_VIEW_QUERY_KEY = 'view';
 
 export const SIGNAL_VIEW_MODES = [
-  'board',
   'swimlane',
+  'board',
   'list',
   'grid',
 ] as const satisfies readonly SignalViewMode[];
@@ -19,5 +19,5 @@ export function parseSignalViewMode(
 }
 
 export function isDefaultSignalViewMode(view: SignalViewMode): boolean {
-  return view === 'board';
+  return view === 'swimlane';
 }

--- a/packages/epics/src/coherence/types.ts
+++ b/packages/epics/src/coherence/types.ts
@@ -12,6 +12,7 @@ export const COHERENCE_ORDERS = [
   'mostviews',
   'mostmessages',
   'mostrecent',
+  'mostupvoted',
 ] as const;
 export type CoherenceOrder = (typeof COHERENCE_ORDERS)[number];
 

--- a/packages/epics/src/coherence/utils/format-voting-power.ts
+++ b/packages/epics/src/coherence/utils/format-voting-power.ts
@@ -1,0 +1,23 @@
+import { formatUnits } from 'viem';
+
+/**
+ * Formats raw voting power units (wei-scale for token sources, whole votes
+ * for 1m1v) into a compact human string, e.g. "12.4K".
+ */
+export function formatVotingPowerCompact(
+  raw: string | undefined,
+  tokenDecimals: number,
+  locale?: string,
+): string {
+  let value = 0;
+  try {
+    value = Number(formatUnits(BigInt(raw ?? '0'), tokenDecimals));
+  } catch {
+    value = 0;
+  }
+  if (!Number.isFinite(value)) value = 0;
+  return new Intl.NumberFormat(locale, {
+    notation: 'compact',
+    maximumFractionDigits: 1,
+  }).format(value);
+}

--- a/packages/i18n/src/messages/de.json
+++ b/packages/i18n/src/messages/de.json
@@ -3493,6 +3493,8 @@
     "signalFormBoardHint": "Organisatorische Swimlane — gruppiert Signale nach Team, Initiative oder Bereich. Nicht dasselbe wie Typ (Chance/Risiko/Erkenntnis) oder Tags.",
     "signalFormDueDate": "Fälligkeitsdatum",
     "signalFormDueDateHint": "Optionales Zieldatum zur Nachverfolgung dieser Signal-Aufgabe.",
+    "signalFormVotingPower": "Deine Stimmkraft",
+    "signalFormVotingPowerHint": "Anteil deiner Stimmkraft, der dieses Signal unterstützt. Standardmäßig wird deine volle Stimmkraft verwendet; du kannst dies später anpassen oder entfernen.",
     "scheduleOnCalendar": "Im Kalender planen",
     "linkedCalendarEventsTitle": "Verknüpfte Kalendertermine",
     "linkedCalendarEventsHint": "Anrufe und Meetings, die für dieses Signal geplant sind.",
@@ -3611,7 +3613,18 @@
     "deleteConfirm": "Dies entfernt das Signal dauerhaft aus dem Space. Fortfahren?",
     "deleteMenu": "Löschen",
     "deleteConfirmAction": "Signal löschen",
-    "deleteFailed": "Signal konnte nicht gelöscht werden. Bitte erneut versuchen."
+    "deleteFailed": "Signal konnte nicht gelöscht werden. Bitte erneut versuchen.",
+    "upvote": "Unterstützen",
+    "updateUpvote": "Unterstützung aktualisieren",
+    "removeUpvote": "Unterstützung entfernen",
+    "upvoteDetails": "Details zur Unterstützung",
+    "totalSupport": "Gesamte Unterstützung",
+    "yourVotingPowerShare": "Anteil deiner Stimmkraft",
+    "supportersCount": "{count, plural, =0 {Noch keine Unterstützer} one {# Unterstützer} other {# Unterstützer}}",
+    "noSupportersYet": "Noch keine Stimmen — sei die erste Person.",
+    "anonymousSupporter": "Mitglied",
+    "signInToUpvote": "Melde dich als Space-Mitglied an, um Signale zu unterstützen.",
+    "upvoteFailed": "Deine Stimme konnte nicht aktualisiert werden. Bitte erneut versuchen."
   },
   "Calendar": {
     "title": "Kalender",

--- a/packages/i18n/src/messages/de.json
+++ b/packages/i18n/src/messages/de.json
@@ -3621,7 +3621,6 @@
     "totalSupport": "Gesamte Unterstützung",
     "yourVotingPowerShare": "Anteil deiner Stimmkraft",
     "supportersCount": "{count, plural, =0 {Noch keine Unterstützer} one {# Unterstützer} other {# Unterstützer}}",
-    "noSupportersYet": "Noch keine Stimmen — sei die erste Person.",
     "anonymousSupporter": "Mitglied",
     "signInToUpvote": "Melde dich als Space-Mitglied an, um Signale zu unterstützen.",
     "upvoteFailed": "Deine Stimme konnte nicht aktualisiert werden. Bitte erneut versuchen."

--- a/packages/i18n/src/messages/de.json
+++ b/packages/i18n/src/messages/de.json
@@ -3149,6 +3149,7 @@
   },
   "CoherenceTab": {
     "signals": "Signale",
+    "loadingSignals": "Signale werden geladen...",
     "signInToSee": "Bitte melden Sie sich an, um Signale, Space Memory und Gespräche zu sehen",
     "searchSignals": "Signale suchen...",
     "newSignal": "Neues Signal",

--- a/packages/i18n/src/messages/en.json
+++ b/packages/i18n/src/messages/en.json
@@ -3664,7 +3664,6 @@
     "totalSupport": "Total support",
     "yourVotingPowerShare": "Share of your voting power",
     "supportersCount": "{count, plural, =0 {No supporters yet} one {# supporter} other {# supporters}}",
-    "noSupportersYet": "No upvotes yet — be the first.",
     "anonymousSupporter": "Member",
     "signInToUpvote": "Sign in as a space member to upvote signals.",
     "upvoteFailed": "Could not update your upvote. Try again."

--- a/packages/i18n/src/messages/en.json
+++ b/packages/i18n/src/messages/en.json
@@ -3532,6 +3532,8 @@
     "signalFormBoardHint": "Organizational swimlane — groups signals by team, initiative, or workstream. Not the same as Type (Opportunity/Risk/Insight) or Tags.",
     "signalFormDueDate": "Due date",
     "signalFormDueDateHint": "Optional target date for tracking this signal task.",
+    "signalFormVotingPower": "Your voting power",
+    "signalFormVotingPowerHint": "Share of your voting power backing this signal. Uses your full voting power by default; you can adjust or remove it later.",
     "scheduleOnCalendar": "Schedule on calendar",
     "linkedCalendarEventsTitle": "Linked calendar events",
     "linkedCalendarEventsHint": "Calls and meetings scheduled to work on this signal.",
@@ -3654,7 +3656,18 @@
     "deleteConfirm": "This permanently removes this signal from the space. Continue?",
     "deleteMenu": "Delete",
     "deleteConfirmAction": "Delete signal",
-    "deleteFailed": "Could not delete this signal. Try again."
+    "deleteFailed": "Could not delete this signal. Try again.",
+    "upvote": "Upvote",
+    "updateUpvote": "Update upvote",
+    "removeUpvote": "Remove upvote",
+    "upvoteDetails": "Support details",
+    "totalSupport": "Total support",
+    "yourVotingPowerShare": "Share of your voting power",
+    "supportersCount": "{count, plural, =0 {No supporters yet} one {# supporter} other {# supporters}}",
+    "noSupportersYet": "No upvotes yet — be the first.",
+    "anonymousSupporter": "Member",
+    "signInToUpvote": "Sign in as a space member to upvote signals.",
+    "upvoteFailed": "Could not update your upvote. Try again."
   },
   "Calendar": {
     "title": "Calendar",

--- a/packages/i18n/src/messages/en.json
+++ b/packages/i18n/src/messages/en.json
@@ -3188,6 +3188,7 @@
   },
   "CoherenceTab": {
     "signals": "Signals",
+    "loadingSignals": "Loading signals...",
     "signInToSee": "Please, sign in to see signals, space memory, and conversations",
     "searchSignals": "Search signals...",
     "newSignal": "New Signal",

--- a/packages/i18n/src/messages/es.json
+++ b/packages/i18n/src/messages/es.json
@@ -3097,7 +3097,6 @@
     "totalSupport": "Apoyo total",
     "yourVotingPowerShare": "Parte de tu poder de voto",
     "supportersCount": "{count, plural, =0 {Aún sin apoyos} one {# apoyo} other {# apoyos}}",
-    "noSupportersYet": "Aún no hay votos — sé la primera persona.",
     "anonymousSupporter": "Miembro",
     "signInToUpvote": "Inicia sesión como miembro del espacio para apoyar señales.",
     "upvoteFailed": "No se pudo actualizar tu voto. Inténtalo de nuevo."

--- a/packages/i18n/src/messages/es.json
+++ b/packages/i18n/src/messages/es.json
@@ -2625,6 +2625,7 @@
   },
   "CoherenceTab": {
     "signals": "Señales",
+    "loadingSignals": "Cargando señales...",
     "signInToSee": "Por favor, inicie sesión para ver señales, la memoria del espacio y conversaciones",
     "searchSignals": "Buscar señales...",
     "newSignal": "Nueva señal",

--- a/packages/i18n/src/messages/es.json
+++ b/packages/i18n/src/messages/es.json
@@ -2969,6 +2969,8 @@
     "signalFormBoardHint": "Carril organizativo: agrupa señales por equipo, iniciativa o área. No es lo mismo que Tipo (Oportunidad/Riesgo/Insight) ni Tags.",
     "signalFormDueDate": "Fecha límite",
     "signalFormDueDateHint": "Fecha objetivo opcional para hacer seguimiento de esta tarea de señal.",
+    "signalFormVotingPower": "Tu poder de voto",
+    "signalFormVotingPowerHint": "Parte de tu poder de voto que respalda esta señal. Por defecto se usa todo tu poder de voto; puedes ajustarlo o retirarlo más tarde.",
     "scheduleOnCalendar": "Programar en el calendario",
     "linkedCalendarEventsTitle": "Eventos de calendario vinculados",
     "linkedCalendarEventsHint": "Llamadas y reuniones programadas para trabajar en esta señal.",
@@ -3087,7 +3089,18 @@
     "deleteConfirm": "Esto elimina permanentemente esta señal del espacio. ¿Continuar?",
     "deleteMenu": "Eliminar",
     "deleteConfirmAction": "Eliminar señal",
-    "deleteFailed": "No se pudo eliminar esta señal. Inténtalo de nuevo."
+    "deleteFailed": "No se pudo eliminar esta señal. Inténtalo de nuevo.",
+    "upvote": "Apoyar",
+    "updateUpvote": "Actualizar apoyo",
+    "removeUpvote": "Retirar apoyo",
+    "upvoteDetails": "Detalles del apoyo",
+    "totalSupport": "Apoyo total",
+    "yourVotingPowerShare": "Parte de tu poder de voto",
+    "supportersCount": "{count, plural, =0 {Aún sin apoyos} one {# apoyo} other {# apoyos}}",
+    "noSupportersYet": "Aún no hay votos — sé la primera persona.",
+    "anonymousSupporter": "Miembro",
+    "signInToUpvote": "Inicia sesión como miembro del espacio para apoyar señales.",
+    "upvoteFailed": "No se pudo actualizar tu voto. Inténtalo de nuevo."
   },
   "BankingTab": {
     "title": "Banca",

--- a/packages/i18n/src/messages/fr.json
+++ b/packages/i18n/src/messages/fr.json
@@ -3093,7 +3093,6 @@
     "totalSupport": "Soutien total",
     "yourVotingPowerShare": "Part de votre pouvoir de vote",
     "supportersCount": "{count, plural, =0 {Aucun soutien pour l'instant} one {# soutien} other {# soutiens}}",
-    "noSupportersYet": "Pas encore de votes — soyez la première personne.",
     "anonymousSupporter": "Membre",
     "signInToUpvote": "Connectez-vous en tant que membre de l'espace pour soutenir des signaux.",
     "upvoteFailed": "Impossible de mettre à jour votre vote. Réessayez."

--- a/packages/i18n/src/messages/fr.json
+++ b/packages/i18n/src/messages/fr.json
@@ -2965,6 +2965,8 @@
     "signalFormBoardHint": "Couloir organisationnel — regroupe les signaux par équipe, initiative ou domaine. Différent du Type (Opportunité/Risque/Insight) et des Tags.",
     "signalFormDueDate": "Date d'échéance",
     "signalFormDueDateHint": "Date cible optionnelle pour suivre cette tâche de signal.",
+    "signalFormVotingPower": "Votre pouvoir de vote",
+    "signalFormVotingPowerHint": "Part de votre pouvoir de vote soutenant ce signal. Par défaut, tout votre pouvoir de vote est utilisé ; vous pourrez l'ajuster ou le retirer plus tard.",
     "scheduleOnCalendar": "Planifier au calendrier",
     "linkedCalendarEventsTitle": "Événements de calendrier liés",
     "linkedCalendarEventsHint": "Appels et réunions planifiés pour travailler sur ce signal.",
@@ -3083,7 +3085,18 @@
     "deleteConfirm": "Cela supprime définitivement ce signal de l'espace. Continuer ?",
     "deleteMenu": "Supprimer",
     "deleteConfirmAction": "Supprimer le signal",
-    "deleteFailed": "Impossible de supprimer ce signal. Réessayez."
+    "deleteFailed": "Impossible de supprimer ce signal. Réessayez.",
+    "upvote": "Soutenir",
+    "updateUpvote": "Mettre à jour le soutien",
+    "removeUpvote": "Retirer le soutien",
+    "upvoteDetails": "Détails du soutien",
+    "totalSupport": "Soutien total",
+    "yourVotingPowerShare": "Part de votre pouvoir de vote",
+    "supportersCount": "{count, plural, =0 {Aucun soutien pour l'instant} one {# soutien} other {# soutiens}}",
+    "noSupportersYet": "Pas encore de votes — soyez la première personne.",
+    "anonymousSupporter": "Membre",
+    "signInToUpvote": "Connectez-vous en tant que membre de l'espace pour soutenir des signaux.",
+    "upvoteFailed": "Impossible de mettre à jour votre vote. Réessayez."
   },
   "BankingTab": {
     "title": "Banque",

--- a/packages/i18n/src/messages/fr.json
+++ b/packages/i18n/src/messages/fr.json
@@ -2623,6 +2623,7 @@
   },
   "CoherenceTab": {
     "signals": "Signaux",
+    "loadingSignals": "Chargement des signaux...",
     "signInToSee": "Veuillez vous connecter pour voir les signaux, la mémoire de l'espace et les conversations",
     "searchSignals": "Rechercher des signaux...",
     "newSignal": "Nouveau signal",

--- a/packages/i18n/src/messages/pt.json
+++ b/packages/i18n/src/messages/pt.json
@@ -2625,6 +2625,7 @@
   },
   "CoherenceTab": {
     "signals": "Sinais",
+    "loadingSignals": "Carregando sinais...",
     "signInToSee": "Por favor, faça login para ver sinais, a memória do espaço e conversas",
     "searchSignals": "Pesquisar sinais...",
     "newSignal": "Novo sinal",

--- a/packages/i18n/src/messages/pt.json
+++ b/packages/i18n/src/messages/pt.json
@@ -3095,7 +3095,6 @@
     "totalSupport": "Apoio total",
     "yourVotingPowerShare": "Parcela do seu poder de voto",
     "supportersCount": "{count, plural, =0 {Ainda sem apoios} one {# apoio} other {# apoios}}",
-    "noSupportersYet": "Ainda não há votos — seja a primeira pessoa.",
     "anonymousSupporter": "Membro",
     "signInToUpvote": "Inicie sessão como membro do espaço para apoiar sinais.",
     "upvoteFailed": "Não foi possível atualizar o seu voto. Tente novamente."

--- a/packages/i18n/src/messages/pt.json
+++ b/packages/i18n/src/messages/pt.json
@@ -2967,6 +2967,8 @@
     "signalFormBoardHint": "Swimlane organizacional — agrupa sinais por equipa, iniciativa ou área. Não é o mesmo que Tipo (Oportunidade/Risco/Insight) ou Tags.",
     "signalFormDueDate": "Data limite",
     "signalFormDueDateHint": "Data-alvo opcional para acompanhar esta tarefa de sinal.",
+    "signalFormVotingPower": "Seu poder de voto",
+    "signalFormVotingPowerHint": "Parcela do seu poder de voto que apoia este sinal. Por padrão, todo o seu poder de voto é usado; você pode ajustar ou remover depois.",
     "scheduleOnCalendar": "Agendar no calendário",
     "linkedCalendarEventsTitle": "Eventos de calendário vinculados",
     "linkedCalendarEventsHint": "Chamadas e reuniões agendadas para trabalhar neste sinal.",
@@ -3085,7 +3087,18 @@
     "deleteConfirm": "Isto remove permanentemente este sinal do espaço. Continuar?",
     "deleteMenu": "Eliminar",
     "deleteConfirmAction": "Eliminar sinal",
-    "deleteFailed": "Não foi possível eliminar este sinal. Tente novamente."
+    "deleteFailed": "Não foi possível eliminar este sinal. Tente novamente.",
+    "upvote": "Apoiar",
+    "updateUpvote": "Atualizar apoio",
+    "removeUpvote": "Remover apoio",
+    "upvoteDetails": "Detalhes do apoio",
+    "totalSupport": "Apoio total",
+    "yourVotingPowerShare": "Parcela do seu poder de voto",
+    "supportersCount": "{count, plural, =0 {Ainda sem apoios} one {# apoio} other {# apoios}}",
+    "noSupportersYet": "Ainda não há votos — seja a primeira pessoa.",
+    "anonymousSupporter": "Membro",
+    "signInToUpvote": "Inicie sessão como membro do espaço para apoiar sinais.",
+    "upvoteFailed": "Não foi possível atualizar o seu voto. Tente novamente."
   },
   "BankingTab": {
     "title": "Banco",

--- a/packages/storage-evm/.openzeppelin/base.json
+++ b/packages/storage-evm/.openzeppelin/base.json
@@ -196,6 +196,11 @@
     {
       "address": "0x447A317cA5516933264Cdd6aeee0633Fa954B576",
       "kind": "uups"
+    },
+    {
+      "address": "0x967A4bD9a10Bba875d0098fbd3206ca4259A509f",
+      "txHash": "0xd9bbd4bdf5f8cc3b5ee1c560a5edeef24f10563f8ed76bbc684a6e62b9bd1335",
+      "kind": "uups"
     }
   ],
   "impls": {
@@ -54777,6 +54782,594 @@
               }
             ],
             "numberOfBytes": "96"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.Ownable": [
+            {
+              "contract": "OwnableUpgradeable",
+              "label": "_owner",
+              "type": "t_address",
+              "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:24",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    },
+    "8b1deb15f1b498b6d8a9a28ed131d6b124935db99e72a794f2b9450757265af1": {
+      "address": "0xE3820aDcBA8ed72d2BA9e4bDEe52c796AB205771",
+      "txHash": "0xdf1ae67172a159b452544dd838419e701cc94acfe45df7c90257f2f4d078c65e",
+      "layout": {
+        "solcVersion": "0.8.28",
+        "storage": [
+          {
+            "label": "spaceId",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint256",
+            "contract": "RegularSpaceToken",
+            "src": "contracts/RegularSpaceToken.sol:25"
+          },
+          {
+            "label": "maxSupply",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_uint256",
+            "contract": "RegularSpaceToken",
+            "src": "contracts/RegularSpaceToken.sol:26"
+          },
+          {
+            "label": "transferable",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_bool",
+            "contract": "RegularSpaceToken",
+            "src": "contracts/RegularSpaceToken.sol:27"
+          },
+          {
+            "label": "executor",
+            "offset": 1,
+            "slot": "2",
+            "type": "t_address",
+            "contract": "RegularSpaceToken",
+            "src": "contracts/RegularSpaceToken.sol:28"
+          },
+          {
+            "label": "transferHelper",
+            "offset": 0,
+            "slot": "3",
+            "type": "t_address",
+            "contract": "RegularSpaceToken",
+            "src": "contracts/RegularSpaceToken.sol:29"
+          },
+          {
+            "label": "fixedMaxSupply",
+            "offset": 20,
+            "slot": "3",
+            "type": "t_bool",
+            "contract": "RegularSpaceToken",
+            "src": "contracts/RegularSpaceToken.sol:32"
+          },
+          {
+            "label": "autoMinting",
+            "offset": 21,
+            "slot": "3",
+            "type": "t_bool",
+            "contract": "RegularSpaceToken",
+            "src": "contracts/RegularSpaceToken.sol:33"
+          },
+          {
+            "label": "priceInUSD",
+            "offset": 0,
+            "slot": "4",
+            "type": "t_uint256",
+            "contract": "RegularSpaceToken",
+            "src": "contracts/RegularSpaceToken.sol:34"
+          },
+          {
+            "label": "canTransfer",
+            "offset": 0,
+            "slot": "5",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "RegularSpaceToken",
+            "src": "contracts/RegularSpaceToken.sol:37"
+          },
+          {
+            "label": "canReceive",
+            "offset": 0,
+            "slot": "6",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "RegularSpaceToken",
+            "src": "contracts/RegularSpaceToken.sol:38"
+          },
+          {
+            "label": "useTransferWhitelist",
+            "offset": 0,
+            "slot": "7",
+            "type": "t_bool",
+            "contract": "RegularSpaceToken",
+            "src": "contracts/RegularSpaceToken.sol:39"
+          },
+          {
+            "label": "useReceiveWhitelist",
+            "offset": 1,
+            "slot": "7",
+            "type": "t_bool",
+            "contract": "RegularSpaceToken",
+            "src": "contracts/RegularSpaceToken.sol:40"
+          },
+          {
+            "label": "archived",
+            "offset": 2,
+            "slot": "7",
+            "type": "t_bool",
+            "contract": "RegularSpaceToken",
+            "src": "contracts/RegularSpaceToken.sol:43"
+          },
+          {
+            "label": "_transferWhitelistedSpaceIds",
+            "offset": 0,
+            "slot": "8",
+            "type": "t_array(t_uint256)dyn_storage",
+            "contract": "RegularSpaceToken",
+            "src": "contracts/RegularSpaceToken.sol:49"
+          },
+          {
+            "label": "_receiveWhitelistedSpaceIds",
+            "offset": 0,
+            "slot": "9",
+            "type": "t_array(t_uint256)dyn_storage",
+            "contract": "RegularSpaceToken",
+            "src": "contracts/RegularSpaceToken.sol:50"
+          },
+          {
+            "label": "isTransferWhitelistedSpace",
+            "offset": 0,
+            "slot": "10",
+            "type": "t_mapping(t_uint256,t_bool)",
+            "contract": "RegularSpaceToken",
+            "src": "contracts/RegularSpaceToken.sol:51"
+          },
+          {
+            "label": "isReceiveWhitelistedSpace",
+            "offset": 0,
+            "slot": "11",
+            "type": "t_mapping(t_uint256,t_bool)",
+            "contract": "RegularSpaceToken",
+            "src": "contracts/RegularSpaceToken.sol:52"
+          },
+          {
+            "label": "priceCurrencyFeed",
+            "offset": 0,
+            "slot": "12",
+            "type": "t_address",
+            "contract": "RegularSpaceToken",
+            "src": "contracts/RegularSpaceToken.sol:57"
+          },
+          {
+            "label": "tokenPrice",
+            "offset": 0,
+            "slot": "13",
+            "type": "t_uint256",
+            "contract": "RegularSpaceToken",
+            "src": "contracts/RegularSpaceToken.sol:62"
+          },
+          {
+            "label": "_customName",
+            "offset": 0,
+            "slot": "14",
+            "type": "t_string_storage",
+            "contract": "RegularSpaceToken",
+            "src": "contracts/RegularSpaceToken.sol:66"
+          },
+          {
+            "label": "_customSymbol",
+            "offset": 0,
+            "slot": "15",
+            "type": "t_string_storage",
+            "contract": "RegularSpaceToken",
+            "src": "contracts/RegularSpaceToken.sol:67"
+          },
+          {
+            "label": "defaultCreditLimit",
+            "offset": 0,
+            "slot": "16",
+            "type": "t_uint256",
+            "contract": "RegularSpaceToken",
+            "src": "contracts/RegularSpaceToken.sol:70"
+          },
+          {
+            "label": "creditBalanceOf",
+            "offset": 0,
+            "slot": "17",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "RegularSpaceToken",
+            "src": "contracts/RegularSpaceToken.sol:71"
+          },
+          {
+            "label": "_creditWhitelistedSpaceIds",
+            "offset": 0,
+            "slot": "18",
+            "type": "t_array(t_uint256)dyn_storage",
+            "contract": "RegularSpaceToken",
+            "src": "contracts/RegularSpaceToken.sol:72"
+          },
+          {
+            "label": "isCreditWhitelistedSpace",
+            "offset": 0,
+            "slot": "19",
+            "type": "t_mapping(t_uint256,t_bool)",
+            "contract": "RegularSpaceToken",
+            "src": "contracts/RegularSpaceToken.sol:73"
+          },
+          {
+            "label": "paymentToken",
+            "offset": 0,
+            "slot": "20",
+            "type": "t_address",
+            "contract": "RegularSpaceToken",
+            "src": "contracts/RegularSpaceToken.sol:76"
+          },
+          {
+            "label": "paymentTokenPricePerToken",
+            "offset": 0,
+            "slot": "21",
+            "type": "t_uint256",
+            "contract": "RegularSpaceToken",
+            "src": "contracts/RegularSpaceToken.sol:77"
+          },
+          {
+            "label": "tokensForSale",
+            "offset": 0,
+            "slot": "22",
+            "type": "t_uint256",
+            "contract": "RegularSpaceToken",
+            "src": "contracts/RegularSpaceToken.sol:78"
+          },
+          {
+            "label": "tokensSold",
+            "offset": 0,
+            "slot": "23",
+            "type": "t_uint256",
+            "contract": "RegularSpaceToken",
+            "src": "contracts/RegularSpaceToken.sol:79"
+          },
+          {
+            "label": "purchaseEligibilityMode",
+            "offset": 0,
+            "slot": "24",
+            "type": "t_uint8",
+            "contract": "RegularSpaceToken",
+            "src": "contracts/RegularSpaceToken.sol:80"
+          },
+          {
+            "label": "_purchaseWhitelistedSpaceIds",
+            "offset": 0,
+            "slot": "25",
+            "type": "t_array(t_uint256)dyn_storage",
+            "contract": "RegularSpaceToken",
+            "src": "contracts/RegularSpaceToken.sol:81"
+          },
+          {
+            "label": "isPurchaseWhitelistedSpace",
+            "offset": 0,
+            "slot": "26",
+            "type": "t_mapping(t_uint256,t_bool)",
+            "contract": "RegularSpaceToken",
+            "src": "contracts/RegularSpaceToken.sol:82"
+          },
+          {
+            "label": "isCreditWhitelistedAddress",
+            "offset": 0,
+            "slot": "27",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "RegularSpaceToken",
+            "src": "contracts/RegularSpaceToken.sol:85"
+          },
+          {
+            "label": "isAuthorizedMinter",
+            "offset": 0,
+            "slot": "28",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "RegularSpaceToken",
+            "src": "contracts/RegularSpaceToken.sol:92"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "29",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "RegularSpaceToken",
+            "src": "contracts/RegularSpaceToken.sol:101"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+            "label": "mapping(address => mapping(address => uint256))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(ERC20Storage)222_storage": {
+            "label": "struct ERC20Upgradeable.ERC20Storage",
+            "members": [
+              {
+                "label": "_balances",
+                "type": "t_mapping(t_address,t_uint256)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_allowances",
+                "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "_totalSupply",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "_name",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "_symbol",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "4"
+              }
+            ],
+            "numberOfBytes": "160"
+          },
+          "t_struct(InitializableStorage)73_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(OwnableStorage)13_storage": {
+            "label": "struct OwnableUpgradeable.OwnableStorage",
+            "members": [
+              {
+                "label": "_owner",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_array(t_uint256)dyn_storage": {
+            "label": "uint256[]",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_bool)": {
+            "label": "mapping(uint256 => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.Ownable": [
+            {
+              "contract": "OwnableUpgradeable",
+              "label": "_owner",
+              "type": "t_address",
+              "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:24",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.ERC20": [
+            {
+              "contract": "ERC20Upgradeable",
+              "label": "_balances",
+              "type": "t_mapping(t_address,t_uint256)",
+              "src": "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol:33",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "ERC20Upgradeable",
+              "label": "_allowances",
+              "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+              "src": "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol:35",
+              "offset": 0,
+              "slot": "1"
+            },
+            {
+              "contract": "ERC20Upgradeable",
+              "label": "_totalSupply",
+              "type": "t_uint256",
+              "src": "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol:37",
+              "offset": 0,
+              "slot": "2"
+            },
+            {
+              "contract": "ERC20Upgradeable",
+              "label": "_name",
+              "type": "t_string_storage",
+              "src": "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol:39",
+              "offset": 0,
+              "slot": "3"
+            },
+            {
+              "contract": "ERC20Upgradeable",
+              "label": "_symbol",
+              "type": "t_string_storage",
+              "src": "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol:40",
+              "offset": 0,
+              "slot": "4"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    },
+    "978858b4d0bbabdee21f1d4f33cbf1962959ecb4747b1223b1f3263c06868d51": {
+      "address": "0x6a1aE10452484c04EBD1a8005E20c945a5d3a71a",
+      "txHash": "0xb59df8536d8edfe8159f642e66ffffd8004ae5adfe4531d97b53524ced23d5d6",
+      "layout": {
+        "solcVersion": "0.8.28",
+        "storage": [
+          {
+            "label": "relayers",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "SignalsStorage",
+            "src": "contracts/storage/SignalsStorage.sol:8"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "SignalsStorage",
+            "src": "contracts/storage/SignalsStorage.sol:14"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_struct(InitializableStorage)73_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(OwnableStorage)13_storage": {
+            "label": "struct OwnableUpgradeable.OwnableStorage",
+            "members": [
+              {
+                "label": "_owner",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
           },
           "t_uint256": {
             "label": "uint256",

--- a/packages/storage-evm/contracts/SignalsImplementation.sol
+++ b/packages/storage-evm/contracts/SignalsImplementation.sol
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import '@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol';
+import '@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol';
+import '@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol';
+import './storage/SignalsStorage.sol';
+
+/**
+ * @title Signals
+ * @dev On-chain event log for signal (coherence) upvotes.
+ *
+ * Signals themselves live off-chain; this contract only mirrors upvote
+ * activity as events so it is publicly auditable. Platform relayers call
+ * `recordUpvote` / `recordUpvoteRemoval` in the background after the
+ * off-chain vote is stored.
+ */
+contract SignalsImplementation is
+  Initializable,
+  OwnableUpgradeable,
+  UUPSUpgradeable,
+  SignalsStorage
+{
+  /**
+   * @dev Emitted when a member upvotes a signal.
+   * @param spaceId The on-chain space id the signal belongs to.
+   * @param signalId The off-chain signal id.
+   * @param voter The member's wallet address.
+   * @param amount The voting power committed to the upvote.
+   */
+  event SignalUpvoted(
+    uint256 indexed spaceId,
+    uint256 indexed signalId,
+    address indexed voter,
+    uint256 amount
+  );
+
+  /**
+   * @dev Emitted when a member removes their upvote from a signal.
+   */
+  event SignalUpvoteRemoved(
+    uint256 indexed spaceId,
+    uint256 indexed signalId,
+    address indexed voter
+  );
+
+  event RelayerSet(address indexed relayer, bool authorized);
+
+  /// @custom:oz-upgrades-unsafe-allow constructor
+  constructor() {
+    _disableInitializers();
+  }
+
+  function initialize(address initialOwner) public initializer {
+    __Ownable_init(initialOwner);
+    __UUPSUpgradeable_init();
+  }
+
+  function _authorizeUpgrade(
+    address newImplementation
+  ) internal override onlyOwner {}
+
+  modifier onlyRelayerOrOwner() {
+    require(
+      relayers[msg.sender] || msg.sender == owner(),
+      'Not an authorized relayer'
+    );
+    _;
+  }
+
+  /**
+   * @dev Authorize or revoke a relayer address.
+   */
+  function setRelayer(address _relayer, bool _authorized) external onlyOwner {
+    require(_relayer != address(0), 'Relayer cannot be zero address');
+    relayers[_relayer] = _authorized;
+    emit RelayerSet(_relayer, _authorized);
+  }
+
+  /**
+   * @dev Record an upvote (or an updated upvote amount) for a signal.
+   */
+  function recordUpvote(
+    uint256 _spaceId,
+    uint256 _signalId,
+    address _voter,
+    uint256 _amount
+  ) external onlyRelayerOrOwner {
+    require(_spaceId > 0, 'Invalid space ID');
+    require(_voter != address(0), 'Voter cannot be zero address');
+    require(_amount > 0, 'Amount must be greater than zero');
+    emit SignalUpvoted(_spaceId, _signalId, _voter, _amount);
+  }
+
+  /**
+   * @dev Record the removal of a voter's upvote from a signal.
+   */
+  function recordUpvoteRemoval(
+    uint256 _spaceId,
+    uint256 _signalId,
+    address _voter
+  ) external onlyRelayerOrOwner {
+    require(_spaceId > 0, 'Invalid space ID');
+    require(_voter != address(0), 'Voter cannot be zero address');
+    emit SignalUpvoteRemoved(_spaceId, _signalId, _voter);
+  }
+}

--- a/packages/storage-evm/contracts/addresses.txt
+++ b/packages/storage-evm/contracts/addresses.txt
@@ -176,3 +176,8 @@ Deploying OwnershipSpaceToken implementation...
 wnershipSpaceToken implementation deployed to: 0xB06f27e16648F36C529839413f307a87b80d6ca1
 
 TokenBackingVault deployed to: 0x9997C22f06F0aC67dF07C8Cb2A08562C53dD4E9f
+
+Deploying with admin address: 0x2687fe290b54d824c136Ceff2d5bD362Bc62019a
+Deploying Signals...
+Signals deployed to: 0x967A4bD9a10Bba875d0098fbd3206ca4259A509f
+Implementation deployed to: 0x6a1aE10452484c04EBD1a8005E20c945a5d3a71a

--- a/packages/storage-evm/contracts/storage/SignalsStorage.sol
+++ b/packages/storage-evm/contracts/storage/SignalsStorage.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import '@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol';
+
+contract SignalsStorage is Initializable {
+  // Addresses allowed to record signal upvotes (platform relayers).
+  mapping(address => bool) public relayers;
+
+  /**
+   * @dev This empty reserved space is put in place to allow future versions to add new
+   * variables without shifting down storage in the inheritance chain.
+   */
+  uint256[49] private __gap;
+}

--- a/packages/storage-evm/scripts/signals-proxy.deploy.ts
+++ b/packages/storage-evm/scripts/signals-proxy.deploy.ts
@@ -1,0 +1,52 @@
+import { ethers, upgrades } from 'hardhat';
+
+// Deploys the Signals contract (UUPS proxy) that mirrors signal upvotes
+// as on-chain events.
+//
+// Usage:
+//   npx hardhat run scripts/signals-proxy.deploy.ts --network base-mainnet
+//
+// Optional env:
+//   SIGNALS_RELAYER_ADDRESS — relayer wallet to authorize right after deploy
+//   (the platform backend account that will call recordUpvote).
+async function main(): Promise<void> {
+  const [deployer] = await ethers.getSigners();
+  const adminAddress = await deployer.getAddress();
+
+  console.log('Deploying with admin address:', adminAddress);
+
+  const Signals = await ethers.getContractFactory('SignalsImplementation');
+  console.log('Deploying Signals...');
+
+  const signals = await upgrades.deployProxy(Signals, [adminAddress], {
+    initializer: 'initialize',
+    kind: 'uups',
+  });
+
+  await signals.waitForDeployment();
+  const proxyAddress = await signals.getAddress();
+  console.log('Signals deployed to:', proxyAddress);
+  console.log(
+    'Implementation deployed to:',
+    await upgrades.erc1967.getImplementationAddress(proxyAddress),
+  );
+
+  const relayerAddress = process.env.SIGNALS_RELAYER_ADDRESS;
+  if (relayerAddress) {
+    console.log('Authorizing relayer:', relayerAddress);
+    const tx = await signals.setRelayer(relayerAddress, true);
+    await tx.wait();
+    console.log('Relayer authorized.');
+  } else {
+    console.log(
+      'No SIGNALS_RELAYER_ADDRESS set — authorize the backend relayer later with setRelayer(address, true).',
+    );
+  }
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error: Error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/packages/storage-evm/scripts/signals-smoke-test.local.ts
+++ b/packages/storage-evm/scripts/signals-smoke-test.local.ts
@@ -1,0 +1,58 @@
+import { ethers, upgrades } from 'hardhat';
+
+// Local smoke test for SignalsImplementation:
+//   npx hardhat run scripts/signals-smoke-test.local.ts
+async function main(): Promise<void> {
+  const [deployer, relayer, voter] = await ethers.getSigners();
+
+  const Signals = await ethers.getContractFactory('SignalsImplementation');
+  const signals = await upgrades.deployProxy(
+    Signals,
+    [await deployer.getAddress()],
+    { initializer: 'initialize', kind: 'uups' },
+  );
+  await signals.waitForDeployment();
+  console.log('deployed:', await signals.getAddress());
+
+  await (await signals.setRelayer(await relayer.getAddress(), true)).wait();
+
+  // Relayer records an upvote
+  const tx = await signals
+    .connect(relayer)
+    .recordUpvote(241, 123, await voter.getAddress(), 500n * 10n ** 18n);
+  const receipt = await tx.wait();
+  const event = receipt.logs
+    .map((log: { topics: string[]; data: string }) =>
+      signals.interface.parseLog(log),
+    )
+    .find((parsed: { name: string } | null) => parsed?.name === 'SignalUpvoted');
+  console.log('SignalUpvoted:', event?.args.toString());
+
+  // Relayer records a removal
+  const tx2 = await signals
+    .connect(relayer)
+    .recordUpvoteRemoval(241, 123, await voter.getAddress());
+  await tx2.wait();
+  console.log('removal ok');
+
+  // Unauthorized caller must revert
+  try {
+    await signals
+      .connect(voter)
+      .recordUpvote(241, 123, await voter.getAddress(), 1n);
+    throw new Error('unauthorized call did not revert');
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (!message.includes('Not an authorized relayer')) throw error;
+    console.log('unauthorized caller reverted as expected');
+  }
+
+  console.log('SMOKE_OK');
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error: Error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/packages/storage-evm/scripts/signals-smoke-test.local.ts
+++ b/packages/storage-evm/scripts/signals-smoke-test.local.ts
@@ -25,7 +25,9 @@ async function main(): Promise<void> {
     .map((log: { topics: string[]; data: string }) =>
       signals.interface.parseLog(log),
     )
-    .find((parsed: { name: string } | null) => parsed?.name === 'SignalUpvoted');
+    .find(
+      (parsed: { name: string } | null) => parsed?.name === 'SignalUpvoted',
+    );
   console.log('SignalUpvoted:', event?.args.toString());
 
   // Relayer records a removal

--- a/packages/storage-postgres/migrations/0064_coherence_upvotes.sql
+++ b/packages/storage-postgres/migrations/0064_coherence_upvotes.sql
@@ -1,0 +1,22 @@
+CREATE TABLE "coherence_upvotes" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"coherence_id" integer NOT NULL,
+	"person_id" integer NOT NULL,
+	"voting_power" numeric(78, 0) NOT NULL,
+	"max_voting_power" numeric(78, 0) NOT NULL,
+	"token_decimals" smallint DEFAULT 0 NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "coherence_upvotes" ADD CONSTRAINT "coherence_upvotes_coherence_id_coherences_id_fk"
+  FOREIGN KEY ("coherence_id") REFERENCES "coherences"("id")
+  ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "coherence_upvotes" ADD CONSTRAINT "coherence_upvotes_person_id_people_id_fk"
+  FOREIGN KEY ("person_id") REFERENCES "people"("id")
+  ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+CREATE UNIQUE INDEX "coherence_upvotes_coherence_person_key" ON "coherence_upvotes" ("coherence_id", "person_id");
+--> statement-breakpoint
+CREATE INDEX "coherence_upvotes_person_idx" ON "coherence_upvotes" ("person_id");

--- a/packages/storage-postgres/migrations/meta/_journal.json
+++ b/packages/storage-postgres/migrations/meta/_journal.json
@@ -449,6 +449,13 @@
       "when": 1782600000000,
       "tag": "0063_reminder_dispatch_date_fields",
       "breakpoints": true
+    },
+    {
+      "idx": 64,
+      "version": "7",
+      "when": 1782700000000,
+      "tag": "0064_coherence_upvotes",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/storage-postgres/src/schema/coherence-upvotes.ts
+++ b/packages/storage-postgres/src/schema/coherence-upvotes.ts
@@ -1,0 +1,50 @@
+import {
+  index,
+  integer,
+  numeric,
+  pgTable,
+  serial,
+  smallint,
+  uniqueIndex,
+} from 'drizzle-orm/pg-core';
+import { InferInsertModel, InferSelectModel } from 'drizzle-orm';
+import { commonDateFields } from './shared';
+import { coherences } from './coherence';
+import { people } from './people';
+
+/**
+ * One row per person per signal. Voting power is snapshotted at vote time from
+ * the same on-chain voting power source the space uses for proposals
+ * (raw units — wei-scale for token sources, whole votes for 1m1v).
+ */
+export const coherenceUpvotes = pgTable(
+  'coherence_upvotes',
+  {
+    id: serial('id').primaryKey(),
+    coherenceId: integer('coherence_id')
+      .notNull()
+      .references(() => coherences.id, { onDelete: 'cascade' }),
+    personId: integer('person_id')
+      .notNull()
+      .references(() => people.id, { onDelete: 'cascade' }),
+    votingPower: numeric('voting_power', { precision: 78, scale: 0 })
+      .notNull()
+      .$type<string>(),
+    maxVotingPower: numeric('max_voting_power', { precision: 78, scale: 0 })
+      .notNull()
+      .$type<string>(),
+    /** Display decimals of the voting power source token (0 for 1m1v, 18 for token/voice). */
+    tokenDecimals: smallint('token_decimals').notNull().default(0),
+    ...commonDateFields,
+  },
+  (table) => [
+    uniqueIndex('coherence_upvotes_coherence_person_key').on(
+      table.coherenceId,
+      table.personId,
+    ),
+    index('coherence_upvotes_person_idx').on(table.personId),
+  ],
+);
+
+export type CoherenceUpvote = InferSelectModel<typeof coherenceUpvotes>;
+export type NewCoherenceUpvote = InferInsertModel<typeof coherenceUpvotes>;

--- a/packages/storage-postgres/src/schema/index.ts
+++ b/packages/storage-postgres/src/schema/index.ts
@@ -11,6 +11,7 @@ import { eventRelations } from './event.relations';
 import { events } from './event';
 import { transfers } from './transfers';
 import { coherences } from './coherence';
+import { coherenceUpvotes } from './coherence-upvotes';
 import { matrixUserLinks } from './matrix-user-link';
 import { tokenUpdates, tokenUpdateRelations } from './token-updates';
 import { bankCustomers } from './bank-customer';
@@ -43,6 +44,7 @@ export * from './tokens';
 export * from './event';
 export * from './transfers';
 export * from './coherence';
+export * from './coherence-upvotes';
 export * from './matrix-user-link';
 export * from './token-updates';
 export * from './bank-customer';
@@ -65,6 +67,7 @@ export const schema = {
   eventRelations,
   transfers,
   coherences,
+  coherenceUpvotes,
   matrixUserLinks,
   tokenUpdates,
   tokenUpdateRelations,


### PR DESCRIPTION
## Summary

Adds upvoting to the signals (coherence) board, weighted by the same on-chain voting power members hold for proposals.

- **Upvote signals with adjustable voting power.** Each member can upvote a signal once. The vote defaults to their full voting power, is adjustable via a percentage slider in a popover, and can be removed at any time.
- **Voting power comes from the space's proposal voting source.** At vote time the server reads the member's live power from the space's configured voting power source contract (token-weighted, one-member-one-vote, or decaying voice) and snapshots it — no new contracts, no gas per upvote.
- **Signals ranked by total support.** New `mostupvoted` order (now the default on the coherence tab) sorts signals by aggregate voting power, with newest-first as tie-breaker.
- **Compact card UI.** Signal cards (grid, board, swimlane, list views) show a single upvote pill with the formatted total; the popover reveals total support, top supporters with avatars, your current share, and the slider/remove controls.
- **Creator's initial vote.** The create-signal form includes a voting power slider (default 100%) so creators seed their signal with an upvote on creation.

## Implementation notes

- **DB:** new `coherence_upvotes` table (migration `0064`) — one row per member per signal, storing `voting_power` / `max_voting_power` as `numeric(78,0)` wei-scale strings plus `token_decimals` for display formatting. Unique on `(coherence_id, person_id)`, cascade deletes.
- **Server:** `getMemberVotingPower` (server-only viem read across the three voting power source contracts), upvote summary/upsert/remove queries, and `upvoteCoherenceAction` / `removeCoherenceUpvoteAction` server actions with Privy auth + space membership checks.
- **API:** `GET /api/v1/spaces/[spaceSlug]/coherences` enriches signals with upvote aggregates (total, count, top supporters, viewer's own vote) and supports `orderBy=mostupvoted`.
- **i18n:** new keys in all 5 locales (en/pt/es/fr/de), parity verified.

## Test plan

- [ ] Apply migration `0064_coherence_upvotes` (`pnpm --filter @hypha-platform/storage-postgres run migrate`)
- [ ] As a space member, upvote a signal from the board — pill shows your power added to the total
- [ ] Adjust the slider to a partial percentage and update the vote; total reflects the change
- [ ] Remove the upvote; total decreases and pill returns to idle state
- [ ] Create a new signal with the voting power slider at various values — signal appears with the creator's initial support
- [ ] Verify ordering: signals with more total support appear first by default
- [ ] Check a one-member-one-vote space (voting power source 2) and a token-weighted space (source 1) format totals correctly
- [ ] Signed-out / non-member users see totals but cannot vote

Type checks pass for `epics` + `web`; eslint 0 errors on changed files; core unit tests: only pre-existing failure (`request-space-bank-onboarding.test.ts`, also fails on `main`).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added coherence/signal upvoting with an adjustable voting-power share, plus voter/supporter breakdown in the UI.
  * Added “most upvoted” sorting for coherences, including updating the default ordering.
  * Signal creation now includes a creator voting-power option with best-effort auto-upvoting.
* **Bug Fixes**
  * Updated the default signal/coherence view to prioritize the swimlane layout and improved loading rendering behavior.
* **Tests**
  * Updated coverage for the default view-mode behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->