### PR TITLE
feat(platform): add dashboard for paying spaces, assets, signals, and memory

### DIFF
--- a/apps/web/src/app/[lang]/platform/dashboard/page.tsx
+++ b/apps/web/src/app/[lang]/platform/dashboard/page.tsx
@@ -1,0 +1,5 @@
+import { PlatformDashboard } from '@hypha-platform/epics';
+
+export default function PlatformDashboardPage() {
+  return <PlatformDashboard />;
+}

--- a/apps/web/src/app/api/v1/ops/platform/dashboard/route.ts
+++ b/apps/web/src/app/api/v1/ops/platform/dashboard/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getPlatformDashboard } from '@hypha-platform/core/server';
+import { db } from '@hypha-platform/storage-postgres';
+import { readOpsSecret } from '../../_lib/ops-auth';
+
+export async function GET(request: NextRequest) {
+  const configuredSecret =
+    process.env.HYPHA_SPACE_MEMORY_OPS_SECRET?.trim() ?? '';
+  if (!configuredSecret) {
+    return NextResponse.json(
+      { error: 'HYPHA_SPACE_MEMORY_OPS_SECRET is not configured' },
+      { status: 503 },
+    );
+  }
+  if (readOpsSecret(request) !== configuredSecret) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const dashboard = await getPlatformDashboard({ db });
+    return NextResponse.json(dashboard);
+  } catch (error) {
+    console.error('[platform-dashboard] Failed to load dashboard', error);
+    return NextResponse.json(
+      { error: 'Failed to load platform dashboard' },
+      { status: 500 },
+    );
+  }
+}

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -24,3 +24,4 @@ export {
   BANK_VIRTUAL_ACCOUNT_CURRENCIES,
 } from './banking/constants';
 export type { BankProvider } from './banking/types';
+export type { PlatformDashboardData } from './platform/types';

--- a/packages/core/src/platform/server/assets-summary.ts
+++ b/packages/core/src/platform/server/assets-summary.ts
@@ -1,0 +1,175 @@
+import 'server-only';
+
+import { findAllSpaces } from '../../space/server/queries';
+import { web3Client } from '../../common/server/web3-rpc/client';
+import { getSpaceDetails } from '../../space/shared/web3/get-space-details';
+import { getTokenBalancesByAddress, getTokenPrice } from '../../common/server';
+import type { DbConfig } from '../../server';
+import { formatEther } from 'viem';
+
+export type PlatformSpaceAssetSummary = {
+  spaceId: number;
+  slug: string;
+  title: string;
+  balanceUsd: number;
+  assetCount: number;
+  topAssets: Array<{
+    symbol: string;
+    name: string;
+    value: number;
+    usdEqual: number;
+  }>;
+};
+
+async function mapInBatches<T, R>(
+  items: T[],
+  batchSize: number,
+  fn: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = [];
+  for (let i = 0; i < items.length; i += batchSize) {
+    const batch = items.slice(i, i + batchSize);
+    const batchResults = await Promise.all(batch.map(fn));
+    results.push(...batchResults);
+  }
+  return results;
+}
+
+async function getSpaceAssetSummary(space: {
+  id: number;
+  slug: string;
+  title: string;
+  web3SpaceId: number | null;
+}): Promise<PlatformSpaceAssetSummary | null> {
+  if (space.web3SpaceId == null || space.web3SpaceId <= 0) {
+    return null;
+  }
+
+  try {
+    const spaceId = BigInt(space.web3SpaceId);
+    const spaceDetails = await web3Client.readContract(
+      getSpaceDetails({ spaceId }),
+    );
+    const executor = spaceDetails[9] as `0x${string}`;
+    if (!executor || !/^0x[a-fA-F0-9]{40}$/.test(executor)) {
+      return {
+        spaceId: space.id,
+        slug: space.slug,
+        title: space.title,
+        balanceUsd: 0,
+        assetCount: 0,
+        topAssets: [],
+      };
+    }
+
+    const externalTokens = await getTokenBalancesByAddress(executor).catch(
+      () => [],
+    );
+    const tokensWithBalance = externalTokens.filter(
+      (token) => token.balance > 0,
+    );
+    const tokenAddresses = tokensWithBalance
+      .slice(0, 12)
+      .map((token) => token.tokenAddress as `0x${string}`);
+
+    let prices: Record<string, number> = {};
+    if (tokenAddresses.length > 0) {
+      try {
+        prices = await getTokenPrice(tokenAddresses);
+      } catch {
+        prices = {};
+      }
+    }
+
+    const tokenAssets = tokensWithBalance.slice(0, 12).map((token) => {
+      const rate = prices[token.tokenAddress] ?? 0;
+      const usdEqual = rate * token.balance;
+      return {
+        symbol: token.symbol,
+        name: token.name,
+        value: token.balance,
+        usdEqual,
+      };
+    });
+
+    const ethBalance = await web3Client.getBalance({ address: executor });
+    const ethAmount = Number(formatEther(ethBalance));
+    const wethAddress = '0x4200000000000000000000000000000000000006' as const;
+    let ethUsd = 0;
+    if (ethAmount > 0) {
+      try {
+        const ethPrices = await getTokenPrice([wethAddress]);
+        ethUsd = (ethPrices[wethAddress] ?? 0) * ethAmount;
+      } catch {
+        ethUsd = 0;
+      }
+    }
+
+    const topAssets = [
+      ...(ethAmount > 0
+        ? [
+            {
+              symbol: 'ETH',
+              name: 'Ether',
+              value: ethAmount,
+              usdEqual: ethUsd,
+            },
+          ]
+        : []),
+      ...tokenAssets,
+    ]
+      .filter((asset) => asset.value > 0)
+      .sort((a, b) => b.usdEqual - a.usdEqual)
+      .slice(0, 4);
+
+    const balanceUsd = topAssets.reduce(
+      (sum, asset) => sum + asset.usdEqual,
+      0,
+    );
+
+    return {
+      spaceId: space.id,
+      slug: space.slug,
+      title: space.title,
+      balanceUsd,
+      assetCount: topAssets.length,
+      topAssets,
+    };
+  } catch (error) {
+    console.warn(
+      `[platform-dashboard] Failed asset summary for ${space.slug}`,
+      error,
+    );
+    return {
+      spaceId: space.id,
+      slug: space.slug,
+      title: space.title,
+      balanceUsd: 0,
+      assetCount: 0,
+      topAssets: [],
+    };
+  }
+}
+
+export async function getPlatformAssetsSummary({ db }: DbConfig) {
+  const spaces = await findAllSpaces(
+    { db },
+    { parentOnly: false, omitSandbox: true, omitArchived: true },
+  );
+
+  const summaries = (
+    await mapInBatches(spaces, 4, (space) => getSpaceAssetSummary(space))
+  ).filter((summary): summary is PlatformSpaceAssetSummary => summary != null);
+
+  const sorted = summaries.sort((a, b) => b.balanceUsd - a.balanceUsd);
+  const totalBalanceUsd = sorted.reduce(
+    (sum, space) => sum + space.balanceUsd,
+    0,
+  );
+
+  return {
+    totalBalanceUsd,
+    spaceCount: sorted.length,
+    spaces: sorted,
+  };
+}

