### PR TITLE
fix(treasury): always show issuer-space tokens in space treasury

### DIFF
--- a/.github/actions/detect-changes/action.yml
+++ b/.github/actions/detect-changes/action.yml
@@ -16,6 +16,10 @@ runs:
     - uses: dorny/paths-filter@9d7afb8d214ad99e78fbd4247752c4caed2b6e4c # v4.0.0
       id: changes
       with:
+        # Empty token forces local git diff instead of GitHub REST API.
+        # Avoids hard failures when API Requests are degraded (unicorn/503).
+        token: ''
+        base: ${{ github.base_ref || github.event.repository.default_branch }}
         filters: |
           migrations:
             - 'packages/storage-postgres/migrations/**'

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -30,7 +30,11 @@ jobs:
       has_migrations: ${{ steps.detect.outputs.has_migrations }}
       has_preview_deploy_changes: ${{ steps.detect.outputs.has_preview_deploy_changes }}
     steps:
+      # Full history so paths-filter can resolve merge-base via local git
+      # (detect-changes uses token: '' to avoid flaky GitHub API change listing).
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Detect Changes
         id: detect
         uses: ./.github/actions/detect-changes

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -32,9 +32,10 @@ jobs:
     steps:
       # Full history so paths-filter can resolve merge-base via local git
       # (detect-changes uses token: '' to avoid flaky GitHub API change listing).
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Detect Changes
         id: detect
         uses: ./.github/actions/detect-changes

--- a/apps/web/src/app/api/v1/people/[personSlug]/assets/route.ts
+++ b/apps/web/src/app/api/v1/people/[personSlug]/assets/route.ts
@@ -20,6 +20,7 @@ import {
   getEnergyBalances,
   getMemberSpaces,
   isHiddenToken,
+  isKnownTreasuryToken,
 } from '@hypha-platform/core/client';
 import { headers } from 'next/headers';
 import { hasEmojiOrLink, tryDecodeUriPart } from '@hypha-platform/ui-utils';
