### PR TITLE
fix(notifications): send invite notifications for join-request proposals

### DIFF
--- a/apps/web/src/app/api/webhooks/proposal/created/route.ts
+++ b/apps/web/src/app/api/webhooks/proposal/created/route.ts
@@ -1,5 +1,6 @@
 import {
   Alchemy,
+  decodeJoinRequestProposal,
   findPersonByWeb3Address,
   findSpaceByWeb3Id,
   findPeopleByWeb3Addresses,
@@ -28,14 +29,30 @@ export const POST = proposalCreatedSigningKey
         event: 'ProposalCreated',
       },
       async (events) => {
-        const eventsData = events.map(({ args }) => ({
-          spaceWeb3Id: args.spaceId,
-          creatorWeb3Address: args.creator,
-          proposalWeb3Id: args.proposalId,
-        }));
+        const eventsData = events.map(({ args }) => {
+          // Join requests are created on-chain by DAOSpaceFactory.joinSpace(),
+          // so the event's `creator` is the factory contract — the actual
+          // requester has to be recovered from the executionData.
+          const joinRequesterAddress = decodeJoinRequestProposal({
+            creator: args.creator,
+            executionData: args.executionData,
+          });
+
+          return {
+            spaceWeb3Id: args.spaceId,
+            creatorWeb3Address: joinRequesterAddress ?? args.creator,
+            proposalWeb3Id: args.proposalId,
+            isJoinRequest: joinRequesterAddress !== null,
+          };
+        });
 
         const fetchingDbData = eventsData.map(
-          async ({ spaceWeb3Id, creatorWeb3Address, proposalWeb3Id }) => {
+          async ({
+            spaceWeb3Id,
+            creatorWeb3Address,
+            proposalWeb3Id,
+            isJoinRequest,
+          }) => {
             const person = findPersonByWeb3Address(
               { address: creatorWeb3Address },
               { db },
@@ -45,7 +62,12 @@ export const POST = proposalCreatedSigningKey
               { db },
             );
 
-            return { proposalWeb3Id, person: await person, space: await space };
+            return {
+              proposalWeb3Id,
+              isJoinRequest,
+              person: await person,
+              space: await space,
+            };
           },
         );
         const resultFetchingDbData = await Promise.allSettled(fetchingDbData);
@@ -82,6 +104,7 @@ export const POST = proposalCreatedSigningKey
           creatorName: data.person?.name,
           spaceTitle: data.space?.title,
           spaceSlug: data.space?.slug,
+          proposalLabel: data.isJoinRequest ? 'Invite' : undefined,
         }));
         const sendingEmails = notificationParams.map(async (params) => {
           const { body, subject } = emailProposalCreationForCreator(params);
@@ -119,7 +142,14 @@ export const POST = proposalCreatedSigningKey
           );
       },
       async (events) => {
-        const spaceIds = events.map(({ args }) => args.spaceId);
+        const eventsData = events.map(({ args }) => ({
+          spaceWeb3Id: args.spaceId,
+          joinRequesterAddress: decodeJoinRequestProposal({
+            creator: args.creator,
+            executionData: args.executionData,
+          }),
+        }));
+        const spaceIds = eventsData.map(({ spaceWeb3Id }) => spaceWeb3Id);
 
         const spacesDetails = await (async () => {
           try {
@@ -141,20 +171,39 @@ export const POST = proposalCreatedSigningKey
           return;
         }
 
-        const fetchingData = spacesDetails.map(async ({ members, spaceId }) => {
-          const people = await findPeopleByWeb3Addresses(
-            {
-              addresses: members as string[],
-            },
-            { db },
-          );
-          const space = await findSpaceByWeb3Id(
-            { id: Number(spaceId) },
-            { db },
-          );
+        // fetchSpaceDetails preserves the input order, so entries align with
+        // eventsData by index.
+        const fetchingData = spacesDetails.map(
+          async ({ members, spaceId }, index) => {
+            const joinRequesterAddress =
+              eventsData[index]?.spaceWeb3Id === spaceId
+                ? eventsData[index]?.joinRequesterAddress ?? null
+                : null;
 
-          return { people, space };
-        });
+            const [people, space, joinRequester] = await Promise.all([
+              findPeopleByWeb3Addresses(
+                {
+                  addresses: members as string[],
+                },
+                { db },
+              ),
+              findSpaceByWeb3Id({ id: Number(spaceId) }, { db }),
+              joinRequesterAddress
+                ? findPersonByWeb3Address(
+                    { address: joinRequesterAddress },
+                    { db },
+                  )
+                : Promise.resolve(null),
+            ]);
+
+            return {
+              people,
+              space,
+              isJoinRequest: joinRequesterAddress !== null,
+              joinRequester,
+            };
+          },
+        );
         const spacesWithPeople = (await Promise.allSettled(fetchingData))
           .filter((res) => res.status === 'fulfilled')
           .map(({ value }) => value)
@@ -166,10 +215,16 @@ export const POST = proposalCreatedSigningKey
           );
 
         const notificationParams = spacesWithPeople.map(
-          ({ space, people }) => ({
+          ({ space, people, isJoinRequest, joinRequester }) => ({
             slugs: people.map(({ slug }) => slug!),
             spaceTitle: space!.title,
             spaceSlug: space!.slug,
+            proposalLabel: isJoinRequest ? 'Invite' : undefined,
+            creatorName: isJoinRequest
+              ? [joinRequester?.name, joinRequester?.surname]
+                  .filter(Boolean)
+                  .join(' ') || undefined
+              : undefined,
           }),
         );
 

--- a/packages/core/src/governance/server/__tests__/decode-join-request-proposal.test.ts
+++ b/packages/core/src/governance/server/__tests__/decode-join-request-proposal.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { encodeFunctionData } from 'viem';
+import {
+  daoSpaceFactoryImplementationAbi,
+  daoSpaceFactoryImplementationAddress,
+} from '@hypha-platform/core/generated';
+import { decodeJoinRequestProposal } from '../decode-join-request-proposal';
+
+const factoryAddress = daoSpaceFactoryImplementationAddress[8453];
+const requesterAddress = '0x1111111111111111111111111111111111111111';
+const walletAddress = '0x2222222222222222222222222222222222222222';
+
+const addMemberExecutionData = encodeFunctionData({
+  abi: daoSpaceFactoryImplementationAbi,
+  functionName: 'addMember',
+  args: [42n, requesterAddress],
+});
+
+describe('decodeJoinRequestProposal', () => {
+  it('returns the requester address for a join-request proposal created by the space factory', () => {
+    expect(
+      decodeJoinRequestProposal({
+        creator: factoryAddress,
+        executionData: addMemberExecutionData,
+      }),
+    ).toBe(requesterAddress);
+  });
+
+  it('matches the factory creator address case-insensitively', () => {
+    expect(
+      decodeJoinRequestProposal({
+        creator: factoryAddress.toUpperCase().replace('0X', '0x'),
+        executionData: addMemberExecutionData,
+      }),
+    ).toBe(requesterAddress);
+  });
+
+  it('returns null when the creator is a regular wallet, even for addMember calldata', () => {
+    expect(
+      decodeJoinRequestProposal({
+        creator: walletAddress,
+        executionData: addMemberExecutionData,
+      }),
+    ).toBeNull();
+  });
+
+  it('returns null for factory-created proposals executing a different function', () => {
+    const joinSpaceExecutionData = encodeFunctionData({
+      abi: daoSpaceFactoryImplementationAbi,
+      functionName: 'joinSpace',
+      args: [42n],
+    });
+
+    expect(
+      decodeJoinRequestProposal({
+        creator: factoryAddress,
+        executionData: joinSpaceExecutionData,
+      }),
+    ).toBeNull();
+  });
+
+  it('returns null for calldata that does not match the factory ABI', () => {
+    expect(
+      decodeJoinRequestProposal({
+        creator: factoryAddress,
+        executionData: '0xdeadbeef',
+      }),
+    ).toBeNull();
+  });
+
+  it('returns null for empty or missing executionData', () => {
+    expect(
+      decodeJoinRequestProposal({
+        creator: factoryAddress,
+        executionData: '0x',
+      }),
+    ).toBeNull();
+    expect(
+      decodeJoinRequestProposal({
+        creator: factoryAddress,
+        executionData: undefined,
+      }),
+    ).toBeNull();
+  });
+});

--- a/packages/core/src/governance/server/decode-join-request-proposal.ts
+++ b/packages/core/src/governance/server/decode-join-request-proposal.ts
@@ -1,0 +1,54 @@
+import { decodeFunctionData, type Hex } from 'viem';
+import {
+  daoSpaceFactoryImplementationAbi,
+  daoSpaceFactoryImplementationAddress,
+} from '@hypha-platform/core/generated';
+
+const spaceFactoryAddresses = new Set<string>(
+  Object.values(daoSpaceFactoryImplementationAddress).map((address) =>
+    address.toLowerCase(),
+  ),
+);
+
+/**
+ * Detects a join-request ("Invite") proposal from a `ProposalCreated` event.
+ *
+ * When a user requests to join an invite-only space, the proposal is created
+ * on-chain by `DAOSpaceFactory.joinSpace()`, which wraps an
+ * `addMember(spaceId, memberAddress)` call. In that case the event's `creator`
+ * is the space factory contract (not the requester), so the requester can only
+ * be recovered by decoding the event's `executionData`.
+ *
+ * Returns the requester's wallet address, or `null` when the event is not a
+ * join-request proposal.
+ */
+export function decodeJoinRequestProposal({
+  creator,
+  executionData,
+}: {
+  creator: string;
+  executionData: Hex | undefined;
+}): `0x${string}` | null {
+  if (!spaceFactoryAddresses.has(creator.toLowerCase())) {
+    return null;
+  }
+  if (!executionData || executionData === '0x') {
+    return null;
+  }
+
+  try {
+    const { functionName, args } = decodeFunctionData({
+      abi: daoSpaceFactoryImplementationAbi,
+      data: executionData,
+    });
+    if (functionName !== 'addMember') {
+      return null;
+    }
+
+    const [, memberAddress] = args;
+
+    return memberAddress ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/core/src/governance/server/index.ts
+++ b/packages/core/src/governance/server/index.ts
@@ -6,6 +6,7 @@ export * from './get-token-holdings-by-space-slug';
 export * from './fetch-org-memory-asset';
 export * from './resolve-document-proposal-status';
 export * from './call-artifacts';
+export * from './decode-join-request-proposal';
 export * from './extract-deployed-token-from-receipt';
 export * from './link-deployed-token';
 export * from './send-human-chat-message';


### PR DESCRIPTION
## Summary

When a user clicks **Request Invite** on an invite-only space, the proposal is created on-chain by `DAOSpaceFactory.joinSpace()`, which internally calls `DAOProposals.createProposal()`. As a result, the `ProposalCreated` event's `creator` is the **space factory contract address**, not the requester's wallet. In the `proposal/created` Alchemy webhook this meant:

- The creator notification was silently skipped (no person found in the DB for the factory address) — the requester never learned their join request was created.
- Space members received only the generic "new proposal" copy, even though dedicated `'Invite'` templates already exist (used today only by the executed/rejected webhooks).

## Changes

- **New `decodeJoinRequestProposal` helper** (`packages/core/src/governance/server/decode-join-request-proposal.ts`): detects join-request proposals by checking that the event creator is the DAOSpaceFactory contract and decoding the event's `executionData` as `addMember(spaceId, memberAddress)` calldata, returning the requester's wallet address. This is race-free — it does not depend on the DB document, whose `web3ProposalId` is only linked client-side after the tx receipt.
- **Webhook creator callback**: for join requests, looks up the person by the decoded requester address and renders the creator templates with `proposalLabel: 'Invite'` ("Your invite to join a space has been created" / "You successfully created a join request").
- **Webhook members callback**: for join requests, passes `proposalLabel: 'Invite'` and the requester's name to the member templates ("New join request to one of your spaces — X wants to join …"). Regular proposals keep the existing behavior.
- Unit tests for the decode helper (6 cases: happy path, case-insensitive factory match, non-factory creator, other factory functions, undecodable calldata, empty data).

## Test plan

- [x] `vitest run src/governance/server/__tests__/decode-join-request-proposal.test.ts` — 6/6 pass
- [x] `tsc --noEmit` clean for `apps/web`; no new type errors in `packages/core`
- [x] `pnpm lint` clean for `@hypha-platform/core` and `web` (only pre-existing warnings)
- [ ] Verify on staging: request an invite on an invite-only space and confirm the requester and space members receive the Invite-specific email/push

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved proposal notifications to better identify join requests and label them as invites where applicable.
  * Added support for showing the correct creator name in member and space notifications for these requests.

* **Bug Fixes**
  * Notifications now more reliably match join requests to the correct space and person details.
  * Added validation to avoid mislabeling non-join proposals as invites.

* **Tests**
  * Added coverage for decoding join-request proposals across valid, invalid, and empty input cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->