### PR TITLE
fix(agreements): stop empty list for network-gated document fetches

### DIFF
--- a/apps/web/src/app/[lang]/dho/[id]/@tab/overview/_components/home-token-holdings-dashboard.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@tab/overview/_components/home-token-holdings-dashboard.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import useSWR from 'swr';
 import * as d3 from 'd3';
 import { z } from 'zod';
-import { useAuthentication } from '@hypha-platform/authentication';
+import { useAccessTokenReady } from '@hypha-platform/authentication';
 import { useLocale, useTranslations } from 'next-intl';
 import { CircleHelp } from 'lucide-react';
 import {
@@ -1451,25 +1451,33 @@ export function HomeTokenHoldingsDashboard({
 }: {
   spaceSlug: string;
 }) {
-  const { getAccessToken } = useAuthentication();
+  const { getAccessToken, isAuthenticated, isAuthLoading, accessTokenReady } =
+    useAccessTokenReady();
   const locale = useLocale();
   const tModalAside = useTranslations('ModalAside');
   const tCommon = useTranslations('Common');
   const tTokenHoldings = useTranslations('TokenHoldingsDashboard');
+  // Network-gated overview APIs need a Bearer token. Wait for Privy + token
+  // and key SWR by auth so we don't cache a premature 401 as a sticky error.
+  const authReady = !isAuthLoading && accessTokenReady;
+  const authKey = isAuthenticated ? 'auth' : 'anon';
   const { data, error, isLoading } = useSWR(
-    ['space-token-holdings-home', spaceSlug],
+    authReady ? ['space-token-holdings-home', spaceSlug, authKey] : null,
     fetchHoldings(spaceSlug, getAccessToken),
     { revalidateOnFocus: true, refreshInterval: 60_000 },
   );
   const {
     data: activityData,
     error: activityError,
-    isLoading: activityLoading,
+    isLoading: activityLoadingRaw,
   } = useSWR(
-    ['space-overview-activity-home', spaceSlug],
+    authReady ? ['space-overview-activity-home', spaceSlug, authKey] : null,
     fetchOverviewActivity(spaceSlug, getAccessToken),
     { revalidateOnFocus: true, refreshInterval: 120_000 },
   );
+  // SWR reports isLoading=false when the key is null — treat auth wait as loading.
+  const activityLoading = !authReady || activityLoadingRaw;
+  const holdingsLoading = !authReady || isLoading;
 
   const [activeFilter, setActiveFilter] =
     React.useState<HomeSectionFilter>('activity');
@@ -1579,7 +1587,7 @@ export function HomeTokenHoldingsDashboard({
 
       {showDistribution ? (
         <>
-          {!isLoading && error ? (
+          {!holdingsLoading && error ? (
             <Card>
               <CardHeader>
                 <CardTitle>
@@ -1598,7 +1606,7 @@ export function HomeTokenHoldingsDashboard({
             </Card>
           ) : null}
 
-          {!isLoading && !error && data && data.tokens.length === 0 ? (
+          {!holdingsLoading && !error && data && data.tokens.length === 0 ? (
             <Card>
               <CardHeader>
                 <CardTitle>{tTokenHoldings('empty.title')}</CardTitle>
@@ -1609,7 +1617,7 @@ export function HomeTokenHoldingsDashboard({
             </Card>
           ) : null}
 
-          {!isLoading && !error && data && data.tokens.length > 0 ? (
+          {!holdingsLoading && !error && data && data.tokens.length > 0 ? (
             <div
               className={
                 showDistributionHistoryWidget

--- a/apps/web/src/app/[lang]/dho/[id]/_components/space-activity-gated-banners.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/space-activity-gated-banners.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { useAuthentication } from '@hypha-platform/authentication';
+import {
+  SalesBanner,
+  SpaceEscrowDepositBanners,
+  checkAccess,
+  useSpaceDiscoverability,
+  useUserSpaceState,
+} from '@hypha-platform/epics';
+import type { Locale } from '@hypha-platform/i18n';
+
+type SpaceActivityGatedBannersProps = {
+  web3SpaceId?: number;
+  spaceDbId: number;
+  spaceSlug: string;
+  lang: Locale;
+};
+
+/**
+ * Renewal / escrow banners are space-member surfaces. Hide them until activity
+ * access is known and allowed so org-gated outsiders don't see a renewal nag
+ * above an empty or denied tab.
+ */
+export function SpaceActivityGatedBanners({
+  web3SpaceId,
+  spaceDbId,
+  spaceSlug,
+  lang,
+}: SpaceActivityGatedBannersProps) {
+  const { isLoading: isAuthLoading } = useAuthentication();
+  const { access, isLoading: isAccessLoading } = useSpaceDiscoverability({
+    spaceId: web3SpaceId != null ? BigInt(web3SpaceId) : undefined,
+  });
+  const { userState } = useUserSpaceState({
+    spaceId: web3SpaceId,
+    spaceSlug,
+  });
+
+  if (web3SpaceId == null) {
+    return null;
+  }
+
+  if (isAuthLoading || isAccessLoading || access === undefined) {
+    return null;
+  }
+
+  // Fail closed: hide member-only banners until activity access is allowed.
+  if (!checkAccess(access, userState)) {
+    return null;
+  }
+
+  return (
+    <>
+      <SalesBanner web3SpaceId={web3SpaceId} />
+      <SpaceEscrowDepositBanners
+        web3SpaceId={web3SpaceId}
+        spaceDbId={spaceDbId}
+        spaceSlug={spaceSlug}
+        lang={lang}
+      />
+    </>
+  );
+}

--- a/apps/web/src/app/[lang]/dho/[id]/_components/space-membership-cta-under-hero.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/space-membership-cta-under-hero.tsx
@@ -51,20 +51,17 @@ export function SpaceMembershipCtaUnderHero({
   const hasActivityAccess = checkAccess(access, userState);
   const isPersonalMember = Boolean(isMember || isDelegate);
   const membershipResolved = !isMemberLoading && !isDelegateLoading;
+  const accessResolved = !isLoading && !isAccessLoading && access !== undefined;
 
   // Guests never get Join here (sign-in lives in denied / auth surfaces).
   if (!isAuthenticated) {
     return null;
   }
 
-  // While access/user-state resolves, still render a disabled Join so the
-  // control never disappears (regression from blank loading states).
-  if (isLoading || isAccessLoading || !membershipResolved) {
-    return (
-      <div className="flex w-full items-center justify-end py-2">
-        <JoinSpace spaceId={spaceId} web3SpaceId={web3SpaceId} hideWhenMember />
-      </div>
-    );
+  // Do not flash under-hero Join while access/membership are unknown.
+  // Denied activity owns the CTA in SpaceAccessDenied once resolved.
+  if (!accessResolved || !membershipResolved) {
+    return null;
   }
 
   if (isPersonalMember) {

--- a/apps/web/src/app/[lang]/dho/[id]/_components/space-membership-cta-under-hero.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/space-membership-cta-under-hero.tsx
@@ -21,12 +21,15 @@ type SpaceMembershipCtaUnderHeroProps = {
  * Membership CTA under the space hero when activity content is visible.
  *
  * Transparency matrix:
- * - Show Become member / Request Invite for authenticated users who are not
- *   personal members/delegates of the target space, whenever they can see
- *   activity (Public / Network / Organisation-eligible).
+ * - Show Become member / Request Invite for authenticated personal non-members
+ *   whenever they can see activity (Public / Network / Organisation-eligible).
  * - Space-to-space participants may count as LOGGED_IN_SPACE for activity
  *   access but still need a personal join CTA (proposal/join boundary).
  * - When activity is denied, Join lives in SpaceAccessDenied instead.
+ *
+ * Do not wait on full `useUserSpaceState.isLoading`: after org membership
+ * resolves (content visible), sibling/participant checks can keep `isLoading`
+ * true and would hide this CTA — the Hypha Energy Iberia regression.
  */
 export function SpaceMembershipCtaUnderHero({
   spaceId,
@@ -34,7 +37,7 @@ export function SpaceMembershipCtaUnderHero({
   spaceSlug,
 }: SpaceMembershipCtaUnderHeroProps) {
   const { isAuthenticated } = useAuthentication();
-  const { userState, isLoading } = useUserSpaceState({
+  const { userState } = useUserSpaceState({
     spaceId: web3SpaceId,
     spaceSlug,
   });
@@ -51,16 +54,16 @@ export function SpaceMembershipCtaUnderHero({
   const hasActivityAccess = checkAccess(access, userState);
   const isPersonalMember = Boolean(isMember || isDelegate);
   const membershipResolved = !isMemberLoading && !isDelegateLoading;
-  const accessResolved = !isLoading && !isAccessLoading && access !== undefined;
+  const accessLevelResolved = !isAccessLoading && access !== undefined;
 
   // Guests never get Join here (sign-in lives in denied / auth surfaces).
   if (!isAuthenticated) {
     return null;
   }
 
-  // Do not flash under-hero Join while access/membership are unknown.
-  // Denied activity owns the CTA in SpaceAccessDenied once resolved.
-  if (!accessResolved || !membershipResolved) {
+  // Wait only for on-chain activity level + personal membership. Full user-state
+  // loading includes org/participant checks that outlive activity becoming visible.
+  if (!accessLevelResolved || !membershipResolved) {
     return null;
   }
 
@@ -69,8 +72,8 @@ export function SpaceMembershipCtaUnderHero({
   }
 
   // Denied activity path owns the CTA (SpaceAccessDenied). Under-hero is for
-  // content-visible non-members — including space-to-space participants who
-  // are not personal members (userState may be LOGGED_IN_SPACE).
+  // content-visible non-members — including org members who are not yet
+  // personal members of this space (userState LOGGED_IN_ORG).
   const isContentVisibleNonMember =
     hasActivityAccess &&
     (userState === UserSpaceState.LOGGED_IN ||

--- a/apps/web/src/app/[lang]/dho/[id]/layout.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/layout.tsx
@@ -1,6 +1,4 @@
 import {
-  SalesBanner,
-  SpaceEscrowDepositBanners,
   SpaceCallJoinHeroBanner,
   SpaceModeLabel,
   SubscriptionBadge,
@@ -24,6 +22,7 @@ import { notFound } from 'next/navigation';
 import { db } from '@hypha-platform/storage-postgres';
 import { canConvertToBigInt } from '@hypha-platform/ui-utils';
 import { getTranslations } from 'next-intl/server';
+import { SpaceActivityGatedBanners } from './_components/space-activity-gated-banners';
 import { SpaceMembershipCtaUnderHero } from './_components/space-membership-cta-under-hero';
 
 async function getSpaceMemberAndAgreementCounts(web3SpaceId: unknown): Promise<{
@@ -185,8 +184,7 @@ export default async function DhoLayout({
               }
             />
             <div className="mt-4 flex flex-col gap-3">
-              <SalesBanner web3SpaceId={web3SpaceId} />
-              <SpaceEscrowDepositBanners
+              <SpaceActivityGatedBanners
                 web3SpaceId={web3SpaceId}
                 spaceDbId={spaceFromDb.id}
                 spaceSlug={daoSlug}

--- a/packages/authentication/src/index.ts
+++ b/packages/authentication/src/index.ts
@@ -4,3 +4,4 @@ export * from './resolve-post-auth-redirect-path';
 export * from './shared/types';
 export * from './provider';
 export * from './use-authentication';
+export * from './use-access-token-ready';

--- a/packages/authentication/src/use-access-token-ready.ts
+++ b/packages/authentication/src/use-access-token-ready.ts
@@ -35,11 +35,16 @@ export function useAccessTokenReady() {
     setAccessTokenReady(false);
     void (async () => {
       for (let attempt = 0; attempt < 10; attempt++) {
-        const token = await getAccessToken();
-        if (cancelled) return;
-        if (token) {
-          setAccessTokenReady(true);
-          return;
+        try {
+          const token = await getAccessToken();
+          if (cancelled) return;
+          if (token) {
+            setAccessTokenReady(true);
+            return;
+          }
+        } catch {
+          // Privy may reject during refresh; keep retrying with backoff.
+          if (cancelled) return;
         }
         await new Promise((resolve) =>
           setTimeout(resolve, 150 * (attempt + 1)),

--- a/packages/authentication/src/use-access-token-ready.ts
+++ b/packages/authentication/src/use-access-token-ready.ts
@@ -1,0 +1,65 @@
+'use client';
+
+import React from 'react';
+import { useAuthentication } from './use-authentication';
+
+/**
+ * Privy can report `authenticated` before `getAccessToken()` returns a Bearer
+ * token. Network/Org/Space-gated APIs 401 without that token; if a fetch runs
+ * then, SWR can cache the failure and never retry.
+ *
+ * Wait until auth has finished hydrating and (when authenticated) a token is
+ * available before kicking off protected fetches.
+ */
+export function useAccessTokenReady() {
+  const {
+    getAccessToken,
+    isAuthenticated,
+    isLoading: isAuthLoading,
+  } = useAuthentication();
+  const [accessTokenReady, setAccessTokenReady] = React.useState(false);
+
+  React.useEffect(() => {
+    let cancelled = false;
+
+    if (isAuthLoading) {
+      setAccessTokenReady(false);
+      return;
+    }
+
+    if (!isAuthenticated) {
+      setAccessTokenReady(true);
+      return;
+    }
+
+    setAccessTokenReady(false);
+    void (async () => {
+      for (let attempt = 0; attempt < 10; attempt++) {
+        const token = await getAccessToken();
+        if (cancelled) return;
+        if (token) {
+          setAccessTokenReady(true);
+          return;
+        }
+        await new Promise((resolve) =>
+          setTimeout(resolve, 150 * (attempt + 1)),
+        );
+      }
+      if (!cancelled) {
+        // Proceed so callers can surface a real error instead of spinning.
+        setAccessTokenReady(true);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isAuthLoading, isAuthenticated, getAccessToken]);
+
+  return {
+    getAccessToken,
+    isAuthenticated,
+    isAuthLoading,
+    accessTokenReady,
+  };
+}

--- a/packages/epics/src/governance/components/document-grid.container.tsx
+++ b/packages/epics/src/governance/components/document-grid.container.tsx
@@ -13,6 +13,7 @@ type DocumentGridContainerProps = {
     order?: Order<Document>;
   };
   documents: Document[];
+  isLoading?: boolean;
 };
 
 export const DocumentGridContainer = ({
@@ -20,6 +21,7 @@ export const DocumentGridContainer = ({
   web3SpaceId,
   pagination,
   documents,
+  isLoading = false,
 }: DocumentGridContainerProps) => {
   const { page, firstPageSize, pageSize } = pagination;
   const startIndex = page <= 1 ? 0 : firstPageSize + (page - 2) * pageSize;
@@ -44,7 +46,7 @@ export const DocumentGridContainer = ({
             />
           ) : null,
       }))}
-      isLoading={false}
+      isLoading={isLoading}
       basePath={basePath}
     />
   );

--- a/packages/epics/src/governance/components/document-grid.tsx
+++ b/packages/epics/src/governance/components/document-grid.tsx
@@ -25,6 +25,18 @@ export const DocumentGrid = ({
   basePath,
   documents,
 }: DocumentGridProps) => {
+  if (isLoading && documents.length === 0) {
+    return (
+      <div className="grid w-full grid-cols-1 items-start gap-2 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, index) => (
+          <div key={`document-skeleton-${index}`} className="w-full min-h-0">
+            <DocumentCard isLoading />
+          </div>
+        ))}
+      </div>
+    );
+  }
+
   return (
     <div className="grid w-full grid-cols-1 items-start gap-2 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
       {documents.map((document) => (

--- a/packages/epics/src/governance/components/document-section.tsx
+++ b/packages/epics/src/governance/components/document-section.tsx
@@ -19,6 +19,7 @@ type DocumentSectionProps = {
   headSectionButton?: React.ReactNode;
   hasSearch?: boolean;
   isLoading: boolean;
+  error?: Error | unknown;
   firstPageSize?: number;
   pageSize?: number;
 };
@@ -31,6 +32,7 @@ export const DocumentSection: FC<DocumentSectionProps> = ({
   headSectionButton,
   hasSearch = false,
   isLoading,
+  error,
   firstPageSize = 3,
   pageSize = 3,
 }) => {
@@ -93,7 +95,11 @@ export const DocumentSection: FC<DocumentSectionProps> = ({
         </div>
       ) : pagination?.totalPages === 0 ? (
         <Empty>
-          <p>{tAgreements('listIsEmpty')}</p>
+          <p>
+            {error
+              ? tAgreements('listFailedToLoad')
+              : tAgreements('listIsEmpty')}
+          </p>
         </Empty>
       ) : (
         <div className="w-full space-y-2">

--- a/packages/epics/src/governance/components/document-section.tsx
+++ b/packages/epics/src/governance/components/document-section.tsx
@@ -70,7 +70,28 @@ export const DocumentSection: FC<DocumentSectionProps> = ({
         ) : null}
       </div>
 
-      {pagination?.totalPages === 0 ? (
+      {isLoading && pagination?.totalPages === 0 ? (
+        <div className="w-full space-y-2">
+          <DocumentGridContainer
+            basePath={basePath}
+            web3SpaceId={web3SpaceId}
+            pagination={{
+              page: 1,
+              firstPageSize,
+              pageSize,
+              searchTerm,
+              order: [
+                {
+                  dir: DirectionType.DESC,
+                  name: 'createdAt',
+                },
+              ],
+            }}
+            documents={[]}
+            isLoading
+          />
+        </div>
+      ) : pagination?.totalPages === 0 ? (
         <Empty>
           <p>{tAgreements('listIsEmpty')}</p>
         </Empty>

--- a/packages/epics/src/governance/components/documents-sections.tsx
+++ b/packages/epics/src/governance/components/documents-sections.tsx
@@ -30,7 +30,7 @@ export function DocumentsSections({
   const format = useFormatter();
   const [activeTab, setActiveTab] = useState('on-voting');
   const [hasUserSelectedTab, setHasUserSelectedTab] = useState(false);
-  const { documents, isLoading } = useSpaceDocumentsWithStatuses({
+  const { documents, isLoading, error } = useSpaceDocumentsWithStatuses({
     spaceId: web3SpaceId,
     spaceSlug,
     order,
@@ -109,6 +109,7 @@ export function DocumentsSections({
           headSectionButton={createProposalButton}
           hasSearch={true}
           isLoading={isLoading}
+          error={error}
           firstPageSize={12}
           pageSize={12}
         />
@@ -121,6 +122,7 @@ export function DocumentsSections({
           headSectionButton={createProposalButton}
           hasSearch={true}
           isLoading={isLoading}
+          error={error}
           firstPageSize={12}
           pageSize={12}
         />
@@ -133,6 +135,7 @@ export function DocumentsSections({
           headSectionButton={createProposalButton}
           hasSearch={true}
           isLoading={isLoading}
+          error={error}
           firstPageSize={12}
           pageSize={12}
         />

--- a/packages/epics/src/governance/components/documents-sections.tsx
+++ b/packages/epics/src/governance/components/documents-sections.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { DocumentSection } from './document-section';
 import { useSpaceDocumentsWithStatuses } from '../hooks/use-space-documents-with-statuses';
 import { Document, Order } from '@hypha-platform/core/client';
@@ -29,6 +29,7 @@ export function DocumentsSections({
   const t = useTranslations('AgreementsTab');
   const format = useFormatter();
   const [activeTab, setActiveTab] = useState('on-voting');
+  const [hasUserSelectedTab, setHasUserSelectedTab] = useState(false);
   const { documents, isLoading } = useSpaceDocumentsWithStatuses({
     spaceId: web3SpaceId,
     spaceSlug,
@@ -41,6 +42,16 @@ export function DocumentsSections({
   const onVotingCount = documents.onVoting.length;
   const acceptedCount = documents.accepted.length;
   const rejectedCount = documents.rejected.length;
+
+  // Header "Agreements | N" counts accepted on-chain proposals. Prefer the
+  // Accepted tab when On Voting is empty so that count isn't paired with an
+  // empty default list.
+  useEffect(() => {
+    if (isLoading || hasUserSelectedTab) return;
+    if (onVotingCount === 0 && acceptedCount > 0) {
+      setActiveTab('accepted');
+    }
+  }, [isLoading, hasUserSelectedTab, onVotingCount, acceptedCount]);
 
   const basePath = `/${lang}/dho/${spaceSlug}/agreements`;
   const createProposalPath = `${basePath}/select-create-action`;
@@ -57,7 +68,10 @@ export function DocumentsSections({
   return (
     <Tabs
       value={activeTab}
-      onValueChange={setActiveTab}
+      onValueChange={(value) => {
+        setHasUserSelectedTab(true);
+        setActiveTab(value);
+      }}
       className="flex flex-col gap-4 py-0"
     >
       <TabsList triggerVariant="switch" className="w-fit">

--- a/packages/epics/src/governance/hooks/use-space-documents-with-statuses.ts
+++ b/packages/epics/src/governance/hooks/use-space-documents-with-statuses.ts
@@ -72,6 +72,12 @@ const getDocumentBadges = (document: Document, t: (key: string) => string) => {
   return badges;
 };
 
+const emptyDocuments = {
+  accepted: [] as Document[],
+  rejected: [] as Document[],
+  onVoting: [] as Document[],
+};
+
 export const useSpaceDocumentsWithStatuses = ({
   spaceSlug,
   spaceId,
@@ -82,11 +88,20 @@ export const useSpaceDocumentsWithStatuses = ({
   order?: Order<Document>;
 }) => {
   const tAgreementFlow = useTranslations('AgreementFlow');
-  const { getAccessToken } = useAuthentication();
-  const { spaceProposalsIds } = useSpaceProposalsWeb3Rpc({ spaceId: spaceId });
-  const { withdrawnProposalsIds } = useWithdrawnProposalsWeb3Rpc({
-    spaceId: spaceId,
-  });
+  const {
+    getAccessToken,
+    isAuthenticated,
+    isLoading: isAuthLoading,
+  } = useAuthentication();
+  const {
+    spaceProposalsIds,
+    isLoading: isProposalsLoading,
+    error: proposalsError,
+  } = useSpaceProposalsWeb3Rpc({ spaceId: spaceId });
+  const { withdrawnProposalsIds, isLoading: isWithdrawnLoading } =
+    useWithdrawnProposalsWeb3Rpc({
+      spaceId: spaceId,
+    });
 
   const getDirection = (dir: DirectionType) => {
     return `${dir === DirectionType.DESC ? '-' : '+'}`;
@@ -109,15 +124,19 @@ export const useSpaceDocumentsWithStatuses = ({
     () => `/api/v1/spaces/${spaceSlug}/documents/all${queryParams}`,
     [spaceSlug, queryParams],
   );
-  const shouldFetchDocuments = Boolean(spaceSlug?.trim());
+
+  // Network/Org/Space activity levels require a Bearer token. Wait for Privy
+  // to finish hydrating and include auth state in the SWR key so we refetch
+  // once the session is ready (avoids a sticky empty list after a premature 401).
+  const shouldFetchDocuments = Boolean(spaceSlug?.trim()) && !isAuthLoading;
 
   const {
     data: documentsFromDb,
-    isLoading,
+    isLoading: isDocumentsLoading,
     mutate,
-    error,
+    error: documentsError,
   } = useSWR(
-    shouldFetchDocuments ? [endpoint] : null,
+    shouldFetchDocuments ? [endpoint, isAuthenticated ? 'auth' : 'anon'] : null,
     async ([endpoint]) => {
       const token = await getAccessToken();
       const headers: HeadersInit = {};
@@ -145,31 +164,32 @@ export const useSpaceDocumentsWithStatuses = ({
       refreshWhenOffline: false,
     },
   );
+
+  const hasValidSpaceId = spaceId != null && Number.isFinite(Number(spaceId));
+  const proposalsReady = !hasValidSpaceId || spaceProposalsIds != null;
+  const documentsReady = Array.isArray(documentsFromDb);
+
   const response = React.useMemo(() => {
-    if (
-      !documentsFromDb ||
-      !Array.isArray(documentsFromDb) ||
-      !spaceProposalsIds
-    ) {
-      return {
-        accepted: [],
-        rejected: [],
-        onVoting: [],
-      };
+    if (!documentsReady || !spaceProposalsIds) {
+      return emptyDocuments;
     }
 
     const withdrawnIdsSet = new Set(
-      Array.from(withdrawnProposalsIds ?? []).map((id) => Number(id)),
+      Array.from(withdrawnProposalsIds ?? []).map((id) => id.toString()),
+    );
+    const acceptedIdsSet = new Set(
+      Array.from(spaceProposalsIds.accepted ?? []).map((id) => id.toString()),
+    );
+    const rejectedIdsSet = new Set(
+      Array.from(spaceProposalsIds.rejected ?? []).map((id) => id.toString()),
     );
 
     const acceptedDocuments = (documentsFromDb as Document[])
       .filter(
         (doc: { web3ProposalId: number | null }) =>
           doc.web3ProposalId != null &&
-          !withdrawnIdsSet.has(doc.web3ProposalId) &&
-          Array.from(spaceProposalsIds?.accepted ?? []).includes(
-            BigInt(doc.web3ProposalId),
-          ),
+          !withdrawnIdsSet.has(String(doc.web3ProposalId)) &&
+          acceptedIdsSet.has(String(doc.web3ProposalId)),
       )
       .map((doc) => {
         const documentWithStatus = { ...doc, status: 'accepted' } as Document;
@@ -183,10 +203,8 @@ export const useSpaceDocumentsWithStatuses = ({
       .filter(
         (doc: { web3ProposalId: number | null }) =>
           doc.web3ProposalId != null &&
-          !withdrawnIdsSet.has(doc.web3ProposalId) &&
-          Array.from(spaceProposalsIds?.rejected ?? []).includes(
-            BigInt(doc.web3ProposalId),
-          ),
+          !withdrawnIdsSet.has(String(doc.web3ProposalId)) &&
+          rejectedIdsSet.has(String(doc.web3ProposalId)),
       )
       .map((doc) => {
         const documentWithStatus = { ...doc, status: 'rejected' } as Document;
@@ -200,13 +218,9 @@ export const useSpaceDocumentsWithStatuses = ({
       .filter(
         (doc: { web3ProposalId: number | null }) =>
           doc.web3ProposalId != null &&
-          !withdrawnIdsSet.has(doc.web3ProposalId) &&
-          !Array.from(spaceProposalsIds?.accepted ?? []).includes(
-            BigInt(doc.web3ProposalId),
-          ) &&
-          !Array.from(spaceProposalsIds?.rejected ?? []).includes(
-            BigInt(doc.web3ProposalId),
-          ),
+          !withdrawnIdsSet.has(String(doc.web3ProposalId)) &&
+          !acceptedIdsSet.has(String(doc.web3ProposalId)) &&
+          !rejectedIdsSet.has(String(doc.web3ProposalId)),
       )
       .map((doc) => {
         const documentWithStatus = { ...doc, status: 'onVoting' } as Document;
@@ -222,14 +236,28 @@ export const useSpaceDocumentsWithStatuses = ({
     };
   }, [
     documentsFromDb,
+    documentsReady,
     spaceProposalsIds,
     withdrawnProposalsIds,
     tAgreementFlow,
   ]);
+
+  const isLoading =
+    isAuthLoading ||
+    (shouldFetchDocuments && isDocumentsLoading) ||
+    (hasValidSpaceId && isProposalsLoading) ||
+    isWithdrawnLoading ||
+    // Still assembling the intersection — keep the UI in a loading state so we
+    // never flash "List is empty" while chain proposal IDs are catching up.
+    (shouldFetchDocuments &&
+      !documentsError &&
+      !proposalsError &&
+      (!documentsReady || !proposalsReady));
+
   return {
     documents: response,
     isLoading,
     update: mutate,
-    error,
+    error: documentsError ?? proposalsError,
   };
 };

--- a/packages/epics/src/governance/hooks/use-space-documents-with-statuses.ts
+++ b/packages/epics/src/governance/hooks/use-space-documents-with-statuses.ts
@@ -95,10 +95,13 @@ export const useSpaceDocumentsWithStatuses = ({
     isLoading: isProposalsLoading,
     error: proposalsError,
   } = useSpaceProposalsWeb3Rpc({ spaceId: spaceId });
-  const { withdrawnProposalsIds, isLoading: isWithdrawnLoading } =
-    useWithdrawnProposalsWeb3Rpc({
-      spaceId: spaceId,
-    });
+  const {
+    withdrawnProposalsIds,
+    isLoading: isWithdrawnLoading,
+    error: withdrawnError,
+  } = useWithdrawnProposalsWeb3Rpc({
+    spaceId: spaceId,
+  });
 
   const getDirection = (dir: DirectionType) => {
     return `${dir === DirectionType.DESC ? '-' : '+'}`;
@@ -251,12 +254,13 @@ export const useSpaceDocumentsWithStatuses = ({
     (shouldFetchDocuments &&
       !documentsError &&
       !proposalsError &&
+      !withdrawnError &&
       (!documentsReady || !proposalsReady));
 
   return {
     documents: response,
     isLoading,
     update: mutate,
-    error: documentsError ?? proposalsError,
+    error: documentsError ?? proposalsError ?? withdrawnError,
   };
 };

--- a/packages/epics/src/governance/hooks/use-space-documents-with-statuses.ts
+++ b/packages/epics/src/governance/hooks/use-space-documents-with-statuses.ts
@@ -11,7 +11,7 @@ import {
 import { Document } from '@hypha-platform/core/client';
 import { DirectionType, Order, OrderField } from '@hypha-platform/core/client';
 import queryString from 'query-string';
-import { useAuthentication } from '@hypha-platform/authentication';
+import { useAccessTokenReady } from '@hypha-platform/authentication';
 
 import {
   DOCUMENT_LABEL_BADGE_KEYS,
@@ -88,11 +88,8 @@ export const useSpaceDocumentsWithStatuses = ({
   order?: Order<Document>;
 }) => {
   const tAgreementFlow = useTranslations('AgreementFlow');
-  const {
-    getAccessToken,
-    isAuthenticated,
-    isLoading: isAuthLoading,
-  } = useAuthentication();
+  const { getAccessToken, isAuthenticated, isAuthLoading, accessTokenReady } =
+    useAccessTokenReady();
   const {
     spaceProposalsIds,
     isLoading: isProposalsLoading,
@@ -102,47 +99,6 @@ export const useSpaceDocumentsWithStatuses = ({
     useWithdrawnProposalsWeb3Rpc({
       spaceId: spaceId,
     });
-
-  // Privy can report authenticated before getAccessToken() is ready. Network
-  // spaces 401 without a Bearer token; if we fetch then, SWR caches the error
-  // under the `auth` key and never retries when the token finally appears.
-  const [accessTokenReady, setAccessTokenReady] = React.useState(false);
-  React.useEffect(() => {
-    let cancelled = false;
-
-    if (isAuthLoading) {
-      setAccessTokenReady(false);
-      return;
-    }
-
-    if (!isAuthenticated) {
-      setAccessTokenReady(true);
-      return;
-    }
-
-    setAccessTokenReady(false);
-    void (async () => {
-      for (let attempt = 0; attempt < 10; attempt++) {
-        const token = await getAccessToken();
-        if (cancelled) return;
-        if (token) {
-          setAccessTokenReady(true);
-          return;
-        }
-        await new Promise((resolve) =>
-          setTimeout(resolve, 150 * (attempt + 1)),
-        );
-      }
-      if (!cancelled) {
-        // Proceed so we surface a real error instead of spinning forever.
-        setAccessTokenReady(true);
-      }
-    })();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [isAuthLoading, isAuthenticated, getAccessToken]);
 
   const getDirection = (dir: DirectionType) => {
     return `${dir === DirectionType.DESC ? '-' : '+'}`;

--- a/packages/epics/src/governance/hooks/use-space-documents-with-statuses.ts
+++ b/packages/epics/src/governance/hooks/use-space-documents-with-statuses.ts
@@ -103,6 +103,47 @@ export const useSpaceDocumentsWithStatuses = ({
       spaceId: spaceId,
     });
 
+  // Privy can report authenticated before getAccessToken() is ready. Network
+  // spaces 401 without a Bearer token; if we fetch then, SWR caches the error
+  // under the `auth` key and never retries when the token finally appears.
+  const [accessTokenReady, setAccessTokenReady] = React.useState(false);
+  React.useEffect(() => {
+    let cancelled = false;
+
+    if (isAuthLoading) {
+      setAccessTokenReady(false);
+      return;
+    }
+
+    if (!isAuthenticated) {
+      setAccessTokenReady(true);
+      return;
+    }
+
+    setAccessTokenReady(false);
+    void (async () => {
+      for (let attempt = 0; attempt < 10; attempt++) {
+        const token = await getAccessToken();
+        if (cancelled) return;
+        if (token) {
+          setAccessTokenReady(true);
+          return;
+        }
+        await new Promise((resolve) =>
+          setTimeout(resolve, 150 * (attempt + 1)),
+        );
+      }
+      if (!cancelled) {
+        // Proceed so we surface a real error instead of spinning forever.
+        setAccessTokenReady(true);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isAuthLoading, isAuthenticated, getAccessToken]);
+
   const getDirection = (dir: DirectionType) => {
     return `${dir === DirectionType.DESC ? '-' : '+'}`;
   };
@@ -126,9 +167,10 @@ export const useSpaceDocumentsWithStatuses = ({
   );
 
   // Network/Org/Space activity levels require a Bearer token. Wait for Privy
-  // to finish hydrating and include auth state in the SWR key so we refetch
-  // once the session is ready (avoids a sticky empty list after a premature 401).
-  const shouldFetchDocuments = Boolean(spaceSlug?.trim()) && !isAuthLoading;
+  // + an actual access token, and key SWR by auth state so we refetch when
+  // the session becomes usable.
+  const shouldFetchDocuments =
+    Boolean(spaceSlug?.trim()) && !isAuthLoading && accessTokenReady;
 
   const {
     data: documentsFromDb,
@@ -244,6 +286,7 @@ export const useSpaceDocumentsWithStatuses = ({
 
   const isLoading =
     isAuthLoading ||
+    !accessTokenReady ||
     (shouldFetchDocuments && isDocumentsLoading) ||
     (hasValidSpaceId && isProposalsLoading) ||
     isWithdrawnLoading ||

--- a/packages/epics/src/spaces/components/space-tab-access-wrapper.tsx
+++ b/packages/epics/src/spaces/components/space-tab-access-wrapper.tsx
@@ -1,10 +1,11 @@
 'use client';
 
+import { Skeleton } from '@hypha-platform/ui';
+import { useSpaceBySlug } from '@hypha-platform/core/client';
 import { useSpaceDiscoverability } from '../hooks/use-space-discoverability';
 import { useUserSpaceState } from '../hooks/use-user-space-state.web3.rpc';
 import { checkAccess } from '../utils/transparency-access';
 import { SpaceAccessDenied } from './space-access-denied';
-import { useSpaceBySlug } from '@hypha-platform/core/client';
 
 type SpaceTabAccessWrapperProps = {
   spaceId?: number;
@@ -31,12 +32,24 @@ export function SpaceTabAccessWrapper({
     space,
   });
 
-  const hasAccess = checkAccess(access, userState);
-  const isLoading = isDiscoverabilityLoading || isUserStateLoading;
+  const isPending =
+    !effectiveSpaceId || isDiscoverabilityLoading || isUserStateLoading;
 
-  if (isLoading) {
-    return <>{children}</>;
+  if (isPending) {
+    return (
+      <div
+        className="flex min-h-[12rem] flex-col gap-3 py-4"
+        aria-busy="true"
+        aria-live="polite"
+      >
+        <Skeleton loading height={28} width="40%" />
+        <Skeleton loading height={120} width="100%" />
+        <Skeleton loading height={120} width="100%" />
+      </div>
+    );
   }
+
+  const hasAccess = checkAccess(access, userState);
 
   if (!hasAccess) {
     return (

--- a/packages/epics/src/spaces/components/space-tab-access-wrapper.tsx
+++ b/packages/epics/src/spaces/components/space-tab-access-wrapper.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useAuthentication } from '@hypha-platform/authentication';
 import { Skeleton } from '@hypha-platform/ui';
 import { useSpaceBySlug } from '@hypha-platform/core/client';
 import { useSpaceDiscoverability } from '../hooks/use-space-discoverability';
@@ -18,6 +19,7 @@ export function SpaceTabAccessWrapper({
   spaceSlug,
   children,
 }: SpaceTabAccessWrapperProps) {
+  const { isLoading: isAuthLoading } = useAuthentication();
   const { space } = useSpaceBySlug(spaceSlug || '');
   const effectiveSpaceId = spaceId || space?.web3SpaceId || undefined;
 
@@ -26,16 +28,21 @@ export function SpaceTabAccessWrapper({
       spaceId: effectiveSpaceId ? BigInt(effectiveSpaceId) : undefined,
     });
 
-  const { userState, isLoading: isUserStateLoading } = useUserSpaceState({
+  const { userState } = useUserSpaceState({
     spaceId: effectiveSpaceId,
     spaceSlug,
     space,
   });
 
-  const isPending =
-    !effectiveSpaceId || isDiscoverabilityLoading || isUserStateLoading;
+  // Wait only for auth hydration + on-chain access level. Do not block the
+  // deny path on slow org/sibling membership checks — those left Belica on an
+  // empty tab under the renewal banner with no Request Invite. If the user
+  // later resolves to LOGGED_IN_ORG / LOGGED_IN_SPACE, checkAccess flips and
+  // children mount.
+  const isAccessLevelPending =
+    !effectiveSpaceId || isAuthLoading || isDiscoverabilityLoading;
 
-  if (isPending) {
+  if (isAccessLevelPending || access === undefined) {
     return (
       <div
         className="flex min-h-[12rem] flex-col gap-3 py-4"

--- a/packages/epics/src/spaces/utils/transparency-access.ts
+++ b/packages/epics/src/spaces/utils/transparency-access.ts
@@ -43,8 +43,11 @@ export function checkAccess(
   accessLevel: TransparencyLevel | undefined,
   userState: UserSpaceState,
 ): boolean {
+  // Fail closed: unknown activity access must not render gated content.
+  // Callers should wait on discoverability loading before treating this as a
+  // final deny (e.g. SpaceTabAccessWrapper shows a skeleton while pending).
   if (accessLevel === undefined) {
-    return true;
+    return false;
   }
 
   switch (userState) {

--- a/packages/i18n/src/messages/de.json
+++ b/packages/i18n/src/messages/de.json
@@ -601,7 +601,8 @@
     "rejected": "Abgelehnt",
     "newProposal": "Neuer Vorschlag",
     "searchDocuments": "Dokumente suchen",
-    "listIsEmpty": "Liste ist leer"
+    "listIsEmpty": "Liste ist leer",
+    "listFailedToLoad": "Dokumente konnten nicht geladen werden. Bitte Seite neu laden."
   },
   "MembersTab": {
     "member": "Mitglied",

--- a/packages/i18n/src/messages/en.json
+++ b/packages/i18n/src/messages/en.json
@@ -600,7 +600,8 @@
     "rejected": "Rejected",
     "newProposal": "New Proposal",
     "searchDocuments": "Search documents",
-    "listIsEmpty": "List is empty"
+    "listIsEmpty": "List is empty",
+    "listFailedToLoad": "Could not load documents. Try refreshing the page."
   },
   "MembersTab": {
     "member": "Member",

--- a/packages/i18n/src/messages/es.json
+++ b/packages/i18n/src/messages/es.json
@@ -1367,7 +1367,8 @@
     "rejected": "Rechazado",
     "newProposal": "Nueva propuesta",
     "searchDocuments": "Buscar documentos",
-    "listIsEmpty": "La lista está vacía"
+    "listIsEmpty": "La lista está vacía",
+    "listFailedToLoad": "No se pudieron cargar los documentos. Prueba a actualizar la página."
   },
   "MembersTab": {
     "member": "Miembro",

--- a/packages/i18n/src/messages/fr.json
+++ b/packages/i18n/src/messages/fr.json
@@ -601,7 +601,8 @@
     "rejected": "Rejetés",
     "newProposal": "Nouvelle proposition",
     "searchDocuments": "Rechercher des documents",
-    "listIsEmpty": "La liste est vide"
+    "listIsEmpty": "La liste est vide",
+    "listFailedToLoad": "Impossible de charger les documents. Essayez d’actualiser la page."
   },
   "MembersTab": {
     "member": "Membre",

--- a/packages/i18n/src/messages/mk.json
+++ b/packages/i18n/src/messages/mk.json
@@ -580,7 +580,8 @@
     "rejected": "Одбиени",
     "newProposal": "Нов предлог",
     "searchDocuments": "Пребарувај документи",
-    "listIsEmpty": "Листата е празна"
+    "listIsEmpty": "Листата е празна",
+    "listFailedToLoad": "Не можеа да се вчитаат документите. Обидете се да ја освежите страницата."
   },
   "MembersTab": {
     "member": "Член",

--- a/packages/i18n/src/messages/pt.json
+++ b/packages/i18n/src/messages/pt.json
@@ -1367,7 +1367,8 @@
     "rejected": "Rejeitado",
     "newProposal": "Nova proposta",
     "searchDocuments": "Pesquisar documentos",
-    "listIsEmpty": "A lista está vazia"
+    "listIsEmpty": "A lista está vazia",
+    "listFailedToLoad": "Não foi possível carregar os documentos. Tente atualizar a página."
   },
   "MembersTab": {
     "member": "Membro",


### PR DESCRIPTION
## Summary
- Fixes Belica-style **Agreements | N** with empty tabs: Network-gated `/documents/all` was fetched before Privy auth was ready (401), and SWR never refetched after the session hydrated.
- Wait for auth, include auth state in the SWR key, keep the list in a loading state until DB docs + on-chain proposal IDs are ready, show skeletons instead of “List is empty”, and default to **Accepted** when On Voting is empty.

## Root cause
Belica (and IslandPower) use Network activity access. The hero count is an ungated on-chain accepted-proposal count; the list comes from authenticated `/documents/all` ∩ chain IDs. A premature anonymous fetch stuck the UI empty.

## Test plan
- [ ] Logged-in non-member on https://app.hypha.earth/en/dho/belica/agreements sees agreements populate (not permanently empty)
- [ ] Hard refresh: brief skeletons/loading, then Accepted tab with documents when On Voting is 0
- [ ] Public activity spaces still load for signed-out users
- [ ] Network/Org spaces still require auth for the documents API
- [ ] Request Invite / Become member CTA still works (PR #2398)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an access-token readiness hook to coordinate when protected data can be fetched.
  - Introduced member-only space activity banners that render only when access is confirmed.

- **Bug Fixes**
  - Prevented unauthorized or prematurely cached token holdings and governance document data by gating requests until auth is ready.
  - Improved access handling by delaying UI until access level is resolved; failed access now “fails closed.”
  - Enhanced governance document UX with skeleton loading, clearer empty/error states, and auto-switching to the accepted tab when appropriate.
  - Added localized “failed to load” messaging for agreement/document lists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->