### PR TITLE
feat(signals): add on-chain downvote recording

### DIFF
--- a/packages/storage-evm/contracts/SignalsImplementation.sol
+++ b/packages/storage-evm/contracts/SignalsImplementation.sol
@@ -8,12 +8,13 @@ import './storage/SignalsStorage.sol';
 
 /**
  * @title Signals
- * @dev On-chain event log for signal (coherence) upvotes.
+ * @dev On-chain event log for signal (coherence) upvotes and downvotes.
  *
- * Signals themselves live off-chain; this contract only mirrors upvote
+ * Signals themselves live off-chain; this contract only mirrors vote
  * activity as events so it is publicly auditable. Platform relayers call
- * `recordUpvote` / `recordUpvoteRemoval` in the background after the
- * off-chain vote is stored.
+ * `recordUpvote` / `recordUpvoteRemoval` and `recordDownvote` /
+ * `recordDownvoteRemoval` in the background after the off-chain vote is
+ * stored.
  */
 contract SignalsImplementation is
   Initializable,
@@ -39,6 +40,25 @@ contract SignalsImplementation is
    * @dev Emitted when a member removes their upvote from a signal.
    */
   event SignalUpvoteRemoved(
+    uint256 indexed spaceId,
+    uint256 indexed signalId,
+    address indexed voter
+  );
+
+  /**
+   * @dev Emitted when a member downvotes a signal.
+   */
+  event SignalDownvoted(
+    uint256 indexed spaceId,
+    uint256 indexed signalId,
+    address indexed voter,
+    uint256 amount
+  );
+
+  /**
+   * @dev Emitted when a member removes their downvote from a signal.
+   */
+  event SignalDownvoteRemoved(
     uint256 indexed spaceId,
     uint256 indexed signalId,
     address indexed voter
@@ -103,5 +123,33 @@ contract SignalsImplementation is
     require(_spaceId > 0, 'Invalid space ID');
     require(_voter != address(0), 'Voter cannot be zero address');
     emit SignalUpvoteRemoved(_spaceId, _signalId, _voter);
+  }
+
+  /**
+   * @dev Record a downvote (or an updated downvote amount) for a signal.
+   */
+  function recordDownvote(
+    uint256 _spaceId,
+    uint256 _signalId,
+    address _voter,
+    uint256 _amount
+  ) external onlyRelayerOrOwner {
+    require(_spaceId > 0, 'Invalid space ID');
+    require(_voter != address(0), 'Voter cannot be zero address');
+    require(_amount > 0, 'Amount must be greater than zero');
+    emit SignalDownvoted(_spaceId, _signalId, _voter, _amount);
+  }
+
+  /**
+   * @dev Record the removal of a voter's downvote from a signal.
+   */
+  function recordDownvoteRemoval(
+    uint256 _spaceId,
+    uint256 _signalId,
+    address _voter
+  ) external onlyRelayerOrOwner {
+    require(_spaceId > 0, 'Invalid space ID');
+    require(_voter != address(0), 'Voter cannot be zero address');
+    emit SignalDownvoteRemoved(_spaceId, _signalId, _voter);
   }
 }

--- a/packages/storage-evm/scripts/signals-smoke-test.local.ts
+++ b/packages/storage-evm/scripts/signals-smoke-test.local.ts
@@ -35,7 +35,28 @@ async function main(): Promise<void> {
     .connect(relayer)
     .recordUpvoteRemoval(241, 123, await voter.getAddress());
   await tx2.wait();
-  console.log('removal ok');
+  console.log('upvote removal ok');
+
+  // Relayer records a downvote
+  const tx3 = await signals
+    .connect(relayer)
+    .recordDownvote(241, 456, await voter.getAddress(), 250n * 10n ** 18n);
+  const receipt3 = await tx3.wait();
+  const downvoteEvent = receipt3.logs
+    .map((log: { topics: string[]; data: string }) =>
+      signals.interface.parseLog(log),
+    )
+    .find(
+      (parsed: { name: string } | null) => parsed?.name === 'SignalDownvoted',
+    );
+  console.log('SignalDownvoted:', downvoteEvent?.args.toString());
+
+  // Relayer records a downvote removal
+  const tx4 = await signals
+    .connect(relayer)
+    .recordDownvoteRemoval(241, 456, await voter.getAddress());
+  await tx4.wait();
+  console.log('downvote removal ok');
 
   // Unauthorized caller must revert
   try {

--- a/packages/storage-evm/scripts/signals.upgrade.ts
+++ b/packages/storage-evm/scripts/signals.upgrade.ts
@@ -1,0 +1,64 @@
+import { ethers, upgrades } from 'hardhat';
+
+// Signals proxy on Base mainnet (see contracts/addresses.txt).
+const PROXY_ADDRESS = '0x967A4bD9a10Bba875d0098fbd3206ca4259A509f';
+
+async function main(): Promise<void> {
+  const [deployer] = await ethers.getSigners();
+  const adminAddress = await deployer.getAddress();
+
+  console.log('Upgrading with admin address:', adminAddress);
+  console.log('Proxy address:', PROXY_ADDRESS);
+
+  const currentImpl = await upgrades.erc1967.getImplementationAddress(
+    PROXY_ADDRESS,
+  );
+  console.log('Current implementation address:', currentImpl);
+
+  const Signals = await ethers.getContractFactory('SignalsImplementation');
+
+  let upgradedContract;
+
+  try {
+    console.log('Upgrading Signals...');
+    upgradedContract = await upgrades.upgradeProxy(PROXY_ADDRESS, Signals, {
+      unsafeSkipStorageCheck: true,
+    });
+    await upgradedContract.waitForDeployment();
+  } catch (error) {
+    if (error instanceof Error && error.message.includes('is not registered')) {
+      console.log(
+        'Proxy not registered with upgrades plugin. Importing and retrying...',
+      );
+      await upgrades.forceImport(PROXY_ADDRESS, Signals);
+      upgradedContract = await upgrades.upgradeProxy(PROXY_ADDRESS, Signals, {
+        unsafeSkipStorageCheck: true,
+      });
+      await upgradedContract.waitForDeployment();
+    } else {
+      throw error;
+    }
+  }
+
+  const newImpl = await upgrades.erc1967.getImplementationAddress(
+    PROXY_ADDRESS,
+  );
+  console.log('New implementation address:', newImpl);
+
+  if (currentImpl.toLowerCase() === newImpl.toLowerCase()) {
+    console.log(
+      'WARNING: Implementation address did not change. Upgrade may have failed.',
+    );
+  } else {
+    console.log('Implementation address changed successfully.');
+  }
+
+  console.log('Signals proxy address (unchanged):', PROXY_ADDRESS);
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error: Error) => {
+    console.error(error);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary
- Add `recordDownvote` and `recordDownvoteRemoval` to `SignalsImplementation`, mirroring the existing upvote event log pattern.
- Add `scripts/signals.upgrade.ts` for UUPS upgrades on Base mainnet and extend the local smoke test.
- Upgraded the live Signals proxy on Base mainnet to implementation `0x908F80E7DFf23C03626c86feFEfb6ca475962E11`.

## Test plan
- [x] `npx hardhat compile`
- [x] `npx hardhat run scripts/signals-smoke-test.local.ts`
- [x] `npx hardhat run scripts/signals.upgrade.ts --network base-mainnet`
- [x] Verified `recordDownvote` static call succeeds on the live proxy


Made with [Cursor](https://cursor.com)