### PR TITLE
fix(energy): show space names and logos for logged-out viewers

### DIFF
--- a/apps/web/src/app/api/v1/spaces/[spaceSlug]/energy/route.ts
+++ b/apps/web/src/app/api/v1/spaces/[spaceSlug]/energy/route.ts
@@ -398,20 +398,15 @@ export async function GET(
       memberDeviceIds.set(detail.address.toLowerCase(), detail.deviceIds);
     }
 
-    const canResolveParticipantProfiles =
-      access.hasAccess && Boolean(access.authToken);
-
-    const participantProfiles = canResolveParticipantProfiles
-      ? await resolveEnergyParticipants(
-          {
-            addresses: memberAddressList.map((a) => a.toLowerCase()),
-            spaceSlug,
-            memberDeviceIds,
-            institutionalByDevice: institutionalLabelsForSpace(spaceSlug),
-          },
-          { db },
-        )
-      : undefined;
+    const participantProfiles = await resolveEnergyParticipants(
+      {
+        addresses: memberAddressList.map((a) => a.toLowerCase()),
+        spaceSlug,
+        memberDeviceIds,
+        institutionalByDevice: institutionalLabelsForSpace(spaceSlug),
+      },
+      { db },
+    );
 
     const [optimizationConfig, socialWalletsRaw] = await Promise.all([
       safeRead<readonly [readonly number[], number, bigint, number, boolean]>(

--- a/packages/epics/src/treasury/components/assets/energy/consumer-consumption-card.tsx
+++ b/packages/epics/src/treasury/components/assets/energy/consumer-consumption-card.tsx
@@ -7,7 +7,6 @@ import { cn } from '@hypha-platform/ui-utils';
 import { Skeleton } from '@hypha-platform/ui';
 import { PersonAvatar } from '../../../../people/components/person-avatar';
 import { useSpaceEnergyTelemetry } from '../../../hooks/use-space-energy-telemetry';
-import type { EnergyPerson } from './use-energy-people';
 import { shortAddr } from './format';
 import { BarChart, ENERGY_PALETTE, type ChartSeries } from './charts';
 import {

--- a/packages/epics/src/treasury/components/assets/energy/ownership-tab.tsx
+++ b/packages/epics/src/treasury/components/assets/energy/ownership-tab.tsx
@@ -350,9 +350,8 @@ export const OwnershipTab = ({
     return map;
   }, [data.sources]);
 
-  const { groups, allAddresses } = React.useMemo(() => {
+  const { groups } = React.useMemo(() => {
     const map = new Map<string, { owners: Owner[] }>();
-    const addresses = new Set<string>();
     for (const member of details) {
       for (const ownership of member.ownerships) {
         // Hide members with no active share in the source.
@@ -363,7 +362,6 @@ export const OwnershipTab = ({
           bps: ownership.ownershipBps,
         });
         map.set(ownership.sourceId, existing);
-        addresses.add(member.address.toLowerCase());
       }
     }
     const groups: SourceGroup[] = Array.from(map.entries())
@@ -388,7 +386,7 @@ export const OwnershipTab = ({
           owners: value.owners.sort((a, b) => b.bps - a.bps),
         };
       });
-    return { groups, allAddresses: Array.from(addresses) };
+    return { groups };
   }, [details, sourceMeta, tShared]);
 
   const participantProfiles = data.participantProfiles;


### PR DESCRIPTION
## Summary
- Resolve energy community member wallets to Hypha space profiles (title + logo) server-side in the energy API, for all viewers including anonymous users.
- Wire `participantProfiles` through overview, ownership, and credits tabs so space treasuries no longer fall back to raw addresses when the viewer is not logged in.
- Keep person and institutional (demo) wallet fallbacks via the same display resolver.

## Test plan
- [ ] Open an energy-enabled space treasury tab while logged out.
- [ ] Verify overview consumers show space names and logos instead of `0x…` addresses.
- [ ] Verify ownership tab owner rows show the same resolved names/avatars.
- [ ] Verify credits tab member settlement rows show resolved names/avatars.
- [ ] Log in and confirm display is unchanged for authenticated viewers.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Energy views now show richer participant identities, including names, avatars, subtitles, and profile information.
  * Participants can be identified as people, spaces, or institutional entities when available.
  * Added consistent identity display across overview, ownership, and credits tabs.
* **Improvements**
  * Participant information is loaded centrally, improving consistency and per-item loading states.
  * Unmatched participants fall back to shortened wallet addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->