### PR TITLE
feat(api): mutual credit whitelist for any token

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,7 +8,7 @@
     "build": "node --max-old-space-size=6144 ./node_modules/next/dist/bin/next build",
     "start": "next start",
     "lint": "next lint",
-    "check-types": "tsc --noEmit",
+    "check-types": "node --max-old-space-size=6144 ./node_modules/typescript/bin/tsc --noEmit",
     "postinstall": "if [ ! -f .env ] && [ -z \"$CI\" ]; then cp .env.template .env; fi"
   },
   "dependencies": {

--- a/apps/web/src/app/api/v1/mutual-credit/whitelist/README.md
+++ b/apps/web/src/app/api/v1/mutual-credit/whitelist/README.md
@@ -1,21 +1,31 @@
 # Mutual Credit Whitelist API
 
-Endpoint:
+Grant or revoke **address-level mutual credit eligibility** on a Hypha regular
+space token (Base). Use this when a user logs in (or links a wallet) so they can
+spend up to that token’s `defaultCreditLimit` even with a zero ERC-20 balance.
 
-```txt
+**Base URL (production):** `https://app.hypha.earth`  
+**Network:** Base mainnet (`8453`)  
+**Auth:** shared API key (issued by Hypha)
+
+---
+
+## Endpoint
+
+```http
 POST /api/v1/mutual-credit/whitelist
 ```
 
-Headers:
+### Headers
 
-```txt
-Authorization: Bearer <MUTUAL_CREDIT_WHITELIST_API_KEY>
-Content-Type: application/json
-```
+| Header | Value |
+| --- | --- |
+| `Authorization` | `Bearer <API_KEY>` |
+| `Content-Type` | `application/json` |
 
-`x-api-key: <MUTUAL_CREDIT_WHITELIST_API_KEY>` is also accepted.
+`x-api-key: <API_KEY>` is also accepted instead of the Bearer header.
 
-Body:
+### Body
 
 ```json
 {
@@ -25,39 +35,13 @@ Body:
 }
 ```
 
-| Field          | Required | Description                                                      |
-| -------------- | -------- | ---------------------------------------------------------------- |
-| `tokenAddress` | yes      | Regular space token contract on Base (e.g. QUAIL, CLARINE)       |
-| `accounts`     | yes      | Addresses to grant or revoke mutual-credit eligibility (max 100) |
-| `allowed`      | yes      | Parallel flags: `true` whitelist, `false` remove                 |
+| Field | Required | Description |
+| --- | --- | --- |
+| `tokenAddress` | **yes** | Token contract on Base to update (checksummed or lowercase) |
+| `accounts` | **yes** | Wallet addresses to grant/revoke (1–100, no duplicates) |
+| `allowed` | **yes** | Parallel booleans: `true` = whitelist, `false` = remove. Must match `accounts.length` |
 
-Example (QUAIL):
-
-```bash
-curl -X POST "https://app.hypha.earth/api/v1/mutual-credit/whitelist" \
-  -H "Authorization: Bearer <MUTUAL_CREDIT_WHITELIST_API_KEY>" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "tokenAddress":"0x2919285decFD2CE657445E8b22928aB84edE6D90",
-    "accounts":["0x1234567890123456789012345678901234567890"],
-    "allowed":[true]
-  }'
-```
-
-Example (La Clarine — previously the hardcoded default):
-
-```bash
-curl -X POST "https://app.hypha.earth/api/v1/mutual-credit/whitelist" \
-  -H "Authorization: Bearer <MUTUAL_CREDIT_WHITELIST_API_KEY>" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "tokenAddress":"0x0692C428864A3e2775C4d4Db3a84124435C7913D",
-    "accounts":["0x1234567890123456789012345678901234567890"],
-    "allowed":[true]
-  }'
-```
-
-Success response:
+### Success (`200`)
 
 ```json
 {
@@ -67,32 +51,131 @@ Success response:
 }
 ```
 
-## Verify on-chain
+- `contractAddress` is always the `tokenAddress` you sent — use it to confirm the right token was updated.
+- Wait for the tx to confirm on Base before treating the user as whitelisted.
 
-After a successful response, confirm the user was added on the **same** token:
+### Errors
+
+| Status | When |
+| --- | --- |
+| `401` | Missing/invalid API key |
+| `400` | Invalid JSON, validation failure, non-contract `tokenAddress`, or Hypha signer not authorized on that token |
+| `500` | Unexpected failure (RPC, simulation, broadcast) |
+
+Validation failures include a `details` object (Zod flatten). Other `400`/`500` bodies look like `{ "error": "…" }`.
+
+---
+
+## Examples
+
+### Whitelist a user on QUAIL (West Marin)
 
 ```bash
-cast call <TOKEN> "isCreditWhitelistedAddress(address)(bool)" <USER> --rpc-url "$RPC_URL"
-cast call <TOKEN> "creditLimitOf(address)(uint256)" <USER> --rpc-url "$RPC_URL"
+curl -X POST "https://app.hypha.earth/api/v1/mutual-credit/whitelist" \
+  -H "Authorization: Bearer <API_KEY>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "tokenAddress": "0x2919285decFD2CE657445E8b22928aB84edE6D90",
+    "accounts": ["0xUSER_WALLET"],
+    "allowed": [true]
+  }'
 ```
 
-`creditLimitOf` returns the token's `defaultCreditLimit` when the address is
-whitelisted (or is a member of a credit-whitelisted space); otherwise `0`.
+### Whitelist a user on La Clarine
 
-## Required Vercel env vars
+```bash
+curl -X POST "https://app.hypha.earth/api/v1/mutual-credit/whitelist" \
+  -H "Authorization: Bearer <API_KEY>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "tokenAddress": "0x0692C428864A3e2775C4d4Db3a84124435C7913D",
+    "accounts": ["0xUSER_WALLET"],
+    "allowed": [true]
+  }'
+```
+
+### Batch (grant + revoke)
+
+```json
+{
+  "tokenAddress": "0x2919285decFD2CE657445E8b22928aB84edE6D90",
+  "accounts": ["0xAAA…", "0xBBB…"],
+  "allowed": [true, false]
+}
+```
+
+### Suggested integration (login)
+
+1. User authenticates / links a Base wallet.
+2. Resolve which mutual-credit token(s) they need (e.g. QUAIL for a West Marin listing).
+3. `POST` whitelist with that `tokenAddress` and `accounts: [wallet]`, `allowed: [true]`.
+4. Optionally poll BaseScan / wait for receipt, then verify on-chain (below).
+5. Only then let them pay with mutual credit.
+
+You must pass **`tokenAddress` for every call**. There is no default token.
+
+---
+
+## Verify on-chain
+
+After a successful response (and tx confirmation), check the **same** token:
+
+```bash
+# true if address-whitelisted
+cast call <TOKEN> \
+  "isCreditWhitelistedAddress(address)(bool)" \
+  <USER> \
+  --rpc-url https://mainnet.base.org
+
+# effective credit limit (wei, 18 decimals). > 0 means they can use credit
+cast call <TOKEN> \
+  "creditLimitOf(address)(uint256)" \
+  <USER> \
+  --rpc-url https://mainnet.base.org
+```
+
+Known tokens:
+
+| Token | Address | Notes |
+| --- | --- | --- |
+| QUAIL (The Quail) | `0x2919285decFD2CE657445E8b22928aB84edE6D90` | `defaultCreditLimit` = 48 QUAIL |
+| CLARINE (La Clarine) | `0x0692C428864A3e2775C4d4Db3a84124435C7913D` | Previous hardcoded API target |
+
+---
+
+## How mutual credit works (short)
+
+- Eligibility is **per token**, not global.
+- An eligible wallet can spend up to `defaultCreditLimit` when their ERC-20 balance is insufficient; the shortfall is **minted as debt** (`creditBalanceOf`).
+- Receiving tokens later **auto-repays** debt (burn).
+- Credit mints still respect `maxSupply`. If `totalSupply == maxSupply`, spends that need new minting fail with `supply exceeded` even for whitelisted users.
+- Amounts use **18 decimals** (e.g. 10 QUAIL = `10000000000000000000`).
+
+Whitelisting via this API is one path to eligibility. Members of a token’s **credit-whitelisted spaces** also get `defaultCreditLimit` without an address whitelist entry.
+
+---
+
+## Breaking change (for existing callers)
+
+Earlier versions always updated La Clarine and ignored other tokens.  
+`tokenAddress` is now **required**. Clarine callers must send:
+
+`0x0692C428864A3e2775C4d4Db3a84124435C7913D`
+
+For QUAIL payments, send the QUAIL address above — otherwise login whitelisting will not affect QUAIL spends (`!credit`).
+
+---
+
+## Hypha ops (not needed by API clients)
+
+Server env (Vercel):
 
 ```txt
 MUTUAL_CREDIT_WHITELIST_API_KEY=<shared API key>
-MUTUAL_CREDIT_WHITELIST_SIGNER_PRIVATE_KEY=<server-only wallet private key>
+MUTUAL_CREDIT_WHITELIST_SIGNER_PRIVATE_KEY=<server-only wallet>
 RPC_URL=<Base RPC URL>
 ```
 
-The signer wallet must be the token contract **owner**, **executor**, or an
-**authorized minter** on each `tokenAddress` you target. The route checks this
-before submitting the transaction.
-
-## Breaking change
-
-`tokenAddress` is now required. Callers that previously relied on the hardcoded
-La Clarine address must pass
-`0x0692C428864A3e2775C4d4Db3a84124435C7913D` explicitly.
+The signer must be **owner**, **executor**, or **authorized minter** on each
+`tokenAddress`. That is configured on Hypha’s side (platform owner key, or an
+Update Issued Token proposal granting the signer as authorized minter).

--- a/apps/web/src/app/api/v1/mutual-credit/whitelist/README.md
+++ b/apps/web/src/app/api/v1/mutual-credit/whitelist/README.md
@@ -13,27 +13,73 @@ Authorization: Bearer <MUTUAL_CREDIT_WHITELIST_API_KEY>
 Content-Type: application/json
 ```
 
+`x-api-key: <MUTUAL_CREDIT_WHITELIST_API_KEY>` is also accepted.
+
 Body:
 
 ```json
 {
+  "tokenAddress": "0x2919285decFD2CE657445E8b22928aB84edE6D90",
   "accounts": ["0x1234567890123456789012345678901234567890"],
   "allowed": [true]
 }
 ```
 
-Use `true` to whitelist an address for Mutual Credit, or `false` to remove it.
+| Field          | Required | Description                                                      |
+| -------------- | -------- | ---------------------------------------------------------------- |
+| `tokenAddress` | yes      | Regular space token contract on Base (e.g. QUAIL, CLARINE)       |
+| `accounts`     | yes      | Addresses to grant or revoke mutual-credit eligibility (max 100) |
+| `allowed`      | yes      | Parallel flags: `true` whitelist, `false` remove                 |
 
-Example:
+Example (QUAIL):
 
 ```bash
-curl -X POST "https://your-domain.com/api/v1/mutual-credit/whitelist" \
+curl -X POST "https://app.hypha.earth/api/v1/mutual-credit/whitelist" \
   -H "Authorization: Bearer <MUTUAL_CREDIT_WHITELIST_API_KEY>" \
   -H "Content-Type: application/json" \
-  -d '{"accounts":["0x1234567890123456789012345678901234567890"],"allowed":[true]}'
+  -d '{
+    "tokenAddress":"0x2919285decFD2CE657445E8b22928aB84edE6D90",
+    "accounts":["0x1234567890123456789012345678901234567890"],
+    "allowed":[true]
+  }'
 ```
 
-Required Vercel env vars:
+Example (La Clarine — previously the hardcoded default):
+
+```bash
+curl -X POST "https://app.hypha.earth/api/v1/mutual-credit/whitelist" \
+  -H "Authorization: Bearer <MUTUAL_CREDIT_WHITELIST_API_KEY>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "tokenAddress":"0x0692C428864A3e2775C4d4Db3a84124435C7913D",
+    "accounts":["0x1234567890123456789012345678901234567890"],
+    "allowed":[true]
+  }'
+```
+
+Success response:
+
+```json
+{
+  "transactionHash": "0x…",
+  "contractAddress": "0x2919285decFD2CE657445E8b22928aB84edE6D90",
+  "accountCount": 1
+}
+```
+
+## Verify on-chain
+
+After a successful response, confirm the user was added on the **same** token:
+
+```bash
+cast call <TOKEN> "isCreditWhitelistedAddress(address)(bool)" <USER> --rpc-url "$RPC_URL"
+cast call <TOKEN> "creditLimitOf(address)(uint256)" <USER> --rpc-url "$RPC_URL"
+```
+
+`creditLimitOf` returns the token's `defaultCreditLimit` when the address is
+whitelisted (or is a member of a credit-whitelisted space); otherwise `0`.
+
+## Required Vercel env vars
 
 ```txt
 MUTUAL_CREDIT_WHITELIST_API_KEY=<shared API key>
