### PR TITLE
fix(spaces): restore logo and photo updates on space configuration

### DIFF
--- a/apps/web/src/app/[lang]/dho/[id]/@aside/[tab]/space-configuration/space-configuration-client.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@aside/[tab]/space-configuration/space-configuration-client.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import {
+  type Space,
   useJwt,
   useMe,
   useSpaceBySlug,
@@ -30,6 +31,56 @@ type SpaceConfigurationClientProps = {
   enableNetworkMap: boolean;
 };
 
+function isSpaceRecord(value: unknown): value is Space {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'id' in value &&
+    typeof (value as { id: unknown }).id === 'number' &&
+    'slug' in value &&
+    typeof (value as { slug: unknown }).slug === 'string'
+  );
+}
+
+async function refreshSpaceCaches({
+  previousSlug,
+  nextSlug,
+  updatedSpace,
+}: {
+  previousSlug: string;
+  nextSlug: string;
+  updatedSpace: Space | null;
+}) {
+  const refreshKeys = new Set<string>([
+    `/api/v1/spaces/${previousSlug}`,
+    `/api/v1/spaces/${nextSlug}`,
+    '/api/v1/spaces?parentOnly=false',
+    `/api/v1/spaces?slugs=${nextSlug}&parentOnly=false`,
+  ]);
+
+  const results = await Promise.allSettled(
+    [...refreshKeys].map((key) => {
+      if (
+        updatedSpace &&
+        (key === `/api/v1/spaces/${previousSlug}` ||
+          key === `/api/v1/spaces/${nextSlug}`)
+      ) {
+        return mutate(key, updatedSpace, { revalidate: true });
+      }
+      return mutate(key);
+    }),
+  );
+
+  results.forEach((result, index) => {
+    if (result.status === 'rejected') {
+      console.error(
+        '[SpaceConfiguration] Failed to refresh space cache before navigation',
+        { key: [...refreshKeys][index], error: result.reason },
+      );
+    }
+  });
+}
+
 export function SpaceConfigurationClient({
   enableNetworkMap,
 }: SpaceConfigurationClientProps) {
@@ -50,7 +101,6 @@ export function SpaceConfigurationClient({
     progress,
     reset,
   } = useUpdateSpaceOrchestrator({ authToken: jwt });
-  const [newSpaceSlug, setNewSpaceSlug] = React.useState(spaceSlug);
   const searchParams = useSearchParams();
   const returnToNetworkMap = React.useMemo(
     () => isNetworkAddLocationReturn(searchParams),
@@ -60,38 +110,14 @@ export function SpaceConfigurationClient({
     () => isSignalWorkflowConfigurationReturn(searchParams),
     [searchParams],
   );
+  const [isRefreshingCaches, setIsRefreshingCaches] = React.useState(false);
 
-  React.useEffect(() => {
-    if (progress === 100 && !isPending && !isError && newSpaceSlug) {
-      if (returnToNetworkMap) {
-        router.push(getNetworkMapReturnPath(lang as Locale));
-        return;
-      }
-      if (returnToSignals) {
-        router.push(
-          getSignalWorkflowReturnPath(
-            lang as Locale,
-            newSpaceSlug,
-            searchParams,
-          ),
-        );
-        return;
-      }
-      router.push(getDhoPathAgreements(lang as Locale, newSpaceSlug));
-    }
-  }, [
-    progress,
-    isPending,
-    isError,
-    newSpaceSlug,
-    lang,
-    router,
-    returnToNetworkMap,
-    returnToSignals,
-    searchParams,
-  ]);
-
-  const isBusy = isLoadingJwt || isLoadingSpace || isPending || isError;
+  const isBusy =
+    isLoadingJwt ||
+    isLoadingSpace ||
+    isPending ||
+    isRefreshingCaches ||
+    isError;
 
   const pathname = usePathname();
   const closeUrl = React.useMemo(() => {
@@ -175,27 +201,49 @@ export function SpaceConfigurationClient({
         const normalizedUpdatedSpace = willBeArchived
           ? { ...updatedSpace, parentId: null }
           : updatedSpace;
+        const nextSlug = normalizedUpdatedSpace.slug || space.slug;
 
-        setNewSpaceSlug(normalizedUpdatedSpace.slug || '');
-        await updateSpaceConfiguration({
+        const result = await updateSpaceConfiguration({
           id: space.id,
           data: normalizedUpdatedSpace,
         });
 
-        const mutateRequests = [mutate('/api/v1/spaces?parentOnly=false')];
-        if (normalizedUpdatedSpace.slug) {
-          mutateRequests.push(
-            mutate(
-              `/api/v1/spaces?slugs=${normalizedUpdatedSpace.slug}&parentOnly=false`,
-            ),
-          );
+        setIsRefreshingCaches(true);
+        const savedSpace = isSpaceRecord(result) ? result : null;
+        await refreshSpaceCaches({
+          previousSlug: spaceSlug,
+          nextSlug,
+          updatedSpace: savedSpace,
+        });
+        // Banner/logo in the DHO layout come from RSC props — refresh so they update live.
+        router.refresh();
+
+        if (returnToNetworkMap) {
+          router.push(getNetworkMapReturnPath(lang as Locale));
+          return;
         }
-        await Promise.all(mutateRequests);
+        if (returnToSignals) {
+          router.push(
+            getSignalWorkflowReturnPath(lang as Locale, nextSlug, searchParams),
+          );
+          return;
+        }
+        router.push(getDhoPathAgreements(lang as Locale, nextSlug));
       } catch (e) {
         console.warn(e);
+        setIsRefreshingCaches(false);
       }
     },
-    [space, updateSpaceConfiguration],
+    [
+      lang,
+      returnToNetworkMap,
+      returnToSignals,
+      router,
+      searchParams,
+      space,
+      spaceSlug,
+      updateSpaceConfiguration,
+    ],
   );
 
   return (
@@ -221,7 +269,7 @@ export function SpaceConfigurationClient({
             </div>
           ) : (
             <div>
-              {isPending
+              {isPending || isRefreshingCaches
                 ? tAgreementFlow('spaceConfiguration.updating')
                 : currentAction}
             </div>

--- a/apps/web/src/app/[lang]/dho/[id]/@aside/[tab]/space-configuration/space-configuration-client.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/@aside/[tab]/space-configuration/space-configuration-client.tsx
@@ -62,7 +62,7 @@ export function SpaceConfigurationClient({
   );
 
   React.useEffect(() => {
-    if (progress === 100 && !isPending && newSpaceSlug) {
+    if (progress === 100 && !isPending && !isError && newSpaceSlug) {
       if (returnToNetworkMap) {
         router.push(getNetworkMapReturnPath(lang as Locale));
         return;
@@ -82,6 +82,7 @@ export function SpaceConfigurationClient({
   }, [
     progress,
     isPending,
+    isError,
     newSpaceSlug,
     lang,
     router,
@@ -90,7 +91,7 @@ export function SpaceConfigurationClient({
     searchParams,
   ]);
 
-  const isBusy = isLoadingJwt || isLoadingSpace || isPending;
+  const isBusy = isLoadingJwt || isLoadingSpace || isPending || isError;
 
   const pathname = usePathname();
   const closeUrl = React.useMemo(() => {

--- a/apps/web/src/app/[lang]/dho/[id]/_components/live-space-hero.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/live-space-hero.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import {
+  DEFAULT_SPACE_AVATAR_IMAGE,
+  DEFAULT_SPACE_LEAD_IMAGE,
+  useSpaceBySlug,
+} from '@hypha-platform/core/client';
+import {
+  CompactSpaceBanner,
+  SpaceAccentFromImages,
+  isSafeImageUrl,
+  type CompactSpaceBannerWithStatsProps,
+} from '@hypha-platform/epics';
+import React from 'react';
+
+type LiveSpaceHeroBannerProps = Omit<
+  CompactSpaceBannerWithStatsProps,
+  | 'showSpaceStats'
+  | 'logoUrl'
+  | 'leadImageUrl'
+  | 'title'
+  | 'description'
+  | 'links'
+> & {
+  spaceSlug: string;
+  title: string;
+  description: string | null | undefined;
+  logoUrl: string;
+  leadImageUrl: string;
+  links?: string[] | null;
+  beforeBanner?: React.ReactNode;
+  children?: React.ReactNode;
+};
+
+function resolveSafeImageUrl(
+  candidate: string | null | undefined,
+  fallback: string,
+): string {
+  const trimmed = candidate?.trim();
+  if (trimmed && isSafeImageUrl(trimmed)) return trimmed;
+  return isSafeImageUrl(fallback) ? fallback : fallback;
+}
+
+/**
+ * Hero chrome that prefers live SWR space identity over the SSR snapshot so
+ * logo/banner changes appear immediately after Configure Space saves.
+ */
+export function LiveSpaceHero({
+  spaceSlug,
+  title,
+  description,
+  logoUrl,
+  leadImageUrl,
+  links,
+  beforeBanner,
+  children,
+  logoAlt: _logoAlt,
+  ...bannerRest
+}: LiveSpaceHeroBannerProps) {
+  const { space: liveSpace } = useSpaceBySlug(spaceSlug);
+
+  const resolvedTitle = liveSpace?.title?.trim() || title;
+  const resolvedDescription =
+    liveSpace?.description !== undefined ? liveSpace.description : description;
+  const resolvedLinks = liveSpace?.links ?? links;
+  const resolvedLogoUrl = resolveSafeImageUrl(
+    liveSpace?.logoUrl ?? logoUrl,
+    DEFAULT_SPACE_AVATAR_IMAGE,
+  );
+  const resolvedLeadImageUrl = resolveSafeImageUrl(
+    liveSpace?.leadImage ?? leadImageUrl,
+    DEFAULT_SPACE_LEAD_IMAGE,
+  );
+
+  return (
+    <SpaceAccentFromImages
+      bannerSrc={resolvedLeadImageUrl}
+      logoSrc={resolvedLogoUrl}
+      className="pt-0"
+    >
+      {beforeBanner}
+      <CompactSpaceBanner
+        key={`${resolvedLogoUrl}|${resolvedLeadImageUrl}|${resolvedTitle}`}
+        {...bannerRest}
+        showSpaceStats
+        title={resolvedTitle}
+        description={resolvedDescription}
+        logoUrl={resolvedLogoUrl}
+        logoAlt={resolvedTitle}
+        links={resolvedLinks}
+        leadImageUrl={resolvedLeadImageUrl}
+      />
+      {children}
+    </SpaceAccentFromImages>
+  );
+}

--- a/apps/web/src/app/[lang]/dho/[id]/layout.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/layout.tsx
@@ -2,8 +2,6 @@ import {
   SpaceCallJoinHeroBanner,
   SpaceModeLabel,
   SubscriptionBadge,
-  CompactSpaceBanner,
-  SpaceAccentFromImages,
   SpaceAccentPortalBridge,
   SpaceCreatedOnText,
   isSafeImageUrl,
@@ -22,6 +20,7 @@ import { notFound } from 'next/navigation';
 import { db } from '@hypha-platform/storage-postgres';
 import { canConvertToBigInt } from '@hypha-platform/ui-utils';
 import { getTranslations } from 'next-intl/server';
+import { LiveSpaceHero } from './_components/live-space-hero';
 import { SpaceActivityGatedBanners } from './_components/space-activity-gated-banners';
 import { SpaceMembershipCtaUnderHero } from './_components/space-membership-cta-under-hero';
 
@@ -125,64 +124,61 @@ export default async function DhoLayout({
               fetchPriority="high"
             />
           ) : null}
-          <SpaceAccentFromImages
-            bannerSrc={heroBannerImageHref}
-            logoSrc={accentLogoHref}
-            className="pt-0"
-          >
-            <SpaceCallJoinHeroBanner
-              spaceSlug={daoSlug}
-              chatRoomId={spaceFromDb.chatRoomId}
-              web3SpaceId={web3SpaceId}
-              spaceTitle={spaceFromDb.title}
-            />
-            <CompactSpaceBanner
-              showSpaceStats
-              title={spaceFromDb.title}
-              description={spaceFromDb.description}
-              logoUrl={accentLogoHref}
-              logoAlt={spaceFromDb.title}
-              defaultLogoSrc={DEFAULT_SPACE_AVATAR_IMAGE}
-              links={spaceFromDb.links}
-              leadImageUrl={heroBannerImageHref}
-              defaultLeadImageSrc={DEFAULT_SPACE_LEAD_IMAGE}
-              memberCount={spaceMembers}
-              agreementCount={spaceAgreements}
-              createdOnText={
-                <SpaceCreatedOnText createdAt={spaceFromDb.createdAt} />
-              }
-              membersLabel={tCommon('Members')}
-              agreementsLabel={tCommon('Agreements')}
-              descriptionLabel={tCommon('spaceBannerDescriptionAria', {
-                title: spaceFromDb.title,
-              })}
-              footerTrailing={
-                <>
-                  {web3SpaceId !== undefined && (
-                    <SubscriptionBadge
-                      web3SpaceId={web3SpaceId}
-                      onHeroBackground
-                      className="rounded-lg"
-                    />
-                  )}
-                  <SpaceModeLabel
+          <LiveSpaceHero
+            spaceSlug={daoSlug}
+            title={spaceFromDb.title}
+            description={spaceFromDb.description}
+            logoUrl={accentLogoHref}
+            logoAlt={spaceFromDb.title}
+            defaultLogoSrc={DEFAULT_SPACE_AVATAR_IMAGE}
+            links={spaceFromDb.links}
+            leadImageUrl={heroBannerImageHref}
+            defaultLeadImageSrc={DEFAULT_SPACE_LEAD_IMAGE}
+            memberCount={spaceMembers}
+            agreementCount={spaceAgreements}
+            createdOnText={
+              <SpaceCreatedOnText createdAt={spaceFromDb.createdAt} />
+            }
+            membersLabel={tCommon('Members')}
+            agreementsLabel={tCommon('Agreements')}
+            descriptionLabel={tCommon('spaceBannerDescriptionAria', {
+              title: spaceFromDb.title,
+            })}
+            footerTrailing={
+              <>
+                {web3SpaceId !== undefined && (
+                  <SubscriptionBadge
                     web3SpaceId={web3SpaceId}
-                    isSandbox={spaceFlags.includes('sandbox')}
-                    isDemo={spaceFlags.includes('demo')}
-                    isArchived={compactBannerSpaceArchived}
-                    configPath={`${getDhoPathAgreements(
-                      lang,
-                      daoSlug,
-                    )}/space-configuration`}
-                    className={
-                      compactBannerSpaceArchived
-                        ? '[&_.border-error-8]:rounded-lg [&_.border-error-8]:border-error-8! [&_.border-error-8]:bg-transparent [&_.border-error-8]:text-white [&_.border-error-8]:hover:border-error-9! [&_.border-error-8]:hover:bg-white/10'
-                        : '[&_.border-accent-8]:rounded-lg [&_.border-accent-8]:border-accent-8! [&_.border-accent-8]:bg-transparent [&_.border-accent-8]:text-white [&_.border-accent-8]:hover:border-accent-9! [&_.border-accent-8]:hover:bg-white/10'
-                    }
+                    onHeroBackground
+                    className="rounded-lg"
                   />
-                </>
-              }
-            />
+                )}
+                <SpaceModeLabel
+                  web3SpaceId={web3SpaceId}
+                  isSandbox={spaceFlags.includes('sandbox')}
+                  isDemo={spaceFlags.includes('demo')}
+                  isArchived={compactBannerSpaceArchived}
+                  configPath={`${getDhoPathAgreements(
+                    lang,
+                    daoSlug,
+                  )}/space-configuration`}
+                  className={
+                    compactBannerSpaceArchived
+                      ? '[&_.border-error-8]:rounded-lg [&_.border-error-8]:border-error-8! [&_.border-error-8]:bg-transparent [&_.border-error-8]:text-white [&_.border-error-8]:hover:border-error-9! [&_.border-error-8]:hover:bg-white/10'
+                      : '[&_.border-accent-8]:rounded-lg [&_.border-accent-8]:border-accent-8! [&_.border-accent-8]:bg-transparent [&_.border-accent-8]:text-white [&_.border-accent-8]:hover:border-accent-9! [&_.border-accent-8]:hover:bg-white/10'
+                  }
+                />
+              </>
+            }
+            beforeBanner={
+              <SpaceCallJoinHeroBanner
+                spaceSlug={daoSlug}
+                chatRoomId={spaceFromDb.chatRoomId}
+                web3SpaceId={web3SpaceId}
+                spaceTitle={spaceFromDb.title}
+              />
+            }
+          >
             <div className="mt-4 flex flex-col gap-3">
               <SpaceActivityGatedBanners
                 web3SpaceId={web3SpaceId}
@@ -200,7 +196,7 @@ export default async function DhoLayout({
             </div>
             {tab}
             {children}
-          </SpaceAccentFromImages>
+          </LiveSpaceHero>
         </div>
         {aside}
       </div>

--- a/packages/core/src/space/client/hooks/useSpaceFileUploads.ts
+++ b/packages/core/src/space/client/hooks/useSpaceFileUploads.ts
@@ -19,7 +19,10 @@ const getUploadResultUrl = (result: unknown): string | undefined => {
 export type UseSpaceFileUploadsReturn = {
   isLoading: boolean;
   files: { [K in keyof Files]?: string } | null;
-  upload: (fileInput: Files, id: number) => Promise<void>;
+  upload: (
+    fileInput: Files,
+    id: number,
+  ) => Promise<{ [K in keyof Files]?: string }>;
   error: string | null;
   reset: () => void;
 };
@@ -66,6 +69,7 @@ export const useSpaceFileUploads = (
       await Promise.all(uploadPromises);
       setFiles(uploadedFiles);
       await onSuccess?.(uploadedFiles, id);
+      return uploadedFiles;
     },
     [upload, onSuccess],
   );

--- a/packages/core/src/space/client/hooks/useUpdateSpaceOrchestrator.ts
+++ b/packages/core/src/space/client/hooks/useUpdateSpaceOrchestrator.ts
@@ -253,7 +253,8 @@ export const useUpdateSpaceOrchestrator = ({
     [
       completeTask,
       errorTask,
-      files,
+      files.reset,
+      files.upload,
       resetTasks,
       resetUpdateSpaceByIdMutation,
       resetUpdateSpaceConfigurationByIdMutation,
@@ -310,7 +311,7 @@ export const useUpdateSpaceOrchestrator = ({
     resetUpdateSpaceConfigurationByIdMutation();
     files.reset();
   }, [
-    files,
+    files.reset,
     resetTasks,
     resetUpdateSpaceByIdMutation,
     resetUpdateSpaceConfigurationByIdMutation,

--- a/packages/core/src/space/client/hooks/useUpdateSpaceOrchestrator.ts
+++ b/packages/core/src/space/client/hooks/useUpdateSpaceOrchestrator.ts
@@ -118,20 +118,15 @@ export const useUpdateSpaceOrchestrator = ({
   authToken,
 }: UseUpdateSpaceInput) => {
   const web2 = useSpaceMutationsWeb2Rsc(authToken);
-  const files = useSpaceFileUploads(authToken, async (uploadedFiles, id) => {
-    if (
-      !uploadedFiles.leadImage &&
-      !uploadedFiles.logoUrl &&
-      !uploadedFiles.ecosystemLogoUrlLight &&
-      !uploadedFiles.ecosystemLogoUrlDark
-    ) {
-      return;
-    }
-    await web2.updateSpaceById({
-      id,
-      ...uploadedFiles,
-    });
-  });
+  const {
+    resetUpdateSpaceByIdMutation,
+    resetUpdateSpaceConfigurationByIdMutation,
+    errorUpdateSpaceByIdMutation,
+    errorUpdateSpaceConfigurationByIdMutation,
+    updateSpaceById,
+    updateSpaceConfigurationById,
+  } = web2;
+  const files = useSpaceFileUploads(authToken);
 
   const [taskState, dispatch] = useReducer(
     progressStateReducer,
@@ -140,6 +135,9 @@ export const useUpdateSpaceOrchestrator = ({
   const [currentAction, setCurrentAction] = useState<string>();
 
   const progress = computeProgress(taskState);
+  const hasTaskError = Object.values(taskState).some(
+    (task) => task.status === TaskStatus.ERROR,
+  );
 
   const startTask = useCallback((task: TaskName) => {
     const message = taskActionDescriptions[task];
@@ -176,6 +174,12 @@ export const useUpdateSpaceOrchestrator = ({
     ) => {
       let activeTask: TaskName | null = null;
       try {
+        // Clear prior attempt errors so a retry can show progress, not a stale overlay.
+        resetUpdateSpaceByIdMutation();
+        resetUpdateSpaceConfigurationByIdMutation();
+        files.reset();
+        resetTasks();
+
         const { id, data } = arg;
         invariant(Number.isFinite(id) && id > 0, 'valid id is required');
 
@@ -186,10 +190,16 @@ export const useUpdateSpaceOrchestrator = ({
           ecosystemLogoUrlLight: data.ecosystemLogoUrlLight ?? undefined,
           ecosystemLogoUrlDark: data.ecosystemLogoUrlDark ?? undefined,
         });
+        let uploadedFiles: {
+          logoUrl?: string;
+          leadImage?: string;
+          ecosystemLogoUrlLight?: string;
+          ecosystemLogoUrlDark?: string;
+        } = {};
         if (Object.values(filesInput).some((file) => file instanceof File)) {
           activeTask = 'UPLOAD_FILES';
           startTask('UPLOAD_FILES');
-          await files.upload(
+          uploadedFiles = await files.upload(
             filesInput as z.infer<typeof schemaCreateSpaceFiles>,
             id,
           );
@@ -204,12 +214,18 @@ export const useUpdateSpaceOrchestrator = ({
 
         activeTask = 'UPDATE_WEB2_SPACE';
         startTask('UPDATE_WEB2_SPACE');
+        // Prefer freshly uploaded URLs over File values (which stringify as undefined).
         const updateInput = schemaUpdateSpace.parse({
           ...data,
-          logoUrl: toNullableString(data.logoUrl),
-          leadImage: toNullableString(data.leadImage),
-          ecosystemLogoUrlLight: toNullableString(data.ecosystemLogoUrlLight),
-          ecosystemLogoUrlDark: toNullableString(data.ecosystemLogoUrlDark),
+          logoUrl: uploadedFiles.logoUrl ?? toNullableString(data.logoUrl),
+          leadImage:
+            uploadedFiles.leadImage ?? toNullableString(data.leadImage),
+          ecosystemLogoUrlLight:
+            uploadedFiles.ecosystemLogoUrlLight ??
+            toNullableString(data.ecosystemLogoUrlLight),
+          ecosystemLogoUrlDark:
+            uploadedFiles.ecosystemLogoUrlDark ??
+            toNullableString(data.ecosystemLogoUrlDark),
         });
         const result = await applyUpdate({
           ...updateInput,
@@ -234,13 +250,21 @@ export const useUpdateSpaceOrchestrator = ({
         throw error;
       }
     },
-    [completeTask, errorTask, files, startTask],
+    [
+      completeTask,
+      errorTask,
+      files,
+      resetTasks,
+      resetUpdateSpaceByIdMutation,
+      resetUpdateSpaceConfigurationByIdMutation,
+      startTask,
+    ],
   );
 
   const { trigger: updateSpace, isMutating: isMutatingSpace } = useSWRMutation(
     'updateSpaceMutation',
     async (_, { arg }: { arg: UpdateSpaceMutationArg }) =>
-      runSpaceUpdate(arg, web2.updateSpaceById),
+      runSpaceUpdate(arg, updateSpaceById),
   );
 
   const {
@@ -249,29 +273,48 @@ export const useUpdateSpaceOrchestrator = ({
   } = useSWRMutation(
     'updateSpaceConfigurationMutation',
     async (_, { arg }: { arg: UpdateSpaceMutationArg }) =>
-      runSpaceUpdate(arg, web2.updateSpaceConfigurationById),
+      runSpaceUpdate(arg, updateSpaceConfigurationById),
   );
 
   const isMutating = isMutatingSpace || isMutatingSpaceConfiguration;
 
+  const taskErrors = useMemo(
+    () =>
+      Object.values(taskState)
+        .filter((task) => task.status === TaskStatus.ERROR)
+        .map((task) => task.message)
+        .filter(
+          (message): message is string =>
+            typeof message === 'string' && message.length > 0,
+        ),
+    [taskState],
+  );
+
   const errors = useMemo(() => {
     return [
-      web2.errorUpdateSpaceByIdMutation,
-      web2.errorUpdateSpaceConfigurationByIdMutation,
+      errorUpdateSpaceByIdMutation,
+      errorUpdateSpaceConfigurationByIdMutation,
       files.error,
+      ...taskErrors,
     ].filter(Boolean);
   }, [
-    web2.errorUpdateSpaceByIdMutation,
-    web2.errorUpdateSpaceConfigurationByIdMutation,
+    errorUpdateSpaceByIdMutation,
+    errorUpdateSpaceConfigurationByIdMutation,
     files.error,
+    taskErrors,
   ]);
 
   const reset = useCallback(() => {
     resetTasks();
-    web2.resetUpdateSpaceByIdMutation();
-    web2.resetUpdateSpaceConfigurationByIdMutation();
+    resetUpdateSpaceByIdMutation();
+    resetUpdateSpaceConfigurationByIdMutation();
     files.reset();
-  }, [resetTasks, web2, files]);
+  }, [
+    files,
+    resetTasks,
+    resetUpdateSpaceByIdMutation,
+    resetUpdateSpaceConfigurationByIdMutation,
+  ]);
 
   return {
     updateSpace,
@@ -281,7 +324,7 @@ export const useUpdateSpaceOrchestrator = ({
     currentAction,
     progress,
     isPending: progress > 0 && progress < 100,
-    isError: errors.length > 0,
+    isError: errors.length > 0 || hasTaskError,
     errors,
     reset,
   };

--- a/packages/core/src/space/validation.ts
+++ b/packages/core/src/space/validation.ts
@@ -245,6 +245,8 @@ export const updateSpaceProps = {
     .optional(),
   title: createSpaceWeb2Props.title.optional(),
   description: createSpaceWeb2Props.description.optional(),
+  // PATCH semantics: omit = leave unchanged; null = clear parent.
+  parentId: createSpaceWeb2Props.parentId.optional(),
   categories: createSpaceWeb2Props.categories.optional(),
   links: createSpaceWeb2Props.links.optional(),
   flags: createSpaceWeb2Props.flags.optional(),


### PR DESCRIPTION
## Summary
- Fix space logo/banner updates failing with a cryptic "Required" error after the REST migration
- Merge uploaded image URLs into the main configuration PATCH instead of a partial mid-upload update that omitted `parentId`
- Keep the error overlay visible until Reset, and make `parentId` optional for PATCH semantics

## Test plan
- [ ] Open Configure Space for a space with an existing logo and banner
- [ ] Change only the logo → Update → confirm save succeeds and navigates away
- [ ] Change only the banner/lead image → Update → confirm save succeeds
- [ ] Change both logo and banner → Update → confirm both persist after reload
- [ ] Update text-only fields (no new files) → confirm still works
- [ ] If an update fails, confirm the error overlay stays until Reset


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented automatic navigation when space updates encounter an error.
  * Improved loading/error handling so the loading state stays visible when an error is present.
  * Reset prior update/upload error state before starting a new update attempt.
* **Improvements**
  * File uploads now return uploaded locations and the update flow uses the freshly uploaded URLs (e.g., for logo fields).
  * Expanded error reporting to include mutation, upload, and task-related failures.
  * Space parent settings can now be omitted to keep the current value, or set to null to clear it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->