### PR TITLE
fix(core): disconnect orphaned LiveKit room on partial join failure

### DIFF
--- a/packages/core/src/matrix/client/hooks/use-space-group-call.ts
+++ b/packages/core/src/matrix/client/hooks/use-space-group-call.ts
@@ -1701,6 +1701,16 @@ export function useSpaceGroupCall(
         });
       };
 
+      /**
+       * Tracks the LiveKit room created for *this* join attempt, independent of
+       * `liveKitRoomRef` (which is only populated once the whole join succeeds).
+       * If `setMicrophoneEnabled`/`setCameraEnabled` partially fail below, one of
+       * the two can still have published a live track to the SFU before the other
+       * rejects — without this, that orphaned room/track was never disconnected,
+       * so the other participant kept seeing/hearing a "failed" local join.
+       */
+      let lkRoomForJoinAttempt: LiveKitRoom | null = null;
+
       try {
         const session = getMatrixRtcSession(client, matrixRoom);
         rtcSessionRef.current = session;
@@ -1722,6 +1732,7 @@ export function useSpaceGroupCall(
         );
         logJoinDebugStep('join-step:livekit-credentials-fetched');
         const lkRoom = createLiveKitRoom();
+        lkRoomForJoinAttempt = lkRoom;
         const detachRtcDebugListeners = attachLiveKitRtcDebugListeners(lkRoom, {
           roomId,
           kind,
@@ -1801,6 +1812,20 @@ export function useSpaceGroupCall(
           joinStartedAtRef.current = null;
         }
       } catch (e) {
+        /**
+         * `setMicrophoneEnabled`/`setCameraEnabled` ran concurrently above — one
+         * can already have published a live track to the SFU before the other
+         * rejected and this catch ran. `liveKitRoomRef` only gets set on full
+         * success, so without this the orphaned room (and its published track)
+         * would never be disconnected, leaking local audio/video to other
+         * participants after a failed join.
+         */
+        if (
+          lkRoomForJoinAttempt &&
+          liveKitRoomRef.current !== lkRoomForJoinAttempt
+        ) {
+          void lkRoomForJoinAttempt.disconnect().catch(() => undefined);
+        }
         if (joinEpoch !== joinEpochRef.current) {
           isJoiningRef.current = false;
           abortStaleJoinAttempt(setCallState);

--- a/packages/core/src/matrix/client/hooks/use-space-group-call.ts
+++ b/packages/core/src/matrix/client/hooks/use-space-group-call.ts
@@ -1776,6 +1776,21 @@ export function useSpaceGroupCall(
         ]);
         logJoinDebugStep('join-step:local-tracks-published');
 
+        /**
+         * `Promise.all` above can take a while (SFU negotiation); if the user
+         * left or the component unmounted during that window, joinEpoch has
+         * already moved on. Without this check we'd resurrect the aborted
+         * join here — assigning the stale room as active and leaking its
+         * just-published local tracks to other participants.
+         */
+        if (joinEpoch !== joinEpochRef.current) {
+          await lkRoom.disconnect().catch(() => undefined);
+          await session.leaveRoomSession(5000).catch(() => undefined);
+          isJoiningRef.current = false;
+          abortStaleJoinAttempt(setCallState);
+          return;
+        }
+
         liveKitRoomRef.current = lkRoom;
         activeCallRoomIdRef.current = activeRoomId;
         setRoom(lkRoom);


### PR DESCRIPTION
## Summary
Reported while testing #2391 (Document PiP re-enable): join a call from a laptop with no working microphone. The join fails and the laptop UI reverts to the "join call" prompt — but the mobile participant keeps seeing the laptop's camera feed, unaware the laptop believes it never connected.

Root cause: `enterWithKind` enables mic and camera concurrently via
```ts
await Promise.all([
  lkRoom.localParticipant.setMicrophoneEnabled(true),
  lkRoom.localParticipant.setCameraEnabled(enableCamera),
]);
```
`Promise.all` rejects as soon as one promise rejects (no mic device found), but it does **not** cancel the other — the camera track can already be publishing to the SFU by the time the join is reported as failed. `liveKitRoomRef` is only set once the whole join succeeds (after this `Promise.all`), so the existing `runCleanup()` disconnect logic never has a reference to this room and never tears it down. The orphaned LiveKit connection — and its published track — is left running.

## Fix
Track the LiveKit room created for the *current* join attempt in a local variable, independent of `liveKitRoomRef`. In the catch block, if that room exists and was never promoted to `liveKitRoomRef` (i.e. the join didn't fully succeed), explicitly `disconnect()` it — this both releases the local camera/mic hardware and stops publishing to the SFU, closing the leak.

## Test plan
- [x] `tsc --noEmit` clean (pre-existing unrelated errors confirmed identical on `main`)
- [x] `eslint` clean (no new warnings)
- [x] `packages/core` relevant test suite passes (16/16)
- [ ] Preview: reproduce original repro (join with no mic available) — confirm the other participant no longer keeps seeing/hearing local media after the join fails
- [ ] Preview: confirm a normal successful join (mic + camera both available) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cleanup after failed group call join attempts.
  - Prevents partially connected calls and unpublished or lingering microphone and camera tracks from remaining active after a join failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->