### PR TITLE
fix(profile): restore Treasury tab with tokens, history, and actions

### DIFF
--- a/apps/web/src/app/[lang]/profile/[personSlug]/_components/profile-tabs.tsx
+++ b/apps/web/src/app/[lang]/profile/[personSlug]/_components/profile-tabs.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { Person, useMe } from '@hypha-platform/core/client';
+import {
+  ProfileBankingSection,
+  UserAssetsSection,
+  UserEnergySection,
+  UserTransactionsSection,
+  PendingRewardsSection,
+} from '@hypha-platform/epics';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@hypha-platform/ui';
+import React from 'react';
+import { useTranslations } from 'next-intl';
+
+export const ProfileTabs = ({
+  person,
+  lang,
+}: {
+  person?: Person;
+  lang: string;
+}) => {
+  const tCommon = useTranslations('Common');
+  const [activeTab, setActiveTab] = React.useState('treasury');
+  const [treasuryView, setTreasuryView] = React.useState('wallet');
+  const { person: authenticatedPerson } = useMe();
+  const isMyProfile =
+    !!person?.address &&
+    !!authenticatedPerson?.address &&
+    person.address.toLowerCase() === authenticatedPerson.address.toLowerCase();
+
+  const walletContent = (
+    <div className="flex flex-col gap-6">
+      <PendingRewardsSection
+        person={person as Person}
+        isMyProfile={isMyProfile}
+      />
+      <UserEnergySection
+        personSlug={person?.slug || ''}
+        isMyProfile={isMyProfile}
+        lang={lang}
+      />
+      <UserAssetsSection
+        isMyProfile={isMyProfile}
+        personSlug={person?.slug || ''}
+        basePath={`/${lang}/profile/${person?.slug}`}
+      />
+      <UserTransactionsSection personSlug={person?.slug || ''} />
+    </div>
+  );
+
+  return (
+    <Tabs value={activeTab} className="w-full flex flex-col gap-4">
+      <TabsList className="w-full">
+        <TabsTrigger
+          value="treasury"
+          className="w-full"
+          variant="ghost"
+          onClick={() => setActiveTab('treasury')}
+        >
+          {tCommon('Treasury')}
+        </TabsTrigger>
+      </TabsList>
+      <TabsContent value="treasury" className="flex flex-col gap-6">
+        {isMyProfile ? (
+          <Tabs
+            value={treasuryView}
+            onValueChange={setTreasuryView}
+            className="flex w-full flex-col gap-4"
+          >
+            <div className="flex w-full justify-start">
+              <TabsList triggerVariant="switch" className="w-fit">
+                <TabsTrigger value="wallet" variant="switch">
+                  {tCommon('Wallet')}
+                </TabsTrigger>
+                <TabsTrigger value="banking" variant="switch">
+                  {tCommon('Banking')}
+                </TabsTrigger>
+              </TabsList>
+            </div>
+
+            <TabsContent value="wallet" className="mt-0">
+              {walletContent}
+            </TabsContent>
+
+            <TabsContent value="banking" className="mt-0">
+              <ProfileBankingSection
+                personSlug={person?.slug || ''}
+                isMyProfile={isMyProfile}
+              />
+            </TabsContent>
+          </Tabs>
+        ) : (
+          walletContent
+        )}
+      </TabsContent>
+    </Tabs>
+  );
+};

--- a/apps/web/src/app/[lang]/profile/[personSlug]/page.tsx
+++ b/apps/web/src/app/[lang]/profile/[personSlug]/page.tsx
@@ -21,6 +21,7 @@ import {
   getMemberSpaces,
   Space,
 } from '@hypha-platform/core/client';
+import { ProfileTabs } from './_components/profile-tabs';
 import { web3Client } from '@hypha-platform/core/server';
 import { Hex, zeroAddress } from 'viem';
 import { tryDecodeUriPart } from '@hypha-platform/ui-utils';
