### PR TITLE
fix(layout): keep both side panels open on desktop widths

### DIFF
--- a/apps/web-e2e/src/panel-layout.spec.ts
+++ b/apps/web-e2e/src/panel-layout.spec.ts
@@ -129,6 +129,37 @@ test.describe('Panel Layout', () => {
     expect(center!.x + center!.width).toBeLessThanOrEqual(right!.x + 2);
   });
 
+  test('opening chat panel keeps expanded AI panel open on desktop', async () => {
+    await layout.openAiPanel();
+    await expect(layout.leftSidebarHeader).toBeVisible();
+    const leftBefore = await layout.leftSidebar.boundingBox();
+    expect(leftBefore).not.toBeNull();
+    expect(leftBefore!.width).toBeGreaterThan(200);
+
+    await layout.openChatPanel();
+    await expect(layout.rightSidebar).toBeVisible();
+    await expect(layout.leftSidebarHeader).toBeVisible();
+
+    const leftAfter = await layout.leftSidebar.boundingBox();
+    expect(leftAfter).not.toBeNull();
+    expect(leftAfter!.width).toBeGreaterThan(200);
+  });
+
+  test('compact viewport closes opposite panel when opening chat', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 375, height: 812 });
+    await layout.openAiPanel();
+    await expect(layout.leftSidebarHeader).toBeVisible();
+
+    await layout.openChatPanel();
+    await expect(layout.rightSidebar).toBeVisible();
+
+    const leftAfter = await layout.leftSidebar.boundingBox();
+    expect(leftAfter).not.toBeNull();
+    expect(leftAfter!.width).toBeLessThanOrEqual(80);
+  });
+
   test('menu bar and panel headers occupy separate columns at same level', async () => {
     await layout.openChatPanel();
     await expect(layout.rightSidebar).toBeVisible();

--- a/packages/epics/src/common/ai-left-panel.tsx
+++ b/packages/epics/src/common/ai-left-panel.tsx
@@ -66,7 +66,7 @@ import { getDhoSpaceContextPath } from './get-dho-space-context-path';
 import { getDhoSpaceSlugFromPathname } from './get-dho-space-slug-from-pathname';
 import { getLocaleFromPath } from './get-locale-from-path';
 import { useAiPanel, useHumanChatPanel } from './human-chat-panel-context';
-import { useCompactHeaderMode } from '@hypha-platform/ui';
+import { useCompactHeaderMode, useCompactPanelsMode } from '@hypha-platform/ui';
 import { useConfig } from 'wagmi';
 import { convertFilesToParts } from './ai-panel/convert-files-to-parts';
 import { CHAT_ATTACHMENT_MAX_SIZE_LABEL } from '@hypha-platform/core/client';
@@ -363,6 +363,7 @@ export function AiLeftPanel({ enableSpaceMemory = false }: AiLeftPanelProps) {
   const { jwt } = useJwt();
   const lang = getLocaleFromPath(pathname);
   const isCompactHeader = useCompactHeaderMode();
+  const isCompactPanels = useCompactPanelsMode();
   const { space } = useSpaceBySlug(spaceSlug ?? '');
   const effectiveSpaceWeb3Id = space?.web3SpaceId ?? undefined;
   const { access: spaceActivityAccess, isLoading: isDiscoverabilityLoading } =
@@ -2844,7 +2845,7 @@ export function AiLeftPanel({ enableSpaceMemory = false }: AiLeftPanelProps) {
       handleOverlayClose();
       return;
     }
-    if (isCompactHeader && rightOpen) {
+    if (isCompactPanels && rightOpen) {
       toggleRight();
     }
     showAiOverlay();
@@ -2852,7 +2853,7 @@ export function AiLeftPanel({ enableSpaceMemory = false }: AiLeftPanelProps) {
     handleOverlayClose,
     isAiOpen,
     overlayVisible,
-    isCompactHeader,
+    isCompactPanels,
     rightOpen,
     toggleRight,
     showAiOverlay,

--- a/packages/epics/src/common/panel-wrap-layout.tsx
+++ b/packages/epics/src/common/panel-wrap-layout.tsx
@@ -14,7 +14,7 @@ import {
   SidebarProvider,
   Sidebar,
   SidebarResizeHandle,
-  useCompactHeaderMode,
+  useCompactPanelsMode,
 } from '@hypha-platform/ui';
 import { useTranslations } from 'next-intl';
 import {
@@ -124,7 +124,7 @@ export function AiSidebarTrigger() {
     useAiPanel();
   const { open: rightOpen, toggle: toggleRight } = useHumanChatPanel();
   const isSpace = useIsSpaceContext();
-  const isCompactHeader = useCompactHeaderMode();
+  const isCompactPanels = useCompactPanelsMode();
   const t = useTranslations('AiPanel');
 
   if (!isSpace) return null;
@@ -139,7 +139,7 @@ export function AiSidebarTrigger() {
           hideAiOverlay();
           return;
         }
-        if (isCompactHeader && rightOpen) {
+        if (isCompactPanels && rightOpen) {
           toggleRight();
         }
         if (open) {
@@ -165,7 +165,7 @@ export function AiPanelTrigger() {
   const { open, openAiPanel, closeAiPanel, setAiOverlayVisible } = useAiPanel();
   const { open: rightOpen, toggle: toggleRight } = useHumanChatPanel();
   const isSpace = useIsSpaceContext();
-  const isCompactHeader = useCompactHeaderMode();
+  const isCompactPanels = useCompactPanelsMode();
   const t = useTranslations('AiPanel');
 
   if (!isSpace) return null;
@@ -178,7 +178,7 @@ export function AiPanelTrigger() {
           closeAiPanel();
           return;
         }
-        if (isCompactHeader && rightOpen) {
+        if (isCompactPanels && rightOpen) {
           toggleRight();
         }
         openAiPanel();
@@ -199,7 +199,7 @@ export function HumanSidebarTrigger() {
   const { open: leftOpen, overlayVisible, closeAiPanel } = useAiPanel();
   const t = useTranslations('HumanChatPanel');
   const isSpace = useIsSpaceContext();
-  const isCompactHeader = useCompactHeaderMode();
+  const isCompactPanels = useCompactPanelsMode();
 
   // Hide header trigger while the chat panel is open — the panel has its own chrome.
   if (!isSpace || open) return null;
@@ -212,7 +212,7 @@ export function HumanSidebarTrigger() {
           toggle();
           return;
         }
-        if (isCompactHeader && (leftOpen || overlayVisible)) {
+        if (isCompactPanels && (leftOpen || overlayVisible)) {
           closeAiPanel();
         }
         openHumanChatPanel();
@@ -307,8 +307,6 @@ export function PanelWrapLayout({
   const { open: rightOpen, toggle: toggleRight } = useHumanChatPanel();
   const isSpace = useIsSpaceContext();
   const isOnboarding = pathname.includes('/onboarding');
-  const isCompactUi = useCompactHeaderMode();
-
   const effectiveLeft = isSpace ? left : undefined;
   // Right human panel remains space-context only.
   const effectiveRight = isSpace ? right : undefined;
@@ -331,7 +329,10 @@ export function PanelWrapLayout({
     (viewportWidth < DUAL_PANEL_MIN_VIEWPORT_PX ||
       viewportWidth - leftFootprintPx - rightFootprintPx <
         MIN_MAIN_COLUMN_WIDTH_PX);
-  const isCompactPanels = isCompactUi || forceCompactPanels;
+  // Panel compact mode is viewport-driven only — do not conflate with header
+  // compact (MenuTop overflow), or opening one panel shrinks the center column
+  // and incorrectly closes the opposite panel on desktop widths.
+  const isCompactPanels = forceCompactPanels;
   const useMobilePanelWidths = viewportWidth < MOBILE_PANEL_BREAKPOINT_PX;
   const rightSidebarWidth = isCompactPanels
     ? useMobilePanelWidths

--- a/packages/ui/src/hooks/use-compact-header-mode.ts
+++ b/packages/ui/src/hooks/use-compact-header-mode.ts
@@ -3,15 +3,10 @@
 import { useEffect, useState } from 'react';
 
 const COMPACT_ATTR = 'data-compact-header';
-const PANEL_COMPACT_ATTR = 'data-compact-panels';
 
 function readCompactHeaderMode(): boolean {
   if (typeof document === 'undefined') return false;
-  const root = document.documentElement;
-  return (
-    root.getAttribute(COMPACT_ATTR) === 'true' ||
-    root.getAttribute(PANEL_COMPACT_ATTR) === 'true'
-  );
+  return document.documentElement.getAttribute(COMPACT_ATTR) === 'true';
 }
 
 export function useCompactHeaderMode(): boolean {
@@ -27,7 +22,7 @@ export function useCompactHeaderMode(): boolean {
     const observer = new MutationObserver(sync);
     observer.observe(root, {
       attributes: true,
-      attributeFilter: [COMPACT_ATTR, PANEL_COMPACT_ATTR],
+      attributeFilter: [COMPACT_ATTR],
     });
     return () => observer.disconnect();
   }, []);


### PR DESCRIPTION
## Summary
- Decouple panel compact mode from header compact mode so opening the right panel no longer closes the left panel on desktop widths.
- Restrict mutual panel exclusion to viewport-constrained compact mode only.
- Add regression e2e coverage for dual-panel desktop and compact mobile behavior.

## Test plan
- [ ] At 1440px, open AI panel then chat panel — both remain open
- [ ] At 375px, opening chat closes expanded AI panel

Made with [Cursor](https://cursor.com)