### PR TITLE
fix(energy): show real source names in Energy by source chart

### DIFF
--- a/packages/epics/src/treasury/components/assets/energy/format.ts
+++ b/packages/epics/src/treasury/components/assets/energy/format.ts
@@ -130,6 +130,20 @@ export const sourceCardLabel = (
   );
 };
 
+/** Readable on-chain metadata only — no "Source N" / type-index fallbacks. */
+export const readableSourceMetadataLabel = (source: {
+  sourceDisplayName?: string;
+  sourceLabel: string;
+}): string | undefined => {
+  if (source.sourceDisplayName && isReadableLabel(source.sourceDisplayName)) {
+    return source.sourceDisplayName;
+  }
+  if (isReadableLabel(source.sourceLabel)) {
+    return source.sourceLabel;
+  }
+  return undefined;
+};
+
 /** Merge Hypha person lookup with server-resolved participant profiles. */
 export const resolveEnergyParticipantDisplay = (
   address: string,

--- a/packages/epics/src/treasury/components/assets/energy/production-consumption-tab.tsx
+++ b/packages/epics/src/treasury/components/assets/energy/production-consumption-tab.tsx
@@ -20,7 +20,7 @@ import {
 } from './dummy-data';
 import { TimeframeToggle } from './timeframe-toggle';
 import { StatCard } from './shared';
-import { sourceCardLabel } from './format';
+import { readableSourceMetadataLabel, sourceCardLabel } from './format';
 
 const sum = (arr: number[]) => arr.reduce((a, b) => a + b, 0);
 
@@ -51,6 +51,11 @@ export const ProductionConsumptionTab = ({
     );
   }, [data.sources, sourceFallback, tShared]);
 
+  const metadataSourceLabels = React.useMemo(
+    () => (data.sources ?? []).map((s) => readableSourceMetadataLabel(s)),
+    [data.sources],
+  );
+
   const dummy = React.useMemo(
     () =>
       buildProductionSeries(
@@ -70,12 +75,12 @@ export const ProductionConsumptionTab = ({
   const labels = useLiveTelemetry
     ? telemetry!.labels
     : timeframeLabels(timeframe, locale);
-  // Prefer on-chain source display names (e.g. "School PV") over telemetry
-  // placeholder meter labels ("Solar park"). Match by index: production
-  // series are sorted by meter id, which follows activation source order.
+  // Prefer readable on-chain metadata (e.g. "School PV") over telemetry meter
+  // labels. Skip generated sourceCardLabel fallbacks ("Source 1"). Match by
+  // index: production series are sorted by meter id / activation order.
   const perSource = useLiveTelemetry
     ? telemetry!.productionBySource.map((s, i) => ({
-        label: sourceLabels[i] ?? s.label,
+        label: metadataSourceLabels[i] ?? s.label,
         values: s.valuesKwh,
       }))
     : dummy.perSource;

--- a/packages/epics/src/treasury/components/assets/energy/production-consumption-tab.tsx
+++ b/packages/epics/src/treasury/components/assets/energy/production-consumption-tab.tsx
@@ -70,9 +70,12 @@ export const ProductionConsumptionTab = ({
   const labels = useLiveTelemetry
     ? telemetry!.labels
     : timeframeLabels(timeframe, locale);
+  // Prefer on-chain source display names (e.g. "School PV") over telemetry
+  // placeholder meter labels ("Solar park"). Match by index: production
+  // series are sorted by meter id, which follows activation source order.
   const perSource = useLiveTelemetry
-    ? telemetry!.productionBySource.map((s) => ({
-        label: s.label,
+    ? telemetry!.productionBySource.map((s, i) => ({
+        label: sourceLabels[i] ?? s.label,
         values: s.valuesKwh,
       }))
     : dummy.perSource;


### PR DESCRIPTION
## Summary
- The Energy by source stacked chart was using hardcoded telemetry meter placeholders (`Solar park`, `Battery 1`, `Battery 2`).
- Prefer on-chain ownership-token display names from the space energy payload (e.g. Ponta do Sol: **School PV**, **Apartment PV**, **Battery**).
- Falls back to telemetry labels when source metadata is missing.

## Test plan
- [ ] Open https://app.hypha.earth/en/dho/ponta-do-sol-energy-community/energy (Production & consumption → Energy by source)
- [ ] Confirm legend shows School PV, Apartment PV, Battery (not Solar park / Battery 1 / Battery 2)
- [ ] Confirm chart series still stack correctly for the selected timeframe
- [ ] Spot-check another energy community (or dummy/fallback mode) still renders sensible source labels


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected live production and consumption charts so telemetry series display the corresponding source card labels.
  * Improved label consistency when sources are sorted or activated in a different order.
  * Preserved fallback labels when a matching source label is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->