--- a/packages/core/src/platform/server/get-platform-dashboard.ts
+++ b/packages/core/src/platform/server/get-platform-dashboard.ts
@@ -1,0 +1,28 @@
+import 'server-only';
+
+import type { DbConfig } from '../../server';
+import { getPayingSpacesMetrics } from './paying-spaces';
+import { getPlatformAssetsSummary } from './assets-summary';
+import { getPlatformSignalsStats } from './signals-stats';
+import { getPlatformSpaceMemoryStats } from './space-memory-stats';
+
+import type { PlatformDashboardData } from '../../platform/types';
+
+export async function getPlatformDashboard({ db }: DbConfig) {
+  const [payingSpaces, assets, signals, spaceMemory] = await Promise.all([
+    getPayingSpacesMetrics({ db }),
+    getPlatformAssetsSummary({ db }),
+    getPlatformSignalsStats({ db }),
+    getPlatformSpaceMemoryStats({ db }),
+  ]);
+
+  return {
+    generatedAt: new Date().toISOString(),
+    payingSpaces,
+    assets,
+    signals,
+    spaceMemory,
+  };
+}
+
+export type { PlatformDashboardData } from '../../platform/types';

--- a/packages/core/src/platform/server/index.ts
+++ b/packages/core/src/platform/server/index.ts
@@ -1,0 +1,5 @@
+export * from './get-platform-dashboard';
+export * from './paying-spaces';
+export * from './assets-summary';
+export * from './signals-stats';
+export * from './space-memory-stats';

