### PR TITLE
fix(airdrop): block ownership airdrops to non-members at creation

### DIFF
--- a/packages/core/src/governance/client/hooks/__tests__/assert-airdrop-ownership-recipients.test.ts
+++ b/packages/core/src/governance/client/hooks/__tests__/assert-airdrop-ownership-recipients.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const readContract = vi.fn();
+const multicall = vi.fn();
+
+vi.mock('../../../../common/web3/public-client', () => ({
+  publicClient: {
+    readContract: (...args: unknown[]) => readContract(...args),
+    multicall: (...args: unknown[]) => multicall(...args),
+  },
+}));
+
+vi.mock('../governance-chain-id', () => ({
+  getGovernanceChainId: () => 8453,
+}));
+
+import {
+  AIRDROP_OWNERSHIP_MEMBERSHIP_CHECK_FAILED,
+  AIRDROP_OWNERSHIP_RECIPIENT_NOT_MEMBER,
+  assertAirdropOwnershipRecipientsAreMembers,
+} from '../assert-airdrop-ownership-recipients';
+
+const OWNERSHIP_TOKEN = '0xeDCcFE61355f0Cb63B3C7265730dC1f60aD96827' as const;
+const MEMBER = '0xbEda819cE46126EeAeA7f738d0593Cac3501Ac4d' as const;
+const NON_MEMBER = '0xA7236dFFf74d1393726265f623fafCe6A7EC7366' as const;
+const OTHER_TOKEN = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913' as const;
+
+describe('assertAirdropOwnershipRecipientsAreMembers', () => {
+  beforeEach(() => {
+    readContract.mockReset();
+    multicall.mockReset();
+  });
+
+  it('no-ops when the token is not a space ownership token', async () => {
+    readContract.mockResolvedValueOnce([OWNERSHIP_TOKEN]);
+
+    await expect(
+      assertAirdropOwnershipRecipientsAreMembers({
+        spaceId: 1143,
+        tokenAddress: OTHER_TOKEN,
+        recipients: [NON_MEMBER],
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(multicall).not.toHaveBeenCalled();
+  });
+
+  it('allows ownership airdrops when every recipient is a member', async () => {
+    readContract.mockResolvedValueOnce([OWNERSHIP_TOKEN]);
+    multicall.mockResolvedValueOnce([true]);
+
+    await expect(
+      assertAirdropOwnershipRecipientsAreMembers({
+        spaceId: 1143,
+        tokenAddress: OWNERSHIP_TOKEN,
+        recipients: [MEMBER],
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(multicall).toHaveBeenCalledOnce();
+  });
+
+  it('rejects ownership airdrops that include a non-member', async () => {
+    readContract.mockResolvedValueOnce([OWNERSHIP_TOKEN]);
+    multicall.mockResolvedValueOnce([true, false]);
+
+    await expect(
+      assertAirdropOwnershipRecipientsAreMembers({
+        spaceId: 1143,
+        tokenAddress: OWNERSHIP_TOKEN,
+        recipients: [MEMBER, NON_MEMBER],
+      }),
+    ).rejects.toThrow(AIRDROP_OWNERSHIP_RECIPIENT_NOT_MEMBER);
+  });
+
+  it('surfaces a retryable error when ownership token lookup fails', async () => {
+    readContract.mockRejectedValueOnce(new Error('rpc down'));
+
+    await expect(
+      assertAirdropOwnershipRecipientsAreMembers({
+        spaceId: 1143,
+        tokenAddress: OWNERSHIP_TOKEN,
+        recipients: [MEMBER],
+      }),
+    ).rejects.toThrow(AIRDROP_OWNERSHIP_MEMBERSHIP_CHECK_FAILED);
+  });
+});

--- a/packages/core/src/governance/client/hooks/assert-airdrop-ownership-recipients.ts
+++ b/packages/core/src/governance/client/hooks/assert-airdrop-ownership-recipients.ts
@@ -1,0 +1,96 @@
+import { getAddress, isAddress } from 'viem';
+
+import { publicClient } from '../../../common/web3/public-client';
+import {
+  getSpaceOwnershipTokens,
+  isMember,
+} from '../../../space/client/web3/dao-space-factory';
+import { getGovernanceChainId } from './governance-chain-id';
+
+/** Stable English message mapped in `proposal-error-translations`. */
+export const AIRDROP_OWNERSHIP_RECIPIENT_NOT_MEMBER =
+  'Ownership token airdrop recipients must be space members.';
+
+export const AIRDROP_OWNERSHIP_MEMBERSHIP_CHECK_FAILED =
+  'Could not verify ownership token recipient membership. Please try again.';
+
+const isEvmAddress = (value: string): value is `0x${string}` =>
+  isAddress(value, { strict: false });
+
+/**
+ * Ownership-space tokens (`OwnershipSpaceToken`) revert transfers/mints from the
+ * space executor to non-members with `!member`. That failure is wrapped by the
+ * Executor as a generic treasury error at vote-auto-execution time.
+ *
+ * Call this before `createProposal` so invalid airdrops never reach the chain.
+ *
+ * No-ops when the token is not one of the space's ownership tokens.
+ */
+export async function assertAirdropOwnershipRecipientsAreMembers({
+  spaceId,
+  tokenAddress,
+  recipients,
+}: {
+  spaceId: number;
+  tokenAddress: string;
+  recipients: readonly string[];
+}): Promise<void> {
+  if (!isEvmAddress(tokenAddress)) {
+    return;
+  }
+
+  const uniqueRecipients = [
+    ...new Set(
+      recipients
+        .map((r) => r?.trim())
+        .filter((r): r is string => Boolean(r) && isEvmAddress(r))
+        .map((r) => getAddress(r)),
+    ),
+  ];
+  if (uniqueRecipients.length === 0) {
+    return;
+  }
+
+  const chainId = getGovernanceChainId();
+  const spaceIdBigInt = BigInt(spaceId);
+  const token = getAddress(tokenAddress);
+
+  let ownershipTokens: readonly `0x${string}`[];
+  try {
+    ownershipTokens = await publicClient.readContract(
+      getSpaceOwnershipTokens({ spaceId: spaceIdBigInt, chain: chainId }),
+    );
+  } catch {
+    throw new Error(AIRDROP_OWNERSHIP_MEMBERSHIP_CHECK_FAILED);
+  }
+
+  const isOwnershipToken = ownershipTokens.some(
+    (addr) => getAddress(addr) === token,
+  );
+  if (!isOwnershipToken) {
+    return;
+  }
+
+  let membershipResults: readonly boolean[];
+  try {
+    membershipResults = await publicClient.multicall({
+      allowFailure: false,
+      contracts: uniqueRecipients.map((memberAddress) =>
+        isMember({
+          spaceId: spaceIdBigInt,
+          memberAddress,
+          chain: chainId,
+        }),
+      ),
+    });
+  } catch {
+    throw new Error(AIRDROP_OWNERSHIP_MEMBERSHIP_CHECK_FAILED);
+  }
+
+  const nonMembers = uniqueRecipients.filter(
+    (_, index) => membershipResults[index] !== true,
+  );
+  if (nonMembers.length > 0) {
+    throw new Error(AIRDROP_OWNERSHIP_RECIPIENT_NOT_MEMBER);
+  }
+}

--- a/packages/core/src/governance/client/hooks/useAirdropMutations.web3.rpc.ts
+++ b/packages/core/src/governance/client/hooks/useAirdropMutations.web3.rpc.ts
@@ -18,6 +18,7 @@ import {
 } from '@hypha-platform/core/client';
 import { getDuration } from '@hypha-platform/ui-utils';
 import { getGovernanceChainId } from './governance-chain-id';
+import { assertAirdropOwnershipRecipientsAreMembers } from './assert-airdrop-ownership-recipients';
 
 export type AirdropMethod = 'transfer' | 'mint';
 
@@ -32,6 +33,12 @@ interface CreateAirdropInput {
   spaceId: number;
   airdrop: AirdropAllocation[];
 }
+
+export {
+  AIRDROP_OWNERSHIP_RECIPIENT_NOT_MEMBER,
+  AIRDROP_OWNERSHIP_MEMBERSHIP_CHECK_FAILED,
+  assertAirdropOwnershipRecipientsAreMembers,
+} from './assert-airdrop-ownership-recipients';
 
 const chainId = getGovernanceChainId();
 
@@ -62,6 +69,17 @@ export const useAirdropMutationsWeb3Rpc = ({
     async (_, { arg }: { arg: CreateAirdropInput }) => {
       if (!client) {
         throw new Error('Smart wallet client not available');
+      }
+
+      // Ownership tokens revert executor transfers/mints to non-members. Block
+      // proposal creation up front so Auto-Execution cannot fail at vote time.
+      const tokenAddress = arg.airdrop[0]?.token;
+      if (tokenAddress) {
+        await assertAirdropOwnershipRecipientsAreMembers({
+          spaceId: arg.spaceId,
+          tokenAddress,
+          recipients: arg.airdrop.map((allocation) => allocation.recipient),
+        });
       }
 
       // readContract can throw (RPC/contract errors); fall back to a safe

--- a/packages/epics/src/agreements/plugins/airdrop/airdrop-recipients-field-array.tsx
+++ b/packages/epics/src/agreements/plugins/airdrop/airdrop-recipients-field-array.tsx
@@ -370,6 +370,16 @@ export const AirdropRecipientsFieldArray = ({
             </div>
           ))}
 
+          <FormField
+            control={control}
+            name={`${name}.recipients`}
+            render={() => (
+              <FormItem>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
           <div className="flex justify-end w-full">
             <Button
               className="w-fit"

--- a/packages/epics/src/agreements/utils/proposal-error-translations.ts
+++ b/packages/epics/src/agreements/utils/proposal-error-translations.ts
@@ -48,6 +48,10 @@ const PROPOSAL_ERROR_KEY_MAP: Record<string, string> = {
     'proposalErrors.atLeastOneAirdropRecipient',
   'Too many recipients for one airdrop proposal.':
     'proposalErrors.tooManyAirdropRecipients',
+  'Ownership token airdrop recipients must be space members.':
+    'proposalErrors.airdropOwnershipRecipientsMustBeMembers',
+  'Could not verify ownership token recipient membership. Please try again.':
+    'proposalErrors.airdropOwnershipMembershipCheckFailed',
   'Please enter a purchase amount.': 'proposalErrors.purchaseAmountRequired',
   'Please select a space to activate.': 'proposalErrors.selectSpaceToActivate',
   'Please enter the number of months to activate.':

--- a/packages/epics/src/governance/components/create-airdrop-form.tsx
+++ b/packages/epics/src/governance/components/create-airdrop-form.tsx
@@ -7,6 +7,8 @@ import {
   useJwt,
   useMe,
   useCreateAirdropOrchestrator,
+  assertAirdropOwnershipRecipientsAreMembers,
+  AIRDROP_OWNERSHIP_RECIPIENT_NOT_MEMBER,
 } from '@hypha-platform/core/client';
 import { z } from 'zod';
 import { Button, Form, Separator } from '@hypha-platform/ui';
@@ -112,6 +114,30 @@ export const CreateAirdropForm = ({
     if (!recipients || recipients.length === 0) {
       console.error('Airdrop recipients are missing');
       return;
+    }
+
+    // Ownership tokens only allow executor transfers/mints to on-chain members.
+    // Validate before starting the orchestrator so we never create a doomed
+    // Web2/Web3 proposal (hard gate also lives in useAirdropMutationsWeb3Rpc).
+    if (typeof web3SpaceId === 'number' && token) {
+      try {
+        await assertAirdropOwnershipRecipientsAreMembers({
+          spaceId: web3SpaceId,
+          tokenAddress: token,
+          recipients: recipients.map((row) => row.recipient),
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        const translationKey =
+          message === AIRDROP_OWNERSHIP_RECIPIENT_NOT_MEMBER
+            ? 'proposalErrors.airdropOwnershipRecipientsMustBeMembers'
+            : 'proposalErrors.airdropOwnershipMembershipCheckFailed';
+        form.setError('airdrop.recipients', {
+          type: 'manual',
+          message: tAgreementFlow(translationKey),
+        });
+        return;
+      }
     }
 
     // The token and method are chosen once; expand into one allocation per

--- a/packages/i18n/src/messages/de.json
+++ b/packages/i18n/src/messages/de.json
@@ -1827,6 +1827,8 @@
       "atLeastOnePayoutRequired": "Mindestens eine Auszahlung ist erforderlich",
       "atLeastOneAirdropRecipient": "Mindestens ein Airdrop-Empfänger ist erforderlich",
       "tooManyAirdropRecipients": "Zu viele Empfänger für einen einzigen Airdrop-Vorschlag.",
+      "airdropOwnershipRecipientsMustBeMembers": "Empfänger von Ownership-Token-Airdrops müssen Space-Mitglieder sein.",
+      "airdropOwnershipMembershipCheckFailed": "Die Mitgliedschaft der Ownership-Token-Empfänger konnte nicht geprüft werden. Bitte versuche es erneut.",
       "purchaseAmountRequired": "Bitte geben Sie einen Kaufbetrag ein.",
       "selectSpaceToActivate": "Bitte wählen Sie einen Space zur Aktivierung aus.",
       "monthsToActivateRequired": "Bitte geben Sie die Anzahl der Monate für die Aktivierung ein.",

--- a/packages/i18n/src/messages/en.json
+++ b/packages/i18n/src/messages/en.json
@@ -1824,6 +1824,8 @@
       "atLeastOnePayoutRequired": "At least one payout is required",
       "atLeastOneAirdropRecipient": "At least one airdrop recipient is required",
       "tooManyAirdropRecipients": "Too many recipients for one airdrop proposal.",
+      "airdropOwnershipRecipientsMustBeMembers": "Ownership token airdrop recipients must be space members.",
+      "airdropOwnershipMembershipCheckFailed": "Could not verify ownership token recipient membership. Please try again.",
       "purchaseAmountRequired": "Please enter a purchase amount.",
       "selectSpaceToActivate": "Please select a space to activate.",
       "monthsToActivateRequired": "Please enter the number of months to activate.",

--- a/packages/i18n/src/messages/es.json
+++ b/packages/i18n/src/messages/es.json
@@ -96,6 +96,8 @@
       "atLeastOnePayoutRequired": "Se requiere al menos un pago",
       "atLeastOneAirdropRecipient": "Se requiere al menos un destinatario del airdrop",
       "tooManyAirdropRecipients": "Demasiados destinatarios para una propuesta de airdrop.",
+      "airdropOwnershipRecipientsMustBeMembers": "Los destinatarios del airdrop de tokens de ownership deben ser miembros del espacio.",
+      "airdropOwnershipMembershipCheckFailed": "No se pudo verificar la membresía de los destinatarios del token de ownership. Inténtalo de nuevo.",
       "purchaseAmountRequired": "Ingresa un monto de compra.",
       "selectSpaceToActivate": "Selecciona un espacio para activar.",
       "monthsToActivateRequired": "Ingresa la cantidad de meses para activar.",

--- a/packages/i18n/src/messages/fr.json
+++ b/packages/i18n/src/messages/fr.json
@@ -1263,6 +1263,8 @@
       "atLeastOnePayoutRequired": "Au moins un paiement est requis",
       "atLeastOneAirdropRecipient": "Au moins un destinataire de l'airdrop est requis",
       "tooManyAirdropRecipients": "Trop de destinataires pour une seule proposition d'airdrop.",
+      "airdropOwnershipRecipientsMustBeMembers": "Les destinataires d’un airdrop de jetons d’ownership doivent être membres de l’espace.",
+      "airdropOwnershipMembershipCheckFailed": "Impossible de vérifier l’appartenance des destinataires du jeton d’ownership. Veuillez réessayer.",
       "purchaseAmountRequired": "Veuillez saisir un montant d'achat.",
       "selectSpaceToActivate": "Veuillez sélectionner un espace à activer.",
       "monthsToActivateRequired": "Veuillez saisir le nombre de mois à activer.",

--- a/packages/i18n/src/messages/mk.json
+++ b/packages/i18n/src/messages/mk.json
@@ -1804,6 +1804,8 @@
       "atLeastOnePayoutRequired": "Потребна е барем една исплата",
       "atLeastOneAirdropRecipient": "Потребен е барем еден примач на ердропот",
       "tooManyAirdropRecipients": "Премногу примачи за еден предлог за ердроп.",
+      "airdropOwnershipRecipientsMustBeMembers": "Примачите на аирдроп со ownership токени мора да бидат членови на просторот.",
+      "airdropOwnershipMembershipCheckFailed": "Не можеше да се провери членството на примачите на ownership токенот. Обидете се повторно.",
       "purchaseAmountRequired": "Ве молиме внесете износ за купување.",
       "selectSpaceToActivate": "Ве молиме изберете простор за активирање.",
       "monthsToActivateRequired": "Ве молиме внесете број на месеци за активирање.",

--- a/packages/i18n/src/messages/nl.json
+++ b/packages/i18n/src/messages/nl.json
@@ -1824,6 +1824,8 @@
       "atLeastOnePayoutRequired": "Er is minimaal één uitbetaling vereist",
       "atLeastOneAirdropRecipient": "Er is minimaal één airdrop-ontvanger vereist",
       "tooManyAirdropRecipients": "Te veel ontvangers voor één airdrop-voorstel.",
+      "airdropOwnershipRecipientsMustBeMembers": "Ontvangers van een ownership-token-airdrop moeten space-leden zijn.",
+      "airdropOwnershipMembershipCheckFailed": "Kon het lidmaatschap van de ownership-token-ontvangers niet verifiëren. Probeer het opnieuw.",
       "purchaseAmountRequired": "Vul een aankoopbedrag in.",
       "selectSpaceToActivate": "Selecteer een ruimte om te activeren.",
       "monthsToActivateRequired": "Voer het aantal maanden in dat u wilt activeren.",

--- a/packages/i18n/src/messages/no.json
+++ b/packages/i18n/src/messages/no.json
@@ -1821,6 +1821,8 @@
       "atLeastOnePayoutRequired": "Minst én utbetaling er påkrevd",
       "atLeastOneAirdropRecipient": "Minst én airdrop-mottaker er påkrevd",
       "tooManyAirdropRecipients": "For mange mottakere for ett airdrop-forslag.",
+      "airdropOwnershipRecipientsMustBeMembers": "Mottakere av ownership-token-airdrop må være space-medlemmer.",
+      "airdropOwnershipMembershipCheckFailed": "Kunne ikke bekrefte medlemskap for mottakere av ownership-token. Prøv igjen.",
       "purchaseAmountRequired": "Angi et kjøpsbeløp.",
       "selectSpaceToActivate": "Velg et rom som skal aktiveres.",
       "monthsToActivateRequired": "Angi antall måneder som skal aktiveres.",

--- a/packages/i18n/src/messages/pt.json
+++ b/packages/i18n/src/messages/pt.json
@@ -98,6 +98,8 @@
       "atLeastOnePayoutRequired": "Pelo menos um pagamento é obrigatório",
       "atLeastOneAirdropRecipient": "É necessário pelo menos um destinatário do airdrop",
       "tooManyAirdropRecipients": "Muitos destinatários para uma proposta de airdrop.",
+      "airdropOwnershipRecipientsMustBeMembers": "Os destinatários do airdrop de tokens de ownership devem ser membros do espaço.",
+      "airdropOwnershipMembershipCheckFailed": "Não foi possível verificar a associação dos destinatários do token de ownership. Tente novamente.",
       "purchaseAmountRequired": "Digite um valor de compra.",
       "selectSpaceToActivate": "Selecione um espaço para ativar.",
       "monthsToActivateRequired": "Digite o número de meses para ativar.",


### PR DESCRIPTION
## Summary
- Ownership tokens (`OwnershipSpaceToken`) revert executor transfers/mints to non-members with `!member`, which the Executor wraps as a misleading “insufficient treasury funds” error at Auto-Execution time.
- Validate on-chain recipient membership during airdrop proposal creation (form submit + Web3 `createProposal` gate) so invalid proposals cannot be created.
- Adds i18n error copy across locales and unit coverage for the membership assert helper.

## Test plan
- [ ] Create an airdrop of an ownership token to a **non-member** wallet → publish is blocked with the membership error; no on-chain proposal is created
- [ ] Create an airdrop of an ownership token to **members only** → publish succeeds
- [ ] Create an airdrop of a non-ownership token (e.g. USDC / regular space token) to a non-member → still allowed
- [ ] `pnpm --filter @hypha-platform/core exec vitest run src/governance/client/hooks/__tests__/assert-airdrop-ownership-recipients.test.ts`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ownership-token airdrops now check that all provided recipients are space members before creating a proposal.
  * Proposal creation is blocked with a clear recipient-specific error when any recipient isn’t a member or when membership can’t be verified.
* **UI Improvements**
  * Recipients validation messages at the field-array level are now shown in the manual entry form.
* **Localization**
  * Added new translated proposal validation/error messages for ownership-token recipient membership checks.
* **Tests**
  * Added automated coverage for member verification success, non-member rejection, skipped checks, and verification failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->