### PR TITLE
fix(ai): navigate to new signal and open its chat after creation

### DIFF
--- a/packages/epics/src/coherence/components/coherence-block.tsx
+++ b/packages/epics/src/coherence/components/coherence-block.tsx
@@ -26,6 +26,7 @@ import { SignalSection, type SignalViewMode } from './signal-section';
 import { SignalViewControls } from './signal-view-controls';
 import { useHumanChatPanel } from '../../common/human-chat-panel-context';
 import { useCanMutateInSpace } from '../../spaces/hooks/use-can-mutate-in-space.web3.rpc';
+import { useCoherenceSignalDeepLink } from '../hooks/use-coherence-signal-deep-link';
 
 type CoherenceBlockProps = {
   lang: Locale;
@@ -192,7 +193,7 @@ export function CoherenceBlock({
     [lang, spaceSlug],
   );
 
-  const { openCoherenceChat } = useHumanChatPanel();
+  const { openCoherenceChat, openHumanChatPanel } = useHumanChatPanel();
 
   const handleSignalClick = React.useCallback(
     (signal: Coherence) => {
@@ -205,6 +206,41 @@ export function CoherenceBlock({
     },
     [openCoherenceChat],
   );
+
+  const handleDeepLinkOpenSignalChat = React.useCallback(
+    (signal: Coherence) => {
+      handleSignalClick(signal);
+      openHumanChatPanel();
+    },
+    [handleSignalClick, openHumanChatPanel],
+  );
+
+  const handleRevealArchivedSignal = React.useCallback(() => {
+    setHideArchived(false);
+  }, []);
+
+  const handleClearPriorityFilter = React.useCallback(() => {
+    const nextParams = new URLSearchParams(searchParams.toString());
+    nextParams.delete('priority');
+    const query = nextParams.toString();
+    router.replace(query ? `${pathname}?${query}` : pathname, {
+      scroll: false,
+    });
+  }, [pathname, router, searchParams]);
+
+  useCoherenceSignalDeepLink({
+    signals,
+    isLoading: isSpaceLoading || (isSignalsLoading && !signals?.length),
+    humanChatEnabled,
+    hideArchived,
+    priorityFilter,
+    onOpenSignalChat: humanChatEnabled
+      ? handleDeepLinkOpenSignalChat
+      : undefined,
+    onRevealArchivedSignal: handleRevealArchivedSignal,
+    onClearPriorityFilter: handleClearPriorityFilter,
+    onRefreshSignals: refreshSignals,
+  });
 
   const onSignalClick = humanChatEnabled ? handleSignalClick : undefined;
 

--- a/packages/epics/src/coherence/components/signal-grid.tsx
+++ b/packages/epics/src/coherence/components/signal-grid.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link';
 import { cn } from '@hypha-platform/ui-utils';
 import { SignalCard } from './signal-card';
 import { Coherence } from '@hypha-platform/core/client';
+import { SIGNAL_SLUG_SELECTOR_ATTR } from '../lib/signal-deep-link-dom';
 
 type SignalGridProps = {
   isLoading: boolean;
@@ -35,6 +36,9 @@ export function SignalGrid({
         ) : onSignalClick ? (
           <div
             key={signal.id}
+            {...(signal.slug
+              ? { [SIGNAL_SLUG_SELECTOR_ATTR]: signal.slug }
+              : {})}
             role="button"
             tabIndex={0}
             className={cn(

--- a/packages/epics/src/coherence/components/signal-list-view.tsx
+++ b/packages/epics/src/coherence/components/signal-list-view.tsx
@@ -19,6 +19,7 @@ import { SignalTagBadges } from './signal-tag-badges';
 import { useSignalCreatorMeta } from '../hooks/use-signal-creator-meta';
 import { priorityLeftBorderEdgeClass } from '../utils/signal-priority-styles';
 import { isSignalDueOverdue } from '../utils/signal-due-date';
+import { SIGNAL_SLUG_SELECTOR_ATTR } from '../lib/signal-deep-link-dom';
 import { PersonAvatar } from '../../people/components/person-avatar';
 import { usePersonById } from '@hypha-platform/core/client';
 
@@ -147,6 +148,9 @@ export function SignalListView({
           return (
             <li
               key={signal.id}
+              {...(signal.slug
+                ? { [SIGNAL_SLUG_SELECTOR_ATTR]: signal.slug }
+                : {})}
               className={cn(
                 'group border-l-[3px] px-3 py-3 transition-colors hover:bg-muted/20 lg:px-4',
                 priorityLeftBorderEdgeClass(signal.priority),

--- a/packages/epics/src/coherence/components/signal-task-card.tsx
+++ b/packages/epics/src/coherence/components/signal-task-card.tsx
@@ -29,6 +29,7 @@ import {
 } from '../utils/signal-priority-styles';
 import { SignalTagBadges } from './signal-tag-badges';
 import { isSignalDueOverdue } from '../utils/signal-due-date';
+import { SIGNAL_SLUG_SELECTOR_ATTR } from '../lib/signal-deep-link-dom';
 
 type SignalTaskCardProps = {
   signal: Coherence;
@@ -138,6 +139,7 @@ export function SignalTaskCard({
 
   return (
     <div
+      {...(signal.slug ? { [SIGNAL_SLUG_SELECTOR_ATTR]: signal.slug } : {})}
       role={onClick ? 'button' : undefined}
       tabIndex={onClick ? 0 : undefined}
       draggable={draggable}

--- a/packages/epics/src/coherence/hooks/use-coherence-signal-deep-link.ts
+++ b/packages/epics/src/coherence/hooks/use-coherence-signal-deep-link.ts
@@ -1,0 +1,95 @@
+'use client';
+
+import React from 'react';
+import { useSearchParams } from 'next/navigation';
+import { Coherence } from '@hypha-platform/core/client';
+import { scrollToSignalCardWithRetry } from '../lib/signal-deep-link-dom';
+
+type UseCoherenceSignalDeepLinkOptions = {
+  signals: Coherence[] | undefined;
+  isLoading: boolean;
+  humanChatEnabled: boolean;
+  hideArchived: boolean;
+  priorityFilter: 'all' | 'critical' | 'high' | 'medium' | 'low';
+  onOpenSignalChat?: (signal: Coherence) => void;
+  onRevealArchivedSignal?: () => void;
+  onClearPriorityFilter?: () => void;
+  onRefreshSignals?: () => void | Promise<void>;
+};
+
+/**
+ * When `?signal=<slug>` is present on a coherence route, scroll the matching
+ * card into view and optionally open its chat thread.
+ */
+export function useCoherenceSignalDeepLink({
+  signals,
+  isLoading,
+  humanChatEnabled,
+  hideArchived,
+  priorityFilter,
+  onOpenSignalChat,
+  onRevealArchivedSignal,
+  onClearPriorityFilter,
+  onRefreshSignals,
+}: UseCoherenceSignalDeepLinkOptions): void {
+  const searchParams = useSearchParams();
+  const signalSlug = searchParams.get('signal')?.trim() ?? null;
+  const openedChatForSlugRef = React.useRef<string | null>(null);
+  const refreshAttemptForSlugRef = React.useRef<string | null>(null);
+
+  React.useEffect(() => {
+    openedChatForSlugRef.current = null;
+    refreshAttemptForSlugRef.current = null;
+  }, [signalSlug]);
+
+  React.useEffect(() => {
+    if (!signalSlug || isLoading) return;
+
+    const signal = (signals ?? []).find(
+      (item) => item.slug?.trim() === signalSlug,
+    );
+    if (!signal) {
+      if (
+        onRefreshSignals &&
+        signals !== undefined &&
+        refreshAttemptForSlugRef.current !== signalSlug
+      ) {
+        refreshAttemptForSlugRef.current = signalSlug;
+        void onRefreshSignals();
+      }
+      return;
+    }
+
+    if (signal.archived && hideArchived) {
+      onRevealArchivedSignal?.();
+      return;
+    }
+
+    if (priorityFilter !== 'all' && signal.priority !== priorityFilter) {
+      onClearPriorityFilter?.();
+      return;
+    }
+
+    if (
+      humanChatEnabled &&
+      onOpenSignalChat &&
+      openedChatForSlugRef.current !== signalSlug
+    ) {
+      openedChatForSlugRef.current = signalSlug;
+      onOpenSignalChat(signal);
+    }
+
+    return scrollToSignalCardWithRetry(signalSlug);
+  }, [
+    hideArchived,
+    humanChatEnabled,
+    isLoading,
+    onClearPriorityFilter,
+    onOpenSignalChat,
+    onRefreshSignals,
+    onRevealArchivedSignal,
+    priorityFilter,
+    signalSlug,
+    signals,
+  ]);
+}

--- a/packages/epics/src/coherence/lib/__tests__/signal-deep-link-dom.test.ts
+++ b/packages/epics/src/coherence/lib/__tests__/signal-deep-link-dom.test.ts
@@ -1,0 +1,24 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+
+import {
+  escapeCssSelector,
+  findSignalCardElement,
+  SIGNAL_SLUG_SELECTOR_ATTR,
+} from '../signal-deep-link-dom';
+
+describe('signal-deep-link-dom', () => {
+  it('finds signal cards by slug attribute', () => {
+    document.body.innerHTML = `
+      <div ${SIGNAL_SLUG_SELECTOR_ATTR}="coh-a6d1d355">Signal A</div>
+      <div ${SIGNAL_SLUG_SELECTOR_ATTR}="coh-other">Signal B</div>
+    `;
+
+    expect(findSignalCardElement('coh-a6d1d355')?.textContent).toBe('Signal A');
+    expect(findSignalCardElement('missing')).toBeNull();
+  });
+
+  it('escapes special characters in slug selectors', () => {
+    expect(escapeCssSelector('coh-"test"')).toContain('\\"');
+  });
+});

--- a/packages/epics/src/coherence/lib/signal-deep-link-dom.ts
+++ b/packages/epics/src/coherence/lib/signal-deep-link-dom.ts
@@ -1,0 +1,61 @@
+export const SIGNAL_SLUG_SELECTOR_ATTR = 'data-signal-slug';
+
+export function escapeCssSelector(value: string): string {
+  if (typeof CSS !== 'undefined' && typeof CSS.escape === 'function') {
+    return CSS.escape(value);
+  }
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+export function findSignalCardElement(slug: string): HTMLElement | null {
+  const trimmed = slug.trim();
+  if (!trimmed) return null;
+  const escaped = escapeCssSelector(trimmed);
+  return document.querySelector(
+    `[${SIGNAL_SLUG_SELECTOR_ATTR}="${escaped}"]`,
+  ) as HTMLElement | null;
+}
+
+export function highlightSignalCardElement(el: HTMLElement): void {
+  el.scrollIntoView({ block: 'center', behavior: 'smooth', inline: 'nearest' });
+  el.classList.add('ring-2', 'ring-primary', 'rounded-xl', 'transition-shadow');
+  window.setTimeout(() => {
+    el.classList.remove(
+      'ring-2',
+      'ring-primary',
+      'rounded-xl',
+      'transition-shadow',
+    );
+  }, 2400);
+}
+
+/** Retry locating a signal card until the coherence view has rendered. */
+export function scrollToSignalCardWithRetry(
+  slug: string,
+  options?: { maxAttempts?: number; onFound?: (el: HTMLElement) => void },
+): () => void {
+  let cancelled = false;
+  let attempts = 0;
+  const maxAttempts = options?.maxAttempts ?? 120;
+  let found = false;
+
+  const tryLocate = () => {
+    if (cancelled || found) return;
+    attempts += 1;
+    const el = findSignalCardElement(slug);
+    if (el) {
+      found = true;
+      highlightSignalCardElement(el);
+      options?.onFound?.(el);
+      return;
+    }
+    if (attempts < maxAttempts) {
+      window.requestAnimationFrame(tryLocate);
+    }
+  };
+
+  window.requestAnimationFrame(tryLocate);
+  return () => {
+    cancelled = true;
+  };
+}

--- a/packages/epics/src/common/ai-left-panel.tsx
+++ b/packages/epics/src/common/ai-left-panel.tsx
@@ -33,6 +33,7 @@ import {
   Category,
   Space,
   SpaceFlags,
+  COHERENCES_SWR_KEY,
   useCreateSpaceOrchestrator,
   useCreateAgreementOrchestrator,
   useJwt,
@@ -40,6 +41,7 @@ import {
   useSpaceBySlug,
   useSpacesBySlugs,
 } from '@hypha-platform/core/client';
+import { mutate } from 'swr';
 import {
   SidebarHeader,
   SidebarContent,
@@ -1543,6 +1545,24 @@ export function AiLeftPanel({ enableSpaceMemory = false }: AiLeftPanelProps) {
 
     const navigationKey = navigationTarget.key;
     if (lastAutoNavigationKeyRef.current === navigationKey) return;
+
+    const isSignalCreateNavigation =
+      navigationTarget.toolName === 'create_space_signal_by_slug' ||
+      navigationTarget.toolName === 'relay_ecosystem_signal';
+
+    if (isAtNavigationTarget(href, pathname, currentSearch)) {
+      if (navigationTarget.openHumanChat && navigationTarget.coherenceChat) {
+        lastAutoNavigationKeyRef.current = navigationKey;
+        openCoherenceChat(
+          navigationTarget.coherenceChat.roomId,
+          navigationTarget.coherenceChat.title,
+          navigationTarget.coherenceChat.slug,
+        );
+        openHumanChatPanel();
+      }
+      return;
+    }
+
     if (shouldSkipStaleOverviewAutoNavigation(pathname, href)) return;
     lastAutoNavigationKeyRef.current = navigationKey;
 
@@ -1567,6 +1587,18 @@ export function AiLeftPanel({ enableSpaceMemory = false }: AiLeftPanelProps) {
         );
       }
       openHumanChatPanel();
+    }
+
+    if (isSignalCreateNavigation) {
+      const targetSpaceSlug = getDhoSpaceSlugFromPathname(href);
+      if (targetSpaceSlug) {
+        void mutate(
+          (key) =>
+            Array.isArray(key) &&
+            key[0] === COHERENCES_SWR_KEY &&
+            key[1] === targetSpaceSlug,
+        );
+      }
     }
 
     router.push(href);

--- a/packages/epics/src/common/human-chat-panel/__tests__/resolve-signal-deep-link.test.ts
+++ b/packages/epics/src/common/human-chat-panel/__tests__/resolve-signal-deep-link.test.ts
@@ -63,12 +63,42 @@ describe('resolveSignalDeepLinkWithRetry (CSH-DISCOVER-2/3)', () => {
   });
 
   it('returns not_found for 404 responses', async () => {
-    const result = await resolveSignalDeepLinkWithRetry({
+    const fetchSignal = vi.fn(async () => new Response(null, { status: 404 }));
+    const resultPromise = resolveSignalDeepLinkWithRetry({
       signalId: 'missing',
       expectedSpaceSlug: 'demo-space',
       getAuthToken: () => 'token',
-      fetchSignal: vi.fn(async () => new Response(null, { status: 404 })),
+      fetchSignal,
     });
-    expect(result).toEqual({ ok: false, reason: 'not_found' });
+    await vi.advanceTimersByTimeAsync(5000);
+    await expect(resultPromise).resolves.toEqual({
+      ok: false,
+      reason: 'not_found',
+    });
+    expect(fetchSignal).toHaveBeenCalledTimes(4);
+  });
+
+  it('succeeds when roomId is not set yet', async () => {
+    const result = await resolveSignalDeepLinkWithRetry({
+      signalId: 'new-signal',
+      expectedSpaceSlug: 'demo-space',
+      getAuthToken: () => 'token',
+      fetchSignal: vi.fn(async () =>
+        Response.json({
+          signalSlug: 'new-signal',
+          signalTitle: 'Fresh signal',
+          spaceSlug: 'demo-space',
+          roomId: null,
+        }),
+      ),
+      maxAttempts: 1,
+    });
+    expect(result).toEqual({
+      ok: true,
+      signalSlug: 'new-signal',
+      signalTitle: 'Fresh signal',
+      spaceSlug: 'demo-space',
+      roomId: null,
+    });
   });
 });

--- a/packages/epics/src/common/human-chat-panel/resolve-signal-deep-link.ts
+++ b/packages/epics/src/common/human-chat-panel/resolve-signal-deep-link.ts
@@ -4,9 +4,11 @@ export type SignalDeepLinkLookupResult =
       signalSlug: string;
       signalTitle?: string;
       spaceSlug: string;
-      roomId: string;
+      roomId: string | null;
     }
   | { ok: false; reason: 'auth_not_ready' | 'not_found' | 'network' };
+
+const NOT_FOUND_RETRY_DELAYS_MS = [400, 1200, 2500] as const;
 
 const AUTH_RETRY_DELAYS_MS = [500, 1500, 4000] as const;
 
@@ -37,6 +39,12 @@ export async function resolveSignalDeepLinkWithRetry(input: {
     try {
       const res = await input.fetchSignal(input.signalId, token);
       if (res.status === 404) {
+        if (attempt < NOT_FOUND_RETRY_DELAYS_MS.length) {
+          await new Promise((resolve) => {
+            window.setTimeout(resolve, NOT_FOUND_RETRY_DELAYS_MS[attempt]);
+          });
+          continue;
+        }
         return { ok: false, reason: 'not_found' };
       }
       if (!res.ok) {
@@ -47,17 +55,22 @@ export async function resolveSignalDeepLinkWithRetry(input: {
         signalSlug?: string;
         signalTitle?: string;
         spaceSlug?: string;
-        roomId?: string;
+        roomId?: string | null;
       };
       const resolvedSlug = data.signalSlug?.trim();
       const resolvedSpaceSlug = data.spaceSlug?.trim();
-      const resolvedRoomId = data.roomId?.trim();
+      const resolvedRoomId = data.roomId?.trim() || null;
       if (
         !resolvedSlug ||
         !resolvedSpaceSlug ||
-        !resolvedRoomId ||
         resolvedSpaceSlug !== input.expectedSpaceSlug.trim()
       ) {
+        if (attempt < NOT_FOUND_RETRY_DELAYS_MS.length) {
+          await new Promise((resolve) => {
+            window.setTimeout(resolve, NOT_FOUND_RETRY_DELAYS_MS[attempt]);
+          });
+          continue;
+        }
         return { ok: false, reason: 'not_found' };
       }
 

--- a/packages/epics/src/common/human-right-panel.tsx
+++ b/packages/epics/src/common/human-right-panel.tsx
@@ -3561,10 +3561,7 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
     const qpMsg = searchParams?.get('msg')?.trim();
     if (!qpSignal) return;
 
-    if (
-      mode === 'coherence' &&
-      coherenceSlug?.trim() === qpSignal
-    ) {
+    if (mode === 'coherence' && coherenceSlug?.trim() === qpSignal) {
       openHumanChatPanel();
       setActiveTab('chat');
       return;

--- a/packages/epics/src/common/human-right-panel.tsx
+++ b/packages/epics/src/common/human-right-panel.tsx
@@ -3563,13 +3563,15 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
 
     if (
       mode === 'coherence' &&
-      coherenceSlug?.trim() === qpSignal &&
-      coherenceRoomId?.trim()
+      coherenceSlug?.trim() === qpSignal
     ) {
+      openHumanChatPanel();
+      setActiveTab('chat');
       return;
     }
 
-    if (mode !== 'space') return;
+    const onCoherenceRoute = pathname.includes('/coherence');
+    if (mode !== 'space' && !onCoherenceRoute) return;
 
     let cancelled = false;
     const epochAtStart = signalDeepLinkEpochRef.current;
@@ -3618,12 +3620,14 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
         return;
       }
 
-      rememberRoomToCoherenceSession(
-        result.roomId,
-        result.signalSlug,
-        result.signalTitle,
-        result.spaceSlug,
-      );
+      if (result.roomId) {
+        rememberRoomToCoherenceSession(
+          result.roomId,
+          result.signalSlug,
+          result.signalTitle,
+          result.spaceSlug,
+        );
+      }
       openCoherenceChat(
         result.roomId,
         result.signalTitle?.trim() || result.signalSlug,


### PR DESCRIPTION
## Summary
- Fix signal deep-link resolution for newly created signals that do not have a Matrix `roomId` yet (no longer strips `?signal=` from the URL).
- After AI creates a signal, auto-navigate to `/coherence?signal=…`, refresh the signals list, scroll/highlight the card, and open the signal’s Human Chat thread.
- Keep Human Chat open when the AI panel already switched to coherence mode before route navigation.

## Root cause
`resolveSignalDeepLinkWithRetry` required a `roomId`, so fresh AI signals failed lookup and the right panel removed the deep-link query param before chat could open.

## Test plan
- [ ] Ask the AI to create a signal in an active paid space.
- [ ] Confirm the app navigates to the signals screen with `?signal=<slug>`.
- [ ] Confirm the new signal card is highlighted and Human Chat opens on that thread.
- [ ] Run `npx vitest run packages/epics/src/common/human-chat-panel/__tests__/resolve-signal-deep-link.test.ts`


Made with [Cursor](https://cursor.com)