--- a/packages/core/src/platform/server/paying-spaces.ts
+++ b/packages/core/src/platform/server/paying-spaces.ts
@@ -1,0 +1,287 @@
+import 'server-only';
+
+import {
+  hyphaTokenAbi,
+  hyphaTokenAddress,
+  spacePaymentTrackerAbi,
+  spacePaymentTrackerAddress,
+} from '../../generated';
+import { findAllSpaces } from '../../space/server/queries';
+import { web3Client } from '../../common/server/web3-rpc/client';
+import type { DbConfig } from '../../server';
+import { formatUnits } from 'viem';
+
+export type PayingSpaceStatus = {
+  spaceId: number;
+  web3SpaceId: number;
+  slug: string;
+  title: string;
+  hasPaidWithHypha: boolean;
+  isActive: boolean;
+  expiryTime: number | null;
+  freeTrialUsed: boolean;
+  totalHyphaPaid: string;
+};
+
+export type HyphaPaymentMonthBucket = {
+  month: string;
+  paymentCount: number;
+  spacesActivated: number;
+  totalHypha: string;
+};
+
+const CHUNK_SIZE = 50_000n;
+const BLOCKS_PER_DAY = 43_200n;
+const HISTORY_DAYS = 365n;
+
+async function mapInBatches<T, R>(
+  items: T[],
+  batchSize: number,
+  fn: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = [];
+  for (let i = 0; i < items.length; i += batchSize) {
+    const batch = items.slice(i, i + batchSize);
+    const batchResults = await Promise.all(batch.map(fn));
+    results.push(...batchResults);
+  }
+  return results;
+}
+
+function toMonthKey(date: Date): string {
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+  return `${year}-${month}`;
+}
+
+export async function getHyphaPaymentEvents() {
+  const tokenAddress = hyphaTokenAddress[8453] as `0x${string}`;
+  const currentBlock = await web3Client.getBlockNumber();
+  const fromBlock =
+    currentBlock > BLOCKS_PER_DAY * HISTORY_DAYS
+      ? currentBlock - BLOCKS_PER_DAY * HISTORY_DAYS
+      : 0n;
+
+  type HyphaPaymentEvent = {
+    blockNumber: bigint;
+    args: {
+      spaceIds: readonly bigint[];
+      durationInDays: readonly bigint[];
+      totalHyphaUsed: bigint;
+    };
+  };
+
+  const allEvents: HyphaPaymentEvent[] = [];
+
+  for (let start = fromBlock; start <= currentBlock; start += CHUNK_SIZE) {
+    const end =
+      start + CHUNK_SIZE - 1n > currentBlock
+        ? currentBlock
+        : start + CHUNK_SIZE - 1n;
+    try {
+      const chunk = await web3Client.getContractEvents({
+        address: tokenAddress,
+        abi: hyphaTokenAbi,
+        eventName: 'SpacesPaymentProcessedWithHypha',
+        fromBlock: start,
+        toBlock: end,
+      });
+      for (const event of chunk) {
+        if (event.blockNumber == null || !('args' in event) || !event.args) {
+          continue;
+        }
+        allEvents.push({
+          blockNumber: event.blockNumber,
+          args: event.args as HyphaPaymentEvent['args'],
+        });
+      }
+    } catch (error) {
+      console.warn(
+        `[platform-dashboard] Failed Hypha payment log chunk ${start}-${end}`,
+        error,
+      );
+    }
+  }
+
+  return allEvents;
+}
+
+export async function getPayingSpacesMetrics({ db }: DbConfig) {
+  const spaces = await findAllSpaces(
+    { db },
+    { parentOnly: false, omitSandbox: true, omitArchived: true },
+  );
+  const spacesWithWeb3 = spaces.filter(
+    (space) =>
+      space.web3SpaceId != null &&
+      Number.isFinite(Number(space.web3SpaceId)) &&
+      Number(space.web3SpaceId) > 0,
+  );
+
+  const trackerAddress = spacePaymentTrackerAddress[8453] as `0x${string}`;
+
+  const paymentStates = await mapInBatches(
+    spacesWithWeb3,
+    40,
+    async (space) => {
+      const web3SpaceId = BigInt(space.web3SpaceId as number);
+      try {
+        const [hasPaid, payment, isActive] = await web3Client.multicall({
+          contracts: [
+            {
+              address: trackerAddress,
+              abi: spacePaymentTrackerAbi,
+              functionName: 'hasSpacePaid',
+              args: [web3SpaceId],
+            },
+            {
+              address: trackerAddress,
+              abi: spacePaymentTrackerAbi,
+              functionName: 'spacePayments',
+              args: [web3SpaceId],
+            },
+            {
+              address: trackerAddress,
+              abi: spacePaymentTrackerAbi,
+              functionName: 'isSpaceActive',
+              args: [web3SpaceId],
+            },
+          ],
+        });
+
+        const expiryTime =
+          payment.status === 'success' ? Number(payment.result[0]) : null;
+        const freeTrialUsed =
+          payment.status === 'success' ? Boolean(payment.result[1]) : false;
+
+        return {
+          spaceId: space.id,
+          web3SpaceId: Number(space.web3SpaceId),
+          slug: space.slug,
+          title: space.title,
+          hasPaidWithHypha:
+            hasPaid.status === 'success' ? Boolean(hasPaid.result) : false,
+          isActive:
+            isActive.status === 'success' ? Boolean(isActive.result) : false,
+          expiryTime,
+          freeTrialUsed,
+          totalHyphaPaid: '0',
+        } satisfies PayingSpaceStatus;
+      } catch (error) {
+        console.warn(
+          `[platform-dashboard] Failed payment state for space ${space.slug}`,
+          error,
+        );
+        return {
+          spaceId: space.id,
+          web3SpaceId: Number(space.web3SpaceId),
+          slug: space.slug,
+          title: space.title,
+          hasPaidWithHypha: false,
+          isActive: false,
+          expiryTime: null,
+          freeTrialUsed: false,
+          totalHyphaPaid: '0',
+        } satisfies PayingSpaceStatus;
+      }
+    },
+  );
+
+  const events = await getHyphaPaymentEvents();
+  const hyphaPaidByWeb3SpaceId = new Map<number, bigint>();
+  const monthBuckets = new Map<
+    string,
+    { paymentCount: number; spaceIds: Set<number>; totalHypha: bigint }
+  >();
+
+  const uniqueBlockNumbers = [
+    ...new Set(events.map((event) => event.blockNumber)),
+  ];
+  const blockTimestamps = new Map<bigint, number>();
+  await mapInBatches(uniqueBlockNumbers, 25, async (blockNumber) => {
+    const block = await web3Client.getBlock({ blockNumber });
+    blockTimestamps.set(blockNumber, Number(block.timestamp));
+  });
+
+  for (const event of events) {
+    const { spaceIds, durationInDays, totalHyphaUsed } = event.args;
+    const totalDays = durationInDays.reduce((sum, days) => sum + days, 0n);
+    const timestamp = blockTimestamps.get(event.blockNumber) ?? 0;
+    const month = toMonthKey(new Date(timestamp * 1000));
+
+    const bucket = monthBuckets.get(month) ?? {
+      paymentCount: 0,
+      spaceIds: new Set<number>(),
+      totalHypha: 0n,
+    };
+    bucket.paymentCount += 1;
+    bucket.totalHypha += totalHyphaUsed;
+
+    for (let index = 0; index < spaceIds.length; index += 1) {
+      const id = Number(spaceIds[index]);
+      const duration = durationInDays[index] ?? 0n;
+      const share =
+        totalDays > 0n
+          ? (totalHyphaUsed * duration) / totalDays
+          : spaceIds.length > 0
+          ? totalHyphaUsed / BigInt(spaceIds.length)
+          : 0n;
+      bucket.spaceIds.add(id);
+      hyphaPaidByWeb3SpaceId.set(
+        id,
+        (hyphaPaidByWeb3SpaceId.get(id) ?? 0n) + share,
+      );
+    }
+    monthBuckets.set(month, bucket);
+  }
+
+  const spacesWithTotals = paymentStates.map((space) => ({
+    ...space,
+    totalHyphaPaid: formatUnits(
+      hyphaPaidByWeb3SpaceId.get(space.web3SpaceId) ?? 0n,
+      18,
+    ),
+  }));
+
+  const monthly: HyphaPaymentMonthBucket[] = [...monthBuckets.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([month, bucket]) => ({
+      month,
+      paymentCount: bucket.paymentCount,
+      spacesActivated: bucket.spaceIds.size,
+      totalHypha: formatUnits(bucket.totalHypha, 18),
+    }));
+
+  const hyphaPaidSpaces = spacesWithTotals.filter(
+    (space) => space.hasPaidWithHypha,
+  );
+  const activePaidSpaces = hyphaPaidSpaces.filter((space) => space.isActive);
+
+  return {
+    summary: {
+      totalSpaces: spacesWithWeb3.length,
+      hyphaPaidSpaces: hyphaPaidSpaces.length,
+      activePaidSpaces: activePaidSpaces.length,
+      expiredPaidSpaces: hyphaPaidSpaces.length - activePaidSpaces.length,
+      freeTrialOnly: spacesWithTotals.filter(
+        (space) => space.freeTrialUsed && !space.hasPaidWithHypha,
+      ).length,
+      totalHyphaBurned: formatUnits(
+        [...hyphaPaidByWeb3SpaceId.values()].reduce(
+          (sum, value) => sum + value,
+          0n,
+        ),
+        18,
+      ),
+      paymentEventsInRange: events.length,
+    },
+    monthly,
+    spaces: spacesWithTotals.sort((a, b) =>
+      a.hasPaidWithHypha === b.hasPaidWithHypha
+        ? a.title.localeCompare(b.title)
+        : a.hasPaidWithHypha
+        ? -1
+        : 1,
+    ),
+  };
+}

