### PR TITLE
fix(spaces): send proposal-created notifications for join requests

### DIFF
--- a/packages/epics/src/spaces/components/join-space.tsx
+++ b/packages/epics/src/spaces/components/join-space.tsx
@@ -102,6 +102,8 @@ export const JoinSpace = ({
     notifyProposalCreated({
       proposalId: inviteProposalId,
       spaceId: BigInt(web3SpaceId),
+      // On-chain ProposalCreated.creator is the space factory for join
+      // requests; pass the requester so member notifications exclude them.
       creator: person.address as `0x${string}`,
       url,
     }).catch((error) =>

--- a/packages/epics/src/spaces/components/join-space.tsx
+++ b/packages/epics/src/spaces/components/join-space.tsx
@@ -12,12 +12,15 @@ import {
   useJwt,
   useAddMemberOrchestrator,
   useCreateEvent,
+  useHookRegistry,
   Person,
 } from '@hypha-platform/core/client';
 import { BaseError, useConfig } from 'wagmi';
 import { useParams } from 'next/navigation';
 import { useInviteStatus, useSpaceMember } from '../hooks';
 import { useAuthentication } from '@hypha-platform/authentication';
+import { getDhoUrlAgreements } from '../../common';
+import type { Locale } from '@hypha-platform/i18n';
 
 type JoinSpaceProps = {
   spaceId: number;
@@ -35,7 +38,7 @@ export const JoinSpace = ({
   hideWhenMember = false,
 }: JoinSpaceProps) => {
   const t = useTranslations('Spaces');
-  const { lang } = useParams();
+  const { lang, id: spaceSlugParam } = useParams();
   const config = useConfig();
   const { jwt } = useJwt();
   const { spaceDetails } = useSpaceDetailsWeb3Rpc({ spaceId: web3SpaceId });
@@ -69,6 +72,50 @@ export const JoinSpace = ({
     memberAddress: person?.address as `0x${string}`,
   });
   const { createEvent } = useCreateEvent({ authToken: jwt });
+
+  const { useSendNotifications } = useHookRegistry();
+  const { notifyProposalCreated } = useSendNotifications({ authToken: jwt });
+
+  // Join requests bypass the proposal form, so the usual in-app notification
+  // watcher (useProposalNotifications) never runs for them. Trigger the same
+  // server action once the invite proposal id is known from the tx receipt.
+  const inviteProposalId = agreement?.proposalId;
+  const notifiedProposalIdRef = React.useRef<bigint | undefined>(undefined);
+  useEffect(() => {
+    if (
+      !inviteRequested ||
+      inviteProposalId === undefined ||
+      !person?.address
+    ) {
+      return;
+    }
+    if (notifiedProposalIdRef.current === inviteProposalId) {
+      return;
+    }
+    notifiedProposalIdRef.current = inviteProposalId;
+
+    const url =
+      typeof spaceSlugParam === 'string'
+        ? getDhoUrlAgreements(lang as Locale, spaceSlugParam)
+        : undefined;
+
+    notifyProposalCreated({
+      proposalId: inviteProposalId,
+      spaceId: BigInt(web3SpaceId),
+      creator: person.address as `0x${string}`,
+      url,
+    }).catch((error) =>
+      console.warn('Failed to send join request notifications:', error),
+    );
+  }, [
+    inviteRequested,
+    inviteProposalId,
+    person?.address,
+    notifyProposalCreated,
+    lang,
+    spaceSlugParam,
+    web3SpaceId,
+  ]);
 
   const { revalidateInviteStatus, isInviteLoading, lastInviteTime } =
     useInviteStatus({

--- a/packages/epics/src/spaces/components/join-space.tsx
+++ b/packages/epics/src/spaces/components/join-space.tsx
@@ -92,23 +92,26 @@ export const JoinSpace = ({
     if (notifiedProposalIdRef.current === inviteProposalId) {
       return;
     }
-    notifiedProposalIdRef.current = inviteProposalId;
 
     const url =
       typeof spaceSlugParam === 'string'
         ? getDhoUrlAgreements(lang as Locale, spaceSlugParam)
         : undefined;
 
-    notifyProposalCreated({
+    void notifyProposalCreated({
       proposalId: inviteProposalId,
       spaceId: BigInt(web3SpaceId),
       // On-chain ProposalCreated.creator is the space factory for join
       // requests; pass the requester so member notifications exclude them.
       creator: person.address as `0x${string}`,
       url,
-    }).catch((error) =>
-      console.warn('Failed to send join request notifications:', error),
-    );
+    })
+      .then(() => {
+        notifiedProposalIdRef.current = inviteProposalId;
+      })
+      .catch((error) =>
+        console.warn('Failed to send join request notifications:', error),
+      );
   }, [
     inviteRequested,
     inviteProposalId,


### PR DESCRIPTION
## Summary

Follow-up to #2373. That PR fixed the Alchemy `proposal/created` webhook path, but production logs show **zero requests to `/api/webhooks/*` in the last 7 days** — the Alchemy webhook is not configured, so the webhook path never runs. All working proposal-created notifications in production come from the in-app path: the proposal form watches the on-chain `ProposalCreated` event and calls the `notifyProposalCreatedAction` server action. Join requests have no form, so nobody was notified.

## Change

In `JoinSpace` (`packages/epics/src/spaces/components/join-space.tsx`), after a successful invite request, trigger the same `notifyProposalCreated` action (via the hook registry, like `useProposalNotifications` does) once the invite proposal id is parsed from the `joinSpace()` tx receipt:

- **creator** = the requester's wallet address (the on-chain event's `creator` is the factory contract, so we pass the requester explicitly) → they get the "your proposal has been created" email/push
- **members** are resolved on-chain by the action, the requester is excluded, and OneSignal preference tags (`sub_newProposalOpen`) apply — identical behavior to regular proposals
- guarded by a ref so the notification fires once per proposal id

## Notes

- Depends on the requester's browser staying open until the tx receipt is parsed (same limitation as the existing in-app path for regular proposals).
- Uses the generic proposal-created OneSignal templates. Invite-specific copy exists only in the webhook path (#2373), which will kick in if/when the Alchemy webhook is configured — at that point dedupe/preference filtering should be added there first.

## Test plan

- [x] `tsc --noEmit` clean for `packages/epics`
- [x] `pnpm lint` clean (0 errors, pre-existing warnings only)
- [ ] On production/staging: request an invite on an invite-only space; confirm the requester gets a creation confirmation and existing members get the new-proposal notification

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Join requests now trigger a notification when an invite proposal is created, so users can follow request status more easily.
  * Notification content now includes the relevant space/proposal details and a direct agreements link when available.

* **Bug Fixes**
  * Improved reliability of join-request notifications: failures are handled gracefully without disrupting the join flow.
  * Prevents duplicate notifications by ensuring the same proposal isn’t notified repeatedly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->