@@ -59,6 +60,8 @@ export async function GET(
      * Run independent top-level fetches in parallel: on-chain energy balance, on-chain
      * member-spaces, off-chain external token balances, and the in-DB tokens list. They
      * share no data dependencies and previously ran sequentially, dominating TTFB.
+     * Alchemy balances are only used to surface held DB-registered / catalogue tokens —
+     * unknown ERC-20 spam is dropped via isKnownTreasuryToken.
      */
     const [
       energyResult,
@@ -104,11 +107,19 @@ export async function GET(
         )
       : new Set();
 
+    /** All DB token addresses — used to allow Alchemy-held registered tokens through. */
+    const dbKnownAddresses = new Set(
+      rawDbTokensForSeed
+        .filter((t) => t.address && /^0x[a-fA-F0-9]{40}$/i.test(t.address))
+        .map((t) => t.address!.toLowerCase()),
+    );
+
     const parsedExternalTokens: Token[] = externalTokens
       .filter(
         (token) =>
           token?.tokenAddress &&
-          /^0x[a-fA-F0-9]{40}$/i.test(token.tokenAddress),
+          /^0x[a-fA-F0-9]{40}$/i.test(token.tokenAddress) &&
+          isKnownTreasuryToken(token.tokenAddress, dbKnownAddresses),
       )
       .map((token) => ({
         symbol: token.symbol || 'UNKNOWN',
@@ -126,11 +137,6 @@ export async function GET(
     TOKENS.forEach((token) =>
       addressMap.set(token.address.toLowerCase(), token),
     );
-    filteredExternalTokens.forEach((token) => {
-      if (!addressMap.has(token.address.toLowerCase())) {
-        addressMap.set(token.address.toLowerCase(), token);
-      }
-    });
 
     if (energyTokenAddress) {
       const lower = energyTokenAddress.toLowerCase();
@@ -219,6 +225,15 @@ export async function GET(
           ? (t.type as TokenType)
           : 'utility',
       });
+    });
+
+    // Alchemy-held tokens that are DB-registered or catalogue (already filtered
+    // above) — covers holdings from spaces the user is not a member of.
+    filteredExternalTokens.forEach((token) => {
+      const lower = token.address.toLowerCase();
+      if (!addressMap.has(lower)) {
+        addressMap.set(lower, token);
+      }
     });
 
     const allTokens: Token[] = Array.from(addressMap.values()).filter(
@@ -369,7 +384,6 @@ export async function GET(
      */
     const knownAddresses = new Set<string>([
       ...TOKENS.map((t) => t.address.toLowerCase()),
-      ...filteredExternalTokens.map((t) => t.address.toLowerCase()),
       ...(energyTokenAddress ? [energyTokenAddress.toLowerCase()] : []),
     ]);
     const visibleAssets = validAssets.filter((a) => {

--- a/apps/web/src/app/api/v1/spaces/[spaceSlug]/assets-without-balances/route.ts
+++ b/apps/web/src/app/api/v1/spaces/[spaceSlug]/assets-without-balances/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import {
   findSpaceBySlug,
-  getTokenBalancesByAddress,
   getTokenMeta,
   web3Client,
   findAllTokens,
@@ -121,27 +120,6 @@ export async function GET(
       );
     }
 
-    let externalTokens: any[] = [];
-    try {
-      externalTokens = await getTokenBalancesByAddress(spaceAddress);
-    } catch (error: unknown) {
-      console.warn('Failed to fetch external token balances:', error);
-    }
-
-    const parsedExternalTokens: Token[] = externalTokens
-      .filter(
-        (token) =>
-          token?.tokenAddress &&
-          /^0x[a-fA-F0-9]{40}$/i.test(token.tokenAddress),
-      )
-      .map((token) => ({
-        symbol: token.symbol || 'UNKNOWN',
-        name: token.name || 'Unnamed',
-        address: token.tokenAddress as `0x${string}`,
-        icon: token.logo || '/placeholder/token-icon.svg',
-        type: 'utility' as const,
-      }));
-
     const addressMap = new Map<string, Token>();
     const filteredTokens = TOKENS.filter((token) => {
       return token.symbol === 'HYPHA'
@@ -203,11 +181,8 @@ export async function GET(
       }
     });
 
-    parsedExternalTokens.forEach((token) => {
-      if (!addressMap.has(token.address.toLowerCase())) {
-        addressMap.set(token.address.toLowerCase(), token);
-      }
-    });
+    // Do not merge Alchemy ERC-20 discovery — spam tokens with no DB/on-chain
+    // space registration must not appear in asset pickers.
 
     const allTokens: Token[] = Array.from(addressMap.values()).filter(
       (token) => !isHiddenToken(token.address),

--- a/apps/web/src/app/api/v1/spaces/[spaceSlug]/assets/route.ts
+++ b/apps/web/src/app/api/v1/spaces/[spaceSlug]/assets/route.ts
@@ -3,7 +3,6 @@ import {
   web3Client,
   findSpaceBySlug,
   getTokenPrice,
-  getTokenBalancesByAddress,
   getBalance,
   getTokenMeta,
   findAllTokens,
@@ -143,27 +142,6 @@ export async function GET(
       );
     }
 
-    let externalTokens: any[] = [];
-    try {
-      externalTokens = await getTokenBalancesByAddress(spaceAddress);
-    } catch (error: unknown) {
-      console.warn('Failed to fetch external token balances:', error);
-    }
-
-    const parsedExternalTokens: Token[] = externalTokens
-      .filter(
-        (token) =>
-          token?.tokenAddress &&
-          /^0x[a-fA-F0-9]{40}$/i.test(token.tokenAddress),
-      )
-      .map((token) => ({
-        symbol: token.symbol || 'UNKNOWN',
-        name: token.name || 'Unnamed',
-        address: token.tokenAddress as `0x${string}`,
-        icon: token.logo || '/placeholder/token-icon.svg',
-        type: 'utility' as const,
-      }));
-
     spaceTokens = spaceTokens
       .filter(
         (response) =>
@@ -216,11 +194,9 @@ export async function GET(
       }
     });
 
-    parsedExternalTokens.forEach((token) => {
-      if (!addressMap.has(token.address.toLowerCase())) {
-        addressMap.set(token.address.toLowerCase(), token);
-      }
-    });
+    // Do not merge Alchemy ERC-20 discovery here — it floods the treasury with
+    // spam tokens that have no DB row. Balances for known addresses come from
+    // getBalance below; catalogue + space-issued + DB cover legit assets.
 
     const allTokens: Token[] = Array.from(addressMap.values()).filter(
       (token) => !isHiddenToken(token.address),

--- a/apps/web/src/app/api/v1/spaces/[spaceSlug]/assets/route.ts
+++ b/apps/web/src/app/api/v1/spaces/[spaceSlug]/assets/route.ts
@@ -173,6 +173,8 @@ export async function GET(
       .flat() as `0x${string}`[];
 
     const addressMap = new Map<string, Token>();
+    /** Tokens issued by this space — always listed in its treasury, even at 0 balance. */
+    const issuedBySpaceAddresses = new Set<string>();
 
     const filteredTokens = TOKENS.filter((token) =>
       token.symbol === 'HYPHA' ? ALLOWED_SPACES.includes(spaceAddress) : true,
@@ -183,13 +185,33 @@ export async function GET(
     );
 
     spaceTokens.forEach((address) => {
-      if (!addressMap.has(address.toLowerCase())) {
-        addressMap.set(address.toLowerCase(), {
+      const lower = address.toLowerCase();
+      issuedBySpaceAddresses.add(lower);
+      if (!addressMap.has(lower)) {
+        addressMap.set(lower, {
           symbol: '',
           name: '',
           address,
           icon: '/placeholder/token-icon.svg',
           type: 'utility' as const,
+        });
+      }
+    });
+
+    // DB-registered tokens for this space (covers newly issued tokens before
+    // on-chain space-token lists / external balance indexers catch up).
+    rawDbTokens.forEach((token) => {
+      if (token.spaceId !== space.id || !token.address) return;
+      const lower = token.address.toLowerCase();
+      if (!/^0x[a-fA-F0-9]{40}$/.test(token.address)) return;
+      issuedBySpaceAddresses.add(lower);
+      if (!addressMap.has(lower)) {
+        addressMap.set(lower, {
+          symbol: token.symbol || '',
+          name: token.name || '',
+          address: token.address as `0x${string}`,
+          icon: token.iconUrl || '/placeholder/token-icon.svg',
+          type: (token.type as Token['type']) || 'utility',
         });
       }
     });
@@ -249,6 +271,9 @@ export async function GET(
             transactions: [],
             closeUrl: [],
             slug: '',
+            issuedBySpace: issuedBySpaceAddresses.has(
+              token.address.toLowerCase(),
+            ),
             supply: totalSupply
               ? {
                   total: Number(totalSupply / 10n ** BigInt(decimals)),

--- a/apps/web/src/app/api/v1/spaces/[spaceSlug]/wallet-transferable-tokens/route.ts
+++ b/apps/web/src/app/api/v1/spaces/[spaceSlug]/wallet-transferable-tokens/route.ts
@@ -11,6 +11,7 @@ import {
   validTokenTypes,
   TokenType,
   isHiddenToken,
+  isKnownTreasuryToken,
 } from '@hypha-platform/core/client';
 import { db } from '@hypha-platform/storage-postgres';
 import { hasEmojiOrLink } from '@hypha-platform/ui-utils';
@@ -83,13 +84,20 @@ export async function GET(
       console.warn('Failed to fetch wallet token balances:', error);
     }
 
+    const dbKnownAddresses = new Set(
+      rawDbTokens
+        .filter((t) => t.address && EVM_ADDRESS.test(t.address))
+        .map((t) => t.address!.toLowerCase()),
+    );
+
     const parsedExternalTokens: Token[] = externalTokens
       .filter(
         (token) =>
           token &&
           token.balance > 0 &&
           token.tokenAddress &&
-          EVM_ADDRESS.test(token.tokenAddress),
+          EVM_ADDRESS.test(token.tokenAddress) &&
+          isKnownTreasuryToken(token.tokenAddress, dbKnownAddresses),
       )
       .map((token) => ({
         symbol: token.symbol || 'UNKNOWN',

--- a/packages/core/src/common/web3/__tests__/tokens.test.ts
+++ b/packages/core/src/common/web3/__tests__/tokens.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import {
-  TOKENS,
-  isCatalogueToken,
-  isKnownTreasuryToken,
-} from '../tokens';
+import { TOKENS, isCatalogueToken, isKnownTreasuryToken } from '../tokens';
 
 describe('isCatalogueToken', () => {
   it('returns true for hardcoded catalogue addresses', () => {

--- a/packages/core/src/common/web3/__tests__/tokens.test.ts
+++ b/packages/core/src/common/web3/__tests__/tokens.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import {
+  TOKENS,
+  isCatalogueToken,
+  isKnownTreasuryToken,
+} from '../tokens';
+
+describe('isCatalogueToken', () => {
+  it('returns true for hardcoded catalogue addresses', () => {
+    for (const token of TOKENS) {
+      expect(isCatalogueToken(token.address)).toBe(true);
+      expect(isCatalogueToken(token.address.toLowerCase())).toBe(true);
+      expect(isCatalogueToken(token.address.toUpperCase())).toBe(true);
+    }
+  });
+
+  it('returns false for unknown or empty addresses', () => {
+    expect(isCatalogueToken('0x0000000000000000000000000000000000000001')).toBe(
+      false,
+    );
+    expect(isCatalogueToken(null)).toBe(false);
+    expect(isCatalogueToken(undefined)).toBe(false);
+    expect(isCatalogueToken('')).toBe(false);
+  });
+});
+
+describe('isKnownTreasuryToken', () => {
+  const spam = '0x1111111111111111111111111111111111111111';
+  const dbToken = '0x2222222222222222222222222222222222222222';
+  const known = new Set([dbToken]);
+
+  it('keeps catalogue tokens even when not in knownAddresses', () => {
+    expect(isKnownTreasuryToken(TOKENS[0].address, new Set())).toBe(true);
+  });
+
+  it('keeps DB-known addresses', () => {
+    expect(isKnownTreasuryToken(dbToken, known)).toBe(true);
+  });
+
+  it('drops unknown spam addresses', () => {
+    expect(isKnownTreasuryToken(spam, known)).toBe(false);
+  });
+});

--- a/packages/core/src/common/web3/tokens.ts
+++ b/packages/core/src/common/web3/tokens.ts
@@ -85,6 +85,26 @@ export function isHiddenToken(address?: string | null): boolean {
   return HIDDEN_TOKEN_ADDRESSES.has(address.toLowerCase());
 }
 
+/** True when `address` is in the hardcoded {@link TOKENS} catalogue (USDC/EURC/WETH/cbBTC/HYPHA). */
+export function isCatalogueToken(address?: string | null): boolean {
+  if (!address) return false;
+  const lower = address.toLowerCase();
+  return TOKENS.some((t) => t.address.toLowerCase() === lower);
+}
+
+/**
+ * True when a token should appear in treasury / wallet asset lists.
+ * `knownAddresses` is typically DB + space-issued addresses (lowercased) already
+ * seeded before Alchemy merge — catalogue tokens are always allowed.
+ */
+export function isKnownTreasuryToken(
+  address: string,
+  knownAddresses: ReadonlySet<string>,
+): boolean {
+  const lower = address.toLowerCase();
+  return knownAddresses.has(lower) || isCatalogueToken(lower);
+}
+
 export const ERC20_TOKEN_TRANSFER_ADDRESSES = [
   '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
   '0x60a3E35Cc302bFA44Cb288Bc5a4F316Fdb1adb42',

--- a/packages/epics/src/treasury/hooks/use-assets-section.ts
+++ b/packages/epics/src/treasury/hooks/use-assets-section.ts
@@ -39,27 +39,24 @@ export const useAssetsSection = ({
   const displayableAssets = React.useMemo(() => {
     // Hide zero-balance noise, but always keep tokens issued by this space
     // (newly created tokens often sit at 0 in the issuer treasury).
-    let result = assets.filter(
-      (asset) => asset.value > 0 || asset.issuedBySpace,
-    );
+    const term = searchTerm.trim().toLowerCase();
 
-    if (hideSmallBalances) {
-      result = result.filter(
-        (asset) => asset.value >= 1 || asset.issuedBySpace,
-      );
-    }
+    return assets.filter((asset) => {
+      const isVisible =
+        asset.issuedBySpace ||
+        (hideSmallBalances ? asset.value >= 1 : asset.value > 0);
+      if (!isVisible) return false;
 
-    if (searchTerm.trim()) {
-      const term = searchTerm.toLowerCase();
-      result = result.filter(
-        (asset) =>
+      if (term) {
+        return (
           asset.name.toLowerCase().includes(term) ||
           asset.symbol.toLowerCase().includes(term) ||
-          (asset.address?.toLowerCase().includes(term) ?? false),
-      );
-    }
+          (asset.address?.toLowerCase().includes(term) ?? false)
+        );
+      }
 
-    return result;
+      return true;
+    });
   }, [assets, hideSmallBalances, searchTerm]);
 
   const filteredAssets = React.useMemo(

--- a/packages/epics/src/treasury/hooks/use-assets-section.ts
+++ b/packages/epics/src/treasury/hooks/use-assets-section.ts
@@ -37,10 +37,16 @@ export const useAssetsSection = ({
   )}`;
 
   const displayableAssets = React.useMemo(() => {
-    let result = assets.filter((asset) => asset.value > 0);
+    // Hide zero-balance noise, but always keep tokens issued by this space
+    // (newly created tokens often sit at 0 in the issuer treasury).
+    let result = assets.filter(
+      (asset) => asset.value > 0 || asset.issuedBySpace,
+    );
 
     if (hideSmallBalances) {
-      result = result.filter((asset) => asset.value >= 1);
+      result = result.filter(
+        (asset) => asset.value >= 1 || asset.issuedBySpace,
+      );
     }
 
     if (searchTerm.trim()) {

--- a/packages/epics/src/treasury/hooks/use-assets.ts
+++ b/packages/epics/src/treasury/hooks/use-assets.ts
@@ -45,6 +45,12 @@ type AssetItem = {
   slug: string;
   address: string;
   createdAt?: Date;
+  /** True when this space issued the token — keep visible at 0 balance. */
+  issuedBySpace?: boolean;
+  space?: {
+    slug: string;
+    title: string;
+  };
 };
 
 type UseAssetsData = {


### PR DESCRIPTION
## Summary
- Space treasury still hides unrelated zero-balance tokens, but always shows tokens issued by that space (including newly created ones at 0 balance).
- Space assets API marks issuer tokens via `issuedBySpace` and includes DB-registered space tokens so they appear before indexers catch up.
- Personal wallet/profile visibility is unchanged for now.

## Test plan
- [ ] Open a space treasury that has issued a token with 0 balance in the executor — token should appear in the assets list
- [ ] Confirm other zero-balance non-issued tokens remain hidden
- [ ] Toggle “hide small balances” — issuer tokens at 0 still remain visible
- [ ] Deposit / hold a non-space token with balance > 0 — still appears as before
- [ ] Confirm My Wallet / personal assets still only show positive balances


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Asset listings now indicate whether each token is issued by the current space.
  * Space-issued tokens stay visible even with zero or “hide small balances” settings.
* **Bug Fixes**
  * External-token results are now restricted to known treasury/catalog tokens, reducing irrelevant or spam entries.
  * “Assets without balances” no longer pulls in external discovery tokens.
  * Improved preview/change-detection reliability by using local git diffing and fetching full git history.
* **Tests**
  * Added unit tests for token helper filtering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->