--- a/packages/core/src/platform/server/signals-stats.ts
+++ b/packages/core/src/platform/server/signals-stats.ts
@@ -1,0 +1,94 @@
+import 'server-only';
+
+import { and, eq, gte, sql } from 'drizzle-orm';
+import { coherences, spaces } from '@hypha-platform/storage-postgres';
+import { getSignalOrchestratorMetrics } from '../../coherence/server/signal-orchestrator';
+import type { DbConfig } from '../../server';
+
+export async function getPlatformSignalsStats({ db }: DbConfig) {
+  const since24h = new Date(Date.now() - 24 * 60 * 60 * 1000);
+  const since7d = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+
+  const [
+    totalsByType,
+    totalsByPriority,
+    perSpaceTotals,
+    createdLast24h,
+    createdLast7d,
+    orchestratorMetrics,
+  ] = await Promise.all([
+    db
+      .select({
+        type: coherences.type,
+        count: sql<number>`count(*)`,
+      })
+      .from(coherences)
+      .where(eq(coherences.archived, false))
+      .groupBy(coherences.type),
+    db
+      .select({
+        priority: coherences.priority,
+        count: sql<number>`count(*)`,
+      })
+      .from(coherences)
+      .where(eq(coherences.archived, false))
+      .groupBy(coherences.priority),
+    db
+      .select({
+        spaceId: coherences.spaceId,
+        spaceSlug: spaces.slug,
+        spaceTitle: spaces.title,
+        count: sql<number>`count(*)`,
+      })
+      .from(coherences)
+      .innerJoin(spaces, eq(coherences.spaceId, spaces.id))
+      .where(eq(coherences.archived, false))
+      .groupBy(coherences.spaceId, spaces.slug, spaces.title)
+      .orderBy(sql`count(*) desc`),
+    db
+      .select({ count: sql<number>`count(*)` })
+      .from(coherences)
+      .where(
+        and(
+          eq(coherences.archived, false),
+          gte(coherences.createdAt, since24h),
+        ),
+      ),
+    db
+      .select({ count: sql<number>`count(*)` })
+      .from(coherences)
+      .where(
+        and(eq(coherences.archived, false), gte(coherences.createdAt, since7d)),
+      ),
+    getSignalOrchestratorMetrics({ db }),
+  ]);
+
+  const totalSignals = perSpaceTotals.reduce(
+    (sum, row) => sum + Number(row.count ?? 0),
+    0,
+  );
+
+  return {
+    summary: {
+      totalSignals,
+      createdLast24h: Number(createdLast24h[0]?.count ?? 0),
+      createdLast7d: Number(createdLast7d[0]?.count ?? 0),
+      spacesWithSignals: perSpaceTotals.length,
+    },
+    byType: totalsByType.map((row) => ({
+      type: row.type,
+      count: Number(row.count ?? 0),
+    })),
+    byPriority: totalsByPriority.map((row) => ({
+      priority: row.priority ?? 'unknown',
+      count: Number(row.count ?? 0),
+    })),
+    bySpace: perSpaceTotals.map((row) => ({
+      spaceId: row.spaceId,
+      slug: row.spaceSlug,
+      title: row.spaceTitle,
+      count: Number(row.count ?? 0),
+    })),
+    orchestrator: orchestratorMetrics,
+  };
+}

