### PR TITLE
docs(ponta-do-sol): rename school to Escola da Ponta do Sol

### DIFF
--- a/apps/web/src/app/api/v1/spaces/[spaceSlug]/energy/route.ts
+++ b/apps/web/src/app/api/v1/spaces/[spaceSlug]/energy/route.ts
@@ -5,6 +5,9 @@ import {
   isMissingEnergyCommunitiesTableError,
   upsertEnergyCommunityActivation,
   web3Client,
+  resolveEnergyParticipants,
+  institutionalLabelsForSpace,
+  readOwnershipTokenName,
   type DatabaseInstance,
 } from '@hypha-platform/core/server';
 import {
@@ -312,22 +315,30 @@ export async function GET(
       ),
     );
 
-    const sources = sourceResults
-      .map((value, index) => {
+    const sourcesWithTokens = await Promise.all(
+      sourceResults.map(async (value, index) => {
         const sourceId = sourceIdList[index];
         if (!sourceId || !value) {
           return null;
         }
+        const ownershipToken = value[1];
+        const tokenName = await readOwnershipTokenName(ownershipToken);
+        const decodedId = decodeSourceId(sourceId);
         return {
           sourceId,
-          sourceLabel: decodeSourceId(sourceId),
+          sourceLabel: decodedId,
+          sourceDisplayName: tokenName ?? decodedId,
           sourceType: SOURCE_TYPES[Number(value[0])] ?? 'UNKNOWN',
-          ownershipToken: value[1],
+          ownershipToken,
           basePricePerKwh: value[2].toString(),
           active: value[3],
         };
-      })
-      .filter((row): row is NonNullable<typeof row> => row !== null);
+      }),
+    );
+
+    const sources = sourcesWithTokens.filter(
+      (row): row is NonNullable<typeof row> => row !== null,
+    );
 
     const memberAddressList = memberAddresses ?? [];
 
@@ -379,6 +390,21 @@ export async function GET(
           })),
         };
       }),
+    );
+
+    const memberDeviceIds = new Map<string, number[] | null>();
+    for (const detail of memberDetails) {
+      memberDeviceIds.set(detail.address.toLowerCase(), detail.deviceIds);
+    }
+
+    const participantProfiles = await resolveEnergyParticipants(
+      {
+        addresses: memberAddressList.map((a) => a.toLowerCase()),
+        spaceSlug,
+        memberDeviceIds,
+        institutionalByDevice: institutionalLabelsForSpace(spaceSlug),
+      },
+      { db },
     );
 
     const [optimizationConfig, socialWalletsRaw] = await Promise.all([
@@ -450,6 +476,7 @@ export async function GET(
       },
       members: memberAddressList.map((a) => a.toLowerCase() as `0x${string}`),
       memberDetails,
+      participantProfiles,
       sources,
       optimization,
     });

--- a/apps/web/src/app/api/v1/spaces/[spaceSlug]/energy/route.ts
+++ b/apps/web/src/app/api/v1/spaces/[spaceSlug]/energy/route.ts
@@ -7,7 +7,7 @@ import {
   web3Client,
   resolveEnergyParticipants,
   institutionalLabelsForSpace,
-  readOwnershipTokenName,
+  readOwnershipTokenNames,
   type DatabaseInstance,
 } from '@hypha-platform/core/server';
 import {
@@ -315,15 +315,20 @@ export async function GET(
       ),
     );
 
