### PR TITLE
fix(ui): stop MenuTop compact-mode jitter across panel widths

### DIFF
--- a/packages/ui/src/organisms/menu-top-compact.ts
+++ b/packages/ui/src/organisms/menu-top-compact.ts
@@ -1,0 +1,67 @@
+/**
+ * Pure helpers for MenuTop collision-aware compact mode.
+ * Kept separate so the hysteresis / measurement rules can be reasoned about
+ * without DOM timing (and to prevent the iPad landscape expand↔collapse loop).
+ */
+
+export type CompactHeaderDecisionInput = {
+  freeSpacePx: number;
+  isCurrentlyCompact: boolean;
+  leftPanelExpanded: boolean;
+  /** Enter compact when free space falls below this (while expanded). */
+  enterBelowPx: number;
+  /** Stay compact until free space reaches this (while compact). Must be > enterBelowPx. */
+  exitBelowPx: number;
+  /** Force compact at mobile CSS breakpoint regardless of measured free space. */
+  forceCompactViewport?: boolean;
+};
+
+/**
+ * Decide compact header mode with hysteresis so sub-pixel / ResizeObserver noise
+ * near the threshold cannot flip the chrome every frame.
+ */
+export function shouldUseCompactHeader({
+  freeSpacePx,
+  isCurrentlyCompact,
+  leftPanelExpanded,
+  enterBelowPx,
+  exitBelowPx,
+  forceCompactViewport = false,
+}: CompactHeaderDecisionInput): boolean {
+  if (leftPanelExpanded || forceCompactViewport) {
+    return true;
+  }
+
+  if (isCurrentlyCompact) {
+    return freeSpacePx < exitBelowPx;
+  }
+
+  return freeSpacePx < enterBelowPx;
+}
+
+/**
+ * Resolve the desktop action cluster's intrinsic width.
+ *
+ * When the cluster is taken out of flow (compact), some engines (notably iPad
+ * WebKit) report a collapsed scroll/client width if `flex` is dropped. Prefer the
+ * last in-flow measurement so compact mode cannot falsely "fit" and reopen.
+ */
+export function resolveDesktopClusterWidth(params: {
+  measuredPx: number;
+  isCompact: boolean;
+  cachedPx: number;
+}): number {
+  const measured = Math.max(0, Math.ceil(params.measuredPx));
+
+  if (!params.isCompact && measured > 0) {
+    return measured;
+  }
+
+  if (params.cachedPx > 0) {
+    // Keep the larger of cache vs live so a partial measure cannot shrink us
+    // into an expand→collapse loop; live can still grow if nav content widens.
+    return Math.max(params.cachedPx, measured);
+  }
+
+  return measured;
+}