--- a/packages/core/src/platform/server/space-memory-stats.ts
+++ b/packages/core/src/platform/server/space-memory-stats.ts
@@ -1,0 +1,107 @@
+import 'server-only';
+
+import { and, eq, gte, isNotNull, sql } from 'drizzle-orm';
+import {
+  spaceCallRecordings,
+  spaceCallTranscripts,
+  spaceDiscussionSummaries,
+  spaces,
+} from '@hypha-platform/storage-postgres';
+import type { DbConfig } from '../../server';
+
+export async function getPlatformSpaceMemoryStats({ db }: DbConfig) {
+  const since24h = new Date(Date.now() - 24 * 60 * 60 * 1000);
+  const since7d = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+
+  const [
+    spacesWithChatRow,
+    summaryTotalRow,
+    transcriptTotalRow,
+    recordingTotalRow,
+    summaries24h,
+    summaries7d,
+    perSpaceSummaries,
+    perSpaceTranscripts,
+    perSpaceRecordings,
+  ] = await Promise.all([
+    db
+      .select({ count: sql<number>`count(*)` })
+      .from(spaces)
+      .where(and(isNotNull(spaces.chatRoomId), eq(spaces.isArchived, false))),
+    db.select({ count: sql<number>`count(*)` }).from(spaceDiscussionSummaries),
+    db.select({ count: sql<number>`count(*)` }).from(spaceCallTranscripts),
+    db.select({ count: sql<number>`count(*)` }).from(spaceCallRecordings),
+    db
+      .select({ count: sql<number>`count(*)` })
+      .from(spaceDiscussionSummaries)
+      .where(gte(spaceDiscussionSummaries.createdAt, since24h)),
+    db
+      .select({ count: sql<number>`count(*)` })
+      .from(spaceDiscussionSummaries)
+      .where(gte(spaceDiscussionSummaries.createdAt, since7d)),
+    db
+      .select({
+        spaceId: spaceDiscussionSummaries.spaceId,
+        spaceSlug: spaces.slug,
+        spaceTitle: spaces.title,
+        count: sql<number>`count(*)`,
+      })
+      .from(spaceDiscussionSummaries)
+      .innerJoin(spaces, eq(spaceDiscussionSummaries.spaceId, spaces.id))
+      .groupBy(spaceDiscussionSummaries.spaceId, spaces.slug, spaces.title)
+      .orderBy(sql`count(*) desc`),
+    db
+      .select({
+        spaceId: spaceCallTranscripts.spaceId,
+        spaceSlug: spaces.slug,
+        spaceTitle: spaces.title,
+        count: sql<number>`count(*)`,
+      })
+      .from(spaceCallTranscripts)
+      .innerJoin(spaces, eq(spaceCallTranscripts.spaceId, spaces.id))
+      .groupBy(spaceCallTranscripts.spaceId, spaces.slug, spaces.title)
+      .orderBy(sql`count(*) desc`),
+    db
+      .select({
+        spaceId: spaceCallRecordings.spaceId,
+        spaceSlug: spaces.slug,
+        spaceTitle: spaces.title,
+        count: sql<number>`count(*)`,
+      })
+      .from(spaceCallRecordings)
+      .innerJoin(spaces, eq(spaceCallRecordings.spaceId, spaces.id))
+      .groupBy(spaceCallRecordings.spaceId, spaces.slug, spaces.title)
+      .orderBy(sql`count(*) desc`),
+  ]);
+
+  return {
+    summary: {
+      spacesWithChat: Number(spacesWithChatRow[0]?.count ?? 0),
+      summariesTotal: Number(summaryTotalRow[0]?.count ?? 0),
+      transcriptsTotal: Number(transcriptTotalRow[0]?.count ?? 0),
+      recordingsTotal: Number(recordingTotalRow[0]?.count ?? 0),
+      summariesLast24h: Number(summaries24h[0]?.count ?? 0),
+      summariesLast7d: Number(summaries7d[0]?.count ?? 0),
+    },
+    bySpace: {
+      summaries: perSpaceSummaries.map((row) => ({
+        spaceId: row.spaceId,
+        slug: row.spaceSlug,
+        title: row.spaceTitle,
+        count: Number(row.count ?? 0),
+      })),
+      transcripts: perSpaceTranscripts.map((row) => ({
+        spaceId: row.spaceId,
+        slug: row.spaceSlug,
+        title: row.spaceTitle,
+        count: Number(row.count ?? 0),
+      })),
+      recordings: perSpaceRecordings.map((row) => ({
+        spaceId: row.spaceId,
+        slug: row.spaceSlug,
+        title: row.spaceTitle,
+        count: Number(row.count ?? 0),
+      })),
+    },
+  };
+}

--- a/packages/core/src/platform/types.ts
+++ b/packages/core/src/platform/types.ts
@@ -1,0 +1,106 @@
+export type PlatformDashboardData = {
+  generatedAt: string;
+  payingSpaces: {
+    summary: {
+      totalSpaces: number;
+      hyphaPaidSpaces: number;
+      activePaidSpaces: number;
+      expiredPaidSpaces: number;
+      freeTrialOnly: number;
+      totalHyphaBurned: string;
+      paymentEventsInRange: number;
+    };
+    monthly: Array<{
+      month: string;
+      paymentCount: number;
+      spacesActivated: number;
+      totalHypha: string;
+    }>;
+    spaces: Array<{
+      spaceId: number;
+      web3SpaceId: number;
+      slug: string;
+      title: string;
+      hasPaidWithHypha: boolean;
+      isActive: boolean;
+      expiryTime: number | null;
+      freeTrialUsed: boolean;
+      totalHyphaPaid: string;
+    }>;
+  };
+  assets: {
+    totalBalanceUsd: number;
+    spaceCount: number;
+    spaces: Array<{
+      spaceId: number;
+      slug: string;
+      title: string;
+      balanceUsd: number;
+      assetCount: number;
+      topAssets: Array<{
+        symbol: string;
+        name: string;
+        value: number;
+        usdEqual: number;
+      }>;
+    }>;
+  };
+  signals: {
+    summary: {
+      totalSignals: number;
+      createdLast24h: number;
+      createdLast7d: number;
+      spacesWithSignals: number;
+    };
+    byType: Array<{ type: string; count: number }>;
+    byPriority: Array<{ priority: string; count: number }>;
+    bySpace: Array<{
+      spaceId: number | null;
+      slug: string;
+      title: string;
+      count: number;
+    }>;
+    orchestrator: {
+      queue_pending: number;
+      queue_failed: number;
+      signals_emitted_last_24h: number;
+      relays_emitted_last_24h: number;
+      latest_errors: Array<{
+        queue_id: number;
+        space_id: number;
+        error: string | null;
+        updated_at: string;
+      }>;
+    };
+  };
+  spaceMemory: {
+    summary: {
+      spacesWithChat: number;
+      summariesTotal: number;
+      transcriptsTotal: number;
+      recordingsTotal: number;
+      summariesLast24h: number;
+      summariesLast7d: number;
+    };
+    bySpace: {
+      summaries: Array<{
+        spaceId: number;
+        slug: string;
+        title: string;
+        count: number;
+      }>;
+      transcripts: Array<{
+        spaceId: number;
+        slug: string;
+        title: string;
+        count: number;
+      }>;
+      recordings: Array<{
+        spaceId: number;
+        slug: string;
+        title: string;
+        count: number;
+      }>;
+    };
+  };
+};

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -42,6 +42,7 @@ export * from './schedule';
 export * from './matrix/server';
 export * from './matrix/types';
 export * from './banking/server';