@@ -41,4 +87,12 @@ MUTUAL_CREDIT_WHITELIST_SIGNER_PRIVATE_KEY=<server-only wallet private key>
 RPC_URL=<Base RPC URL>
 ```
 
-The signer wallet must be the token contract owner or executor.
+The signer wallet must be the token contract **owner**, **executor**, or an
+**authorized minter** on each `tokenAddress` you target. The route checks this
+before submitting the transaction.
+
+## Breaking change
+
+`tokenAddress` is now required. Callers that previously relied on the hardcoded
+La Clarine address must pass
+`0x0692C428864A3e2775C4d4Db3a84124435C7913D` explicitly.

--- a/apps/web/src/app/api/v1/mutual-credit/whitelist/route.ts
+++ b/apps/web/src/app/api/v1/mutual-credit/whitelist/route.ts
@@ -5,8 +5,11 @@ import {
   createPublicClient,
   createWalletClient,
   defineChain,
+  getAddress,
   http,
   isAddress,
+  isAddressEqual,
+  zeroAddress,
 } from 'viem';
 import { nonceManager, privateKeyToAccount } from 'viem/accounts';
 
@@ -14,7 +17,6 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 export const maxDuration = 60;
 
-const regularSpaceTokenAddress = '0x0692C428864A3e2775C4d4Db3a84124435C7913D';
 const maxBatchSize = 100;
 const signerQueues = new Map<string, Promise<void>>();
 
@@ -40,6 +42,27 @@ const creditWhitelistAbi = [
     ],
     outputs: [],
   },
+  {
+    type: 'function',
+    name: 'owner',
+    stateMutability: 'view',
+    inputs: [],
+    outputs: [{ name: '', type: 'address', internalType: 'address' }],
+  },
+  {
+    type: 'function',
+    name: 'executor',
+    stateMutability: 'view',
+    inputs: [],
+    outputs: [{ name: '', type: 'address', internalType: 'address' }],
+  },
+  {
+    type: 'function',
+    name: 'isAuthorizedMinter',
+    stateMutability: 'view',
+    inputs: [{ name: 'account', type: 'address', internalType: 'address' }],
+    outputs: [{ name: '', type: 'bool', internalType: 'bool' }],
+  },
 ] as const;
 
 const addressSchema = z
@@ -48,10 +71,16 @@ const addressSchema = z
   .refine((value) => isAddress(value), {
     message: 'Invalid EVM address',
   })
-  .transform((value) => value as `0x${string}`);
+  .transform((value) => getAddress(value));
+
+const tokenAddressSchema = addressSchema.refine(
+  (value) => !isAddressEqual(value, zeroAddress),
+  { message: 'tokenAddress must not be the zero address' },
+);
 
 const requestSchema = z
   .object({
+    tokenAddress: tokenAddressSchema,
     accounts: z.array(addressSchema).min(1).max(maxBatchSize),
     allowed: z.array(z.boolean()).min(1).max(maxBatchSize),
   })
@@ -168,6 +197,60 @@ async function withSignerQueue<T>(
   }
 }
 
+async function assertSignerCanManageCreditWhitelist(
+  publicClient: ReturnType<typeof createPublicClient>,
+  tokenAddress: `0x${string}`,
+  signerAddress: `0x${string}`,
+) {
+  const bytecode = await publicClient.getBytecode({ address: tokenAddress });
+  if (!bytecode || bytecode === '0x') {
+    throw new Error('tokenAddress is not a contract');
+  }
+
+  const [owner, executor] = await Promise.all([
+    publicClient.readContract({
+      address: tokenAddress,
+      abi: creditWhitelistAbi,
+      functionName: 'owner',
+    }),
+    publicClient.readContract({
+      address: tokenAddress,
+      abi: creditWhitelistAbi,
+      functionName: 'executor',
+    }),
+  ]);
+
+  let isAuthorizedMinter = false;
+  try {
+    isAuthorizedMinter = await publicClient.readContract({
+      address: tokenAddress,
+      abi: creditWhitelistAbi,
+      functionName: 'isAuthorizedMinter',
+      args: [signerAddress],
+    });
+  } catch {
+    // Older token implementations may not expose authorized minters.
+  }
+
+  const canManage =
+    isAddressEqual(owner, signerAddress) ||
+    isAddressEqual(executor, signerAddress) ||
+    isAuthorizedMinter;
+
+  if (!canManage) {
+    throw new Error(
+      'Signer is not owner, executor, or authorized minter on tokenAddress',
+    );
+  }
+}
+
+function isClientError(message: string) {
+  return (
+    message.includes('tokenAddress is not a contract') ||
+    message.includes('Signer is not owner, executor, or authorized minter')
+  );
+}
+
 export async function POST(request: Request) {
   if (!verifyApiKey(request)) {
     return unauthorized();
@@ -188,6 +271,8 @@ export async function POST(request: Request) {
     );
   }
 
+  const { tokenAddress, accounts, allowed } = parsed.data;
+
   try {
     const rpcUrl = getRpcUrl();
     const account = privateKeyToAccount(getSignerPrivateKey(), {
@@ -204,13 +289,19 @@ export async function POST(request: Request) {
       transport,
     });
 
+    await assertSignerCanManageCreditWhitelist(
+      publicClient,
+      tokenAddress,
+      account.address,
+    );
+
     const transactionHash = await withSignerQueue(account.address, async () => {
       const { request: contractRequest } = await publicClient.simulateContract({
         account,
-        address: regularSpaceTokenAddress,
+        address: tokenAddress,
         abi: creditWhitelistAbi,
         functionName: 'batchSetCreditWhitelistAddresses',
-        args: [parsed.data.accounts, parsed.data.allowed],
+        args: [accounts, allowed],
       });
 
       return await walletClient.writeContract(contractRequest);
@@ -218,13 +309,19 @@ export async function POST(request: Request) {
 
     return NextResponse.json({
       transactionHash,
-      contractAddress: regularSpaceTokenAddress,
-      accountCount: parsed.data.accounts.length,
+      contractAddress: tokenAddress,
+      accountCount: accounts.length,
     });
   } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
     console.error('Failed to update mutual credit whitelist:', {
-      message: error instanceof Error ? error.message : String(error),
+      message,
+      tokenAddress,
     });
+
+    if (isClientError(message)) {
+      return NextResponse.json({ error: message }, { status: 400 });
+    }
 
     return NextResponse.json(
       { error: 'Failed to update mutual credit whitelist' },

--- a/apps/web/src/app/api/v1/mutual-credit/whitelist/route.ts
+++ b/apps/web/src/app/api/v1/mutual-credit/whitelist/route.ts
@@ -207,18 +207,26 @@ async function assertSignerCanManageCreditWhitelist(
     throw new Error('tokenAddress is not a contract');
   }
 
-  const [owner, executor] = await Promise.all([
-    publicClient.readContract({
-      address: tokenAddress,
-      abi: creditWhitelistAbi,
-      functionName: 'owner',
-    }),
-    publicClient.readContract({
-      address: tokenAddress,
-      abi: creditWhitelistAbi,
-      functionName: 'executor',
-    }),
-  ]);
+  let owner: `0x${string}`;
+  let executor: `0x${string}`;
+  try {
+    [owner, executor] = await Promise.all([
+      publicClient.readContract({
+        address: tokenAddress,
+        abi: creditWhitelistAbi,
+        functionName: 'owner',
+      }),
+      publicClient.readContract({
+        address: tokenAddress,
+        abi: creditWhitelistAbi,
+        functionName: 'executor',
+      }),
+    ]);
+  } catch {
+    throw new Error(
+      'tokenAddress does not expose owner and executor for credit-whitelist management',
+    );
+  }
 
   let isAuthorizedMinter = false;
   try {
@@ -247,6 +255,9 @@ async function assertSignerCanManageCreditWhitelist(
 function isClientError(message: string) {
   return (
     message.includes('tokenAddress is not a contract') ||
+    message.includes(
+      'tokenAddress does not expose owner and executor for credit-whitelist management',
+    ) ||
     message.includes('Signer is not owner, executor, or authorized minter')
   );
 }


### PR DESCRIPTION
## Summary
- `POST /api/v1/mutual-credit/whitelist` now requires `tokenAddress`, so LocalScale (and others) can whitelist users on QUAIL, CLARINE, or any mutual-credit regular space token — not only the previously hardcoded La Clarine address.
- Before submitting, the route verifies the address is a contract and that the signer is owner, executor, or authorized minter on that token; returns a clear 400 when not.
- Docs updated with request shape, examples (including QUAIL), on-chain verification via `cast`, and the breaking-change note for existing Clarine callers.

## Test plan
- [ ] Call the endpoint without `tokenAddress` → 400 validation error
- [ ] Call with La Clarine `tokenAddress` + valid API key → tx succeeds (backward-compatible caller update)
- [ ] Call with QUAIL `tokenAddress` when signer is authorized on QUAIL → tx succeeds; `isCreditWhitelistedAddress(user)` is true
- [ ] Call with QUAIL when signer is **not** authorized → 400 explaining missing owner/executor/minter rights
- [ ] Call with an EOA / non-contract `tokenAddress` → 400 `tokenAddress is not a contract`
- [ ] Confirm response `contractAddress` matches the requested `tokenAddress`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Whitelist updates now support explicitly selecting the token contract by address.
  * Added validation to ensure the token address is valid and checksummed.
  * Added authorization checks to confirm the signer can manage the selected token.
  * Successful responses now include the selected contract address.
* **Documentation**
  * Updated API authentication, request examples, breaking-change guidance, and on-chain verification instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->