--- a/packages/ui/src/organisms/menu-top.tsx
+++ b/packages/ui/src/organisms/menu-top.tsx
@@ -281,27 +281,30 @@ export const MenuTop = ({
         </div>
 
         {/* Desktop Nav + Trailing action (right-aligned group).
+            Always mount so desktopActionsRef is available on first paint —
+            a children/trailingAction guard would skip ResizeObserver setup and
+            leave isCompact stuck true if content appears later.
             When compact, keep `flex w-max` so intrinsic width stays measurable;
             dropping `flex` was collapsing scrollWidth on iPad WebKit and
             oscillating compact ↔ expanded every frame. */}
-        {(children || trailingAction) && (
-          <div
-            ref={desktopActionsRef}
-            id="menu-top-actions"
-            className={clsx(
-              'flex w-max items-center gap-2',
-              isCompact
-                ? // Keep flex + intrinsic width while out of flow. Zero-height clip
-                  // avoids document scroll growth; cache still guards WebKit quirks.
-                  'pointer-events-none absolute left-0 top-0 h-0 overflow-hidden opacity-0'
-                : 'relative',
-            )}
-            aria-hidden={isCompact || undefined}
-          >
-            {children}
-            {trailingAction}
-          </div>
-        )}
+        <div
+          ref={desktopActionsRef}
+          id="menu-top-actions"
+          className={clsx(
+            !(children || trailingAction)
+              ? 'hidden'
+              : 'flex w-max items-center gap-2',
+            isCompact
+              ? // Keep flex + intrinsic width while out of flow. Zero-height clip
+                // avoids document scroll growth; cache still guards WebKit quirks.
+                'pointer-events-none absolute left-0 top-0 h-0 overflow-hidden opacity-0'
+              : 'relative',
+          )}
+          aria-hidden={isCompact || undefined}
+        >
+          {children}
+          {trailingAction}
+        </div>
 
         {/* Compact action group (right side): chat, profile, optional hamburger.
             Always show below `md` so auth (e.g. Sign in) stays visible whenever the

--- a/packages/ui/src/organisms/menu-top.tsx
+++ b/packages/ui/src/organisms/menu-top.tsx
@@ -7,6 +7,10 @@ import { RxCross1 } from 'react-icons/rx';
 import { usePathname } from 'next/navigation';
 import clsx from 'clsx';
 import Link from 'next/link';
+import {
+  resolveDesktopClusterWidth,
+  shouldUseCompactHeader,
+} from './menu-top-compact';
 
 type MenuTopProps = {
   children?: React.ReactNode;
@@ -28,6 +32,9 @@ type MenuTopProps = {
   forceCompactWhenLeftPanelExpanded?: boolean;
 };
 
+/** Gap reserved between leading cluster and desktop actions in the free-space math. */
+const ROW_CLUSTER_GAP_PX = 16;
+
 export const MenuTop = ({
   children,
   leadingAction,
@@ -40,8 +47,10 @@ export const MenuTop = ({
   openMenuLabel = 'Open menu',
   closeMenuLabel = 'Close menu',
   showMobileHamburger = true,
+  // Wider band than the original 232/256: My Wallet widened the desktop cluster,
+  // so iPad-landscape widths sit near the threshold and need more hysteresis.
   compactSafeThresholdPx = 232,
-  compactReleaseThresholdPx = 256,
+  compactReleaseThresholdPx = 320,
   compactDataAttribute = 'data-compact-header',
   showLeadingActionOnlyWhenCompact = false,
   forceCompactWhenLeftPanelExpanded = true,
@@ -52,7 +61,10 @@ export const MenuTop = ({
   const leadingClusterRef = useRef<HTMLDivElement>(null);
   const desktopActionsRef = useRef<HTMLDivElement>(null);
   const [headerHeight, setHeaderHeight] = useState(0);
-  const [isCompact, setIsCompact] = useState(false);
+  // Conservative SSR/first-paint: prefer compact until measured (avoids overlap flash).
+  const [isCompact, setIsCompact] = useState(true);
+  const isCompactRef = useRef(true);
+  const desktopNeededRef = useRef(0);
   const pathname = usePathname();
 
   useEffect(() => {
@@ -98,31 +110,44 @@ export const MenuTop = ({
     if (!rowEl || !leadEl || !desktopEl) return;
 
     let raf = 0;
-    let compactRef = isCompact;
+    const mobileMq = window.matchMedia('(max-width: 767px)');
+
     const evaluate = () => {
       raf = 0;
       const root = document.documentElement;
       const rowWidth = rowEl.getBoundingClientRect().width;
       const leadWidth = leadEl.getBoundingClientRect().width;
-      // Keep measurable even when visually hidden; use scrollWidth as "needed" width.
-      const desktopNeeded = Math.max(
+      const liveDesktopWidth = Math.max(
         desktopEl.scrollWidth,
+        desktopEl.offsetWidth,
         desktopEl.getBoundingClientRect().width,
       );
-      const freeSpace = rowWidth - leadWidth - desktopNeeded - 16;
+      const desktopNeeded = resolveDesktopClusterWidth({
+        measuredPx: liveDesktopWidth,
+        isCompact: isCompactRef.current,
+        cachedPx: desktopNeededRef.current,
+      });
+      if (desktopNeeded > 0) {
+        desktopNeededRef.current = desktopNeeded;
+      }
+
+      const freeSpace =
+        rowWidth - leadWidth - desktopNeeded - ROW_CLUSTER_GAP_PX;
       const leftPanelExpanded =
         forceCompactWhenLeftPanelExpanded &&
         root.getAttribute('data-left-panel-expanded') === 'true';
 
-      const shouldCompact = leftPanelExpanded
-        ? true
-        : compactRef
-        ? freeSpace < compactReleaseThresholdPx
-        : freeSpace < compactSafeThresholdPx;
+      const nextCompact = shouldUseCompactHeader({
+        freeSpacePx: freeSpace,
+        isCurrentlyCompact: isCompactRef.current,
+        leftPanelExpanded,
+        enterBelowPx: compactSafeThresholdPx,
+        exitBelowPx: compactReleaseThresholdPx,
+        forceCompactViewport: mobileMq.matches,
+      });
 
-      const nextCompact = shouldCompact;
-      if (nextCompact !== compactRef) {
-        compactRef = nextCompact;
+      if (nextCompact !== isCompactRef.current) {
+        isCompactRef.current = nextCompact;
         setIsCompact(nextCompact);
       }
     };
@@ -141,6 +166,13 @@ export const MenuTop = ({
       attributes: true,
       attributeFilter: ['data-left-panel-expanded'],
     });
+    const onMobileMq = () => schedule();
+    if (typeof mobileMq.addEventListener === 'function') {
+      mobileMq.addEventListener('change', onMobileMq);
+    } else {
+      // Safari < 14
+      mobileMq.addListener(onMobileMq);
+    }
     window.addEventListener('resize', schedule);
     schedule();
 
@@ -150,13 +182,19 @@ export const MenuTop = ({
       }
       ro.disconnect();
       panelObserver.disconnect();
+      if (typeof mobileMq.removeEventListener === 'function') {
+        mobileMq.removeEventListener('change', onMobileMq);
+      } else {
+        mobileMq.removeListener(onMobileMq);
+      }
       window.removeEventListener('resize', schedule);
     };
+    // Intentionally omit `isCompact`: hysteresis lives in isCompactRef so toggling
+    // compact does not tear down ResizeObserver (which itself caused re-entry jitter).
   }, [
     compactReleaseThresholdPx,
     compactSafeThresholdPx,
     forceCompactWhenLeftPanelExpanded,
-    isCompact,
   ]);
 
   useEffect(() => {
@@ -242,17 +280,23 @@ export const MenuTop = ({
           ) : null}
         </div>
 
-        {/* Desktop Nav + Trailing action (right-aligned group) */}
+        {/* Desktop Nav + Trailing action (right-aligned group).
+            When compact, keep `flex w-max` so intrinsic width stays measurable;
+            dropping `flex` was collapsing scrollWidth on iPad WebKit and
+            oscillating compact ↔ expanded every frame. */}
         {(children || trailingAction) && (
           <div
             ref={desktopActionsRef}
             id="menu-top-actions"
             className={clsx(
-              'items-center gap-2',
+              'flex w-max items-center gap-2',
               isCompact
-                ? 'pointer-events-none invisible absolute'
-                : 'relative flex',
+                ? // Keep flex + intrinsic width while out of flow. Zero-height clip
+                  // avoids document scroll growth; cache still guards WebKit quirks.
+                  'pointer-events-none absolute left-0 top-0 h-0 overflow-hidden opacity-0'
+                : 'relative',
             )}
+            aria-hidden={isCompact || undefined}
           >
             {children}
             {trailingAction}


### PR DESCRIPTION
## Summary
- Fix the top-menu expand/collapse oscillation (visible on iPad landscape, and at other mid widths after My Wallet widened the desktop nav).
- Keep the desktop action cluster measurable while compact (`flex` + intrinsic width + cached width) so WebKit cannot report a collapsed width and flip the chrome every frame.
- Widen hysteresis (exit at 320px), keep compact state in a ref (no ResizeObserver teardown on toggle), and force compact below the `md` breakpoint.

Applies for all panel combinations: none / left / right / both.

## Test plan
- [ ] iPad landscape (and Chrome device mode ~1024×768): load a space with My Wallet in the nav — header must not flicker between full nav and compact.
- [ ] Repeat with no panels, left AI open, right chat open, and both open (where dual-open is allowed).
- [ ] Desktop wide (≥1280): full nav remains stable; open/close panels without header flicker.
- [ ] Narrow / phone width: compact header (profile + panel triggers) stays stable; no duplicate hamburger.
- [ ] Resize slowly across the compact threshold and confirm a single clean transition (no oscillation).


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the top navigation’s compact-mode behavior across different viewport sizes.
  * Added smoother transitions between expanded and compact layouts to prevent unnecessary layout switching.
  * Compact mode now responds more reliably when the left panel is expanded or on mobile-sized screens.

* **Bug Fixes**
  * Improved navigation sizing stability during resizing and dynamic layout changes.
  * Enhanced compatibility for media query updates in Safari.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->