+export * from './platform/server';
 export * from './geo/server';
 export {
   geocodeRequestSchema,

--- a/packages/epics/src/index.ts
+++ b/packages/epics/src/index.ts
@@ -11,4 +11,5 @@ export * from './hooks';
 
 export * from './coherence';
 export * from './network-map';
+export * from './platform-dashboard';
 export * from './schedule';

--- a/packages/epics/src/platform-dashboard/components/platform-dashboard-gate.tsx
+++ b/packages/epics/src/platform-dashboard/components/platform-dashboard-gate.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import * as React from 'react';
+import {
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Input,
+} from '@hypha-platform/ui';
+
+const OPS_SECRET_STORAGE_KEY = 'hypha-ops-secret';
+
+export function PlatformDashboardGate({
+  children,
+}: {
+  children: (fetchDashboard: () => Promise<Response>) => React.ReactNode;
+}) {
+  const [secret, setSecret] = React.useState('');
+  const [storedSecret, setStoredSecret] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    const existing = sessionStorage.getItem(OPS_SECRET_STORAGE_KEY);
+    if (existing) {
+      setStoredSecret(existing);
+    }
+  }, []);
+
+  const fetchDashboard = React.useCallback(async () => {
+    const activeSecret = storedSecret ?? secret;
+    return fetch('/api/v1/ops/platform/dashboard', {
+      headers: {
+        'x-hypha-ops-secret': activeSecret,
+      },
+    });
+  }, [secret, storedSecret]);
+
+  if (!storedSecret) {
+    return (
+      <div className="mx-auto flex min-h-[60vh] max-w-md flex-col justify-center gap-4 p-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>Platform dashboard access</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <p className="text-3 text-muted-foreground">
+              Enter the Hypha ops secret to view platform metrics. This uses the
+              same secret as space-memory ops routes.
+            </p>
+            <Input
+              type="password"
+              placeholder="Ops secret"
+              value={secret}
+              onChange={(event) => setSecret(event.target.value)}
+            />
+            <Button
+              disabled={!secret.trim()}
+              onClick={() => {
+                sessionStorage.setItem(OPS_SECRET_STORAGE_KEY, secret.trim());
+                setStoredSecret(secret.trim());
+              }}
+            >
+              Continue
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return <>{children(fetchDashboard)}</>;
+}

--- a/packages/epics/src/platform-dashboard/components/platform-dashboard-gate.tsx
+++ b/packages/epics/src/platform-dashboard/components/platform-dashboard-gate.tsx
@@ -10,33 +10,26 @@ import {
   Input,
 } from '@hypha-platform/ui';
 
-const OPS_SECRET_STORAGE_KEY = 'hypha-ops-secret';
-
 export function PlatformDashboardGate({
   children,
 }: {
   children: (fetchDashboard: () => Promise<Response>) => React.ReactNode;
 }) {
-  const [secret, setSecret] = React.useState('');
-  const [storedSecret, setStoredSecret] = React.useState<string | null>(null);
-
-  React.useEffect(() => {
-    const existing = sessionStorage.getItem(OPS_SECRET_STORAGE_KEY);
-    if (existing) {
-      setStoredSecret(existing);
-    }
-  }, []);
+  const [secretInput, setSecretInput] = React.useState('');
+  const [activeSecret, setActiveSecret] = React.useState<string | null>(null);
 
   const fetchDashboard = React.useCallback(async () => {
-    const activeSecret = storedSecret ?? secret;
+    if (!activeSecret) {
+      throw new Error('Ops secret is required');
+    }
     return fetch('/api/v1/ops/platform/dashboard', {
       headers: {
         'x-hypha-ops-secret': activeSecret,
       },
     });
-  }, [secret, storedSecret]);
+  }, [activeSecret]);
 
