### PR TITLE
fix(spaces): restore membership CTA per transparency matrix

### DIFF
--- a/apps/web/src/app/[lang]/dho/[id]/_components/space-membership-cta-under-hero.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/space-membership-cta-under-hero.tsx
@@ -1,10 +1,13 @@
 'use client';
 
+import { useAuthentication } from '@hypha-platform/authentication';
+import { useIsDelegate } from '@hypha-platform/core/client';
 import {
   JoinSpace,
   UserSpaceState,
   checkAccess,
   useSpaceDiscoverability,
+  useSpaceMember,
   useUserSpaceState,
 } from '@hypha-platform/epics';
 
@@ -14,11 +17,23 @@ type SpaceMembershipCtaUnderHeroProps = {
   spaceSlug: string;
 };
 
+/**
+ * Membership CTA under the space hero when activity content is visible.
+ *
+ * Transparency matrix:
+ * - Show Become member / Request Invite for authenticated users who are not
+ *   personal members/delegates of the target space, whenever they can see
+ *   activity (Public / Network / Organisation-eligible).
+ * - Space-to-space participants may count as LOGGED_IN_SPACE for activity
+ *   access but still need a personal join CTA (proposal/join boundary).
+ * - When activity is denied, Join lives in SpaceAccessDenied instead.
+ */
 export function SpaceMembershipCtaUnderHero({
   spaceId,
   web3SpaceId,
   spaceSlug,
 }: SpaceMembershipCtaUnderHeroProps) {
+  const { isAuthenticated } = useAuthentication();
   const { userState, isLoading } = useUserSpaceState({
     spaceId: web3SpaceId,
     spaceSlug,
@@ -26,21 +41,46 @@ export function SpaceMembershipCtaUnderHero({
   const { access, isLoading: isAccessLoading } = useSpaceDiscoverability({
     spaceId: BigInt(web3SpaceId),
   });
+  const { isMember, isMemberLoading } = useSpaceMember({
+    spaceId: web3SpaceId,
+  });
+  const { isDelegate, isLoading: isDelegateLoading } = useIsDelegate({
+    spaceId: web3SpaceId,
+  });
 
   const hasActivityAccess = checkAccess(access, userState);
+  const isPersonalMember = Boolean(isMember || isDelegate);
+  const membershipResolved = !isMemberLoading && !isDelegateLoading;
 
-  const isLoggedInNonMember =
-    userState === UserSpaceState.LOGGED_IN ||
-    userState === UserSpaceState.LOGGED_IN_ORG;
+  // Guests never get Join here (sign-in lives in denied / auth surfaces).
+  if (!isAuthenticated) {
+    return null;
+  }
 
-  // Under-hero CTA when activity is visible (public/network/org) but user is not
-  // a space member — same JoinSpace affordance as SpaceAccessDenied empty state.
-  if (
-    isLoading ||
-    isAccessLoading ||
-    !isLoggedInNonMember ||
-    !hasActivityAccess
-  ) {
+  // While access/user-state resolves, still render a disabled Join so the
+  // control never disappears (regression from blank loading states).
+  if (isLoading || isAccessLoading || !membershipResolved) {
+    return (
+      <div className="flex w-full items-center justify-end py-2">
+        <JoinSpace spaceId={spaceId} web3SpaceId={web3SpaceId} hideWhenMember />
+      </div>
+    );
+  }
+
+  if (isPersonalMember) {
+    return null;
+  }
+
+  // Denied activity path owns the CTA (SpaceAccessDenied). Under-hero is for
+  // content-visible non-members — including space-to-space participants who
+  // are not personal members (userState may be LOGGED_IN_SPACE).
+  const isContentVisibleNonMember =
+    hasActivityAccess &&
+    (userState === UserSpaceState.LOGGED_IN ||
+      userState === UserSpaceState.LOGGED_IN_ORG ||
+      userState === UserSpaceState.LOGGED_IN_SPACE);
+
+  if (!isContentVisibleNonMember) {
     return null;
   }
 

--- a/packages/epics/src/spaces/components/join-space.tsx
+++ b/packages/epics/src/spaces/components/join-space.tsx
@@ -8,6 +8,7 @@ import { Loader2 } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import {
   useSpaceDetailsWeb3Rpc,
+  useSpacesByWeb3Ids,
   useMe,
   useJwt,
   useAddMemberOrchestrator,
@@ -23,7 +24,8 @@ import { getDhoUrlAgreements } from '../../common';
 import type { Locale } from '@hypha-platform/i18n';
 
 type JoinSpaceProps = {
-  spaceId: number;
+  /** DB space id — optional; resolved from web3SpaceId when omitted (FR-4 / D-2). */
+  spaceId?: number;
   web3SpaceId: number;
   hideWhenMember?: boolean;
 };
@@ -33,7 +35,7 @@ function isBaseError(error: unknown): error is BaseError {
 }
 
 export const JoinSpace = ({
-  spaceId,
+  spaceId: spaceIdProp,
   web3SpaceId,
   hideWhenMember = false,
 }: JoinSpaceProps) => {
@@ -42,6 +44,11 @@ export const JoinSpace = ({
   const config = useConfig();
   const { jwt } = useJwt();
   const { spaceDetails } = useSpaceDetailsWeb3Rpc({ spaceId: web3SpaceId });
+  const { spaces: spacesByWeb3Id } = useSpacesByWeb3Ids(
+    spaceIdProp == null ? [BigInt(web3SpaceId)] : [],
+    false,
+  );
+  const spaceId = spaceIdProp ?? spacesByWeb3Id[0]?.id;
   const [joinError, setJoinError] = useState<BaseError | null>(null);
   const [isProcessing, setIsProcessing] = useState(false);
   const [inviteRequested, setInviteRequested] = useState(false);
@@ -181,8 +188,15 @@ export const JoinSpace = ({
 
     try {
       if (isInviteOnly) {
+        if (spaceId == null) {
+          setJoinError({
+            shortMessage: 'Space data not available yet. Please try again.',
+          } as BaseError);
+          setIsProcessing(false);
+          return;
+        }
         await requestInvite({
-          spaceId: spaceId,
+          spaceId,
           title: 'Invite Member',
           description: `**${person.name} ${person.surname} has just requested to join as a member!**
 
@@ -199,7 +213,9 @@ export const JoinSpace = ({
         setIsProcessing(false);
       } else {
         await joinSpace();
-        await createJoinEvent({ spaceId, person });
+        if (spaceId != null) {
+          await createJoinEvent({ spaceId, person });
+        }
         setJustJoined(true);
         await revalidateIsMember();
         setIsProcessing(false);
@@ -247,17 +263,21 @@ export const JoinSpace = ({
   }, [isMember, justJoined, isInviteOnly, isInvitePending, t]);
 
   const showLoader = isProcessing || isJoiningSpace || isCreating;
+  const needsDbSpaceId = isInviteOnly && spaceId == null;
   const isButtonDisabled =
     isMember ||
     justJoined ||
     isMemberLoading ||
     isInviteLoading ||
     isInvitePending ||
+    needsDbSpaceId ||
     showLoader;
 
   const { isAuthenticated } = useAuthentication();
 
-  if (hideWhenMember && (isMemberLoading || isMember || justJoined)) {
+  // Only hide once membership is confirmed — never blank the CTA while loading
+  // (that regression made Become member / Request Invite disappear entirely).
+  if (hideWhenMember && !isMemberLoading && (isMember || justJoined)) {
     return null;
   }
 

--- a/packages/epics/src/spaces/components/space-access-denied.tsx
+++ b/packages/epics/src/spaces/components/space-access-denied.tsx
@@ -4,10 +4,7 @@ import { Button } from '@hypha-platform/ui';
 import { Empty } from '../../common/empty';
 import { UserSpaceState } from '../hooks/use-user-space-state.web3.rpc';
 import { useAuthentication } from '@hypha-platform/authentication';
-import {
-  useSpaceDetailsWeb3Rpc,
-  useSpacesByWeb3Ids,
-} from '@hypha-platform/core/client';
+import { useSpacesByWeb3Ids } from '@hypha-platform/core/client';
 import { useSpaceBySlug } from '@hypha-platform/core/client';
 import { useTranslations } from 'next-intl';
 import { JoinSpace } from './join-space';
@@ -35,12 +32,6 @@ export function SpaceAccessDenied({
   );
   const resolvedSpaceId = space?.id ?? spacesByWeb3Id[0]?.id;
 
-  const { spaceDetails } = useSpaceDetailsWeb3Rpc({
-    spaceId: effectiveSpaceId as number,
-  });
-
-  const isInviteOnly = spaceDetails?.joinMethod === 2n;
-
   if (userState === UserSpaceState.NOT_LOGGED_IN) {
     return (
       <Empty className={className}>
@@ -61,17 +52,15 @@ export function SpaceAccessDenied({
     userState === UserSpaceState.LOGGED_IN ||
     userState === UserSpaceState.LOGGED_IN_ORG
   ) {
-    const joinSpaceDbId =
-      resolvedSpaceId ?? space?.id ?? spacesByWeb3Id[0]?.id ?? undefined;
-
     return (
       <Empty className={className}>
         <div className="flex flex-col gap-7">
           <p>{t('accessDeniedNotMember')}</p>
-          {effectiveSpaceId && joinSpaceDbId ? (
+          {/* FR-4 / D-2: web3 identity is enough — do not require DB space.id */}
+          {effectiveSpaceId ? (
             <div className="flex items-center justify-center">
               <JoinSpace
-                spaceId={joinSpaceDbId}
+                spaceId={resolvedSpaceId}
                 web3SpaceId={effectiveSpaceId}
                 hideWhenMember
               />


### PR DESCRIPTION
## Summary
- Restores **Become member / Request Invite** for authenticated non-members (regression from Join leaving the hero and blanking while membership loaded).
- Follows the [transparency matrix](docs/requirements/Features/space-transparency-matrix-organisation-visibility/requirements.md): under-hero CTA when activity is visible; denied-state CTA when activity is blocked (**FR-4 / D-2** web3-first).
- Personal non-members still see Join even if space-to-space participation classifies them as `LOGGED_IN_SPACE` for activity access.

## Changes
- `SpaceMembershipCtaUnderHero`: show for content-visible personal non-members; keep a disabled CTA while state resolves (no blank).
- `SpaceAccessDenied`: render `JoinSpace` whenever web3 space id is known (DB id optional).
- `JoinSpace`: optional DB `spaceId` (resolve from web3); only hide when membership is confirmed, not while loading.

## Test plan
- [ ] Logged-in non-member on a Public/Network space (e.g. IslandPower) sees **Become member** / **Request Invite** under the hero
- [ ] Invite-only space shows **Request Invite**; open join shows **Become member**
- [ ] Space-level activity denial still shows Join in the access-denied empty state
- [ ] Organisation-eligible sibling member can see Org-level activity and still gets Join if not a personal member
- [ ] Confirmed personal members do not see Join
- [ ] Signed-out users still get Sign in / Get started on denied views (no Join under hero)


Made with [Cursor](https://cursor.com)