### PR TITLE
fix(i18n): correct Dutch translations and localize hardcoded UI strings

### DIFF
--- a/packages/epics/src/agreements/components/create-agreement-base-fields.tsx
+++ b/packages/epics/src/agreements/components/create-agreement-base-fields.tsx
@@ -35,7 +35,7 @@ import {
   PostNotifyProposalCreatedInput,
 } from '@hypha-platform/core/client';
 import { useParams, usePathname, useRouter } from 'next/navigation';
-import { formatDuration } from '@hypha-platform/ui-utils';
+import { getDurationParts } from '@hypha-platform/ui-utils';
 
 import { useTheme } from 'next-themes';
 import { Locale } from '@hypha-platform/i18n';
@@ -272,6 +272,13 @@ export function CreateAgreementBaseFields({
   const durationNumber =
     duration !== undefined && duration !== null ? Number(duration) : NaN;
   const hasVotingDuration = Number.isFinite(durationNumber);
+
+  const formatVotingDuration = (seconds: number) => {
+    const { unit, count } = getDurationParts(seconds);
+    return tCommon(unit === 'hours' ? 'durationHours' : 'durationDays', {
+      count,
+    });
+  };
 
   const quorumPct =
     spaceDetails?.quorum != null ? Number(spaceDetails.quorum) : NaN;
@@ -525,7 +532,7 @@ export function CreateAgreementBaseFields({
                             )}
                           </span>
                           {votingThresholdSummary ? (
-                            <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground text-nowrap tabular-nums">
+                            <span className="text-[10px] font-medium tracking-wider text-muted-foreground text-nowrap tabular-nums">
                               {votingThresholdSummary}
                             </span>
                           ) : null}
@@ -551,12 +558,12 @@ export function CreateAgreementBaseFields({
                             {tAgreementFlow(
                               'createAgreementBaseFields.toVote',
                               {
-                                duration: formatDuration(durationNumber),
+                                duration: formatVotingDuration(durationNumber),
                               },
                             )}
                           </span>
                           {votingThresholdSummary ? (
-                            <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground text-nowrap tabular-nums">
+                            <span className="text-[10px] font-medium tracking-wider text-muted-foreground text-nowrap tabular-nums">
                               {votingThresholdSummary}
                             </span>
                           ) : null}

--- a/packages/epics/src/agreements/plugins/redeem-tokens/plugin.tsx
+++ b/packages/epics/src/agreements/plugins/redeem-tokens/plugin.tsx
@@ -772,7 +772,7 @@ export const RedeemTokensPlugin = ({
         <TokenPayoutFieldArray
           tokens={redeemableTokens}
           name="redemptions"
-          label="Redemption Amount"
+          label={tProposal('redemptionAmountLabel')}
           allowAddOrRemove={false}
           showTreasuryBalanceHint
           selectedTokenPriceHint={selectedTokenPriceHint}

--- a/packages/epics/src/governance/components/create-redeem-tokens-form.tsx
+++ b/packages/epics/src/governance/components/create-redeem-tokens-form.tsx
@@ -245,7 +245,7 @@ const CreateRedeemTokensFormInner = ({
             closeUrl={successfulUrl}
             backUrl={backUrl}
             isLoading={false}
-            label="Redeem Tokens"
+            label={tAgreementFlow('documentBadges.redeemTokens')}
             progress={progress}
           />
           {React.isValidElement(plugin)
@@ -257,7 +257,7 @@ const CreateRedeemTokensFormInner = ({
           <Separator />
           <div className="flex justify-end w-full">
             <Button type="submit" disabled={web3SpaceId == null}>
-              Publish
+              {tAgreementFlow('buttons.publish')}
             </Button>
           </div>
         </form>

--- a/packages/epics/src/governance/components/proposal-voting-info.tsx
+++ b/packages/epics/src/governance/components/proposal-voting-info.tsx
@@ -3,7 +3,7 @@
 import { useTokens } from '../../treasury';
 import { Token } from '@hypha-platform/core/client';
 import { Image } from '@hypha-platform/ui';
-import { formatDuration } from '@hypha-platform/ui-utils';
+import { getDurationParts } from '@hypha-platform/ui-utils';
 import { useTheme } from 'next-themes';
 import { VOTING_METHOD_TEMPLATES } from '../hooks';
 import { useTranslations } from 'next-intl';
@@ -46,6 +46,7 @@ export const ProposalVotingInfo = ({
 }: ProposalVotingInfoProps) => {
   const tProposalDetails = useTranslations('ProposalDetails');
   const tAgreementFlow = useTranslations('AgreementFlow');
+  const tCommon = useTranslations('Common');
   const { tokens } = useTokens({ spaceSlug });
   const parsedTokenData = tokens.find(
     (t: Token) => t.address.toLowerCase() === token.token?.toLowerCase(),
@@ -144,7 +145,15 @@ export const ProposalVotingInfo = ({
                 alt={tProposalDetails('voting.proposalVotingIconAlt')}
               />{' '}
               {tProposalDetails('voting.toVote', {
-                duration: formatDuration(Number(minimumProposalVotingDuration)),
+                duration: (() => {
+                  const { unit, count } = getDurationParts(
+                    Number(minimumProposalVotingDuration),
+                  );
+                  return tCommon(
+                    unit === 'hours' ? 'durationHours' : 'durationDays',
+                    { count },
+                  );
+                })(),
               })}
             </span>
           ) : (

--- a/packages/epics/src/governance/components/vote-proposal-button.tsx
+++ b/packages/epics/src/governance/components/vote-proposal-button.tsx
@@ -6,6 +6,7 @@ import {
 } from '@hypha-platform/core/client';
 import { Button } from '@hypha-platform/ui';
 import React from 'react';
+import { useTranslations } from 'next-intl';
 import { useSpaceMember } from '../../spaces';
 import { formatISO, isPast } from 'date-fns';
 
@@ -22,6 +23,7 @@ export const VoteProposalButton = ({
   proposalStatus?: DocumentStatus;
   className?: string;
 }) => {
+  const t = useTranslations('ProposalDetails.voteButton');
   const { myVote } = useMyVote(documentSlug);
   const { proposalDetails } = useProposalDetailsWeb3Rpc({
     proposalId: web3ProposalId,
@@ -43,7 +45,7 @@ export const VoteProposalButton = ({
     if (proposalStatus === 'onVoting' && needsDecision) {
       return (
         <Button className={className} variant="outline" colorVariant="accent">
-          Confirm Decision
+          {t('confirmDecision')}
         </Button>
       );
     }
@@ -58,7 +60,7 @@ export const VoteProposalButton = ({
             colorVariant="success"
             disabled={isSettled}
           >
-            You Voted Yes
+            {t('youVotedYes')}
           </Button>
         );
       case 'no':
@@ -69,7 +71,7 @@ export const VoteProposalButton = ({
             colorVariant="error"
             disabled={isSettled}
           >
-            You Voted No
+            {t('youVotedNo')}
           </Button>
         );
       default:
@@ -80,10 +82,18 @@ export const VoteProposalButton = ({
             colorVariant="accent"
             disabled={isSettled}
           >
-            {isSettled ? 'No Vote' : 'Vote Now'}
+            {isSettled ? t('noVote') : t('voteNow')}
           </Button>
         );
     }
-  }, [proposalStatus, myVote, proposalDetails, isMember, isDelegate]);
+  }, [
+    proposalStatus,
+    myVote,
+    proposalDetails,
+    isMember,
+    isDelegate,
+    t,
+    className,
+  ]);
   return output;
 };

--- a/packages/epics/src/people/components/people-transfer-form.tsx
+++ b/packages/epics/src/people/components/people-transfer-form.tsx
@@ -217,7 +217,7 @@ export const PeopleTransferForm = ({
               </div>
             ) : (
               <Button type="submit" disabled={isTransferring}>
-                Transfer
+                {tActions('transferFunds.form.submitLabel')}
               </Button>
             )}
           </div>

--- a/packages/epics/src/proposals/components/form-voting.tsx
+++ b/packages/epics/src/proposals/components/form-voting.tsx
@@ -25,7 +25,7 @@ import {
   type UpdateTokenProposalSnapshot,
 } from '../update-issued-token-resubmit';
 import { useSpaceMember } from '../../spaces';
-import { formatDuration } from '@hypha-platform/ui-utils';
+import { getDurationParts } from '@hypha-platform/ui-utils';
 import { useTheme } from 'next-themes';
 import { useEffect, useRef, useState } from 'react';
 import { useRouter, useParams } from 'next/navigation';
@@ -542,7 +542,15 @@ export const FormVoting = ({
                   <div className="flex flex-col">
                     <span className="text-1 text-accent-11 text-nowrap font-medium">
                       {tProposalDetails('voting.toVote', {
-                        duration: formatDuration(Number(duration)),
+                        duration: (() => {
+                          const { unit, count } = getDurationParts(
+                            Number(duration),
+                          );
+                          return tCommon(
+                            unit === 'hours' ? 'durationHours' : 'durationDays',
+                            { count },
+                          );
+                        })(),
                       })}
                     </span>
                     <span className="text-[9px] text-accent-11 text-nowrap font-medium">

--- a/packages/epics/src/proposals/components/proposal-detail.tsx
+++ b/packages/epics/src/proposals/components/proposal-detail.tsx
@@ -1237,7 +1237,10 @@ export const ProposalDetail = ({
         web3SpaceId={proposalDetails?.spaceId}
       />
       {descriptionMarkdown}
-      <AttachmentList attachments={attachments || []} />
+      <AttachmentList
+        attachments={attachments || []}
+        label={tProposalDetails('labels.attachments')}
+      />
       {label === 'Investment' ? (
         <ProposalAcceptInvestmentData
           descriptionMarkdown={content}

--- a/packages/epics/src/utils/date-fns-locale.ts
+++ b/packages/epics/src/utils/date-fns-locale.ts
@@ -9,6 +9,9 @@ import {
   enUS,
   es,
   fr,
+  mk,
+  nb,
+  nl,
   ptBR,
   type Locale as DateFnsLocale,
 } from 'date-fns/locale';
@@ -18,6 +21,9 @@ const DATE_FNS_LOCALES: Record<string, DateFnsLocale> = {
   de,
   fr,
   es,
+  mk,
+  nl,
+  no: nb,
   pt: ptBR,
   'pt-br': ptBR,
 };

--- a/packages/i18n/src/messages/de.json
+++ b/packages/i18n/src/messages/de.json
@@ -61,7 +61,9 @@
       "fileTooLarge": "Ihr Bild ist zu groß (max. 16 MB) und konnte nicht hochgeladen werden. Bitte verkleinern Sie es und versuchen Sie es erneut.",
       "uploadFailed": "Die Datei konnte nicht hochgeladen werden."
     },
-    "Pipeline": "Pipeline"
+    "Pipeline": "Pipeline",
+    "durationHours": "{count, plural, one {# Stunde} other {# Stunden}}",
+    "durationDays": "{count, plural, one {# Tag} other {# Tage}}"
   },
   "ModalAside": {
     "spaceSettings": "Space-Einstellungen",
@@ -1466,7 +1468,8 @@
       "title": "Mittel übertragen",
       "content": "Senden Sie ganz einfach Mittel aus Ihrer Wallet an ein Mitglied oder einen Space.",
       "form": {
-        "amountLabel": "Betrag"
+        "amountLabel": "Betrag",
+        "submitLabel": "Überweisen"
       }
     },
     "redeemTokens": {
@@ -1907,8 +1910,8 @@
       "proposalMinimumVotingIconAlt": "Symbol für minimale Abstimmungsdauer",
       "autoExecution": "Automatische Ausführung",
       "toVote": "{duration} zum Abstimmen",
-      "quorumLabel": "Quorum",
-      "unityLabel": "Einheit",
+      "quorumLabel": "QUORUM",
+      "unityLabel": "EINHEIT",
       "quorumUnityLine": "{quorumPercent}% {quorumLabel} | {unityPercent}% {unityLabel}",
       "uploadImageLabel": "<accent>Bild</accent> hochladen",
       "addAttachmentLabel": "Anhang hinzufügen (JPEG, PNG, WebP oder PDF — max. 16 MB)",
@@ -2293,7 +2296,8 @@
           "vaultLine": "Im Vault: {amount} {symbol}",
           "priceLine": "Preis: {currency}{price}",
           "requestedLine": "Angefordert: {currency}{amount}"
-        }
+        },
+        "redemptionAmountLabel": "Einlösungsbetrag"
       },
       "tokenPercentageFieldArray": {
         "convertedInto": "Umgewandelt in",
@@ -2634,7 +2638,8 @@
       "mutualCreditEligibleSpaces": "Berechtigte Spaces",
       "mutualCreditEligibleSpacesAdded": "Hinzugefügte berechtigte Spaces",
       "mutualCreditEligibleSpacesRemoved": "Entfernte berechtigte Spaces",
-      "spaceLogoAlt": "Logo von {title}"
+      "spaceLogoAlt": "Logo von {title}",
+      "attachments": "Anhänge"
     },
     "entryMethods": {
       "openAccess": "Open Access",
@@ -2734,7 +2739,14 @@
     "selectReferenceCurrency": "Bitte wählen Sie eine Referenzwährung",
     "tokenPriceGreaterThanZero": "Bitte geben Sie einen Token-Preis größer als 0 ein",
     "updateTokenLabel": "Token aktualisieren",
-    "spaceInformationMissing": "Space-Informationen fehlen. Bitte versuchen Sie es erneut."
+    "spaceInformationMissing": "Space-Informationen fehlen. Bitte versuchen Sie es erneut.",
+    "voteButton": {
+      "voteNow": "Jetzt abstimmen",
+      "youVotedYes": "Sie haben mit Ja gestimmt",
+      "youVotedNo": "Sie haben mit Nein gestimmt",
+      "noVote": "Keine Stimme",
+      "confirmDecision": "Entscheidung bestätigen"
+    }
   },
   "AiPanel": {
     "title": "Hypha AI",

--- a/packages/i18n/src/messages/en.json
+++ b/packages/i18n/src/messages/en.json
@@ -61,7 +61,9 @@
       "fileTooLarge": "Your image is too large (max 16 MB) and could not be uploaded. Resize it and try again.",
       "uploadFailed": "File could not be uploaded."
     },
-    "Pipeline": "Pipeline"
+    "Pipeline": "Pipeline",
+    "durationHours": "{count, plural, one {# Hour} other {# Hours}}",
+    "durationDays": "{count, plural, one {# Day} other {# Days}}"
   },
   "ModalAside": {
     "spaceSettings": "Space Settings",
@@ -1465,7 +1467,8 @@
       "title": "Transfer Funds",
       "content": "Easily send funds from your wallet to a member or a space.",
       "form": {
-        "amountLabel": "Amount"
+        "amountLabel": "Amount",
+        "submitLabel": "Transfer"
       }
     },
     "redeemTokens": {
@@ -1906,8 +1909,8 @@
       "proposalMinimumVotingIconAlt": "Proposal minimum voting icon",
       "autoExecution": "Auto-Execution",
       "toVote": "{duration} to Vote",
-      "quorumLabel": "Quorum",
-      "unityLabel": "Unity",
+      "quorumLabel": "QUORUM",
+      "unityLabel": "UNITY",
       "quorumUnityLine": "{quorumPercent}% {quorumLabel} | {unityPercent}% {unityLabel}",
       "uploadImageLabel": "<accent>Upload</accent> an image",
       "addAttachmentLabel": "Add Attachment (JPEG, PNG, WebP, or PDF — max 16MB)",
@@ -2295,7 +2298,8 @@
           "vaultLine": "In vault: {amount} {symbol}",
           "priceLine": "Price: {currency}{price}",
           "requestedLine": "Requested: {currency}{amount}"
-        }
+        },
+        "redemptionAmountLabel": "Redemption Amount"
       },
       "tokenPercentageFieldArray": {
         "convertedInto": "Converted into",
@@ -2636,7 +2640,8 @@
       "mutualCreditEligibleSpaces": "Eligible Spaces",
       "mutualCreditEligibleSpacesAdded": "Eligible Spaces Added",
       "mutualCreditEligibleSpacesRemoved": "Eligible Spaces Removed",
-      "spaceLogoAlt": "{title} logo"
+      "spaceLogoAlt": "{title} logo",
+      "attachments": "Attachments"
     },
     "entryMethods": {
       "openAccess": "Open Access",
@@ -2736,7 +2741,14 @@
     "selectReferenceCurrency": "Please select a reference currency",
     "tokenPriceGreaterThanZero": "Please enter a token price greater than 0",
     "updateTokenLabel": "Update Token",
-    "spaceInformationMissing": "Space information is missing. Please try again."
+    "spaceInformationMissing": "Space information is missing. Please try again.",
+    "voteButton": {
+      "voteNow": "Vote Now",
+      "youVotedYes": "You Voted Yes",
+      "youVotedNo": "You Voted No",
+      "noVote": "No Vote",
+      "confirmDecision": "Confirm Decision"
+    }
   },
   "AiPanel": {
     "title": "Hypha AI",

--- a/packages/i18n/src/messages/es.json
+++ b/packages/i18n/src/messages/es.json
@@ -61,7 +61,9 @@
       "fileTooLarge": "Tu imagen es demasiado grande (máx. 16 MB) y no se pudo subir. Reduce el tamaño e inténtalo de nuevo.",
       "uploadFailed": "No se pudo subir el archivo."
     },
-    "Pipeline": "Pipeline"
+    "Pipeline": "Pipeline",
+    "durationHours": "{count, plural, one {# hora} other {# horas}}",
+    "durationDays": "{count, plural, one {# día} other {# días}}"
   },
   "ModalAside": {
     "spaceSettings": "Configuración del espacio",
@@ -466,7 +468,8 @@
           "vaultLine": "En la bóveda: {amount} {symbol}",
           "priceLine": "Precio: {currency}{price}",
           "requestedLine": "Solicitado: {currency}{amount}"
-        }
+        },
+        "redemptionAmountLabel": "Importe de canje"
       },
       "tokenPercentageFieldArray": {
         "convertedInto": "Convertido en",
@@ -782,8 +785,8 @@
       "proposalMinimumVotingIconAlt": "Ícono de votación mínima de propuesta",
       "autoExecution": "Ejecución automática",
       "toVote": "{duration} para votar",
-      "quorumLabel": "Quórum",
-      "unityLabel": "Unidad",
+      "quorumLabel": "QUÓRUM",
+      "unityLabel": "UNIDAD",
       "quorumUnityLine": "{quorumPercent}% {quorumLabel} | {unityPercent}% {unityLabel}",
       "uploadImageLabel": "<accent>Subir</accent> una imagen",
       "addAttachmentLabel": "Agregar archivo adjunto (JPEG, PNG, WebP o PDF, máximo 16 MB)",
@@ -1668,7 +1671,8 @@
       "title": "Transferir fondos",
       "content": "Envía fondos fácilmente desde tu billetera a un miembro o un espacio.",
       "form": {
-        "amountLabel": "Cantidad"
+        "amountLabel": "Cantidad",
+        "submitLabel": "Transferir"
       }
     },
     "redeemTokens": {
@@ -2070,7 +2074,8 @@
       "mutualCreditEligibleSpaces": "Espacios elegibles",
       "mutualCreditEligibleSpacesAdded": "Espacios elegibles añadidos",
       "mutualCreditEligibleSpacesRemoved": "Espacios elegibles eliminados",
-      "spaceLogoAlt": "Logo de {title}"
+      "spaceLogoAlt": "Logo de {title}",
+      "attachments": "Adjuntos"
     },
     "entryMethods": {
       "openAccess": "Acceso abierto",
@@ -2170,7 +2175,14 @@
     "selectReferenceCurrency": "Selecciona una moneda de referencia",
     "tokenPriceGreaterThanZero": "Introduce un precio de token mayor que 0",
     "updateTokenLabel": "Actualizar token",
-    "spaceInformationMissing": "Falta información del espacio. Inténtalo de nuevo."
+    "spaceInformationMissing": "Falta información del espacio. Inténtalo de nuevo.",
+    "voteButton": {
+      "voteNow": "Votar ahora",
+      "youVotedYes": "Votaste Sí",
+      "youVotedNo": "Votaste No",
+      "noVote": "Sin voto",
+      "confirmDecision": "Confirmar decisión"
+    }
   },
   "AiPanel": {
     "title": "Hypha AI",

--- a/packages/i18n/src/messages/fr.json
+++ b/packages/i18n/src/messages/fr.json
@@ -61,7 +61,9 @@
       "fileTooLarge": "Votre image est trop volumineuse (max. 16 Mo) et n’a pas pu être téléversée. Réduisez-la et réessayez.",
       "uploadFailed": "Le fichier n’a pas pu être téléversé."
     },
-    "Pipeline": "Pipeline"
+    "Pipeline": "Pipeline",
+    "durationHours": "{count, plural, one {# heure} other {# heures}}",
+    "durationDays": "{count, plural, one {# jour} other {# jours}}"
   },
   "ModalAside": {
     "spaceSettings": "Paramètres de l’espace",
@@ -902,7 +904,8 @@
       "title": "Transférer des fonds",
       "content": "Envoyez facilement des fonds depuis votre portefeuille vers un membre ou un espace.",
       "form": {
-        "amountLabel": "Montant"
+        "amountLabel": "Montant",
+        "submitLabel": "Transférer"
       }
     },
     "redeemTokens": {
@@ -1343,8 +1346,8 @@
       "proposalMinimumVotingIconAlt": "Icône de durée minimale de vote",
       "autoExecution": "Exécution automatique",
       "toVote": "{duration} pour voter",
-      "quorumLabel": "Quorum",
-      "unityLabel": "Unité",
+      "quorumLabel": "QUORUM",
+      "unityLabel": "UNITÉ",
       "quorumUnityLine": "{quorumPercent}% {quorumLabel} | {unityPercent}% {unityLabel}",
       "uploadImageLabel": "<accent>Téléverser</accent> une image",
       "addAttachmentLabel": "Ajouter une pièce jointe (JPEG, PNG, WebP ou PDF — max 16 Mo)",
@@ -1729,7 +1732,8 @@
           "vaultLine": "Dans le coffre : {amount} {symbol}",
           "priceLine": "Prix : {currency}{price}",
           "requestedLine": "Demandé : {currency}{amount}"
-        }
+        },
+        "redemptionAmountLabel": "Montant de rachat"
       },
       "tokenPercentageFieldArray": {
         "convertedInto": "Converti en",
@@ -2070,7 +2074,8 @@
       "mutualCreditEligibleSpaces": "Espaces éligibles",
       "mutualCreditEligibleSpacesAdded": "Espaces éligibles ajoutés",
       "mutualCreditEligibleSpacesRemoved": "Espaces éligibles retirés",
-      "spaceLogoAlt": "Logo de {title}"
+      "spaceLogoAlt": "Logo de {title}",
+      "attachments": "Pièces jointes"
     },
     "entryMethods": {
       "openAccess": "Accès libre",
@@ -2170,7 +2175,14 @@
     "selectReferenceCurrency": "Veuillez sélectionner une devise de référence",
     "tokenPriceGreaterThanZero": "Veuillez saisir un prix de token supérieur à 0",
     "updateTokenLabel": "Mettre à jour le token",
-    "spaceInformationMissing": "Les informations de l'espace sont manquantes. Veuillez réessayer."
+    "spaceInformationMissing": "Les informations de l'espace sont manquantes. Veuillez réessayer.",
+    "voteButton": {
+      "voteNow": "Voter maintenant",
+      "youVotedYes": "Vous avez voté Oui",
+      "youVotedNo": "Vous avez voté Non",
+      "noVote": "Aucun vote",
+      "confirmDecision": "Confirmer la décision"
+    }
   },
   "AiPanel": {
     "title": "Hypha AI",

--- a/packages/i18n/src/messages/mk.json
+++ b/packages/i18n/src/messages/mk.json
@@ -61,7 +61,9 @@
       "uploadFailed": "Датотеката не можеше да се прикачи."
     },
     "Energy": "Енергија",
-    "Pipeline": "Пајплајн"
+    "Pipeline": "Пајплајн",
+    "durationHours": "{count, plural, one {# час} other {# часа}}",
+    "durationDays": "{count, plural, one {# ден} other {# дена}}"
   },
   "ModalAside": {
     "spaceSettings": "Поставки на просторот",
@@ -1445,7 +1447,8 @@
       "title": "Префрли средства",
       "content": "Лесно испрати средства од твојот паричник до член или простор.",
       "form": {
-        "amountLabel": "Износ"
+        "amountLabel": "Износ",
+        "submitLabel": "Пренеси"
       }
     },
     "redeemTokens": {
@@ -1886,8 +1889,8 @@
       "proposalMinimumVotingIconAlt": "Икона за минимално гласање на предлогот",
       "autoExecution": "Автоматско извршување",
       "toVote": "{duration} за гласање",
-      "quorumLabel": "Кворум",
-      "unityLabel": "Единство",
+      "quorumLabel": "КВОРУМ",
+      "unityLabel": "ЕДИНСТВО",
       "quorumUnityLine": "{quorumPercent}% {quorumLabel} | {unityPercent}% {unityLabel}",
       "uploadImageLabel": "<accent>Прикачете</accent> слика",
       "addAttachmentLabel": "Додај прилог (JPEG, PNG, WebP или PDF — макс. 16MB)",
@@ -2275,7 +2278,8 @@
           "vaultLine": "Во сефот: {amount} {symbol}",
           "priceLine": "Цена: {currency}{price}",
           "requestedLine": "Побарано: {currency}{amount}"
-        }
+        },
+        "redemptionAmountLabel": "Износ за откуп"
       },
       "tokenPercentageFieldArray": {
         "convertedInto": "Конвертирано во",
@@ -2616,7 +2620,8 @@
       "mutualCreditEligibleSpaces": "Квалификувани простори",
       "mutualCreditEligibleSpacesAdded": "Додадени квалификувани простори",
       "mutualCreditEligibleSpacesRemoved": "Отстранети квалификувани простори",
-      "spaceLogoAlt": "Лого на {title}"
+      "spaceLogoAlt": "Лого на {title}",
+      "attachments": "Прилози"
     },
     "entryMethods": {
       "openAccess": "Отворен пристап",
@@ -2716,7 +2721,14 @@
     "selectReferenceCurrency": "Те молиме избери референтна валута",
     "tokenPriceGreaterThanZero": "Те молиме внеси цена на токенот поголема од 0",
     "updateTokenLabel": "Ажурирај токен",
-    "spaceInformationMissing": "Недостасуваат информации за просторот. Те молиме обиди се повторно."
+    "spaceInformationMissing": "Недостасуваат информации за просторот. Те молиме обиди се повторно.",
+    "voteButton": {
+      "voteNow": "Гласај сега",
+      "youVotedYes": "Гласавте Да",
+      "youVotedNo": "Гласавте Не",
+      "noVote": "Без глас",
+      "confirmDecision": "Потврди одлука"
+    }
   },
   "AiPanel": {
     "title": "Hypha AI",

--- a/packages/i18n/src/messages/nl.json
+++ b/packages/i18n/src/messages/nl.json
@@ -28,7 +28,7 @@
     "otherMembers": "+ andere {count} leden",
     "exploreSpaces": "Verken ruimtes",
     "findCategory": "Zoek een categorie",
-    "noSpacesYet": "Er zijn nog geen ruimtes aangemaakt of lid geworden. Verken ons netwerk en sluit u aan bij een Space, of creëer uw eigen Space.",
+    "noSpacesYet": "Er zijn nog geen ruimtes aangemaakt of lid geworden. Verken ons netwerk en sluit u aan bij een ruimte, of creëer uw eigen ruimte.",
     "close": "Sluiten",
     "comingSoonBadge": "Binnenkort",
     "notFoundOops": "Oeps!",
@@ -61,7 +61,9 @@
       "fileTooLarge": "Uw afbeelding is te groot (max. 16 MB) en kan niet worden geüpload. Pas het formaat aan en probeer het opnieuw.",
       "uploadFailed": "Bestand kon niet worden geüpload."
     },
-    "Pipeline": "Pipeline"
+    "Pipeline": "Pipeline",
+    "durationHours": "{count, plural, one {# uur} other {# uur}}",
+    "durationDays": "{count, plural, one {# dag} other {# dagen}}"
   },
   "ModalAside": {
     "spaceSettings": "Ruimte-instellingen",
@@ -134,10 +136,10 @@
     "subtitle": "Maak er een moedige, intelligente organisatie van die ernaar handelt.",
     "returnSubtitle": "Vervolg uw reis — of vraag Hypha AI wat u vervolgens moet doen.",
     "heroPill": {
-      "build": "Bouwen",
-      "together": ", Samen.",
+      "build": "Bouw",
+      "together": ", samen.",
       "rotating": {
-        "anything": "Iets",
+        "anything": "iets",
         "projects": "Projecten",
         "startUps": "Start-ups",
         "ventures": "Ondernemingen",
@@ -223,9 +225,9 @@
     },
     "spacePlaceholder": "Selecteer een ruimte",
     "spaceSearchPlaceholder": "Zoek ruimtes...",
-    "searchToSeeSpaces": "Begin met typen om overeenkomende spaties te zien.",
+    "searchToSeeSpaces": "Begin met typen om overeenkomende ruimtes te zien.",
     "selected": "Gekozen",
-    "noSpacesFound": "Geen spaties gevonden.",
+    "noSpacesFound": "Geen ruimtes gevonden.",
     "loadingSpaces": "Laadruimtes...",
     "explore": {
       "title": "Verken het netwerk",
@@ -416,7 +418,7 @@
   "SpaceSettingsAction": {
     "title": "Ruimte-instellingen",
     "content": "Open en beheer de instellingen voor uw ruimte, inclusief het uiterlijk, de structuur, de methoden, het lidmaatschap en de schatkist.",
-    "searchMenus": "Zoekmenu's",
+    "searchMenus": "Zoek instellingen",
     "noMenusFound": "Geen menu's gevonden",
     "groups": {
       "overview": "Overzicht",
@@ -543,7 +545,7 @@
     "content": "Selecteer een actie om bij te dragen, samen te werken, beslissingen te nemen of bronnen binnen uw ruimte te beheren.",
     "actions": {
       "makeCollectiveAgreement": {
-        "title": "Maak een CAO",
+        "title": "Beleidsvoorstel",
         "description": "Definieer en formaliseer een wederzijds begrip, beleid of besluit tussen de leden van de ruimte."
       },
       "proposeContribution": {
@@ -577,7 +579,7 @@
     }
   },
   "SelectActivateAction": {
-    "title": "Activeer Spatie",
+    "title": "Activeer ruimte",
     "content": "Kies een van de onderstaande opties om uw Space te activeren en alle functies te ontgrendelen die beschikbaar zijn op het Hypha Network.",
     "actions": {
       "depositFunds": {
@@ -617,7 +619,7 @@
       "noAccessAddSpace": "U heeft geen toegang om ruimtes toe te voegen aan deze organisatie.",
       "visitSpace": "Bezoek Ruimte",
       "searchSpaces": "Zoek ruimtes",
-      "noSpacesFound": "Geen spaties gevonden"
+      "noSpacesFound": "Geen ruimtes gevonden"
     }
   },
   "AgreementsTab": {
@@ -655,7 +657,7 @@
       "delegatedVotingMember": "Gedelegeerd stemgerechtigd lid",
       "findMember": "Vind lid",
       "noMembersFound": "Geen leden gevonden.",
-      "save": "Redden",
+      "save": "Opslaan",
       "delegating": "Delegeren...",
       "undelegate": "Niet-delegeren",
       "undelegating": "Delegeren ongedaan maken...",
@@ -1244,7 +1246,7 @@
     "depositFunds": "Stort geld",
     "listIsEmpty": "Lijst is leeg",
     "emptyAssetsTreasury": "Uw schatkist bevat nog geen activa. Stort geld of maak een ruimtetoken om aan de slag te gaan.",
-    "emptyAssetsWallet": "Uw portemonnee bevat nog geen activa. Koop ruimtefiches of HYPHA om te beginnen met het opbouwen van uw saldo.",
+    "emptyAssetsWallet": "Uw portemonnee bevat nog geen activa. Koop ruimtetokens of HYPHA om te beginnen met het opbouwen van uw saldo.",
     "emptyAssetsSearch": "Er zijn geen items die overeenkomen met uw zoekopdracht.",
     "loadMoreAssets": "Laad meer items",
     "transactions": "Transacties",
@@ -1351,7 +1353,7 @@
       },
       "actions": {
         "retry": "Opnieuw proberen",
-        "save": "Redden"
+        "save": "Opslaan"
       },
       "errors": {
         "firstNameRequired": "Voer uw voornaam in",
@@ -1396,7 +1398,7 @@
         "description": "Sponsor en activeer uw favoriete ruimte(s) door een bijdrage te leveren aan HYPHA of USDC, ter ondersteuning van het Hypha-netwerk."
       },
       "migrateHyphaTokens": {
-        "title": "Hypha-tokens migreren (Telos → Basis)",
+        "title": "Hypha-tokens migreren (Telos → Base)",
         "description": "Verplaats uw Hypha-tokens van de Telos-blockchain naar het basisnetwerk. Initieert de migratie-ervaring."
       },
       "redeemTokens": {
@@ -1449,7 +1451,7 @@
         "errors": {
           "selectSpaceToActivate": "Selecteer een ruimte om te activeren.",
           "monthsRequired": "Voer het aantal maanden in dat u wilt activeren.",
-          "atLeastOneSpace": "Er moet minimaal één spatie worden toegevoegd",
+          "atLeastOneSpace": "Er moet minimaal één ruimte worden toegevoegd",
           "recipientRequired": "Voeg een ontvanger of portefeuilleadres toe",
           "invalidEthereumAddress": "Ongeldig Ethereum-adres",
           "invalidWalletAddress": "Ongeldig portemonnee-adres",
@@ -1465,7 +1467,8 @@
       "title": "Geld overmaken",
       "content": "Stuur eenvoudig geld vanuit uw portemonnee naar een lid of een ruimte.",
       "form": {
-        "amountLabel": "Hoeveelheid"
+        "amountLabel": "Hoeveelheid",
+        "submitLabel": "Overmaken"
       }
     },
     "redeemTokens": {
@@ -1513,7 +1516,7 @@
           "profileLoadFailed": "Kan profielgegevens niet laden",
           "noWalletAddress": "Profiel heeft geen portemonnee-adres",
           "spacesLoadFailed": "Kan ledenruimten niet laden",
-          "spacesFallback": "Het opzoeken van lidmaatschapsruimten leverde geen spaties op; gebruik makend van een fallback voor wallet-tokenruimtes",
+          "spacesFallback": "Het opzoeken van lidmaatschapsruimten leverde geen ruimtes op; gebruik makend van een fallback voor wallet-tokenruimtes",
           "noSpaces": "Er zijn geen ruimtes gevonden voor dit lid",
           "balanceReadFailed": "Kan het saldo in de keten niet lezen voor {failed}/{total} kluistoken(s)",
           "noVaultTokens": "Er zijn geen kluistokens gevonden die inwisselen mogelijk maken",
@@ -1523,7 +1526,7 @@
       }
     },
     "errors": {
-      "loadSpaces": "Kan spaties niet laden. Probeer het later opnieuw."
+      "loadSpaces": "Kan ruimtes niet laden. Probeer het later opnieuw."
     }
   },
   "Network": {
@@ -1597,7 +1600,7 @@
       "amountRequired": "Voer een bedrag in",
       "amountPositive": "Bedrag moet groter zijn dan 0"
     },
-    "empty": "Er zijn momenteel geen ruimtefiches te koop.",
+    "empty": "Er zijn momenteel geen ruimtetokens te koop.",
     "eligibilityLoadError": "Kan niet controleren welke tokens beschikbaar zijn. Probeer het opnieuw.",
     "selectToken": "Selecteer Token",
     "selectPlaceholder": "Selecteer een token",
@@ -1627,8 +1630,8 @@
     "configureSpace": "Configureer ruimte",
     "nameYourSpace": "Geef uw ruimte een naam...",
     "createdBy": "Gemaakt door",
-    "uploadSpaceBanner": "Uploaden",
-    "spaceBanner": "ruimte spandoek",
+    "uploadSpaceBanner": "Ruimtebanner",
+    "spaceBanner": "uploaden",
     "purpose": "Doel",
     "purposePlaceholder": "Typ hier uw ruimtedoel...",
     "organisationLevel": "Organisatieniveau",
@@ -1652,7 +1655,7 @@
     "selectParentError": "Selecteer een gekoppelde ruimte of schakel 'Rootruimte' in",
     "slugFieldRegex": "Dit veld mag alleen kleine letters, cijfers, koppeltekens en apostrofs bevatten.",
     "slugAlreadyExists": "Ruimte-ID bestaat al",
-    "slugAlreadyExistsLong": "Er bestaat al een spatie met deze naam. Kies een andere naam voor uw ruimte.",
+    "slugAlreadyExistsLong": "Er bestaat al een ruimte met deze naam. Kies een andere naam voor uw ruimte.",
     "alreadyMember": "Al lid",
     "invitePending": "Uitnodiging in behandeling",
     "requestInvite": "Vraag uitnodiging aan",
@@ -1672,7 +1675,7 @@
     "getStarted": "Aan de slag",
     "accessDeniedNotMember": "Om toegang te krijgen tot deze functie moet u lid worden. Word nu lid van de ruimte om de activiteit van deze ruimte te bekijken.",
     "accessDenied": "Toegang geweigerd",
-    "noSpaces": "Geen spaties",
+    "noSpaces": "Geen ruimtes",
     "errorOhSnap": "O knap! Er is een fout opgetreden",
     "reset": "Opnieuw instellen",
     "backToSettings": "Terug naar Instellingen",
@@ -1715,7 +1718,7 @@
     "ecosystemLogoLightDescription": "Upload een lichtmoduslogo voor uw ecosysteem (PNG, JPG, GIF of WEBP).",
     "ecosystemLogoDarkDescription": "Upload een logo in de donkere modus voor uw ecosysteem (PNG, JPG, GIF of WEBP).",
     "search": "Zoekopdracht...",
-    "noSpacesFound": "Geen spaties gevonden",
+    "noSpacesFound": "Geen ruimtes gevonden",
     "addYourUrl": "Voeg uw URL toe",
     "exchangeDepositProposalTitleBanner": "Voltooi de zijde van een uitwisseling op dit veld",
     "exchangeDepositProposalBody": "Een ruilvoorstel vermeldt deze ruimte als tegenpartij (escrow #{escrowId}). Maak een voorstel om <send></send> te storten en <receive></receive> te ontvangen van de andere partij.",
@@ -1744,7 +1747,7 @@
   },
   "AgreementFlow": {
     "labels": {
-      "activateSpaces": "Activeer spaties",
+      "activateSpaces": "Activeer ruimtes",
       "votingMethod": "Stemmethode",
       "entryMethod": "Invoermethode",
       "membershipExit": "Lidmaatschap verlaten",
@@ -1786,7 +1789,7 @@
       "publish": "Publiceren"
     },
     "pageErrors": {
-      "loadSpaces": "Kan spaties niet laden. Probeer het later opnieuw."
+      "loadSpaces": "Kan ruimtes niet laden. Probeer het later opnieuw."
     },
     "spaceConfiguration": {
       "update": "Update",
@@ -1906,10 +1909,10 @@
       "proposalMinimumVotingIconAlt": "Voorstel minimum stempictogram",
       "autoExecution": "Automatische uitvoering",
       "toVote": "{duration} om te stemmen",
-      "quorumLabel": "Quorum",
-      "unityLabel": "Eenheid",
+      "quorumLabel": "quorum",
+      "unityLabel": "eenheid",
       "quorumUnityLine": "{quorumPercent}% {quorumLabel} | {unityPercent}% {unityLabel}",
-      "uploadImageLabel": "<accent>Upload</accent> een afbeelding",
+      "uploadImageLabel": "<accent>Voorbeeldafbeelding</accent> uploaden",
       "addAttachmentLabel": "Bijlage toevoegen (JPEG, PNG, WebP of PDF – max. 16 MB)",
       "proposalContent": "Voorstel Inhoud",
       "proposalContentPlaceholder": "Typ hier de inhoud van uw voorstel...",
@@ -2144,7 +2147,7 @@
             "selectMemberPlaceholder": "Lid selecteren...",
             "selectSpacePlaceholder": "Selecteer ruimte...",
             "noMembersFound": "Er zijn geen leden die overeenkomen met uw zoekopdracht.",
-            "noSpacesFound": "Er zijn geen spaties die overeenkomen met uw zoekopdracht.",
+            "noSpacesFound": "Er zijn geen ruimtes die overeenkomen met uw zoekopdracht.",
             "blockchainAddress": "Blockchain-adres",
             "spaceAccessScope": "Toegangsbereik ruimte",
             "spaceAccessScopeDescription": "Schakel in of overdrachten het volledige lidmaatschap van de ruimte moeten omvatten of alleen het ruimte-account.",
@@ -2197,7 +2200,7 @@
           "eligibleSpacesLabel": "In aanmerking komende ruimtes",
           "eligibleSpacesDescription": "Leden van deze ruimtes kunnen gebruik maken van de kredietlijn. De uitgifteruimte is altijd inbegrepen.",
           "currentSpaceTag": "ruimte uitgeven",
-          "addSpacePlaceholder": "Voeg een spatie toe...",
+          "addSpacePlaceholder": "Voeg een ruimte toe...",
           "removeSpace": "Ruimte verwijderen"
         },
         "authorizedMinters": {
@@ -2295,7 +2298,8 @@
           "vaultLine": "In kluis: {amount} {symbol}",
           "priceLine": "Prijs: {currency}{price}",
           "requestedLine": "Gevraagd: {currency}{amount}"
-        }
+        },
+        "redemptionAmountLabel": "Inwisselbedrag"
       },
       "tokenPercentageFieldArray": {
         "convertedInto": "Omgezet in",
@@ -2411,7 +2415,7 @@
         "currentSpaceTag": "Huidige ruimte",
         "allBalance": "Allemaal balans",
         "noMembersFound": "Geen leden gevonden.",
-        "noSpacesFound": "Geen spaties gevonden.",
+        "noSpacesFound": "Geen ruimtes gevonden.",
         "allBalanceWarning": "Wanneer 'Alle saldo' is geselecteerd, wordt het volledige tokensaldo voor dit lid of deze ruimte permanent verbrand.",
         "add": "Toevoegen",
         "remove": "Verwijderen"
@@ -2420,7 +2424,7 @@
         "spaces": "Ruimte(n)",
         "contribution": "Bijdrage:",
         "contributionPerMonthPerSpace": "$ 11 per maand per ruimte",
-        "removeSpace": "Verwijder de spatie",
+        "removeSpace": "Verwijder de ruimte",
         "addSpace": "Voeg ruimte toe",
         "selectSpace": "Selecteer Ruimte",
         "selectSpacePlaceholder": "Selecteer ruimte...",
@@ -2635,8 +2639,9 @@
       "mutualCreditLimit": "Standaard kredietlimiet",
       "mutualCreditEligibleSpaces": "In aanmerking komende ruimtes",
       "mutualCreditEligibleSpacesAdded": "In aanmerking komende ruimtes toegevoegd",
-      "mutualCreditEligibleSpacesRemoved": "In aanmerking komende spaties verwijderd",
-      "spaceLogoAlt": "{title}-logo"
+      "mutualCreditEligibleSpacesRemoved": "In aanmerking komende ruimtes verwijderd",
+      "spaceLogoAlt": "{title}-logo",
+      "attachments": "Bijlagen"
     },
     "entryMethods": {
       "openAccess": "Open toegang",
@@ -2736,7 +2741,14 @@
     "selectReferenceCurrency": "Selecteer een referentievaluta",
     "tokenPriceGreaterThanZero": "Voer een tokenprijs in die groter is dan 0",
     "updateTokenLabel": "Token bijwerken",
-    "spaceInformationMissing": "Ruimte-informatie ontbreekt. Probeer het opnieuw."
+    "spaceInformationMissing": "Ruimte-informatie ontbreekt. Probeer het opnieuw.",
+    "voteButton": {
+      "voteNow": "Stem nu",
+      "youVotedYes": "Je stemde Ja",
+      "youVotedNo": "Je stemde Nee",
+      "noVote": "Geen stem",
+      "confirmDecision": "Bevestig beslissing"
+    }
   },
   "AiPanel": {
     "title": "Hypha AI",
@@ -2779,11 +2791,11 @@
     "copyButton": "Kopiëren",
     "copiedButton": "Gekopieerd!",
     "toolLookingUp": "Ruimte opzoeken...",
-    "toolLookingUpSlug": "Spatie opzoeken \"{slug}\"...",
+    "toolLookingUpSlug": "Ruimte opzoeken \"{slug}\"...",
     "toolCompleted": "Gereedschapsoproep voltooid.",
     "toolFoundSpace": "{title} ({slug}) - {memberCount} leden, {documentCount} overeenkomsten gevonden",
     "toolNoSpace": "Geen ruimte gevonden voor naaktslak \"{slug}\"",
-    "toolTokens": "{count} token(s) opgehaald voor spatie \"{slug}\".",
+    "toolTokens": "{count} token(s) opgehaald voor ruimte \"{slug}\".",
     "toolError": "Fout: {message}",
     "pendingAction": "Actie in behandeling",
     "confirmWith": "Bevestig met:",
@@ -3606,7 +3618,7 @@
     "signalFormStatus": "Status",
     "signalFormStatusHint": "Workflowfase voor dit signaal (weergegeven als kolommen in Kanban Board- en Swimlane-weergaven).",
     "signalFormBoard": "Categorie bord",
-    "signalFormBoardHint": "Organisatorische zwembaan: groepeert signalen per team, initiatief of werkstroom. Niet hetzelfde als Type (Opportunity/Risk/Insight) of Tags.",
+    "signalFormBoardHint": "Organisatorische swimlane: groepeert signalen per team, initiatief of werkstroom. Niet hetzelfde als Type (Kans/Risico/Inzicht) of Tags.",
     "signalFormDueDate": "Deadline",
     "signalFormDueDateHint": "Optionele streefdatum voor het volgen van deze signaaltaak.",
     "signalFormVotingPower": "Jouw stemkracht",
@@ -3618,7 +3630,7 @@
     "linkedCalendarEventsEmpty": "Er zijn nog geen agenda-evenementen gekoppeld.",
     "linkedCalendarEventsOpenCalendar": "Kalender openen",
     "signalWorkflowSettingsTitle": "Signaalworkflow",
-    "signalWorkflowSettingsDescription": "Pas Kanban-kolommen (statussen) en zwembaanrijen (bordcategorieën) aan voor signalen in deze ruimte.",
+    "signalWorkflowSettingsDescription": "Pas Kanban-kolommen (statussen) en swimlane-rijen (bordcategorieën) aan voor signalen in deze ruimte.",
     "signalWorkflowStatuses": "Kanban-statussen",
     "signalWorkflowBoards": "Bordcategorieën",
     "signalWorkflowAddStatus": "Status toevoegen",
@@ -3785,7 +3797,7 @@
     "fieldDescriptionPlaceholder": "Agenda, deelnemers of context",
     "createdAt": "Gemaakt {date}",
     "cancel": "Annuleren",
-    "save": "Redden",
+    "save": "Opslaan",
     "saving": "Besparing…",
     "delete": "Verwijderen",
     "deleteConfirmTitle": "Gepland item verwijderen",
@@ -4028,7 +4040,7 @@
         "adminAddress": "Beheerdersadres (ruimte-uitvoerder)",
         "adminHint": "Automatisch ingevuld met de executor van deze space.",
         "stablecoinAddress": "Stablecoin-adres",
-        "stablecoinPlaceholder": "0x... (standaard ingesteld op Basis USDC)",
+        "stablecoinPlaceholder": "0x... (standaard ingesteld op Base USDC)",
         "gridOperatorAddress": "Adres netbeheerder (optioneel)",
         "gridOperatorPlaceholder": "0x... (standaard ingesteld op uitvoerder)",
         "communityFeeAddress": "Adres gemeenschapsbijdrage (optioneel)",

--- a/packages/i18n/src/messages/no.json
+++ b/packages/i18n/src/messages/no.json
@@ -60,7 +60,9 @@
       "genericUploadFallback": "<accent>Last opp</accent> et bilde",
       "fileTooLarge": "Bildet ditt er for stort (maks 16 MB) og kunne ikke lastes opp. Endre størrelsen og prøv igjen.",
       "uploadFailed": "Filen kunne ikke lastes opp."
-    }
+    },
+    "durationHours": "{count, plural, one {# time} other {# timer}}",
+    "durationDays": "{count, plural, one {# dag} other {# dager}}"
   },
   "ModalAside": {
     "spaceSettings": "Rominnstillinger",
@@ -1464,7 +1466,8 @@
       "title": "Overfør midler",
       "content": "Send enkelt midler fra lommeboken din til et medlem eller et rom.",
       "form": {
-        "amountLabel": "Beløp"
+        "amountLabel": "Beløp",
+        "submitLabel": "Overfør"
       }
     },
     "redeemTokens": {
@@ -1903,8 +1906,8 @@
       "proposalMinimumVotingIconAlt": "Ikon for minste avstemning for forslag",
       "autoExecution": "Automatisk utførelse",
       "toVote": "{duration} til å stemme",
-      "quorumLabel": "Quorum",
-      "unityLabel": "Enighet",
+      "quorumLabel": "QUORUM",
+      "unityLabel": "ENIGHET",
       "quorumUnityLine": "{quorumPercent}% {quorumLabel} | {unityPercent}% {unityLabel}",
       "uploadImageLabel": "<accent>Last opp</accent> et bilde",
       "addAttachmentLabel": "Legg til vedlegg (JPEG, PNG, WebP eller PDF — maks 16 MB)",
@@ -2292,7 +2295,8 @@
           "vaultLine": "I hvelvet: {amount} {symbol}",
           "priceLine": "Pris: {currency}{price}",
           "requestedLine": "Forespurt: {currency}{amount}"
-        }
+        },
+        "redemptionAmountLabel": "Innløsningsbeløp"
       },
       "tokenPercentageFieldArray": {
         "convertedInto": "Konvertert til",
@@ -2633,7 +2637,8 @@
       "mutualCreditEligibleSpaces": "Kvalifiserte rom",
       "mutualCreditEligibleSpacesAdded": "Kvalifiserte rom lagt til",
       "mutualCreditEligibleSpacesRemoved": "Kvalifiserte rom fjernet",
-      "spaceLogoAlt": "{title}-logo"
+      "spaceLogoAlt": "{title}-logo",
+      "attachments": "Vedlegg"
     },
     "entryMethods": {
       "openAccess": "Åpen tilgang",
@@ -2733,7 +2738,14 @@
     "selectReferenceCurrency": "Velg en referansevaluta",
     "tokenPriceGreaterThanZero": "Angi en tokenpris større enn 0",
     "updateTokenLabel": "Oppdater token",
-    "spaceInformationMissing": "Informasjon om rommet mangler. Prøv igjen."
+    "spaceInformationMissing": "Informasjon om rommet mangler. Prøv igjen.",
+    "voteButton": {
+      "voteNow": "Stem nå",
+      "youVotedYes": "Du stemte Ja",
+      "youVotedNo": "Du stemte Nei",
+      "noVote": "Ingen stemme",
+      "confirmDecision": "Bekreft beslutning"
+    }
   },
   "AiPanel": {
     "title": "Hypha AI",

--- a/packages/i18n/src/messages/pt.json
+++ b/packages/i18n/src/messages/pt.json
@@ -61,7 +61,9 @@
       "fileTooLarge": "Sua imagem é muito grande (máx. 16 MB) e não foi possível carregá-la. Reduza o tamanho e tente novamente.",
       "uploadFailed": "Não foi possível carregar o arquivo."
     },
-    "Pipeline": "Pipeline"
+    "Pipeline": "Pipeline",
+    "durationHours": "{count, plural, one {# hora} other {# horas}}",
+    "durationDays": "{count, plural, one {# dia} other {# dias}}"
   },
   "ModalAside": {
     "spaceSettings": "Definições do espaço",
@@ -466,7 +468,8 @@
           "vaultLine": "No cofre: {amount} {symbol}",
           "priceLine": "Preço: {currency}{price}",
           "requestedLine": "Solicitado: {currency}{amount}"
-        }
+        },
+        "redemptionAmountLabel": "Valor de resgate"
       },
       "tokenPercentageFieldArray": {
         "convertedInto": "Convertido em",
@@ -782,8 +785,8 @@
       "proposalMinimumVotingIconAlt": "Ícone de votação mínima da proposta",
       "autoExecution": "Execução automática",
       "toVote": "{duration} para votar",
-      "quorumLabel": "Quórum",
-      "unityLabel": "Unidade",
+      "quorumLabel": "QUÓRUM",
+      "unityLabel": "UNIDADE",
       "quorumUnityLine": "{quorumPercent}% {quorumLabel} | {unityPercent}% {unityLabel}",
       "uploadImageLabel": "<accent>Carregar</accent> uma imagem",
       "addAttachmentLabel": "Adicionar anexo (JPEG, PNG, WebP ou PDF — máximo 16 MB)",
@@ -1668,7 +1671,8 @@
       "title": "Transferir fundos",
       "content": "Envie facilmente fundos da sua carteira para um membro ou espaço.",
       "form": {
-        "amountLabel": "Quantia"
+        "amountLabel": "Quantia",
+        "submitLabel": "Transferir"
       }
     },
     "redeemTokens": {
@@ -2070,7 +2074,8 @@
       "mutualCreditEligibleSpaces": "Espaços elegíveis",
       "mutualCreditEligibleSpacesAdded": "Espaços elegíveis adicionados",
       "mutualCreditEligibleSpacesRemoved": "Espaços elegíveis removidos",
-      "spaceLogoAlt": "Logo de {title}"
+      "spaceLogoAlt": "Logo de {title}",
+      "attachments": "Anexos"
     },
     "entryMethods": {
       "openAccess": "Acesso aberto",
@@ -2170,7 +2175,14 @@
     "selectReferenceCurrency": "Selecione uma moeda de referência",
     "tokenPriceGreaterThanZero": "Digite um preço de token maior que 0",
     "updateTokenLabel": "Atualizar token",
-    "spaceInformationMissing": "Faltam informações do espaço. Tente novamente."
+    "spaceInformationMissing": "Faltam informações do espaço. Tente novamente.",
+    "voteButton": {
+      "voteNow": "Votar agora",
+      "youVotedYes": "Você votou Sim",
+      "youVotedNo": "Você votou Não",
+      "noVote": "Sem voto",
+      "confirmDecision": "Confirmar decisão"
+    }
   },
   "AiPanel": {
     "title": "Hypha AI",

--- a/packages/ui-utils/src/formatDuration.ts
+++ b/packages/ui-utils/src/formatDuration.ts
@@ -1,10 +1,26 @@
-export const formatDuration = (seconds: number): string => {
+export type DurationParts = {
+  unit: 'hours' | 'days';
+  count: number;
+};
+
+/**
+ * Split a duration in seconds into a display unit and count, so callers can
+ * localize the unit label (e.g. via next-intl plural messages).
+ */
+export const getDurationParts = (seconds: number): DurationParts => {
   const hours = seconds / 3600;
-  const days = hours / 24;
 
   if (hours < 24) {
-    return `${hours} Hour${hours !== 1 ? 's' : ''}`;
-  } else {
-    return `${days} Day${days !== 1 ? 's' : ''}`;
+    return { unit: 'hours', count: hours };
   }
+  return { unit: 'days', count: hours / 24 };
+};
+
+export const formatDuration = (seconds: number): string => {
+  const { unit, count } = getDurationParts(seconds);
+
+  if (unit === 'hours') {
+    return `${count} Hour${count !== 1 ? 's' : ''}`;
+  }
+  return `${count} Day${count !== 1 ? 's' : ''}`;
 };

--- a/packages/ui/src/upload/attachments-list.tsx
+++ b/packages/ui/src/upload/attachments-list.tsx
@@ -12,6 +12,8 @@ interface Attachment {
 
 interface AttachmentListProps {
   attachments: (string | Attachment)[];
+  /** Section heading; pass a translated string (defaults to English). */
+  label?: React.ReactNode;
 }
 
 function isString(variable: unknown): variable is string {
@@ -58,6 +60,7 @@ function AttachmentRowImage({ src }: { src: string }) {
 
 export const AttachmentList: React.FC<AttachmentListProps> = ({
   attachments,
+  label = 'Attachments',
 }) => {
   const renderFileIcon = (url: string, displayFileName: string) => {
     const extFromName = extensionFromFileName(displayFileName);
@@ -77,7 +80,7 @@ export const AttachmentList: React.FC<AttachmentListProps> = ({
 
   return (
     <div className="flex flex-col w-full">
-      {attachments.length > 0 && <Label>Attachments</Label>}
+      {attachments.length > 0 && <Label>{label}</Label>}
       <div className="space-y-2 mt-2 w-full">
         {attachments.map((attachment, idx) => {
           const fileName = isString(attachment)

--- a/packages/ui/src/upload/attachments-list.tsx
+++ b/packages/ui/src/upload/attachments-list.tsx
@@ -10,7 +10,7 @@ interface Attachment {
   url: string;
 }
 
-interface AttachmentListProps {
+export interface AttachmentListProps {
   attachments: (string | Attachment)[];
   /** Section heading; pass a translated string (defaults to English). */
   label?: React.ReactNode;


### PR DESCRIPTION
## Summary

Fixes the Dutch (nl) translation issues reported in review, in two categories:

### 1. Mistranslations in `nl.json`

| Before | After |
|---|---|
| "spatie(s)" (whitespace) for spaces/DAOs — 19 keys incl. "Verwijder de spatie", "Geen spaties gevonden", "Activeer spaties", "Begin met typen om overeenkomende spaties te zien" | "ruimte(s)" |
| "Redden" (to rescue) on save buttons (calendar event form, profile edit, delegate section) | "Opslaan" |
| "ruimtefiches" | "ruimtetokens" (consistent with "Ruimtetokens kopen") |
| "Basis" for the Base network ("Telos → Basis", "Basis USDC") | "Base" (brand name, untranslated; "Basisprijs per kWh" untouched — there it really means base price) |
| "Maak een CAO" | "Beleidsvoorstel" |
| "Bouwen Iets, Samen." (onboarding hero) | "Bouw iets, samen." |
| "Uploaden ruimte spandoek" | "Ruimtebanner uploaden" |
| "creëer uw eigen Space" | "creëer uw eigen ruimte" |
| "Zoekmenu's" (settings search placeholder) | "Zoek instellingen" |
| "Organisatorische zwembaan" (signal board tooltip) | "Organisatorische swimlane" (+ Opportunity/Risk/Insight → Kans/Risico/Inzicht) |
| "20% QUORUM \| 80% EENHEID" | "20% quorum \| 80% eenheid" |
| "Upload een afbeelding" (proposal file upload) | "Voorbeeldafbeelding uploaden" |

### 2. Hardcoded English strings, now localized (keys added to all 8 locales)

- **Vote buttons** (`vote-proposal-button.tsx`): Vote Now / You Voted Yes / You Voted No / No Vote / Confirm Decision → `ProposalDetails.voteButton.*` (nl: Stem nu / Je stemde Ja / Je stemde Nee / Bevestig beslissing)
- **Agreement detail attachments**: `AttachmentList` got a `label` prop; proposal detail passes the translated label (nl: Bijlagen)
- **Redeem Tokens form**: panel label, "Redemption Amount" (nl: Inwisselbedrag), and "Publish" (nl: Publiceren) now use translations
- **Transfer form**: submit button uses new `ProfileActions.transferFunds.form.submitLabel` (nl: Overmaken)
- **"3 Days om te stemmen"**: `formatDuration` hardcoded English units; added `getDurationParts` to `ui-utils` and ICU plural keys `Common.durationDays/durationHours` (nl: "3 dagen om te stemmen")
- **Calendar month/day names** ("July 2026", MON/TUE/…): `nl` (plus `mk`, `no`) were missing from the date-fns locale map and fell back to English — now render "juli 2026" and MA/DI/WO/DO/VR/ZA/ZO
- **Quorum/unity caption casing**: was forced to ALL CAPS via CSS `uppercase`; casing now lives in the locale values (other locales keep their previous all-caps look, nl is lowercase)

### Not fixable in app code
- **"Choose Files"** on file inputs is the browser's native control label — it follows the browser UI language, not the app locale.

### Verification
- `pnpm verify:messages` ✓ (key parity across 8 locales)
- `tsc --noEmit` on `@hypha-platform/epics` ✓
- Prettier on all touched files ✓

Confirmed correct, unchanged: "Ondersteun Hypha", "Onlangs bezocht".

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added localized labels for voting actions, proposal attachments, token redemptions, and fund transfers.
  * Added clearer voting duration displays using hours or days.
  * Added support for Macedonian, Dutch, and Norwegian date formatting.
* **Improvements**
  * Standardized agreement quorum and unity labels with updated capitalization.
  * Removed unnecessary uppercase styling from voting threshold summaries.
  * Expanded translations across English, German, Spanish, French, Macedonian, Dutch, Norwegian, and Portuguese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->