@@ -112,6 +113,7 @@ export default async function ProfilePage(props: PageProps) {
             spaces={spaces}
             profileView={true}
           />
+          <ProfileTabs person={person} lang={lang} />
         </div>
       ) : (
         <p>{tProfile('personNotFound')}</p>

--- a/packages/i18n/src/messages/de.json
+++ b/packages/i18n/src/messages/de.json
@@ -6,6 +6,8 @@
     "delegatedVotingMemberLabel": "Delegiertes Stimmmitglied",
     "Treasury": "Schatzkammer",
     "Energy": "Energie",
+    "Wallet": "Wallet",
+    "Banking": "Bankdienste",
     "Agreements": "Vereinbarungen",
     "Spaces": "Spaces",
     "loadMore": "Mehr laden",

--- a/packages/i18n/src/messages/en.json
+++ b/packages/i18n/src/messages/en.json
@@ -6,6 +6,8 @@
     "delegatedVotingMemberLabel": "Delegated voting member",
     "Treasury": "Treasury",
     "Energy": "Energy",
+    "Wallet": "Wallet",
+    "Banking": "Banking",
     "Agreements": "Agreements",
     "Spaces": "Spaces",
     "loadMore": "Load more",

--- a/packages/i18n/src/messages/es.json
+++ b/packages/i18n/src/messages/es.json
@@ -11,6 +11,8 @@
     "delegatedVotingMemberLabel": "Miembro con voto delegado",
     "Treasury": "Tesorería",
     "Energy": "Energía",
+    "Wallet": "Billetera",
+    "Banking": "Banca",
     "Agreements": "Acuerdos",
     "Spaces": "Espacios",
     "loadMore": "Cargar más",

--- a/packages/i18n/src/messages/fr.json
+++ b/packages/i18n/src/messages/fr.json
@@ -6,6 +6,8 @@
     "delegatedVotingMemberLabel": "Membre avec vote délégué",
     "Treasury": "Trésorerie",
     "Energy": "Énergie",
+    "Wallet": "Portefeuille",
+    "Banking": "Banque",
     "Agreements": "Accords",
     "Spaces": "Espaces",
     "loadMore": "Charger plus",

--- a/packages/i18n/src/messages/pt.json
+++ b/packages/i18n/src/messages/pt.json
@@ -11,6 +11,8 @@
     "delegatedVotingMemberLabel": "Membro com voto delegado",
     "Treasury": "Tesouraria",
     "Energy": "Energia",
+    "Wallet": "Carteira",
+    "Banking": "Banco",
     "Agreements": "Acordos",
     "Spaces": "Espaços",
     "loadMore": "Carregar mais",


### PR DESCRIPTION
## Summary
- Restores the profile `ProfileTabs` / Treasury section removed in #2394, which had stripped tokens (`UserAssetsSection`), transaction history (`UserTransactionsSection`), action buttons (Buy Space Tokens / Buy Hypha / Actions), plus rewards, energy, and banking sub-tabs from user profiles.
- Re-adds `Common.Wallet` / `Common.Banking` i18n keys across all locales used by the Wallet/Banking switcher.
- `/my-wallet` remains available; this puts the previous profile wallet experience back in place alongside it.

## Test plan
- [ ] Open own profile (`/[lang]/profile/[slug]`) — Treasury tab shows tokens, action buttons, history, rewards/energy; Wallet/Banking switcher works
- [ ] Open another member's profile — wallet content visible without banking switcher; action buttons disabled
- [ ] Click Actions / Buy Space Tokens / Buy Hypha — aside routes still open
- [ ] Confirm `/my-wallet` still works independently
- [ ] `pnpm --filter @hypha-platform/i18n run verify:messages`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added profile tabs with a Treasury section.
  - Added Wallet and Banking views for the profile owner.
  - Added wallet sections for pending rewards, energy, assets, and transactions.
  - Added localized Wallet and Banking labels in English, German, Spanish, French, and Portuguese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->