-    const sourcesWithTokens = await Promise.all(
-      sourceResults.map(async (value, index) => {
+    const ownershipTokens = sourceResults.flatMap((value, index) =>
+      value && sourceIdList[index] ? [value[1]] : [],
+    );
+    const tokenNamesByAddress = await readOwnershipTokenNames(ownershipTokens);
+
+    const sources = sourceResults
+      .map((value, index) => {
         const sourceId = sourceIdList[index];
         if (!sourceId || !value) {
           return null;
         }
         const ownershipToken = value[1];
-        const tokenName = await readOwnershipTokenName(ownershipToken);
         const decodedId = decodeSourceId(sourceId);
+        const tokenName = tokenNamesByAddress[ownershipToken.toLowerCase()];
         return {
           sourceId,
           sourceLabel: decodedId,
@@ -333,12 +338,8 @@ export async function GET(
           basePricePerKwh: value[2].toString(),
           active: value[3],
         };
-      }),
-    );
-
-    const sources = sourcesWithTokens.filter(
-      (row): row is NonNullable<typeof row> => row !== null,
-    );
+      })
+      .filter((row): row is NonNullable<typeof row> => row !== null);
 
     const memberAddressList = memberAddresses ?? [];
 
@@ -397,15 +398,20 @@ export async function GET(
       memberDeviceIds.set(detail.address.toLowerCase(), detail.deviceIds);
     }
 
-    const participantProfiles = await resolveEnergyParticipants(
-      {
-        addresses: memberAddressList.map((a) => a.toLowerCase()),
-        spaceSlug,
-        memberDeviceIds,
-        institutionalByDevice: institutionalLabelsForSpace(spaceSlug),
-      },
-      { db },
-    );
+    const canResolveParticipantProfiles =
+      access.hasAccess && Boolean(access.authToken);
+
+    const participantProfiles = canResolveParticipantProfiles
+      ? await resolveEnergyParticipants(
+          {
+            addresses: memberAddressList.map((a) => a.toLowerCase()),
+            spaceSlug,
+            memberDeviceIds,
+            institutionalByDevice: institutionalLabelsForSpace(spaceSlug),
+          },
+          { db },
+        )
+      : undefined;
 
     const [optimizationConfig, socialWalletsRaw] = await Promise.all([
       safeRead<readonly [readonly number[], number, bigint, number, boolean]>(

--- a/docs/ponta-do-sol-demo-setup.md
+++ b/docs/ponta-do-sol-demo-setup.md
@@ -56,7 +56,7 @@ flowchart TB
 | Field | Value |
 |-------|-------|
 | Title | `Ponta do Sol Energy Community` |
-| Slug | `ponta-do-sol` |
+| Slug | `ponta-do-sol-energy-community` *(deployed; UI may auto-append suffix if `ponta-do-sol` was taken)* |
 | Description | Ponta do Sol pools rooftop solar from school and apartments in one shared community. By day, school surplus supplies the banana farm. By evening, a shared 150 kWh battery—charged from both roofs at midday—supports apartment EV charging. School, residents, and investors co-own each asset. *(292 chars)* |
 | Activation mode | **Pilot** (`demo` flag) — visible for demos, not full public launch |
 | Location | Ponta do Sol, Madeira (~`32.6897`, `-17.1042`) |
@@ -91,7 +91,7 @@ Correct Portuguese spelling: **Básica**, **Secundária**, lowercase **e**, **da
 1. Submit proposal with Part 2 form values (see ownership and members below; full copy-paste wallet doc TBD).
 2. Set **voting duration = 0** if you are the sole voter initially.
 3. Vote and execute — executor calls `EnergyPPAv2Factory.deployCommunity`.
-4. Verify sync: `GET /api/v1/spaces/ponta-do-sol/energy` returns `enabled: true` with `factoryCommunityId`.
+4. Verify sync: `GET /api/v1/spaces/ponta-do-sol-energy-community/energy` returns `enabled: true` with `factoryCommunityId` (requires space auth if demo flag is private).
 
 **Post-activation proposals (can follow later):**
 
@@ -102,7 +102,7 @@ Correct Portuguese spelling: **Básica**, **Secundária**, lowercase **e**, **da
 
 #### C1. Neon PostgreSQL (`DATABASE_URL`)
 
-Update `spaces` row for `ponta-do-sol`:
+Update `spaces` row for `ponta-do-sol-energy-community`:
 
 - `logoUrl`, `leadImage`, `description`, `links`
 - **Full description** (Neon — operational): *"Ponta do Sol is a Madeira village energy community. Escola Básica e Secundária da Ponta do Sol and the apartment block each host rooftop solar; a 150 kWh battery shared between both buildings stores midday surplus. During daylight hours, excess school generation supplies Quinta da Bananeira. In the evening, stored energy supports apartment EV charging. The school co-owns its rooftop with two investors; apartment residents co-own their rooftop with the same investors; the battery is co-owned by school, residents, and investors. The municipality receives community fees."*
@@ -111,17 +111,7 @@ Update `spaces` row for `ponta-do-sol`:
 
 #### C2. Azure energy DB (`ENERGY_DB_*` env vars)
 
-Per `packages/storage-evm/ENERGY_INTERVAL_DATA_FEED.md`, seed `accounting.interval_readings`:
-
-| meter_id | Role |
-|---------:|------|
-| 1 | Escola Básica e Secundária da Ponta do Sol (consumption) |
-| 2–9 | 8 individual apartment residents (1 meter each) |
-| 10 | Quinta da Bananeira (banana farm) |
-| 9001 | Escola Básica e Secundária da Ponta do Sol rooftop PV |
-| 9002 | Apartment rooftop PV production |
-| 9003 | Community shared battery (school + apartment) |
-| 9999 | Grid export (computed by VPP) |
+Seed `accounting.interval_readings` using the meter IDs and `community_id` in **Part 3 — Backend developer handoff** below. See also `packages/storage-evm/ENERGY_INTERVAL_DATA_FEED.md` for row shape and examples.
 
 Run settlement loop:
 
@@ -274,7 +264,7 @@ The **default demo** uses two named individuals (**Vlad Hramtsov**, **Suzana Sou
 | Vehicle | Best for | Notes |
 |---------|----------|-------|
 | **SPV** (e.g. Portuguese *sociedade por quotas*) | Single asset or small portfolio | SPV holds `RegularSpaceToken` shares; investors buy tokenized equity or debt in the SPV. Simplest for a pilot. |
-| **Energy cooperative** (*cooperativa de energia*) | Community members + local LPs | Strong fit for RED II / local energy communities; one member wallet replaces Ana + João. |
+| **Energy cooperative** (*cooperativa de energia*) | Community members + local LPs | Strong fit for RED II / local energy communities; one member wallet replaces Vlad + Suzana. |
 | **AIF** (Alternative Investment Fund) | Professional / qualified investors | Regulated wrapper; on-chain tokens map to fund units. Higher setup cost. |
 | **ELTIF 2.0** | Retail, long-term (EU) | Allows broader investor access to illiquid infrastructure; long onboarding. |
 
@@ -282,7 +272,7 @@ The **default demo** uses two named individuals (**Vlad Hramtsov**, **Suzana Sou
 
 #### Example fund ownership (mirrors individual scenario economics)
 
-| Asset | School / residents | **Ponta do Sol Energy Fund** (replaces Ana + João) |
+| Asset | School / residents | **Ponta do Sol Energy Fund** (replaces Vlad + Suzana) |
 |-------|-------------------|-----------------------------------------------------|
 | School PV | School **50%** | Fund **50%** |
 | Apartment PV | 8 residents **30%** | Fund **70%** |
@@ -331,22 +321,24 @@ On **~€55k** fund capital deployed → **~12–15% gross cash yield** in year 
 
 ### Energy members (settlement accounts)
 
-**12 member rows**
+**12 member rows** — device IDs **as deployed on-chain** (community `2`):
 
-| # | Role | device ID | Notes |
-|---|------|-----------|-------|
-| 1 | Escola Básica e Secundária da Ponta do Sol | `1` | School consumption meter (institutional wallet, not a Hypha person) |
-| 2 | Sofia Costa | `2` | Apt 1 |
-| 3 | Miguel Pereira | `3` | Apt 2 |
-| 4 | Ana Rodrigues | `4` | Apt 3 |
-| 5 | João Ferreira | `5` | Apt 4 |
-| 6 | Inês Sousa | `6` | Apt 5 |
-| 7 | Beatriz Silva | `7` | Apt 6 |
-| 8 | Pedro Freire | `8` | Apt 7 |
-| 9 | Rogério Ivan | `9` | Apt 8 |
-| 10 | Quinta da Bananeira (banana farm) | `10` | Institutional wallet — daytime irrigation, packing, cold storage |
-| 11 | Vlad Hramtsov (individual investor) | `9101` | Revenue-only sentinel ID |
-| 12 | Suzana Souza (individual investor) | `9102` | Revenue-only sentinel ID |
+| # | Role | device ID | Member wallet |
+|---|------|-----------|---------------|
+| 1 | Apartment resident | `1` | `0x1E7333eBEFa2CBd17b06AE2d88008Af914750732` |
+| 2 | Apartment resident | `2` | `0xCdc96173d473FEE6ce356e6E0E6121ff486D9024` |
+| 3 | Apartment resident | `3` | `0xB8566cBD813a286B21af8CEd83373073b536D7A3` |
+| 4 | Apartment resident | `4` | `0x0676AacA620FD9611d1a51af6b54E5b7027Df580` |
+| 5 | Apartment resident | `5` | `0xd0156d4aEb966f555F75E2241F6C7Cbee94c4f03` |
+| 6 | Apartment resident | `6` | `0x7223bCEF39CFebec0f3dC0388e57E247D6e4Ac79` |
+| 7 | **Escola da Ponta do Sol** (school) | **`7`** | `0x1092b8538fCFe579aBE55d81EEc8F8A5Fee0a3Be` |
+| 8 | **Quinta da Bananeira** (banana farm) | **`8`** | `0x528A45E8EfEDF33dCD239682aa8652EE9CcF0b66` |
+| 9 | Apartment resident | `9` | `0x9D8D70573e4f186A564a6f2517C944E445a3d3f6` |
+| 10 | Apartment resident | `10` | `0x746B118a33A55C711e2dD88564d994957b89Ab55` |
+| 11 | Vlad Hramtsov (investor) | *(none)* | `0xE27F33cA8037A2B0F4D3d4F9B8CcD896c2674484` |
+| 12 | Suzana Souza (investor) | *(none)* | `0x6Fa7884B440054Fdf7797DE7f87Ce9Af43fFC691` |
+
+*Planned proposal copy used meter `1` = school and meter `10` = farm; the executed form assigned different device IDs. Backend telemetry must follow the deployed table above.*
 
 ### Fees and operators
 
@@ -367,13 +359,175 @@ On **~€55k** fund capital deployed → **~12–15% gross cash yield** in year 
 
 ---
 
+## Part 3 — Backend developer handoff (interval telemetry)
+
+Use this section when generating 15-minute demo data for Azure PostgreSQL (`accounting.interval_readings`) and running the settlement loop. **Do not start seeding until the Enable Energy Community proposal has executed** — you need the on-chain `factoryCommunityId` first.
+
+### Community identifier
+
+Every interval row must use the same numeric **`community_id`**. For Ponta do Sol this equals the on-chain **`factoryCommunityId`** assigned by `EnergyPPAv2Factory.deployCommunity` (a sequential factory index: `0`, `1`, `2`, … — not the Hypha space ID or slug).
+
+**Deployed (2026-07-14, Base mainnet):**
+
+| Field | Value |
+|-------|-------|
+| Hypha space slug | `ponta-do-sol-energy-community` |
+| Hypha space ID (PG) | `775` |
+| On-chain space ID (`web3SpaceId`) | `1132` |
+| Space wallet / PPA admin | `0xE3885bcfA73538a1737815bc9597598fbf8b6E7a` |
+| **`community_id` / `factoryCommunityId`** | **`2`** |
+| PPA proxy | `0xf0c6659841f1D7080e68140cEbB28ba972cB469B` |
+| Energy token | `0x46bC7A3072a44A03a89b4017eaC00019e0E26D21` |
+| Factory | `0x5F07320B3C95C6fB0A0D77d707F14aC95A897E90` |
+| Deployed at (UTC) | `2026-07-14T15:21:31Z` |
+| Network | Base mainnet (chain ID `8453`) |
+| Interval cadence | 15 minutes, UTC quarter-hour boundaries |
+| Target table | `accounting.interval_readings` |
+
+```text
+PONTA_DO_SOL_COMMUNITY_ID=2
+ENERGY_COMMUNITY_ID=2
+```
+
+Set `ENERGY_COMMUNITY_ID=2` in the settlement loop env — see `energy-ppav2-rds-loop.ts`.
+
+**Re-verify if needed:**
+
+1. **API:** `GET https://app.hypha.earth/api/v1/spaces/ponta-do-sol-energy-community/energy` → `activation.factoryCommunityId` *(auth required for this demo space)*
+2. **Neon:** `SELECT factory_community_id FROM energy_communities ec JOIN spaces s ON s.id = ec.space_id WHERE s.slug = 'ponta-do-sol-energy-community' ORDER BY ec.created_at DESC LIMIT 1;`
+3. **On-chain:** `EnergyPPAv2Factory.getAdminCommunities(0xE3885bcfA73538a1737815bc9597598fbf8b6E7a)` → `[2]`
+
+### Meter ID inventory (summary)
+
+| Category | Count | meter_id(s) | Send interval rows? |
+|----------|------:|-------------|---------------------|
+| **School** (institutional consumer) | 1 | **`7`** | Yes — `direction: consumption` |
+| **Apartment residents** (8 households) | 8 | **`1`–`6`, `9`, `10`** | Yes — `direction: consumption` |
+| **Banana farm** (institutional consumer) | 1 | **`8`** | Yes — `direction: consumption` |
+| **Production sources** (PV + battery) | 3 | `9001`, `9002`, `9003` | Yes — `direction: production` |
+| **Grid export** | 1 | `9999` | **No** — computed and written by the VPP / settlement loop |
+| **Investors** (revenue-only, no meters) | 0 | `9101`, `9102` | **No** — sentinel on-chain device IDs only |
+
+**Totals for your ingest job:**
+
+- **10 consumption meters** to seed every interval: school **`7`**, farm **`8`**, apartments **`1`–`6`, `9`, `10`**
+- **3 production meters** to seed every interval (`9001`–`9003`)
+- **13 meter IDs** you generate data for; **`9999` is not pre-seeded**
+
+Per interval you typically insert **13 rows** (10 consumption + 3 production), all with the same `community_id` and `interval_start`.
+
+### Consumption meters — full registry (as deployed on-chain)
+
+**Important:** The proposal *design* used meter `1` = school and meter `10` = banana farm. The **executed** deployment registered different device IDs. Telemetry and settlement **must** use the on-chain IDs below (verified from PPA `0xf0c6659841f1D7080e68140cEbB28ba972cB469B`, community `2`).
+
+| meter_id | Category | Wallet | Notes |
+|---------:|----------|--------|-------|
+| **7** | **School** | `0x1092b8538fCFe579aBE55d81EEc8F8A5Fee0a3Be` | Escola da Ponta do Sol subspace wallet. Daytime school load; lower evening use. |
+| **8** | **Banana farm** | `0x528A45E8EfEDF33dCD239682aa8652EE9CcF0b66` | Quinta da Bananeira subspace wallet. **Daytime-heavy** agricultural load. |
+| **1** | Apartment | `0x1E7333eBEFa2CBd17b06AE2d88008Af914750732` | Resident (Hypha smart wallet) |
+| **2** | Apartment | `0xCdc96173d473FEE6ce356e6E0E6121ff486D9024` | Resident |
+| **3** | Apartment | `0xB8566cBD813a286B21af8CEd83373073b536D7A3` | Resident |
+| **4** | Apartment | `0x0676AacA620FD9611d1a51af6b54E5b7027Df580` | Resident |
+| **5** | Apartment | `0xd0156d4aEb966f555F75E2241F6C7Cbee94c4f03` | Resident |
+| **6** | Apartment | `0x7223bCEF39CFebec0f3dC0388e57E247D6e4Ac79` | Resident |
+| **9** | Apartment | `0x9D8D70573e4f186A564a6f2517C944E445a3d3f6` | Resident |
+| **10** | Apartment | `0x746B118a33A55C711e2dD88564d994957b89Ab55` | Resident |
+
+**Quick lookup (deployed):**
+
+- **School:** meter **`7`** — *not* meter `1`
+- **Banana farm:** meter **`8`** — *not* meter `10`
+- **Apartments:** meters **`1`, `2`, `3`, `4`, `5`, `6`, `9`, `10`**
+
+Investors (`0xE27F33cA8037A2B0F4D3d4F9B8CcD896c2674484`, `0x6Fa7884B440054Fdf7797DE7f87Ce9Af43fFC691`) have **no consumption meters** on-chain — revenue-only members.
+
+### Production meters — mapping to on-chain sources
+
+These numeric IDs are for the **Azure ingest / VPP layer**. Map them to on-chain source IDs in backend config (`productionDeviceToSource` or equivalent):
+
+| meter_id | On-chain source name (form **Name**) | Asset | Typical `direction` |
+|---------:|--------------------------------------|-------|---------------------|
+| **9001** | `PONTA_SCHOOL_PV` | School rooftop solar (~75 kWp) | `production` |
+| **9002** | `PONTA_APT_PV` | Apartment rooftop solar (~18 kWp) | `production` |
+| **9003** | `PONTA_COMMUNITY_BATTERY` | Shared 150 kWh battery (discharge = production to grid/load) | `production` |
+
+After activation, resolve bytes32 source IDs from `GET /api/v1/spaces/ponta-do-sol-energy-community/energy` (`sources[].sourceId`) or from PPA `0xf0c6659841f1D7080e68140cEbB28ba972cB469B` — do not hard-code demo community `0` IDs from `ENERGY_INTERVAL_DATA_FEED.md`.
+
+### Interval row shape
+
+```ts
+type IntervalReading = {
+  interval_start: string;   // ISO-8601 UTC, e.g. "2026-07-14T12:00:00Z"
+  meter_id: number;
+  community_id: number;     // = factoryCommunityId for ponta-do-sol
+  energy_wh: number;        // integer watt-hours for the 15-min bucket
+  direction: 'consumption' | 'production' | 'import';
+};
+```
+
+Example — one interval, school (meter 7) + one apartment + school PV:
+
+```json
+[
+  {
+    "interval_start": "2026-07-14T12:00:00Z",
+    "meter_id": 7,
+    "community_id": 2,
+    "energy_wh": 4500,
+    "direction": "consumption"
+  },
+  {
+    "interval_start": "2026-07-14T12:00:00Z",
+    "meter_id": 2,
+    "community_id": 2,
+    "energy_wh": 1200,
+    "direction": "consumption"
+  },
+  {
+    "interval_start": "2026-07-14T12:00:00Z",
+    "meter_id": 9001,
+    "community_id": 2,
+    "energy_wh": 18500,
+    "direction": "production"
+  }
+]
+```
+
+### Realistic load patterns (demo narrative)
+
+Use Part 2 annual balance as a sanity check (~136 MWh/yr generation, ~86 MWh/yr demand):
+
+| meter_id | Pattern hint |
+|---------:|--------------|
+| **7** (school) | Higher weekdays 08:00–17:00; minimal nights/weekends |
+| **1–6, 9, 10** (apartments) | Evening peaks (18:00–23:00), AC in summer; some EV charging after battery discharge |
+| **8** (farm) | **Daytime only** — align surplus school PV to mid-day farm load |
+| 9001 (school PV) | Peak mid-day; east–west array → broader plateau than single-orientation |
+| 9002 (apt PV) | Mid-day peak; smaller nameplate than school |
+| 9003 (battery) | `production` rows when discharging; charge periods may show as lower net export elsewhere — match VPP expectations |
+
+### Settlement loop
+
+After rows are in Azure PG:
+
+```bash
+cd packages/storage-evm
+ENERGY_COMMUNITY_ID=2 \
+ENERGY_DEMO_COMMAND=loop \
+npx hardhat run scripts/base-mainnet-contracts-scripts/energy-ppav2-rds-loop.ts --network base-mainnet
+```
+
+Ensure the ops wallet calling `consumeEnergy` is **whitelisted** on the Ponta PPA proxy. Reference: `energy-ppav2-rds-loop.ts`, `docs/energy-community-initiation-ui-flow.md`.
+
+---
+
 ## Execution order
 
 1. Generate demo wallet manifest + UI copy-paste doc
-2. Create space in UI (`ponta-do-sol`, pilot/demo, location)
+2. Create space in UI (`ponta-do-sol-energy-community`, pilot/demo, location)
 3. Submit + pass Enable Energy Community proposal
-4. Share `DATABASE_URL` and `ENERGY_DB_*` connection
-5. Neon metadata script + Azure interval seed + checkpoint state file
+4. Share `DATABASE_URL` and `ENERGY_DB_*` connection; confirm `factoryCommunityId` (Part 3)
+5. Neon metadata script + Azure interval seed (Part 3 meter IDs) + checkpoint state file
 6. Whitelist + run one settlement interval; verify Energy tab
 7. Optional: Add Energy Member proposals as real users onboard
 

--- a/docs/ponta-do-sol-demo-setup.md
+++ b/docs/ponta-do-sol-demo-setup.md
@@ -83,10 +83,10 @@ Form: `packages/epics/src/governance/components/create-enable-energy-community-f
 ```markdown
 This proposal activates the Ponta do Sol energy community on Base mainnet via EnergyPPAv2.
 
-It registers rooftop solar on **Escola Básica e Secundária de Machico** and the apartment block, a shared 150 kWh battery, eight households, Quinta da Bananeira, and two individual investors — with on-chain ownership and automated settlement.
+It registers rooftop solar on **Escola Básica e Secundária da Ponta do Sol** and the apartment block, a shared 150 kWh battery, eight households, Quinta da Bananeira, and two individual investors — with on-chain ownership and automated settlement.
 ```
 
-Correct Portuguese spelling: **Básica**, **Secundária**, lowercase **e**. Machico is the school location; Ponta do Sol remains the community name.
+Correct Portuguese spelling: **Básica**, **Secundária**, lowercase **e**, **da Ponta do Sol**.
 
 1. Submit proposal with Part 2 form values (see ownership and members below; full copy-paste wallet doc TBD).
 2. Set **voting duration = 0** if you are the sole voter initially.
@@ -105,7 +105,7 @@ Correct Portuguese spelling: **Básica**, **Secundária**, lowercase **e**. Mach
 Update `spaces` row for `ponta-do-sol`:
 
 - `logoUrl`, `leadImage`, `description`, `links`
-- **Full description** (Neon — operational): *"Ponta do Sol is a Madeira village energy community. Escola Básica e Secundária de Machico and the apartment block each host rooftop solar; a 150 kWh battery shared between both buildings stores midday surplus. During daylight hours, excess school generation supplies Quinta da Bananeira. In the evening, stored energy supports apartment EV charging. The school co-owns its rooftop with two investors; apartment residents co-own their rooftop with the same investors; the battery is co-owned by school, residents, and investors. The municipality receives community fees."*
+- **Full description** (Neon — operational): *"Ponta do Sol is a Madeira village energy community. Escola Básica e Secundária da Ponta do Sol and the apartment block each host rooftop solar; a 150 kWh battery shared between both buildings stores midday surplus. During daylight hours, excess school generation supplies Quinta da Bananeira. In the evening, stored energy supports apartment EV charging. The school co-owns its rooftop with two investors; apartment residents co-own their rooftop with the same investors; the battery is co-owned by school, residents, and investors. The municipality receives community fees."*
 - `latitude`, `longitude`, `locationLabel` = "Ponta do Sol, Madeira, Portugal"
 - `flags` = `["demo"]`
 
@@ -115,10 +115,10 @@ Per `packages/storage-evm/ENERGY_INTERVAL_DATA_FEED.md`, seed `accounting.interv
 
 | meter_id | Role |
 |---------:|------|
-| 1 | Escola Básica e Secundária de Machico (consumption) |
+| 1 | Escola Básica e Secundária da Ponta do Sol (consumption) |
 | 2–9 | 8 individual apartment residents (1 meter each) |
 | 10 | Quinta da Bananeira (banana farm) |
-| 9001 | Escola Básica e Secundária de Machico rooftop PV |
+| 9001 | Escola Básica e Secundária da Ponta do Sol rooftop PV |
 | 9002 | Apartment rooftop PV production |
 | 9003 | Community shared battery (school + apartment) |
 | 9999 | Grid export (computed by VPP) |
@@ -134,7 +134,7 @@ ENERGY_DEMO_COMMAND=loop npx hardhat run scripts/base-mainnet-contracts-scripts/
 
 Generate **~15 team-controlled addresses** (see `energy-ppav2-mainnet-demo.ts` for pattern):
 
-- **Institutional:** `communityTreasury`, `escolaMachico`, `bananaFarm`, `gridOperator`, `hyphaAggregator`
+- **Institutional:** `communityTreasury`, `escolaPontaDoSol`, `bananaFarm`, `gridOperator`, `hyphaAggregator`
 - **8 individual residents:** `resident01` … `resident08`
 - **2 individual investors:** `investorAna`, `investorJoao`
 - Store in `ponta-do-sol-demo-wallets.json` (gitignored) — **never commit private keys**
@@ -155,7 +155,7 @@ Ponta do Sol is a **village-scale local energy community** in Madeira. **Each bu
 
 - **Community shared battery** — single storage asset serving both school and apartment; charged from school PV midday surplus and apartment PV surplus; discharges for apartment evening EV load
 - **Edifício de Apartamentos** (8 homes) — own rooftop PV (~18 kWp); hosts the shared battery and most evening load
-- **Escola Básica e Secundária de Machico** — own rooftop PV (~75 kWp); surplus feeds shared battery, banana farm, and export
+- **Escola Básica e Secundária da Ponta do Sol** — own rooftop PV (~75 kWp); surplus feeds shared battery, banana farm, and export
 - **Quinta da Bananeira** — consumer only (no rooftop); daytime agricultural load
 - **Two individual investors** — private citizens who co-invested in PV and battery
 - **Eight individual apartment residents** — each with own meter and ownership stake in apartment PV + shared battery
@@ -165,8 +165,8 @@ Ponta do Sol is a **village-scale local energy community** in Madeira. **Each bu
 
 ```mermaid
 flowchart LR
-  subgraph schoolBuilding [Escola Basica e Secundaria de Machico]
-    SchoolRoof["Rooftop PV\nMACHICO_SCHOOL_PV\n~75 kWp SOLAR"]
+  subgraph schoolBuilding [Escola Basica e Secundaria da Ponta do Sol]
+    SchoolRoof["Rooftop PV\nPONTA_SCHOOL_PV\n~75 kWp SOLAR"]
     SchoolLoad["School meter"]
   end
   subgraph communityStorage [Community storage]
@@ -189,7 +189,7 @@ flowchart LR
 
 | Source | Location | Type | Demo size | Est. production / role | Base price |
 |--------|----------|------|-----------|------------------------|------------|
-| `MACHICO_SCHOOL_PV` | Escola Básica e Secundária de Machico rooftop | SOLAR | 75 kWp | ~110,000 kWh/yr | €0.10/kWh |
+| `PONTA_SCHOOL_PV` | Escola Básica e Secundária da Ponta do Sol rooftop | SOLAR | 75 kWp | ~110,000 kWh/yr | €0.10/kWh |
 | `PONTA_APT_PV` | Apartment rooftop | SOLAR | ~18 kWp | ~26,000 kWh/yr | €0.10/kWh |
 | `PONTA_COMMUNITY_BATTERY` | Shared (school + apartment) | BATTERY | ~150 kWh | shifts ~15–20 MWh/yr | €0.15/kWh |
 
@@ -206,17 +206,17 @@ flowchart LR
 | **Total demand** | **~86,000** |
 | **Net community surplus** | **~50,000** |
 
-**Investor pitch line:** *"The Escola de Machico roof powers the village — surplus solar runs the banana farm by day, stores energy for apartment EVs by night."*
+**Investor pitch line:** *"The school roof powers the village — surplus solar runs the banana farm by day, stores energy for apartment EVs by night."*
 
 ### Ownership split (basis points, total 10,000 per source)
 
 No municipality on source tokens (municipality only receives the 5% community fee at settlement).
 
-**Escola Básica e Secundária de Machico rooftop PV** — school + two individual investors:
+**Escola Básica e Secundária da Ponta do Sol rooftop PV** — school + two individual investors:
 
 | Holder | % | BPS |
 |--------|---|-----|
-| Escola Básica e Secundária de Machico | 50% | 5,000 |
+| Escola Básica e Secundária da Ponta do Sol | 50% | 5,000 |
 | Ana Silva (individual investor) | 25% | 2,500 |
 | João Mendes (individual investor) | 25% | 2,500 |
 
@@ -232,16 +232,16 @@ No municipality on source tokens (municipality only receives the 5% community fe
 
 | Holder | % | BPS |
 |--------|---|-----|
-| Escola Básica e Secundária de Machico | 10% | 1,000 |
+| Escola Básica e Secundária da Ponta do Sol | 10% | 1,000 |
 | 8 apartment residents (2.5% each) | 20% | 250 × 8 |
 | Ana Silva (individual investor) | 35% | 3,500 |
 | João Mendes (individual investor) | 35% | 3,500 |
 
 | Asset | Owners |
 |-------|--------|
-| School PV | Escola Básica e Secundária de Machico, Ana, João |
+| School PV | Escola Básica e Secundária da Ponta do Sol, Ana, João |
 | Apartment PV | 8 residents, Ana, João |
-| Shared battery | Escola Básica e Secundária de Machico, 8 residents, Ana, João |
+| Shared battery | Escola Básica e Secundária da Ponta do Sol, 8 residents, Ana, João |
 
 **Rationale — school PV at 50%:** The array is on the school roof and the school is the primary operational beneficiary (lower bills + revenue share). Investors at 25% each provide capital while the school retains majority ownership of its own asset.
 
@@ -315,7 +315,7 @@ On **~€55k** fund capital deployed → **~12–15% gross cash yield** in year 
 
 | # | Role | device ID | Notes |
 |---|------|-----------|-------|
-| 1 | Escola Básica e Secundária de Machico | `1` | School consumption meter |
+| 1 | Escola Básica e Secundária da Ponta do Sol | `1` | School consumption meter |
 | 2–9 | Resident 1 … Resident 8 | `2`–`9` | 8 individual households |
 | 10 | Quinta da Bananeira (banana farm) | `10` | Daytime irrigation, packing, cold storage |
 | 11 | Ana Silva (individual investor) | `9101` | Revenue-only sentinel ID |

--- a/docs/ponta-do-sol-demo-setup.md
+++ b/docs/ponta-do-sol-demo-setup.md
@@ -83,7 +83,7 @@ Form: `packages/epics/src/governance/components/create-enable-energy-community-f
 ```markdown
 This proposal activates the Ponta do Sol energy community on Base mainnet via EnergyPPAv2.
 
-It registers rooftop solar on **Escola Básica e Secundária da Ponta do Sol** and the apartment block, a shared 150 kWh battery, eight households, Quinta da Bananeira, and two individual investors — with on-chain ownership and automated settlement.
+It registers rooftop solar on **Escola Básica e Secundária da Ponta do Sol** and the apartment block, a shared 150 kWh battery, eight households, Quinta da Bananeira, and two individual investors (Vlad Hramtsov, Suzana Souza) — with on-chain ownership and automated settlement.
 ```
 
 Correct Portuguese spelling: **Básica**, **Secundária**, lowercase **e**, **da Ponta do Sol**.
@@ -136,7 +136,7 @@ Generate **~15 team-controlled addresses** (see `energy-ppav2-mainnet-demo.ts` f
 
 - **Institutional:** `communityTreasury`, `escolaPontaDoSol`, `bananaFarm`, `gridOperator`, `hyphaAggregator`
 - **8 individual residents:** `resident01` … `resident08`
-- **2 individual investors:** `investorAna`, `investorJoao`
+- **2 individual investors:** `investorVlad`, `investorSuzana`
 - Store in `ponta-do-sol-demo-wallets.json` (gitignored) — **never commit private keys**
 
 ### What is NOT possible / not recommended
@@ -157,8 +157,8 @@ Ponta do Sol is a **village-scale local energy community** in Madeira. **Each bu
 - **Edifício de Apartamentos** (8 homes) — own rooftop PV (~18 kWp); hosts the shared battery and most evening load
 - **Escola Básica e Secundária da Ponta do Sol** — own rooftop PV (~75 kWp); surplus feeds shared battery, banana farm, and export
 - **Quinta da Bananeira** — consumer only (no rooftop); daytime agricultural load
-- **Two individual investors** — private citizens who co-invested in PV and battery
-- **Eight individual apartment residents** — each with own meter and ownership stake in apartment PV + shared battery
+- **Two individual investors** — Vlad Hramtsov and Suzana Souza, co-investors in PV and battery
+- **Eight individual apartment residents** — Sofia Costa, Miguel Pereira, Ana Rodrigues, João Ferreira, Inês Sousa, Beatriz Silva, Pedro Freire, Rogério Ivan (each with own meter and ownership stake)
 - **Município / community treasury** — receives community fee (5%); no source ownership tokens
 
 ### On-site generation assets (2 rooftop PV + 1 shared battery)
@@ -187,11 +187,17 @@ flowchart LR
   SharedBattery --> SchoolLoad
 ```
 
-| Source | Location | Type | Demo size | Est. production / role | Base price |
-|--------|----------|------|-----------|------------------------|------------|
-| `PONTA_SCHOOL_PV` | Escola Básica e Secundária da Ponta do Sol rooftop | SOLAR | 75 kWp | ~110,000 kWh/yr | €0.10/kWh |
-| `PONTA_APT_PV` | Apartment rooftop | SOLAR | ~18 kWp | ~26,000 kWh/yr | €0.10/kWh |
-| `PONTA_COMMUNITY_BATTERY` | Shared (school + apartment) | BATTERY | ~150 kWh | shifts ~15–20 MWh/yr | €0.15/kWh |
+| Source ID (form **Name**) | Token / display name (form **Token name**) | Type | Current price / kWh |
+|---------------------------|--------------------------------------------|------|---------------------|
+| `PONTA_SCHOOL_PV` | Ponta do Sol School Solar | SOLAR | `0.10` |
+| `PONTA_APT_PV` | Ponta Apartment Solar | SOLAR | `0.10` |
+| `PONTA_COMMUNITY_BATTERY` | Ponta Community Battery | BATTERY | `0.15` |
+
+| Source | Demo size | Est. production / role |
+|--------|-----------|------------------------|
+| School PV | 75 kWp | ~110,000 kWh/yr |
+| Apartment PV | ~18 kWp | ~26,000 kWh/yr |
+| Shared battery | ~150 kWh | shifts ~15–20 MWh/yr |
 
 ### Community energy balance (annual, planning-level)
 
@@ -212,42 +218,56 @@ flowchart LR
 
 No municipality on source tokens (municipality only receives the 5% community fee at settlement).
 
-**Escola Básica e Secundária da Ponta do Sol rooftop PV** — school + two individual investors:
+**Escola Básica e Secundária da Ponta do Sol rooftop PV** — school wallet + two investors:
 
 | Holder | % | BPS |
 |--------|---|-----|
-| Escola Básica e Secundária da Ponta do Sol | 50% | 5,000 |
-| Ana Silva (individual investor) | 25% | 2,500 |
-| João Mendes (individual investor) | 25% | 2,500 |
+| Escola Básica e Secundária da Ponta do Sol (institutional wallet) | 50% | 5,000 |
+| Vlad Hramtsov (individual investor) | 25% | 2,500 |
+| Suzana Souza (individual investor) | 25% | 2,500 |
 
 **Apartment rooftop PV** — eight households + two investors:
 
 | Holder | % | BPS |
 |--------|---|-----|
-| 8 apartment residents (3.75% each) | 30% | 375 × 8 |
-| Ana Silva (individual investor) | 35% | 3,500 |
-| João Mendes (individual investor) | 35% | 3,500 |
+| Sofia Costa | 8% | 800 |
+| Miguel Pereira | 7% | 700 |
+| Ana Rodrigues | 5% | 500 |
+| João Ferreira | 5% | 500 |
+| Inês Sousa | 6% | 600 |
+| Beatriz Silva | 10% | 1,000 |
+| Pedro Freire | 10% | 1,000 |
+| Rogério Ivan | 9% | 900 |
+| Vlad Hramtsov (individual investor) | 20% | 2,000 |
+| Suzana Souza (individual investor) | 20% | 2,000 |
 
 **Community shared battery** — school + eight households + two investors:
 
 | Holder | % | BPS |
 |--------|---|-----|
-| Escola Básica e Secundária da Ponta do Sol | 10% | 1,000 |
-| 8 apartment residents (2.5% each) | 20% | 250 × 8 |
-| Ana Silva (individual investor) | 35% | 3,500 |
-| João Mendes (individual investor) | 35% | 3,500 |
+| Escola Básica e Secundária da Ponta do Sol (institutional wallet) | 30% | 3,000 |
+| Sofia Costa | 5% | 500 |
+| Miguel Pereira | 5% | 500 |
+| Ana Rodrigues | 5% | 500 |
+| João Ferreira | 5% | 500 |
+| Inês Sousa | 5% | 500 |
+| Beatriz Silva | 5% | 500 |
+| Pedro Freire | 5% | 500 |
+| Rogério Ivan | 5% | 500 |
+| Vlad Hramtsov (individual investor) | 15% | 1,500 |
+| Suzana Souza (individual investor) | 15% | 1,500 |
 
 | Asset | Owners |
 |-------|--------|
-| School PV | Escola Básica e Secundária da Ponta do Sol, Ana, João |
-| Apartment PV | 8 residents, Ana, João |
-| Shared battery | Escola Básica e Secundária da Ponta do Sol, 8 residents, Ana, João |
+| School PV | Escola (wallet), Vlad, Suzana |
+| Apartment PV | 8 residents, Vlad, Suzana |
+| Shared battery | Escola (wallet), 8 residents, Vlad, Suzana |
 
 **Rationale — school PV at 50%:** The array is on the school roof and the school is the primary operational beneficiary (lower bills + revenue share). Investors at 25% each provide capital while the school retains majority ownership of its own asset.
 
 ### Alternative scenario — RWA fund instead of individual investors
 
-The **default demo** uses two named individuals (Ana Silva, João Mendes) as co-investors. An alternative pitch treats generation assets as **real-world assets (RWAs)** wrapped in a fund-like vehicle, where external investors buy units and receive **cash yield** from community energy settlement (similar to interest / coupon on production revenues).
+The **default demo** uses two named individuals (**Vlad Hramtsov**, **Suzana Souza**) as co-investors. An alternative pitch treats generation assets as **real-world assets (RWAs)** wrapped in a fund-like vehicle, where external investors buy units and receive **cash yield** from community energy settlement (similar to interest / coupon on production revenues).
 
 #### Legal vehicle options (EU / Portugal)
 
@@ -315,11 +335,18 @@ On **~€55k** fund capital deployed → **~12–15% gross cash yield** in year 
 
 | # | Role | device ID | Notes |
 |---|------|-----------|-------|
-| 1 | Escola Básica e Secundária da Ponta do Sol | `1` | School consumption meter |
-| 2–9 | Resident 1 … Resident 8 | `2`–`9` | 8 individual households |
-| 10 | Quinta da Bananeira (banana farm) | `10` | Daytime irrigation, packing, cold storage |
-| 11 | Ana Silva (individual investor) | `9101` | Revenue-only sentinel ID |
-| 12 | João Mendes (individual investor) | `9102` | Revenue-only sentinel ID |
+| 1 | Escola Básica e Secundária da Ponta do Sol | `1` | School consumption meter (institutional wallet, not a Hypha person) |
+| 2 | Sofia Costa | `2` | Apt 1 |
+| 3 | Miguel Pereira | `3` | Apt 2 |
+| 4 | Ana Rodrigues | `4` | Apt 3 |
+| 5 | João Ferreira | `5` | Apt 4 |
+| 6 | Inês Sousa | `6` | Apt 5 |
+| 7 | Beatriz Silva | `7` | Apt 6 |
+| 8 | Pedro Freire | `8` | Apt 7 |
+| 9 | Rogério Ivan | `9` | Apt 8 |
+| 10 | Quinta da Bananeira (banana farm) | `10` | Institutional wallet — daytime irrigation, packing, cold storage |
+| 11 | Vlad Hramtsov (individual investor) | `9101` | Revenue-only sentinel ID |
+| 12 | Suzana Souza (individual investor) | `9102` | Revenue-only sentinel ID |
 
 ### Fees and operators
 

--- a/packages/core/src/energy/server/index.ts
+++ b/packages/core/src/energy/server/index.ts
@@ -2,3 +2,5 @@ export * from './queries';
 export * from './azure-db-config';
 export * from './telemetry-types';
 export * from './telemetry-queries';
+export * from './resolve-energy-participants';
+export * from './read-ownership-token-name';

--- a/packages/core/src/energy/server/read-ownership-token-name.ts
+++ b/packages/core/src/energy/server/read-ownership-token-name.ts
@@ -68,12 +68,12 @@ export async function readOwnershipTokenNames(
   });
 
   const lookup: Record<string, string> = {};
-  for (let index = 0; index < unique.length; index += 1) {
+  for (const [index, address] of unique.entries()) {
     const result = results[index];
     if (result?.status !== 'success') continue;
     const trimmed = String(result.result).trim();
     if (trimmed.length > 0) {
-      lookup[unique[index]] = trimmed;
+      lookup[address] = trimmed;
     }
   }
 

--- a/packages/core/src/energy/server/read-ownership-token-name.ts
+++ b/packages/core/src/energy/server/read-ownership-token-name.ts
@@ -1,0 +1,37 @@
+import 'server-only';
+
+import { web3Client } from '../../common/server/web3-rpc/client';
+
+const ownershipTokenNameAbi = [
+  {
+    type: 'function',
+    name: 'name',
+    stateMutability: 'view',
+    inputs: [],
+    outputs: [{ type: 'string' }],
+  },
+] as const;
+
+/**
+ * Read the human-readable name from a source ownership token (RegularSpaceToken).
+ */
+export async function readOwnershipTokenName(
+  tokenAddress: `0x${string}` | string | null | undefined,
+): Promise<string | null> {
+  if (!tokenAddress) return null;
+  const normalized = tokenAddress.trim().toLowerCase();
+  if (!/^0x[a-f0-9]{40}$/.test(normalized)) return null;
+  if (normalized === '0x0000000000000000000000000000000000000000') return null;
+
+  try {
+    const name = await web3Client.readContract({
+      address: normalized as `0x${string}`,
+      abi: ownershipTokenNameAbi,
+      functionName: 'name',
+    });
+    const trimmed = String(name).trim();
+    return trimmed.length > 0 ? trimmed : null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/core/src/energy/server/read-ownership-token-name.ts
+++ b/packages/core/src/energy/server/read-ownership-token-name.ts
@@ -15,17 +15,25 @@ const ownershipTokenNameAbi = [
 /**
  * Read the human-readable name from a source ownership token (RegularSpaceToken).
  */
-export async function readOwnershipTokenName(
+const normalizeOwnershipTokenAddress = (
   tokenAddress: `0x${string}` | string | null | undefined,
-): Promise<string | null> {
+): `0x${string}` | null => {
   if (!tokenAddress) return null;
   const normalized = tokenAddress.trim().toLowerCase();
   if (!/^0x[a-f0-9]{40}$/.test(normalized)) return null;
   if (normalized === '0x0000000000000000000000000000000000000000') return null;
+  return normalized as `0x${string}`;
+};
+
+export async function readOwnershipTokenName(
+  tokenAddress: `0x${string}` | string | null | undefined,
+): Promise<string | null> {
+  const normalized = normalizeOwnershipTokenAddress(tokenAddress);
+  if (!normalized) return null;
 
   try {
     const name = await web3Client.readContract({
-      address: normalized as `0x${string}`,
+      address: normalized,
       abi: ownershipTokenNameAbi,
       functionName: 'name',
     });
@@ -34,4 +42,40 @@ export async function readOwnershipTokenName(
   } catch {
     return null;
   }
+}
+
+/** Batch-read ownership token names, deduplicating addresses and using multicall. */
+export async function readOwnershipTokenNames(
+  tokenAddresses: readonly (`0x${string}` | string | null | undefined)[],
+): Promise<Record<string, string>> {
+  const unique = [
+    ...new Set(
+      tokenAddresses
+        .map((address) => normalizeOwnershipTokenAddress(address))
+        .filter((address): address is `0x${string}` => address !== null),
+    ),
+  ];
+
+  if (unique.length === 0) return {};
+
+  const results = await web3Client.multicall({
+    allowFailure: true,
+    contracts: unique.map((address) => ({
+      address,
+      abi: ownershipTokenNameAbi,
+      functionName: 'name' as const,
+    })),
+  });
+
+  const lookup: Record<string, string> = {};
+  for (let index = 0; index < unique.length; index += 1) {
+    const result = results[index];
+    if (result?.status !== 'success') continue;
+    const trimmed = String(result.result).trim();
+    if (trimmed.length > 0) {
+      lookup[unique[index]] = trimmed;
+    }
+  }
+
+  return lookup;
 }

--- a/packages/core/src/energy/server/read-ownership-token-name.ts
+++ b/packages/core/src/energy/server/read-ownership-token-name.ts
@@ -58,24 +58,32 @@ export async function readOwnershipTokenNames(
 
   if (unique.length === 0) return {};
 
-  const results = await web3Client.multicall({
-    allowFailure: true,
-    contracts: unique.map((address) => ({
-      address,
-      abi: ownershipTokenNameAbi,
-      functionName: 'name' as const,
-    })),
-  });
+  try {
+    const results = await web3Client.multicall({
+      allowFailure: true,
+      contracts: unique.map((address) => ({
+        address,
+        abi: ownershipTokenNameAbi,
+        functionName: 'name' as const,
+      })),
+    });
 
-  const lookup: Record<string, string> = {};
-  for (const [index, address] of unique.entries()) {
-    const result = results[index];
-    if (result?.status !== 'success') continue;
-    const trimmed = String(result.result).trim();
-    if (trimmed.length > 0) {
-      lookup[address] = trimmed;
+    const lookup: Record<string, string> = {};
+    for (const [index, address] of unique.entries()) {
+      const result = results[index];
+      if (result?.status !== 'success') continue;
+      const trimmed = String(result.result).trim();
+      if (trimmed.length > 0) {
+        lookup[address] = trimmed;
+      }
     }
-  }
 
-  return lookup;
+    return lookup;
+  } catch (error) {
+    console.warn(
+      '[spaces/energy] readOwnershipTokenNames multicall failed',
+      error,
+    );
+    return {};
+  }
 }

--- a/packages/core/src/energy/server/resolve-energy-participants.ts
+++ b/packages/core/src/energy/server/resolve-energy-participants.ts
@@ -1,0 +1,153 @@
+import 'server-only';
+
+import { findPeopleByWeb3Addresses } from '../../people/server/queries';
+import { findSpaceByAddresses } from '../../space/server/queries';
+import type { DatabaseInstance } from '../../server';
+
+export type EnergyParticipantDisplay = {
+  displayName: string;
+  avatarUrl?: string | null;
+  subtitle?: string | null;
+  profileSlug?: string | null;
+  kind: 'person' | 'space' | 'institutional';
+};
+
+export type ResolveEnergyParticipantsInput = {
+  addresses: string[];
+  spaceSlug?: string;
+  memberDeviceIds?: Map<string, number[] | null>;
+  institutionalByDevice?: Record<
+    number,
+    { displayName: string; avatarUrl?: string; subtitle?: string }
+  >;
+};
+
+const personFullName = (person: {
+  name?: string | null;
+  surname?: string | null;
+  nickname?: string | null;
+}) => {
+  const full = [person.name, person.surname].filter(Boolean).join(' ').trim();
+  return full || person.nickname || null;
+};
+
+/**
+ * Resolve wallet addresses to Hypha people or spaces for Energy tab display.
+ * Falls back to per-space institutional labels (by meter device id) when
+ * neither a person nor a space profile exists — e.g. school / farm demo wallets.
+ */
+export async function resolveEnergyParticipants(
+  {
+    addresses,
+    spaceSlug,
+    memberDeviceIds,
+    institutionalByDevice,
+  }: ResolveEnergyParticipantsInput,
+  { db }: { db: DatabaseInstance },
+): Promise<Record<string, EnergyParticipantDisplay>> {
+  const unique = Array.from(
+    new Set(addresses.map((a) => a.toLowerCase()).filter(Boolean)),
+  );
+  if (unique.length === 0) return {};
+
+  const [people, spacesResult] = await Promise.all([
+    findPeopleByWeb3Addresses({ addresses: unique }, { db }),
+    findSpaceByAddresses(unique, {}, { db }),
+  ]);
+  const spaces = spacesResult.data;
+
+  const peopleByAddress = new Map(
+    people.filter((p) => p.address).map((p) => [p.address!.toLowerCase(), p]),
+  );
+  const spacesByAddress = new Map(
+    spaces.filter((s) => s.address).map((s) => [s.address!.toLowerCase(), s]),
+  );
+
+  const result: Record<string, EnergyParticipantDisplay> = {};
+
+  for (const address of unique) {
+    const person = peopleByAddress.get(address);
+    if (person) {
+      const displayName = personFullName(person);
+      if (displayName) {
+        result[address] = {
+          displayName,
+          avatarUrl: person.avatarUrl ?? null,
+          subtitle: person.nickname
+            ? `@${person.nickname}`
+            : person.location ?? null,
+          profileSlug: person.slug ?? null,
+          kind: 'person',
+        };
+        continue;
+      }
+    }
+
+    const space = spacesByAddress.get(address);
+    if (space?.title) {
+      result[address] = {
+        displayName: space.title,
+        avatarUrl: space.logoUrl ?? null,
+        subtitle: space.slug ? `@${space.slug}` : null,
+        profileSlug: null,
+        kind: 'space',
+      };
+      continue;
+    }
+
+    const deviceIds = memberDeviceIds?.get(address);
+    if (
+      institutionalByDevice &&
+      deviceIds?.length === 1 &&
+      institutionalByDevice[deviceIds[0]!]
+    ) {
+      const inst = institutionalByDevice[deviceIds[0]!]!;
+      result[address] = {
+        displayName: inst.displayName,
+        avatarUrl: inst.avatarUrl ?? null,
+        subtitle: inst.subtitle ?? null,
+        profileSlug: null,
+        kind: 'institutional',
+      };
+      continue;
+    }
+
+    // Unused: spaceSlug kept for future per-space config from DB.
+    void spaceSlug;
+  }
+
+  return result;
+}
+
+/** Ponta do Sol demo — institutional wallets without Hypha person profiles. */
+export const PONTA_DO_SOL_INSTITUTIONAL_BY_DEVICE: Record<
+  number,
+  { displayName: string; avatarUrl?: string; subtitle?: string }
+> = {
+  1: {
+    displayName: 'Escola Básica e Secundária da Ponta do Sol',
+    subtitle: 'School consumption · meter 1',
+    avatarUrl:
+      'https://ui-avatars.com/api/?name=Escola+Ponta+do+Sol&background=2563eb&color=fff&size=128',
+  },
+  10: {
+    displayName: 'Quinta da Bananeira',
+    subtitle: 'Banana farm · meter 10',
+    avatarUrl:
+      'https://ui-avatars.com/api/?name=Quinta+Bananeira&background=ca8a04&color=fff&size=128',
+  },
+};
+
+export function institutionalLabelsForSpace(
+  spaceSlug: string | undefined,
+):
+  | Record<
+      number,
+      { displayName: string; avatarUrl?: string; subtitle?: string }
+    >
+  | undefined {
+  if (spaceSlug === 'ponta-do-sol') {
+    return PONTA_DO_SOL_INSTITUTIONAL_BY_DEVICE;
+  }
+  return undefined;
+}

--- a/packages/core/src/energy/server/resolve-energy-participants.ts
+++ b/packages/core/src/energy/server/resolve-energy-participants.ts
@@ -124,15 +124,15 @@ export const PONTA_DO_SOL_INSTITUTIONAL_BY_DEVICE: Record<
   number,
   { displayName: string; avatarUrl?: string; subtitle?: string }
 > = {
-  1: {
+  7: {
     displayName: 'Escola Básica e Secundária da Ponta do Sol',
-    subtitle: 'School consumption · meter 1',
+    subtitle: 'School consumption · meter 7',
     avatarUrl:
       'https://ui-avatars.com/api/?name=Escola+Ponta+do+Sol&background=2563eb&color=fff&size=128',
   },
-  10: {
+  8: {
     displayName: 'Quinta da Bananeira',
-    subtitle: 'Banana farm · meter 10',
+    subtitle: 'Banana farm · meter 8',
     avatarUrl:
       'https://ui-avatars.com/api/?name=Quinta+Bananeira&background=ca8a04&color=fff&size=128',
   },
@@ -146,7 +146,10 @@ export function institutionalLabelsForSpace(
       { displayName: string; avatarUrl?: string; subtitle?: string }
     >
   | undefined {
-  if (spaceSlug === 'ponta-do-sol') {
+  if (
+    spaceSlug === 'ponta-do-sol-energy-community' ||
+    spaceSlug === 'ponta-do-sol'
+  ) {
     return PONTA_DO_SOL_INSTITUTIONAL_BY_DEVICE;
   }
   return undefined;

--- a/packages/epics/src/treasury/components/assets/energy/consumer-consumption-card.tsx
+++ b/packages/epics/src/treasury/components/assets/energy/consumer-consumption-card.tsx
@@ -8,7 +8,7 @@ import { Skeleton } from '@hypha-platform/ui';
 import { PersonAvatar } from '../../../../people/components/person-avatar';
 import { useSpaceEnergyTelemetry } from '../../../hooks/use-space-energy-telemetry';
 import type { EnergyPerson } from './use-energy-people';
-import { personDisplayName, shortAddr } from './format';
+import { shortAddr } from './format';
 import { BarChart, ENERGY_PALETTE, type ChartSeries } from './charts';
 import {
   buildMemberConsumptionSeries,
@@ -110,17 +110,20 @@ const ConsumerConsumptionChart = ({
 
 export const ConsumerConsumptionCard = ({
   address,
-  person,
+  displayName,
+  avatarUrl,
+  subtitle,
   isLoading,
   deviceIds,
 }: {
   address: string;
-  person?: EnergyPerson | null;
+  displayName: string;
+  avatarUrl?: string;
+  subtitle?: string;
   isLoading?: boolean;
   deviceIds: number[] | null;
 }) => {
   const [expanded, setExpanded] = React.useState(false);
-  const name = personDisplayName(person) ?? shortAddr(address);
 
   return (
     <div
@@ -136,16 +139,16 @@ export const ConsumerConsumptionCard = ({
         aria-expanded={expanded}
       >
         <PersonAvatar
-          avatarSrc={person?.avatarUrl ?? undefined}
-          userName={personDisplayName(person) ?? undefined}
+          avatarSrc={avatarUrl}
+          userName={displayName}
           size="md"
           shape="circle"
           isLoading={isLoading}
         />
         <div className="min-w-0 flex-1">
-          <p className="truncate font-medium text-foreground">{name}</p>
+          <p className="truncate font-medium text-foreground">{displayName}</p>
           <p className="truncate text-1 text-neutral-11">
-            {person?.nickname ? `@${person.nickname}` : shortAddr(address)}
+            {subtitle ?? shortAddr(address)}
           </p>
         </div>
         <ChevronDownIcon

--- a/packages/epics/src/treasury/components/assets/energy/credits-tab.tsx
+++ b/packages/epics/src/treasury/components/assets/energy/credits-tab.tsx
@@ -3,11 +3,14 @@
 import * as React from 'react';
 import { useTranslations } from 'next-intl';
 import { Card, CardContent, CardHeader, CardTitle } from '@hypha-platform/ui';
-import type { SpaceEnergyResponse } from '../../../hooks/use-space-energy';
 import { EnergyPersonCard, GridOperatorCard } from './shared';
-import { useEnergyPeople } from './use-energy-people';
 import { ENERGY_PALETTE } from './charts';
-import { formatStablecoinMicro } from './format';
+import {
+  formatStablecoinMicro,
+  resolveEnergyParticipantDisplay,
+} from './format';
+import type { EnergyTabProps } from './energy-tab-props';
+import { energyAvatarLoading } from './energy-tab-props';
 
 type Row = {
   address: string;
@@ -53,26 +56,22 @@ const sortRows = (a: Row, b: Row) => {
   return 0;
 };
 
-export const CreditsTab = ({ data }: { data: SpaceEnergyResponse }) => {
+export const CreditsTab = ({ data, people, peopleLoading }: EnergyTabProps) => {
   const t = useTranslations('Energy.credits');
   const details = data.memberDetails ?? [];
+  const participantProfiles = data.participantProfiles;
   const gridOperator = data.roles?.gridOperator ?? null;
   const gridBalanceInternal = toSignedBigInt(data.overview?.gridBalance);
 
-  const { rows, addresses } = React.useMemo(() => {
+  const rows = React.useMemo(() => {
     const rows: Row[] = details.map((member) => ({
       address: member.address,
       toSettleMicro: toBigInt(member.debtInStablecoin),
       creditMicro: toBigInt(member.creditInStablecoin),
     }));
     rows.sort(sortRows);
-    return {
-      rows,
-      addresses: details.map((m) => m.address.toLowerCase()),
-    };
+    return rows;
   }, [details]);
-
-  const { people, isLoading } = useEnergyPeople(addresses);
 
   const gridToSettleMicro =
     gridBalanceInternal > 0n
@@ -162,44 +161,58 @@ export const CreditsTab = ({ data }: { data: SpaceEnergyResponse }) => {
             <CardTitle>{t('memberSettlement')}</CardTitle>
           </CardHeader>
           <CardContent className="flex flex-col gap-3">
-            {rows.map((row) => (
-              <div key={row.address}>
-                <EnergyPersonCard
-                  address={row.address}
-                  person={people[row.address.toLowerCase()]}
-                  isLoading={isLoading}
-                  right={
-                    <div className="text-right">
-                      {row.toSettleMicro > 0n ? (
-                        <p
-                          className="font-medium"
-                          style={{ color: ENERGY_PALETTE[4] }}
-                        >
-                          {t('toSettle', {
-                            amount: eurcAmount(row.toSettleMicro),
-                          })}
-                        </p>
-                      ) : null}
-                      {row.creditMicro > 0n ? (
-                        <p
-                          className="font-medium"
-                          style={{ color: ENERGY_PALETTE[1] }}
-                        >
-                          {t('credit', {
-                            amount: eurcAmount(row.creditMicro),
-                          })}
-                        </p>
-                      ) : null}
-                      {row.toSettleMicro === 0n && row.creditMicro === 0n ? (
-                        <p className="font-medium text-neutral-11">
-                          {t('zeroEurc')}
-                        </p>
-                      ) : null}
-                    </div>
-                  }
-                />
-              </div>
-            ))}
+            {rows.map((row) => {
+              const display = resolveEnergyParticipantDisplay(
+                row.address,
+                people,
+                participantProfiles,
+              );
+              return (
+                <div key={row.address}>
+                  <EnergyPersonCard
+                    address={row.address}
+                    person={people[row.address.toLowerCase()]}
+                    displayName={display.displayName}
+                    avatarUrl={display.avatarUrl}
+                    subtitle={display.subtitle}
+                    isLoading={energyAvatarLoading(
+                      row.address,
+                      peopleLoading,
+                      participantProfiles,
+                    )}
+                    right={
+                      <div className="text-right">
+                        {row.toSettleMicro > 0n ? (
+                          <p
+                            className="font-medium"
+                            style={{ color: ENERGY_PALETTE[4] }}
+                          >
+                            {t('toSettle', {
+                              amount: eurcAmount(row.toSettleMicro),
+                            })}
+                          </p>
+                        ) : null}
+                        {row.creditMicro > 0n ? (
+                          <p
+                            className="font-medium"
+                            style={{ color: ENERGY_PALETTE[1] }}
+                          >
+                            {t('credit', {
+                              amount: eurcAmount(row.creditMicro),
+                            })}
+                          </p>
+                        ) : null}
+                        {row.toSettleMicro === 0n && row.creditMicro === 0n ? (
+                          <p className="font-medium text-neutral-11">
+                            {t('zeroEurc')}
+                          </p>
+                        ) : null}
+                      </div>
+                    }
+                  />
+                </div>
+              );
+            })}
             <p className="text-1 text-neutral-11">{t('balancesHint')}</p>
           </CardContent>
         </Card>

--- a/packages/epics/src/treasury/components/assets/energy/energy-tab-props.ts
+++ b/packages/epics/src/treasury/components/assets/energy/energy-tab-props.ts
@@ -12,5 +12,4 @@ export const energyAvatarLoading = (
   peopleLoading: boolean,
   participantProfiles?: SpaceEnergyResponse['participantProfiles'],
 ) =>
-  peopleLoading &&
-  !participantProfiles?.[address.toLowerCase()]?.displayName;
+  peopleLoading && !participantProfiles?.[address.toLowerCase()]?.displayName;

--- a/packages/epics/src/treasury/components/assets/energy/energy-tab-props.ts
+++ b/packages/epics/src/treasury/components/assets/energy/energy-tab-props.ts
@@ -1,0 +1,16 @@
+import type { SpaceEnergyResponse } from '../../../hooks/use-space-energy';
+import type { EnergyPeopleMap } from './use-energy-people';
+
+export type EnergyTabProps = {
+  data: SpaceEnergyResponse;
+  people: EnergyPeopleMap;
+  peopleLoading: boolean;
+};
+
+export const energyAvatarLoading = (
+  address: string,
+  peopleLoading: boolean,
+  participantProfiles?: SpaceEnergyResponse['participantProfiles'],
+) =>
+  peopleLoading &&
+  !participantProfiles?.[address.toLowerCase()]?.displayName;

--- a/packages/epics/src/treasury/components/assets/energy/format.ts
+++ b/packages/epics/src/treasury/components/assets/energy/format.ts
@@ -1,4 +1,6 @@
 import { formatUnits } from 'viem';
+import type { EnergyParticipantProfile } from '../../../hooks/use-space-energy';
+import type { EnergyPerson } from './use-energy-people';
 
 export const UNAVAILABLE = '—';
 export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
@@ -128,26 +130,10 @@ export const sourceCardLabel = (
   );
 };
 
-export type EnergyParticipantProfile = {
-  displayName: string;
-  avatarUrl?: string | null;
-  subtitle?: string | null;
-  profileSlug?: string | null;
-  kind?: 'person' | 'space' | 'institutional';
-};
-
 /** Merge Hypha person lookup with server-resolved participant profiles. */
 export const resolveEnergyParticipantDisplay = (
   address: string,
-  people: Record<
-    string,
-    {
-      name?: string | null;
-      surname?: string | null;
-      nickname?: string | null;
-      avatarUrl?: string | null;
-    } | null
-  >,
+  people: Record<string, EnergyPerson | null>,
   profiles?: Record<string, EnergyParticipantProfile>,
 ) => {
   const key = address.toLowerCase();

--- a/packages/epics/src/treasury/components/assets/energy/format.ts
+++ b/packages/epics/src/treasury/components/assets/energy/format.ts
@@ -78,8 +78,8 @@ export const prettySourceLabel = (
 };
 
 /**
- * Display name for an energy source preferring the human label, then the type
- * (e.g. "Solar", "Battery"), then a numbered fallback.
+ * Display name for an energy source preferring the ownership token name, then
+ * the human label, then the type (e.g. "Solar", "Battery"), then a numbered fallback.
  */
 export const sourceDisplayName = (
   type?: string,
@@ -87,12 +87,92 @@ export const sourceDisplayName = (
   index = 0,
   sourceFallback = 'Source',
   typeLabels?: { SOLAR?: string; BATTERY?: string },
+  tokenDisplayName?: string,
 ) => {
+  if (tokenDisplayName && isReadableLabel(tokenDisplayName)) {
+    return tokenDisplayName;
+  }
   if (label && isReadableLabel(label)) return label;
   const typeLabel = resolveTypeLabel(type, sourceFallback, typeLabels);
   return typeLabel === sourceFallback
     ? `${sourceFallback} ${index + 1}`
     : typeLabel;
+};
+
+export const formatEnergyPricePerKwh = (internalUnits: string | number) => {
+  const n =
+    typeof internalUnits === 'number' ? internalUnits : Number(internalUnits);
+  if (!Number.isFinite(n)) return UNAVAILABLE;
+  return (n / 100).toFixed(2);
+};
+
+export const sourceCardLabel = (
+  source: {
+    sourceDisplayName?: string;
+    sourceLabel: string;
+    sourceType?: string;
+  },
+  index: number,
+  sourceFallback = 'Source',
+  typeLabels?: { SOLAR?: string; BATTERY?: string },
+) => {
+  if (source.sourceDisplayName && isReadableLabel(source.sourceDisplayName)) {
+    return source.sourceDisplayName;
+  }
+  return prettySourceLabel(
+    source.sourceLabel,
+    index,
+    source.sourceType,
+    sourceFallback,
+    typeLabels,
+  );
+};
+
+export type EnergyParticipantProfile = {
+  displayName: string;
+  avatarUrl?: string | null;
+  subtitle?: string | null;
+  profileSlug?: string | null;
+  kind?: 'person' | 'space' | 'institutional';
+};
+
+/** Merge Hypha person lookup with server-resolved participant profiles. */
+export const resolveEnergyParticipantDisplay = (
+  address: string,
+  people: Record<
+    string,
+    {
+      name?: string | null;
+      surname?: string | null;
+      nickname?: string | null;
+      avatarUrl?: string | null;
+    } | null
+  >,
+  profiles?: Record<string, EnergyParticipantProfile>,
+) => {
+  const key = address.toLowerCase();
+  const profile = profiles?.[key];
+  if (profile?.displayName) {
+    return {
+      displayName: profile.displayName,
+      avatarUrl: profile.avatarUrl ?? undefined,
+      subtitle: profile.subtitle ?? undefined,
+    };
+  }
+  const person = people[key];
+  const name = personDisplayName(person);
+  if (name) {
+    return {
+      displayName: name,
+      avatarUrl: person?.avatarUrl ?? undefined,
+      subtitle: person?.nickname ? `@${person.nickname}` : undefined,
+    };
+  }
+  return {
+    displayName: shortAddr(address),
+    avatarUrl: undefined,
+    subtitle: shortAddr(address),
+  };
 };
 
 export const personDisplayName = (

--- a/packages/epics/src/treasury/components/assets/energy/overview-tab.tsx
+++ b/packages/epics/src/treasury/components/assets/energy/overview-tab.tsx
@@ -3,18 +3,22 @@
 import * as React from 'react';
 import { useTranslations } from 'next-intl';
 import { UsersIcon, ZapIcon } from 'lucide-react';
-import type { SpaceEnergyResponse } from '../../../hooks/use-space-energy';
 import { ENERGY_PALETTE } from './charts';
 import { SourceCard, SectionTitle } from './shared';
 import { ConsumerConsumptionCard } from './consumer-consumption-card';
-import { useEnergyPeople } from './use-energy-people';
 import {
   formatEnergyPricePerKwh,
   resolveEnergyParticipantDisplay,
   sourceCardLabel,
 } from './format';
+import type { EnergyTabProps } from './energy-tab-props';
+import { energyAvatarLoading } from './energy-tab-props';
 
-export const EnergyOverviewTab = ({ data }: { data: SpaceEnergyResponse }) => {
+export const EnergyOverviewTab = ({
+  data,
+  people,
+  peopleLoading,
+}: EnergyTabProps) => {
   const t = useTranslations('Energy.overview');
   const tShared = useTranslations('Energy.shared');
   const sources = data.sources ?? [];
@@ -38,7 +42,6 @@ export const EnergyOverviewTab = ({ data }: { data: SpaceEnergyResponse }) => {
     [data.members, deviceIdsByAddress],
   );
 
-  const { people, isLoading } = useEnergyPeople(consumers);
   const participantProfiles = data.participantProfiles;
   const sourceFallback = tShared('source');
   const sourceTypeLabels = {
@@ -74,7 +77,11 @@ export const EnergyOverviewTab = ({ data }: { data: SpaceEnergyResponse }) => {
                   displayName={display.displayName}
                   avatarUrl={display.avatarUrl}
                   subtitle={display.subtitle}
-                  isLoading={isLoading}
+                  isLoading={energyAvatarLoading(
+                    address,
+                    peopleLoading,
+                    participantProfiles,
+                  )}
                   deviceIds={
                     deviceIdsByAddress.get(address.toLowerCase()) ?? null
                   }

--- a/packages/epics/src/treasury/components/assets/energy/overview-tab.tsx
+++ b/packages/epics/src/treasury/components/assets/energy/overview-tab.tsx
@@ -8,7 +8,11 @@ import { ENERGY_PALETTE } from './charts';
 import { SourceCard, SectionTitle } from './shared';
 import { ConsumerConsumptionCard } from './consumer-consumption-card';
 import { useEnergyPeople } from './use-energy-people';
-import { prettySourceLabel } from './format';
+import {
+  formatEnergyPricePerKwh,
+  resolveEnergyParticipantDisplay,
+  sourceCardLabel,
+} from './format';
 
 export const EnergyOverviewTab = ({ data }: { data: SpaceEnergyResponse }) => {
   const t = useTranslations('Energy.overview');
@@ -35,6 +39,7 @@ export const EnergyOverviewTab = ({ data }: { data: SpaceEnergyResponse }) => {
   );
 
   const { people, isLoading } = useEnergyPeople(consumers);
+  const participantProfiles = data.participantProfiles;
   const sourceFallback = tShared('source');
   const sourceTypeLabels = {
     SOLAR: tShared('sourceTypeSolar'),
@@ -56,17 +61,26 @@ export const EnergyOverviewTab = ({ data }: { data: SpaceEnergyResponse }) => {
         />
         {consumers.length ? (
           <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3">
-            {consumers.map((address) => (
-              <ConsumerConsumptionCard
-                key={address}
-                address={address}
-                person={people[address.toLowerCase()]}
-                isLoading={isLoading}
-                deviceIds={
-                  deviceIdsByAddress.get(address.toLowerCase()) ?? null
-                }
-              />
-            ))}
+            {consumers.map((address) => {
+              const display = resolveEnergyParticipantDisplay(
+                address,
+                people,
+                participantProfiles,
+              );
+              return (
+                <ConsumerConsumptionCard
+                  key={address}
+                  address={address}
+                  displayName={display.displayName}
+                  avatarUrl={display.avatarUrl}
+                  subtitle={display.subtitle}
+                  isLoading={isLoading}
+                  deviceIds={
+                    deviceIdsByAddress.get(address.toLowerCase()) ?? null
+                  }
+                />
+              );
+            })}
           </div>
         ) : (
           <p className="text-2 text-neutral-11">{t('noConsumers')}</p>
@@ -89,15 +103,14 @@ export const EnergyOverviewTab = ({ data }: { data: SpaceEnergyResponse }) => {
             {sources.map((source, index) => (
               <SourceCard
                 key={source.sourceId}
-                label={prettySourceLabel(
-                  source.sourceLabel,
+                label={sourceCardLabel(
+                  source,
                   index,
-                  source.sourceType,
                   sourceFallback,
                   sourceTypeLabels,
                 )}
                 type={source.sourceType}
-                basePrice={source.basePricePerKwh}
+                basePrice={formatEnergyPricePerKwh(source.basePricePerKwh)}
                 active={source.active}
                 accent={ENERGY_PALETTE[index % ENERGY_PALETTE.length]!}
               />

--- a/packages/epics/src/treasury/components/assets/energy/ownership-tab.tsx
+++ b/packages/epics/src/treasury/components/assets/energy/ownership-tab.tsx
@@ -12,15 +12,18 @@ import {
 } from '@hypha-platform/ui';
 import { cn } from '@hypha-platform/ui-utils';
 import { PersonAvatar } from '../../../../people/components/person-avatar';
-import type { SpaceEnergyResponse } from '../../../hooks/use-space-energy';
+import type {
+  SpaceEnergyResponse,
+  EnergyParticipantProfile,
+} from '../../../hooks/use-space-energy';
 import { useSpaceEnergyTelemetry } from '../../../hooks/use-space-energy-telemetry';
 import { BarChart, ENERGY_PALETTE, type ChartSeries } from './charts';
 import { useEnergyPeople, type EnergyPerson } from './use-energy-people';
 import {
   formatBpsPct,
-  personDisplayName,
-  shortAddr,
+  resolveEnergyParticipantDisplay,
   sourceDisplayName,
+  shortAddr,
 } from './format';
 import {
   buildSourceProductionSeries,
@@ -174,7 +177,8 @@ const OwnerEarningsChart = ({
 const OwnerEarningsRow = ({
   group,
   owner,
-  person,
+  displayName,
+  avatarUrl,
   isLoading,
   accent,
   totalEarned,
@@ -182,7 +186,8 @@ const OwnerEarningsRow = ({
 }: {
   group: SourceGroup;
   owner: Owner;
-  person?: EnergyPerson | null;
+  displayName: string;
+  avatarUrl?: string;
   isLoading?: boolean;
   accent: string;
   totalEarned: number;
@@ -190,7 +195,6 @@ const OwnerEarningsRow = ({
 }) => {
   const t = useTranslations('Energy.ownership');
   const [expanded, setExpanded] = React.useState(false);
-  const name = personDisplayName(person) ?? shortAddr(owner.address);
 
   return (
     <div className="rounded-xl border border-border bg-background-2">
@@ -201,14 +205,14 @@ const OwnerEarningsRow = ({
         aria-expanded={expanded}
       >
         <PersonAvatar
-          avatarSrc={person?.avatarUrl ?? undefined}
-          userName={personDisplayName(person) ?? undefined}
+          avatarSrc={avatarUrl}
+          userName={displayName}
           size="md"
           shape="circle"
           isLoading={isLoading}
         />
         <div className="min-w-0 flex-1">
-          <p className="truncate font-medium text-foreground">{name}</p>
+          <p className="truncate font-medium text-foreground">{displayName}</p>
           <p className="truncate text-1 text-neutral-11">
             {t('earnedFromSource', {
               prefix: totalIsPlaceholder ? '≈ ' : '',
@@ -242,11 +246,13 @@ const SourceOwnershipCard = ({
   group,
   accent,
   people,
+  participantProfiles,
   peopleLoading,
 }: {
   group: SourceGroup;
   accent: string;
   people: Record<string, EnergyPerson | null>;
+  participantProfiles?: Record<string, EnergyParticipantProfile>;
   peopleLoading: boolean;
 }) => {
   const locale = useLocale();
@@ -272,22 +278,30 @@ const SourceOwnershipCard = ({
         </div>
       </CardHeader>
       <CardContent className="flex flex-col gap-2">
-        {group.owners.map((owner) => (
-          <OwnerEarningsRow
-            key={`${group.sourceId}-${owner.address}`}
-            group={group}
-            owner={owner}
-            person={people[owner.address.toLowerCase()]}
-            isLoading={peopleLoading}
-            accent={accent}
-            totalEarned={
-              totalProductionKwh *
-              (group.basePricePerKwh / 100) *
-              (owner.bps / 10_000)
-            }
-            totalIsPlaceholder={production.isPlaceholder}
-          />
-        ))}
+        {group.owners.map((owner) => {
+          const display = resolveEnergyParticipantDisplay(
+            owner.address,
+            people,
+            participantProfiles,
+          );
+          return (
+            <OwnerEarningsRow
+              key={`${group.sourceId}-${owner.address}`}
+              group={group}
+              owner={owner}
+              displayName={display.displayName}
+              avatarUrl={display.avatarUrl}
+              isLoading={peopleLoading}
+              accent={accent}
+              totalEarned={
+                totalProductionKwh *
+                (group.basePricePerKwh / 100) *
+                (owner.bps / 10_000)
+              }
+              totalIsPlaceholder={production.isPlaceholder}
+            />
+          );
+        })}
         <p className="text-1 text-neutral-11">
           {t('earningsHint', {
             dataType: production.isPlaceholder ? t('placeholder') : t('live'),
@@ -309,12 +323,19 @@ export const OwnershipTab = ({ data }: { data: SpaceEnergyResponse }) => {
   const sourceMeta = React.useMemo(() => {
     const map = new Map<
       string,
-      { type: string; label: string; index: number; basePricePerKwh: number }
+      {
+        type: string;
+        label: string;
+        displayName?: string;
+        index: number;
+        basePricePerKwh: number;
+      }
     >();
     (data.sources ?? []).forEach((source, index) => {
       map.set(source.sourceId.toLowerCase(), {
         type: source.sourceType,
         label: source.sourceLabel,
+        displayName: source.sourceDisplayName,
         index,
         basePricePerKwh: Number(source.basePricePerKwh) || 0,
       });
@@ -353,6 +374,7 @@ export const OwnershipTab = ({ data }: { data: SpaceEnergyResponse }) => {
               SOLAR: tShared('sourceTypeSolar'),
               BATTERY: tShared('sourceTypeBattery'),
             },
+            meta?.displayName,
           ),
           sourceIndex: meta?.index ?? index,
           basePricePerKwh: meta?.basePricePerKwh ?? 0,
@@ -363,6 +385,7 @@ export const OwnershipTab = ({ data }: { data: SpaceEnergyResponse }) => {
   }, [details, sourceMeta, tShared]);
 
   const { people, isLoading } = useEnergyPeople(allAddresses);
+  const participantProfiles = data.participantProfiles;
 
   if (!groups.length) {
     return <p className="text-2 text-neutral-11">{t('noOwnership')}</p>;
@@ -376,6 +399,7 @@ export const OwnershipTab = ({ data }: { data: SpaceEnergyResponse }) => {
           group={group}
           accent={ENERGY_PALETTE[index % ENERGY_PALETTE.length]!}
           people={people}
+          participantProfiles={participantProfiles}
           peopleLoading={isLoading}
         />
       ))}

--- a/packages/epics/src/treasury/components/assets/energy/ownership-tab.tsx
+++ b/packages/epics/src/treasury/components/assets/energy/ownership-tab.tsx
@@ -12,13 +12,10 @@ import {
 } from '@hypha-platform/ui';
 import { cn } from '@hypha-platform/ui-utils';
 import { PersonAvatar } from '../../../../people/components/person-avatar';
-import type {
-  SpaceEnergyResponse,
-  EnergyParticipantProfile,
-} from '../../../hooks/use-space-energy';
+import type { EnergyParticipantProfile } from '../../../hooks/use-space-energy';
 import { useSpaceEnergyTelemetry } from '../../../hooks/use-space-energy-telemetry';
 import { BarChart, ENERGY_PALETTE, type ChartSeries } from './charts';
-import { useEnergyPeople, type EnergyPerson } from './use-energy-people';
+import { type EnergyPerson } from './use-energy-people';
 import {
   formatBpsPct,
   resolveEnergyParticipantDisplay,
@@ -32,6 +29,8 @@ import {
   type Granularity,
 } from './granularity';
 import { GranularityToggle } from './granularity-toggle';
+import type { EnergyTabProps } from './energy-tab-props';
+import { energyAvatarLoading } from './energy-tab-props';
 
 type Owner = { address: string; bps: number };
 
@@ -291,7 +290,11 @@ const SourceOwnershipCard = ({
               owner={owner}
               displayName={display.displayName}
               avatarUrl={display.avatarUrl}
-              isLoading={peopleLoading}
+              isLoading={energyAvatarLoading(
+                owner.address,
+                peopleLoading,
+                participantProfiles,
+              )}
               accent={accent}
               totalEarned={
                 totalProductionKwh *
@@ -312,7 +315,11 @@ const SourceOwnershipCard = ({
   );
 };
 
-export const OwnershipTab = ({ data }: { data: SpaceEnergyResponse }) => {
+export const OwnershipTab = ({
+  data,
+  people,
+  peopleLoading,
+}: EnergyTabProps) => {
   const t = useTranslations('Energy.ownership');
   const tShared = useTranslations('Energy.shared');
   const details = data.memberDetails ?? [];
@@ -384,7 +391,6 @@ export const OwnershipTab = ({ data }: { data: SpaceEnergyResponse }) => {
     return { groups, allAddresses: Array.from(addresses) };
   }, [details, sourceMeta, tShared]);
 
-  const { people, isLoading } = useEnergyPeople(allAddresses);
   const participantProfiles = data.participantProfiles;
 
   if (!groups.length) {
@@ -400,7 +406,7 @@ export const OwnershipTab = ({ data }: { data: SpaceEnergyResponse }) => {
           accent={ENERGY_PALETTE[index % ENERGY_PALETTE.length]!}
           people={people}
           participantProfiles={participantProfiles}
-          peopleLoading={isLoading}
+          peopleLoading={peopleLoading}
         />
       ))}
     </div>

--- a/packages/epics/src/treasury/components/assets/energy/production-consumption-tab.tsx
+++ b/packages/epics/src/treasury/components/assets/energy/production-consumption-tab.tsx
@@ -41,18 +41,15 @@ export const ProductionConsumptionTab = ({
 
   const sourceFallback = tShared('source');
 
-  const sourceLabels = React.useMemo(
-    () => {
-      const sourceTypeLabels = {
-        SOLAR: tShared('sourceTypeSolar'),
-        BATTERY: tShared('sourceTypeBattery'),
-      };
-      return (data.sources ?? []).map((s, i) =>
-        sourceCardLabel(s, i, sourceFallback, sourceTypeLabels),
-      );
-    },
-    [data.sources, sourceFallback, tShared],
-  );
+  const sourceLabels = React.useMemo(() => {
+    const sourceTypeLabels = {
+      SOLAR: tShared('sourceTypeSolar'),
+      BATTERY: tShared('sourceTypeBattery'),
+    };
+    return (data.sources ?? []).map((s, i) =>
+      sourceCardLabel(s, i, sourceFallback, sourceTypeLabels),
+    );
+  }, [data.sources, sourceFallback, tShared]);
 
   const dummy = React.useMemo(
     () =>

--- a/packages/epics/src/treasury/components/assets/energy/production-consumption-tab.tsx
+++ b/packages/epics/src/treasury/components/assets/energy/production-consumption-tab.tsx
@@ -40,17 +40,18 @@ export const ProductionConsumptionTab = ({
   } = useSpaceEnergyTelemetry(timeframe);
 
   const sourceFallback = tShared('source');
-  const sourceTypeLabels = {
-    SOLAR: tShared('sourceTypeSolar'),
-    BATTERY: tShared('sourceTypeBattery'),
-  };
 
   const sourceLabels = React.useMemo(
-    () =>
-      (data.sources ?? []).map((s, i) =>
+    () => {
+      const sourceTypeLabels = {
+        SOLAR: tShared('sourceTypeSolar'),
+        BATTERY: tShared('sourceTypeBattery'),
+      };
+      return (data.sources ?? []).map((s, i) =>
         sourceCardLabel(s, i, sourceFallback, sourceTypeLabels),
-      ),
-    [data.sources, sourceFallback, sourceTypeLabels],
+      );
+    },
+    [data.sources, sourceFallback, tShared],
   );
 
   const dummy = React.useMemo(

--- a/packages/epics/src/treasury/components/assets/energy/production-consumption-tab.tsx
+++ b/packages/epics/src/treasury/components/assets/energy/production-consumption-tab.tsx
@@ -20,7 +20,7 @@ import {
 } from './dummy-data';
 import { TimeframeToggle } from './timeframe-toggle';
 import { StatCard } from './shared';
-import { prettySourceLabel } from './format';
+import { sourceCardLabel } from './format';
 
 const sum = (arr: number[]) => arr.reduce((a, b) => a + b, 0);
 
@@ -48,13 +48,7 @@ export const ProductionConsumptionTab = ({
   const sourceLabels = React.useMemo(
     () =>
       (data.sources ?? []).map((s, i) =>
-        prettySourceLabel(
-          s.sourceLabel,
-          i,
-          s.sourceType,
-          sourceFallback,
-          sourceTypeLabels,
-        ),
+        sourceCardLabel(s, i, sourceFallback, sourceTypeLabels),
       ),
     [data.sources, sourceFallback, sourceTypeLabels],
   );

--- a/packages/epics/src/treasury/components/assets/energy/shared.tsx
+++ b/packages/epics/src/treasury/components/assets/energy/shared.tsx
@@ -132,7 +132,7 @@ export const SourceCard = ({
         <p className="text-1 text-neutral-11">{typeLabel}</p>
       </div>
       <div className="shrink-0 text-right">
-        <p className="text-1 text-neutral-11">{t('basePerKwh')}</p>
+        <p className="text-1 text-neutral-11">{t('currentPerKwh')}</p>
         <p className="font-medium text-foreground">{basePrice}</p>
         <span
           className={cn(

--- a/packages/epics/src/treasury/components/assets/energy/shared.tsx
+++ b/packages/epics/src/treasury/components/assets/energy/shared.tsx
@@ -74,19 +74,25 @@ export const EnergyPersonCard = ({
   isLoading,
   right,
   subtitle,
+  displayName: displayNameProp,
+  avatarUrl: avatarUrlProp,
 }: {
   address: string;
   person?: EnergyPerson | null;
   isLoading?: boolean;
   right?: React.ReactNode;
   subtitle?: React.ReactNode;
+  displayName?: string;
+  avatarUrl?: string;
 }) => {
-  const name = personDisplayName(person) ?? shortAddr(address);
+  const name =
+    displayNameProp ?? personDisplayName(person) ?? shortAddr(address);
+  const avatarSrc = avatarUrlProp ?? person?.avatarUrl ?? undefined;
   return (
     <div className="flex items-center gap-3 rounded-xl border border-border bg-background-2 p-3">
       <PersonAvatar
-        avatarSrc={person?.avatarUrl ?? undefined}
-        userName={personDisplayName(person) ?? undefined}
+        avatarSrc={avatarSrc}
+        userName={name}
         size="md"
         shape="circle"
         isLoading={isLoading}

--- a/packages/epics/src/treasury/components/assets/energy/use-preload-images.ts
+++ b/packages/epics/src/treasury/components/assets/energy/use-preload-images.ts
@@ -1,0 +1,20 @@
+'use client';
+
+import * as React from 'react';
+
+/** Warm the browser image cache for avatar URLs used across Energy tabs. */
+export const usePreloadImages = (urls: readonly string[]) => {
+  const serialized = React.useMemo(
+    () => [...new Set(urls.filter(Boolean))].sort().join('\0'),
+    [urls],
+  );
+
+  React.useEffect(() => {
+    if (!serialized) return;
+    for (const url of serialized.split('\0')) {
+      const image = new Image();
+      image.decoding = 'async';
+      image.src = url;
+    }
+  }, [serialized]);
+};

--- a/packages/epics/src/treasury/components/assets/space-energy-section.tsx
+++ b/packages/epics/src/treasury/components/assets/space-energy-section.tsx
@@ -18,6 +18,8 @@ import { EnergyOverviewTab } from './energy/overview-tab';
 import { ProductionConsumptionTab } from './energy/production-consumption-tab';
 import { OwnershipTab } from './energy/ownership-tab';
 import { CreditsTab } from './energy/credits-tab';
+import { useEnergyPeople } from './energy/use-energy-people';
+import { usePreloadImages } from './energy/use-preload-images';
 
 const TAB_VALUES = ['overview', 'flows', 'ownership', 'credits'] as const;
 
@@ -26,6 +28,29 @@ export const SpaceEnergySection = () => {
   const tOverview = useTranslations('Energy.overview');
   const { data, isLoading } = useSpaceEnergy();
   const [tab, setTab] = React.useState<string>('overview');
+
+  const memberAddresses = React.useMemo(
+    () =>
+      data?.enabled && data.members
+        ? data.members.map((address) => address.toLowerCase())
+        : [],
+    [data?.enabled, data?.members],
+  );
+
+  const { people, isLoading: peopleLoading } = useEnergyPeople(memberAddresses);
+
+  const avatarUrls = React.useMemo(() => {
+    const urls = new Set<string>();
+    for (const profile of Object.values(data?.participantProfiles ?? {})) {
+      if (profile.avatarUrl) urls.add(profile.avatarUrl);
+    }
+    for (const person of Object.values(people)) {
+      if (person?.avatarUrl) urls.add(person.avatarUrl);
+    }
+    return [...urls];
+  }, [data?.participantProfiles, people]);
+
+  usePreloadImages(avatarUrls);
 
   if (isLoading) {
     return (
@@ -91,16 +116,28 @@ export const SpaceEnergySection = () => {
         </TabsList>
 
         <TabsContent value="overview" className="mt-6">
-          <EnergyOverviewTab data={data} />
+          <EnergyOverviewTab
+            data={data}
+            people={people}
+            peopleLoading={peopleLoading}
+          />
         </TabsContent>
         <TabsContent value="flows" className="mt-6">
           <ProductionConsumptionTab data={data} />
         </TabsContent>
         <TabsContent value="ownership" className="mt-6">
-          <OwnershipTab data={data} />
+          <OwnershipTab
+            data={data}
+            people={people}
+            peopleLoading={peopleLoading}
+          />
         </TabsContent>
         <TabsContent value="credits" className="mt-6">
-          <CreditsTab data={data} />
+          <CreditsTab
+            data={data}
+            people={people}
+            peopleLoading={peopleLoading}
+          />
         </TabsContent>
       </Tabs>
     </div>

--- a/packages/epics/src/treasury/hooks/use-space-energy.ts
+++ b/packages/epics/src/treasury/hooks/use-space-energy.ts
@@ -9,10 +9,20 @@ import { getDhoSpaceSlugFromPathname } from '../../common/get-dho-space-slug-fro
 export type SpaceEnergySource = {
   sourceId: `0x${string}`;
   sourceLabel: string;
+  /** Human-readable name from ownership token contract, when available. */
+  sourceDisplayName?: string;
   sourceType: string;
   ownershipToken: `0x${string}`;
   basePricePerKwh: string;
   active: boolean;
+};
+
+export type EnergyParticipantProfile = {
+  displayName: string;
+  avatarUrl?: string | null;
+  subtitle?: string | null;
+  profileSlug?: string | null;
+  kind: 'person' | 'space' | 'institutional';
 };
 
 export type SpaceEnergyMemberDetail = {
@@ -66,6 +76,8 @@ export type SpaceEnergyResponse = {
   };
   members?: `0x${string}`[];
   memberDetails?: SpaceEnergyMemberDetail[];
+  /** Server-resolved display info for people, spaces, and institutional wallets. */
+  participantProfiles?: Record<string, EnergyParticipantProfile>;
   optimization?: {
     configured: boolean;
     purposeRanking: string[];

--- a/packages/i18n/src/messages/de.json
+++ b/packages/i18n/src/messages/de.json
@@ -3875,7 +3875,7 @@
     "shared": {
       "gridOperatorName": "Lokaler Netzbetreiber",
       "gridOperatorSubtitle": "Externer Energielieferant",
-      "basePerKwh": "Grundpreis / kWh",
+      "currentPerKwh": "Aktuell / kWh",
       "active": "Aktiv",
       "inactive": "Inaktiv",
       "source": "Quelle",

--- a/packages/i18n/src/messages/en.json
+++ b/packages/i18n/src/messages/en.json
@@ -3856,7 +3856,7 @@
       "earnings": "Earnings",
       "earnedFromSource": "{prefix}{amount} EURC earned from this source",
       "placeholderEstimate": "Placeholder estimate — live production telemetry is not connected yet.",
-      "liveEstimate": "Estimated from live production telemetry × base price × ownership share.",
+      "liveEstimate": "Estimated from live production telemetry × current price × ownership share.",
       "earningsHint": "Earnings are estimated over the last 12 months from {dataType} production data. Click an owner for daily, weekly or monthly detail.",
       "placeholder": "placeholder",
       "live": "live",
@@ -3883,7 +3883,7 @@
     "shared": {
       "gridOperatorName": "Local grid operator",
       "gridOperatorSubtitle": "External energy supplier",
-      "basePerKwh": "Base / kWh",
+      "currentPerKwh": "Current / kWh",
       "active": "Active",
       "inactive": "Inactive",
       "source": "Source",

--- a/packages/i18n/src/messages/es.json
+++ b/packages/i18n/src/messages/es.json
@@ -3875,7 +3875,7 @@
     "shared": {
       "gridOperatorName": "Operador de red local",
       "gridOperatorSubtitle": "Proveedor externo de energía",
-      "basePerKwh": "Base / kWh",
+      "currentPerKwh": "Actual / kWh",
       "active": "Activo",
       "inactive": "Inactivo",
       "source": "Fuente",

--- a/packages/i18n/src/messages/fr.json
+++ b/packages/i18n/src/messages/fr.json
@@ -3871,7 +3871,7 @@
     "shared": {
       "gridOperatorName": "Gestionnaire de réseau local",
       "gridOperatorSubtitle": "Fournisseur d'énergie externe",
-      "basePerKwh": "Base / kWh",
+      "currentPerKwh": "Actuel / kWh",
       "active": "Actif",
       "inactive": "Inactif",
       "source": "Source",

--- a/packages/i18n/src/messages/mk.json
+++ b/packages/i18n/src/messages/mk.json
@@ -3860,7 +3860,7 @@
     "shared": {
       "gridOperatorName": "Локален оператор на мрежата",
       "gridOperatorSubtitle": "Надворешен снабдувач со енергија",
-      "basePerKwh": "Основна / kWh",
+      "currentPerKwh": "Тековна / kWh",
       "active": "Активно",
       "inactive": "Неактивно",
       "source": "Извор",

--- a/packages/i18n/src/messages/pt.json
+++ b/packages/i18n/src/messages/pt.json
@@ -3873,7 +3873,7 @@
     "shared": {
       "gridOperatorName": "Operador de rede local",
       "gridOperatorSubtitle": "Fornecedor externo de energia",
-      "basePerKwh": "Base / kWh",
+      "currentPerKwh": "Atual / kWh",
       "active": "Ativo",
       "inactive": "Inativo",
       "source": "Fonte",


### PR DESCRIPTION
## Summary
- Renames the demo school from **Escola Básica e Secundária de Machico** to **Escola Básica e Secundária da Ponta do Sol** so it matches the Ponta do Sol community location
- Updates related identifiers: `PONTA_SCHOOL_PV`, `escolaPontaDoSol`, mermaid diagram, and investor pitch copy

## Test plan
- [ ] Review `docs/ponta-do-sol-demo-setup.md` for consistent naming (no remaining Machico references)
- [ ] Confirm ownership tables and Enable Energy Community copy-paste values still align with renamed asset id


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced Energy views to show resolved participant profile details (display name, avatar, subtitles) for consumers and owners, including optional ownership-based naming.
  * Improved source labeling by using ownership token names when available and adding richer participant profile data to Energy responses.
* **Bug Fixes**
  * Updated per-kWh pricing labels/text to consistently reflect the current price across supported languages.
* **Documentation**
  * Revised the Ponta do Sol demo setup guide with updated school/entity identifiers, wallet/investor details, and demo telemetry and meter mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->