### PR TITLE
fix(calendar): accept empty recurrence preset when saving edits

### DIFF
--- a/packages/core/src/schedule/__tests__/merge-update.test.ts
+++ b/packages/core/src/schedule/__tests__/merge-update.test.ts
@@ -123,4 +123,29 @@ describe('safeParseMergedScheduledItemUpdate', () => {
     );
     expect(result.success).toBe(false);
   });
+
+  it('treats empty recurrencePreset as non-recurring', () => {
+    const result = safeParseMergedScheduledItemUpdate(
+      baseExisting({
+        recurrenceRule: 'FREQ=WEEKLY;BYDAY=MO',
+        recurrenceUntil: new Date('2026-07-31T22:59:00.000Z'),
+      }),
+      baseEditPatch({ recurrencePreset: '' }),
+      1,
+    );
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.recurrenceRule).toBeNull();
+      expect(result.data.recurrenceUntil).toBeNull();
+    }
+  });
+
+  it('accepts empty recurrencePreset for non-recurring items', () => {
+    const result = safeParseMergedScheduledItemUpdate(
+      baseExisting(),
+      baseEditPatch({ recurrencePreset: '' }),
+      1,
+    );
+    expect(result.success).toBe(true);
+  });
 });

--- a/packages/core/src/schedule/validation.ts
+++ b/packages/core/src/schedule/validation.ts
@@ -69,14 +69,11 @@ const recurrenceRuleSchema = z
   .nullable()
   .transform((value) => value ?? null);
 
-const recurrencePresetSchema = z.preprocess(
-  (value) => {
-    if (value === '') return 'none';
-    if (value == null) return undefined;
-    return value;
-  },
-  z.enum(RECURRENCE_PRESETS).optional(),
-);
+const recurrencePresetSchema = z.preprocess((value) => {
+  if (value === '') return 'none';
+  if (value == null) return undefined;
+  return value;
+}, z.enum(RECURRENCE_PRESETS).optional());
 
 const reminderMinutesSchema = z
   .number()

--- a/packages/core/src/schedule/validation.ts
+++ b/packages/core/src/schedule/validation.ts
@@ -69,7 +69,14 @@ const recurrenceRuleSchema = z
   .nullable()
   .transform((value) => value ?? null);
 
-const recurrencePresetSchema = z.enum(RECURRENCE_PRESETS).optional();
+const recurrencePresetSchema = z.preprocess(
+  (value) => {
+    if (value === '') return 'none';
+    if (value == null) return undefined;
+    return value;
+  },
+  z.enum(RECURRENCE_PRESETS).optional(),
+);
 
 const reminderMinutesSchema = z
   .number()

--- a/packages/epics/src/schedule/components/scheduled-item-form-dialog.tsx
+++ b/packages/epics/src/schedule/components/scheduled-item-form-dialog.tsx
@@ -581,7 +581,10 @@ export function ScheduledItemForm({
         allDay,
         location: location.trim() || null,
         meetingUrl: matrixAutoLink ? null : meetingUrl.trim() || null,
-        recurrencePreset,
+        recurrencePreset:
+          recurrencePreset && RECURRENCE_PRESETS.includes(recurrencePreset)
+            ? recurrencePreset
+            : 'none',
         recurrenceUntil:
           recurrencePreset !== 'none' && recurrenceUntilLocal
             ? fromDatetimeLocalValue(`${recurrenceUntilLocal}T23:59`)
@@ -840,7 +843,7 @@ export function ScheduledItemForm({
           <div className="flex flex-col gap-2">
             <Label>{t('fieldRecurrence')}</Label>
             <Select
-              value={recurrencePreset}
+              value={recurrencePreset || 'none'}
               onValueChange={(value) =>
                 setRecurrencePreset(value as RecurrencePreset)
               }


### PR DESCRIPTION
## Summary
- Coerce blank `recurrencePreset` values to `none` in Zod validation.
- Normalize scheduled item form submit payload and Select controlled value.

## Test plan
- [ ] Edit a non-recurring meeting and save — no enum validation error
- [ ] Edit a recurring event and change/clear recurrence — saves correctly

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed recurrence settings so clearing the recurrence option now correctly removes repeating behavior when editing an item.
  * Improved handling of empty or missing recurrence values, preventing inconsistent save behavior.
  * The recurrence selector now reliably shows a default non-recurring state when no recurrence is chosen.
* **Tests**
  * Added coverage for editing scheduled items with an empty recurrence selection, including both recurring and non-recurring cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->