-  if (!storedSecret) {
+  if (!activeSecret) {
     return (
       <div className="mx-auto flex min-h-[60vh] max-w-md flex-col justify-center gap-4 p-6">
         <Card>
@@ -46,20 +39,18 @@ export function PlatformDashboardGate({
           <CardContent className="space-y-4">
             <p className="text-3 text-muted-foreground">
               Enter the Hypha ops secret to view platform metrics. This uses the
-              same secret as space-memory ops routes.
+              same secret as space-memory ops routes. The secret stays in memory
+              for this tab only and is cleared when you refresh.
             </p>
             <Input
               type="password"
               placeholder="Ops secret"
-              value={secret}
-              onChange={(event) => setSecret(event.target.value)}
+              value={secretInput}
+              onChange={(event) => setSecretInput(event.target.value)}
             />
             <Button
-              disabled={!secret.trim()}
-              onClick={() => {
-                sessionStorage.setItem(OPS_SECRET_STORAGE_KEY, secret.trim());
-                setStoredSecret(secret.trim());
-              }}
+              disabled={!secretInput.trim()}
+              onClick={() => setActiveSecret(secretInput.trim())}
             >
               Continue
             </Button>

--- a/packages/epics/src/platform-dashboard/components/platform-dashboard.tsx
+++ b/packages/epics/src/platform-dashboard/components/platform-dashboard.tsx
@@ -1,0 +1,374 @@
+'use client';
+
+import * as React from 'react';
+import type { PlatformDashboardData } from '@hypha-platform/core/client';
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Skeleton,
+  Button,
+} from '@hypha-platform/ui';
+import { formatCurrencyValue } from '@hypha-platform/ui-utils';
+import Link from 'next/link';
+import { PlatformDashboardGate } from './platform-dashboard-gate';
+
+function MetricCard({
+  label,
+  value,
+  hint,
+}: {
+  label: string;
+  value: string | number;
+  hint?: string;
+}) {
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-3 font-normal text-muted-foreground">
+          {label}
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <p className="text-6 font-semibold">{value}</p>
+        {hint ? (
+          <p className="mt-1 text-2 text-muted-foreground">{hint}</p>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}
+
+function BarChart({
+  title,
+  items,
+  valueKey,
+  labelKey,
+}: {
+  title: string;
+  items: Array<Record<string, string | number>>;
+  valueKey: string;
+  labelKey: string;
+}) {
+  const max = Math.max(...items.map((item) => Number(item[valueKey] ?? 0)), 1);
+
+  return (
+    <Card className="h-full">
+      <CardHeader>
+        <CardTitle>{title}</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {items.length === 0 ? (
+          <p className="text-3 text-muted-foreground">No data yet.</p>
+        ) : (
+          items.map((item) => {
+            const value = Number(item[valueKey] ?? 0);
+            const label = String(item[labelKey] ?? '');
+            return (
+              <div key={label} className="space-y-1">
+                <div className="flex items-center justify-between text-2">
+                  <span>{label}</span>
+                  <span className="font-medium">{value}</span>
+                </div>
+                <div className="h-2 rounded-full bg-muted">
+                  <div
+                    className="h-2 rounded-full bg-primary"
+                    style={{ width: `${Math.max(4, (value / max) * 100)}%` }}
+                  />
+                </div>
+              </div>
+            );
+          })
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function PlatformDashboardContent({
+  fetchDashboard,
+}: {
+  fetchDashboard: () => Promise<Response>;
+}) {
+  const [data, setData] = React.useState<PlatformDashboardData | null>(null);
+  const [error, setError] = React.useState<string | null>(null);
+  const [isLoading, setIsLoading] = React.useState(true);
+
+  const load = React.useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const response = await fetchDashboard();
+      if (!response.ok) {
+        throw new Error(`Failed to load dashboard (${response.status})`);
+      }
+      setData((await response.json()) as PlatformDashboardData);
+    } catch (loadError) {
+      setError(
+        loadError instanceof Error
+          ? loadError.message
+          : 'Failed to load dashboard',
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }, [fetchDashboard]);
+
+  React.useEffect(() => {
+    void load();
+  }, [load]);
+
+  if (isLoading) {
+    return (
+      <div className="space-y-6 p-6">
+        <Skeleton className="h-10 w-72" />
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          {Array.from({ length: 4 }).map((_, index) => (
+            <Skeleton key={index} className="h-28" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <div className="space-y-4 p-6">
+        <p className="text-destructive">{error ?? 'Dashboard unavailable'}</p>
+        <Button onClick={() => void load()}>Retry</Button>
+      </div>
+    );
+  }
+
+  const payingSummary = data.payingSpaces.summary;
+  const topAssetSpaces = data.assets.spaces.slice(0, 12);
+  const topSignalSpaces = data.signals.bySpace.slice(0, 10);
+  const topMemorySpaces = data.spaceMemory.bySpace.summaries.slice(0, 10);
+
+  return (
+    <div className="space-y-8 p-6">
+      <div className="flex flex-wrap items-end justify-between gap-4">
+        <div>
+          <h1 className="text-7 font-semibold">Hypha Platform Dashboard</h1>
+          <p className="text-3 text-muted-foreground">
+            Updated {new Date(data.generatedAt).toLocaleString()}
+          </p>
+        </div>
+        <Button variant="outline" onClick={() => void load()}>
+          Refresh
+        </Button>
+      </div>
+
+      <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <MetricCard
+          label="HYPHA-paid spaces"
+          value={payingSummary.hyphaPaidSpaces}
+          hint={`${payingSummary.activePaidSpaces} active · ${payingSummary.expiredPaidSpaces} expired`}
+        />
+        <MetricCard
+          label="Total platform balance"
+          value={formatCurrencyValue(data.assets.totalBalanceUsd)}
+          hint={`${data.assets.spaceCount} spaces tracked`}
+        />
+        <MetricCard
+          label="Signals"
+          value={data.signals.summary.totalSignals}
+          hint={`${data.signals.summary.createdLast7d} created in 7d`}
+        />
+        <MetricCard
+          label="Space memory items"
+          value={
+            data.spaceMemory.summary.summariesTotal +
+            data.spaceMemory.summary.transcriptsTotal +
+            data.spaceMemory.summary.recordingsTotal
+          }
+          hint={`${data.spaceMemory.summary.spacesWithChat} spaces with chat`}
+        />
+      </section>
+
+      <section className="grid gap-6 xl:grid-cols-2">
+        <BarChart
+          title="HYPHA activate-space payments by month"
+          items={data.payingSpaces.monthly.map((bucket) => ({
+            label: bucket.month,
+            value: bucket.spacesActivated,
+          }))}
+          labelKey="label"
+          valueKey="value"
+        />
+        <Card>
+          <CardHeader>
+            <CardTitle>Paying spaces breakdown</CardTitle>
+          </CardHeader>
+          <CardContent className="grid gap-3 sm:grid-cols-2">
+            <MetricCard
+              label="Total HYPHA burned"
+              value={Number(payingSummary.totalHyphaBurned).toLocaleString(
+                undefined,
+                {
+                  maximumFractionDigits: 0,
+                },
+              )}
+            />
+            <MetricCard
+              label="Free trial only"
+              value={payingSummary.freeTrialOnly}
+            />
+            <MetricCard
+              label="Payment events (365d)"
+              value={payingSummary.paymentEventsInRange}
+            />
+            <MetricCard
+              label="Tracked spaces"
+              value={payingSummary.totalSpaces}
+            />
+          </CardContent>
+        </Card>
+      </section>
+
+      <section>
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-5 font-semibold">Assets by space</h2>
+          <p className="text-3 text-muted-foreground">
+            Total $ {formatCurrencyValue(data.assets.totalBalanceUsd)}
+          </p>
+        </div>
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+          {topAssetSpaces.map((space) => (
+            <Card key={space.slug}>
+              <CardHeader className="pb-2">
+                <CardTitle className="text-4">
+                  <Link
+                    href={`/en/dho/${space.slug}/treasury`}
+                    className="hover:underline"
+                  >
+                    {space.title}
+                  </Link>
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-2">
+                <p className="text-5 font-semibold">
+                  {formatCurrencyValue(space.balanceUsd)}
+                </p>
+                <div className="space-y-1">
+                  {space.topAssets.map((asset) => (
+                    <div
+                      key={`${space.slug}-${asset.symbol}`}
+                      className="flex justify-between text-2 text-muted-foreground"
+                    >
+                      <span>{asset.symbol}</span>
+                      <span>{formatCurrencyValue(asset.usdEqual)}</span>
+                    </div>
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </section>
+
+      <section className="grid gap-6 xl:grid-cols-2">
+        <BarChart
+          title="Signals by type"
+          items={data.signals.byType.map((row) => ({
+            label: row.type,
+            value: row.count,
+          }))}
+          labelKey="label"
+          valueKey="value"
+        />
+        <BarChart
+          title="Signals by priority"
+          items={data.signals.byPriority.map((row) => ({
+            label: row.priority,
+            value: row.count,
+          }))}
+          labelKey="label"
+          valueKey="value"
+        />
+      </section>
+
+      <section className="grid gap-6 xl:grid-cols-2">
+        <BarChart
+          title="Top spaces by signals"
+          items={topSignalSpaces.map((row) => ({
+            label: row.title,
+            value: row.count,
+          }))}
+          labelKey="label"
+          valueKey="value"
+        />
+        <Card>
+          <CardHeader>
+            <CardTitle>Signal orchestrator</CardTitle>
+          </CardHeader>
+          <CardContent className="grid gap-3 sm:grid-cols-2">
+            <MetricCard
+              label="Queue pending"
+              value={data.signals.orchestrator.queue_pending}
+            />
+            <MetricCard
+              label="Queue failed"
+              value={data.signals.orchestrator.queue_failed}
+            />
+            <MetricCard
+              label="Signals emitted (24h)"
+              value={data.signals.orchestrator.signals_emitted_last_24h}
+            />
+            <MetricCard
+              label="Relays emitted (24h)"
+              value={data.signals.orchestrator.relays_emitted_last_24h}
+            />
+          </CardContent>
+        </Card>
+      </section>
+
+      <section className="grid gap-6 xl:grid-cols-2">
+        <BarChart
+          title="Space memory summaries by space"
+          items={topMemorySpaces.map((row) => ({
+            label: row.title,
+            value: row.count,
+          }))}
+          labelKey="label"
+          valueKey="value"
+        />
+        <Card>
+          <CardHeader>
+            <CardTitle>Space memory totals</CardTitle>
+          </CardHeader>
+          <CardContent className="grid gap-3 sm:grid-cols-2">
+            <MetricCard
+              label="Summaries"
+              value={data.spaceMemory.summary.summariesTotal}
+              hint={`${data.spaceMemory.summary.summariesLast24h} in 24h`}
+            />
+            <MetricCard
+              label="Transcripts"
+              value={data.spaceMemory.summary.transcriptsTotal}
+            />
+            <MetricCard
+              label="Recordings"
+              value={data.spaceMemory.summary.recordingsTotal}
+            />
+            <MetricCard
+              label="Summaries (7d)"
+              value={data.spaceMemory.summary.summariesLast7d}
+            />
+          </CardContent>
+        </Card>
+      </section>
+    </div>
+  );
+}
+
+export function PlatformDashboard() {
+  return (
+    <PlatformDashboardGate>
+      {(fetchDashboard) => (
+        <PlatformDashboardContent fetchDashboard={fetchDashboard} />
+      )}
+    </PlatformDashboardGate>
+  );
+}

--- a/packages/epics/src/platform-dashboard/index.ts
+++ b/packages/epics/src/platform-dashboard/index.ts
@@ -1,0 +1,2 @@
+export * from './components/platform-dashboard';
+export * from './components/platform-dashboard-gate';


### PR DESCRIPTION
## Summary
- Adds a Hypha Platform ops dashboard at `/[lang]/platform/dashboard` with KPI cards and bar charts for paying spaces, treasury rollups, signals, and space memory.
- Paying spaces are derived from on-chain `SpacesPaymentProcessedWithHypha` events (activate-space profile + proposal flows) plus live `SpacePaymentTracker` status — USDC payments and free trials are excluded from the paid count.
- Introduces aggregate server queries in `packages/core/src/platform/server/` and an ops-gated API at `GET /api/v1/ops/platform/dashboard` (uses `HYPHA_SPACE_MEMORY_OPS_SECRET`).

## Test plan
- [ ] Set `HYPHA_SPACE_MEMORY_OPS_SECRET` locally and open `/en/platform/dashboard`
- [ ] Enter the ops secret and confirm dashboard loads without 401/503
- [ ] Verify paying spaces section shows HYPHA-paid counts and monthly activation chart
- [ ] Verify assets cards list spaces with non-zero balances and a platform total
- [ ] Verify signals section shows type/priority breakdown and orchestrator queue metrics
- [ ] Verify space memory section shows summary totals and per-space summary counts


Made with [Cursor](https://cursor.com)