### PR TITLE
feat(coherence): add external signal ingestion API for community apps

### DIFF
--- a/apps/web/.env.template
+++ b/apps/web/.env.template
@@ -13,6 +13,9 @@ MUTUAL_CREDIT_WHITELIST_SIGNER_PRIVATE_KEY=
 # On-chain mirror of signal upvotes (optional; off when unset)
 SIGNALS_CONTRACT_ADDRESS=
 SIGNALS_RELAYER_PRIVATE_KEY=
+# Issues/revokes per-space integration keys for external signal ingestion.
+# Ops-only on purpose: public spaces must never expose their write credentials.
+HYPHA_SPACE_API_KEY_OPS_SECRET=
 
 # Escrow proxy (EscrowImplementation) for Accept Investment — optional override (defaults to Base mainnet address in code, same batch as DAO proposals).
 # Set only if you deploy a different proxy: cd packages/storage-evm && npx hardhat run scripts/escrow-proxy.deploy.ts --network <network>

--- a/apps/web/.env.template
+++ b/apps/web/.env.template
@@ -118,7 +118,8 @@ MATRIX_PASSWORD_SECRET=
 # LiveKit JWT service (MatrixRTC SFU) — local dev fallback when .well-known has no rtc_foci.
 # NEXT_PUBLIC_LIVEKIT_JWT_SERVICE_URL=http://localhost:8080
 
-# Feature flags — AI / Coherence / Space Memory / Human Chat default to OFF in code.
+# Feature flags — AI / Coherence / Space Memory / Human Chat default to ON in code; set these to
+# false as an instant rollback.
 # (NEXT_PUBLIC_* are build-time: rebuild after change.) For runtime without rebuild, use HYPHA_ENABLE_*
 # cookies; see @hypha-platform/feature-flags.
 # NEXT_PUBLIC_ENABLE_AI_CHAT=true

--- a/apps/web/src/app/api/v1/ops/_lib/ops-auth.ts
+++ b/apps/web/src/app/api/v1/ops/_lib/ops-auth.ts
@@ -4,6 +4,14 @@ import type { NextRequest } from 'next/server';
 /**
  * Compare secrets through their digests so neither length nor content leaks
  * through timing.
+ *
+ * The digest only exists to hand `timingSafeEqual` two equal-length buffers —
+ * it is never persisted, so hash strength is not what protects the secret. What
+ * protects it is that the operator generates a high-entropy value (see the
+ * integration docs) and keeps it to the ops team.
+ *
+ * CodeQL flags this as `js/insufficient-password-hash`; the rule assumes a
+ * password is being hashed for storage, which is not what happens here.
  */
 export function opsSecretMatches(presented: string, expected: string): boolean {
   const digest = (value: string) =>

--- a/apps/web/src/app/api/v1/ops/_lib/ops-auth.ts
+++ b/apps/web/src/app/api/v1/ops/_lib/ops-auth.ts
@@ -1,4 +1,15 @@
+import { createHash, timingSafeEqual } from 'node:crypto';
 import type { NextRequest } from 'next/server';
+
+/**
+ * Compare secrets through their digests so neither length nor content leaks
+ * through timing.
+ */
+export function opsSecretMatches(presented: string, expected: string): boolean {
+  const digest = (value: string) =>
+    createHash('sha256').update(value, 'utf8').digest();
+  return timingSafeEqual(digest(presented), digest(expected));
+}
 
 export function readOpsSecret(request: NextRequest): string {
   const explicitSecret = request.headers.get('x-hypha-ops-secret')?.trim();

--- a/apps/web/src/app/api/v1/ops/spaces/[spaceSlug]/api-keys/[keyId]/route.ts
+++ b/apps/web/src/app/api/v1/ops/spaces/[spaceSlug]/api-keys/[keyId]/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  findSpaceBySlug,
+  revokeSpaceApiKey,
+} from '@hypha-platform/core/server';
+import { db } from '@hypha-platform/storage-postgres';
+
+import { authorizeSpaceApiKeyOps } from '../_lib/authorize-ops';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+type Params = { spaceSlug: string; keyId: string };
+
+/** Revoke a key. Idempotent: revoking an already-revoked key returns 404. */
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<Params> },
+) {
+  const denied = authorizeSpaceApiKeyOps(request);
+  if (denied) return denied;
+
+  const { spaceSlug, keyId } = await params;
+  const id = Number.parseInt(keyId, 10);
+  if (!Number.isInteger(id) || id < 1) {
+    return NextResponse.json({ error: 'Invalid key id' }, { status: 400 });
+  }
+
+  try {
+    const space = await findSpaceBySlug({ slug: spaceSlug }, { db });
+    if (!space) {
+      return NextResponse.json({ error: 'Space not found' }, { status: 404 });
+    }
+
+    const revoked = await revokeSpaceApiKey({ id, spaceId: space.id }, { db });
+    if (!revoked) {
+      return NextResponse.json(
+        { error: 'No active key with that id for this space' },
+        { status: 404 },
+      );
+    }
+
+    return NextResponse.json({ revoked: true, id });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error('Failed to revoke space API key:', {
+      spaceSlug,
+      keyId,
+      message,
+    });
+    return NextResponse.json(
+      { error: 'Failed to revoke space API key' },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/src/app/api/v1/ops/spaces/[spaceSlug]/api-keys/[keyId]/route.ts
+++ b/apps/web/src/app/api/v1/ops/spaces/[spaceSlug]/api-keys/[keyId]/route.ts
@@ -21,8 +21,10 @@ export async function DELETE(
   if (denied) return denied;
 
   const { spaceSlug, keyId } = await params;
-  const id = Number.parseInt(keyId, 10);
-  if (!Number.isInteger(id) || id < 1) {
+  // Match the whole segment: `parseInt` would read "1junk" as 1 and revoke a
+  // key the caller never named.
+  const id = /^[1-9]\d*$/.test(keyId) ? Number(keyId) : Number.NaN;
+  if (!Number.isSafeInteger(id)) {
     return NextResponse.json({ error: 'Invalid key id' }, { status: 400 });
   }
 

--- a/apps/web/src/app/api/v1/ops/spaces/[spaceSlug]/api-keys/_lib/authorize-ops.ts
+++ b/apps/web/src/app/api/v1/ops/spaces/[spaceSlug]/api-keys/_lib/authorize-ops.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { opsSecretMatches, readOpsSecret } from '../../../../_lib/ops-auth';
+
+/**
+ * Guard for space API key administration. Returns a response to send back when
+ * the caller is not authorized, or null to continue.
+ */
+export function authorizeSpaceApiKeyOps(
+  request: NextRequest,
+): NextResponse | null {
+  const configuredSecret =
+    process.env.HYPHA_SPACE_API_KEY_OPS_SECRET?.trim() ?? '';
+  if (!configuredSecret) {
+    return NextResponse.json(
+      { error: 'HYPHA_SPACE_API_KEY_OPS_SECRET is not configured' },
+      { status: 503 },
+    );
+  }
+
+  const presented = readOpsSecret(request);
+  if (!presented || !opsSecretMatches(presented, configuredSecret)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  return null;
+}

--- a/apps/web/src/app/api/v1/ops/spaces/[spaceSlug]/api-keys/route.ts
+++ b/apps/web/src/app/api/v1/ops/spaces/[spaceSlug]/api-keys/route.ts
@@ -1,0 +1,119 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  createSpaceApiKey,
+  findSpaceBySlug,
+  listSpaceApiKeys,
+  schemaCreateSpaceApiKey,
+} from '@hypha-platform/core/server';
+import { db } from '@hypha-platform/storage-postgres';
+
+import { authorizeSpaceApiKeyOps } from './_lib/authorize-ops';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+type Params = { spaceSlug: string };
+
+/**
+ * Issue an integration key for a space.
+ *
+ * Deliberately behind the ops secret rather than space membership: a space can
+ * be fully public, and anyone able to read a space must never be able to read
+ * or mint its write credentials. The plaintext key is returned by this call
+ * only — afterwards only its SHA-256 digest exists.
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<Params> },
+) {
+  const denied = authorizeSpaceApiKeyOps(request);
+  if (denied) return denied;
+
+  const { spaceSlug } = await params;
+
+  try {
+    const space = await findSpaceBySlug({ slug: spaceSlug }, { db });
+    if (!space) {
+      return NextResponse.json({ error: 'Space not found' }, { status: 404 });
+    }
+
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+    }
+
+    const parsed = schemaCreateSpaceApiKey.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: 'Validation failed', details: parsed.error.flatten() },
+        { status: 400 },
+      );
+    }
+
+    const existing = await listSpaceApiKeys({ spaceId: space.id }, { db });
+    if (
+      existing.some(
+        (key) => key.source === parsed.data.source && key.revokedAt === null,
+      )
+    ) {
+      return NextResponse.json(
+        {
+          error: `An active key already exists for source "${parsed.data.source}". Revoke it before issuing a replacement.`,
+        },
+        { status: 409 },
+      );
+    }
+
+    const { key, plaintext } = await createSpaceApiKey(
+      { spaceId: space.id, ...parsed.data },
+      { db },
+    );
+
+    return NextResponse.json(
+      {
+        key,
+        apiKey: plaintext,
+        warning:
+          'Store this key now — it is not recoverable. Never expose it in client-side code.',
+      },
+      { status: 201 },
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error('Failed to issue space API key:', { spaceSlug, message });
+    return NextResponse.json(
+      { error: 'Failed to issue space API key' },
+      { status: 500 },
+    );
+  }
+}
+
+/** List key metadata for a space. Never returns key material. */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<Params> },
+) {
+  const denied = authorizeSpaceApiKeyOps(request);
+  if (denied) return denied;
+
+  const { spaceSlug } = await params;
+
+  try {
+    const space = await findSpaceBySlug({ slug: spaceSlug }, { db });
+    if (!space) {
+      return NextResponse.json({ error: 'Space not found' }, { status: 404 });
+    }
+
+    const keys = await listSpaceApiKeys({ spaceId: space.id }, { db });
+    return NextResponse.json({ keys });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error('Failed to list space API keys:', { spaceSlug, message });
+    return NextResponse.json(
+      { error: 'Failed to list space API keys' },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/src/app/api/v1/ops/spaces/[spaceSlug]/api-keys/route.ts
+++ b/apps/web/src/app/api/v1/ops/spaces/[spaceSlug]/api-keys/route.ts
@@ -1,8 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import {
+  buildPaginatedResponse,
   createSpaceApiKey,
   findSpaceBySlug,
+  isUniqueViolation,
   listSpaceApiKeys,
+  parseHttpPaginationParams,
   schemaCreateSpaceApiKey,
 } from '@hypha-platform/core/server';
 import { db } from '@hypha-platform/storage-postgres';
@@ -13,6 +16,15 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 type Params = { spaceSlug: string };
+
+function activeKeyConflict(source: string) {
+  return NextResponse.json(
+    {
+      error: `An active key already exists for source "${source}". Revoke it before issuing a replacement.`,
+    },
+    { status: 409 },
+  );
+}
 
 /**
  * Issue an integration key for a space.
@@ -58,18 +70,24 @@ export async function POST(
         (key) => key.source === parsed.data.source && key.revokedAt === null,
       )
     ) {
-      return NextResponse.json(
-        {
-          error: `An active key already exists for source "${parsed.data.source}". Revoke it before issuing a replacement.`,
-        },
-        { status: 409 },
-      );
+      return activeKeyConflict(parsed.data.source);
     }
 
-    const { key, plaintext } = await createSpaceApiKey(
-      { spaceId: space.id, ...parsed.data },
-      { db },
-    );
+    let issued: Awaited<ReturnType<typeof createSpaceApiKey>>;
+    try {
+      issued = await createSpaceApiKey(
+        { spaceId: space.id, ...parsed.data },
+        { db },
+      );
+    } catch (error) {
+      // The check above cannot see a key a concurrent request is inserting, so
+      // the index has the last word — report it as the same conflict.
+      if (isUniqueViolation(error, 'space_api_keys_space_source_unique')) {
+        return activeKeyConflict(parsed.data.source);
+      }
+      throw error;
+    }
+    const { key, plaintext } = issued;
 
     return NextResponse.json(
       {
@@ -106,8 +124,21 @@ export async function GET(
       return NextResponse.json({ error: 'Space not found' }, { status: 404 });
     }
 
+    // A space holds one key per integration, so paging the loaded rows is
+    // cheaper than a second count query and still honours the list contract.
+    const { page, pageSize } = parseHttpPaginationParams(new URL(request.url), {
+      defaultPageSize: 50,
+    });
     const keys = await listSpaceApiKeys({ spaceId: space.id }, { db });
-    return NextResponse.json({ keys });
+    const offset = (page - 1) * pageSize;
+    return NextResponse.json(
+      buildPaginatedResponse(
+        keys.slice(offset, offset + pageSize),
+        keys.length,
+        page,
+        pageSize,
+      ),
+    );
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.error('Failed to list space API keys:', { spaceSlug, message });

--- a/apps/web/src/app/api/v1/spaces/[spaceSlug]/signals/README.md
+++ b/apps/web/src/app/api/v1/spaces/[spaceSlug]/signals/README.md
@@ -1,0 +1,511 @@
+# Signals Ingestion API
+
+Let a community's **own app** publish signals onto the Hypha **Signals Board** of one Space.
+
+Ingested signals are written into the same `coherences` table the board already reads, so they show
+up in the Coherence tab at `/{lang}/dho/{spaceSlug}/coherence` next to signals raised inside Hypha.
+There is no separate view and no sync step.
+
+**Base URL (production):** `https://app.hypha.earth`
+**Auth:** per-space API key, issued by Hypha ops
+**Scopes:** `signals:write` (create + update), `signals:upvote` (record + remove upvotes)
+
+```
+Community app ──x-hypha-api-key──▶ POST /api/v1/spaces/{spaceSlug}/signals
+                                      │
+                                      ├─ verify key + scope against this space
+                                      ├─ credit a known Hypha person, else the space
+                                      └─ insert into coherences (source = <your slug>)
+                                            │
+                                            ▼
+                                     Signals Board (existing UI)
+```
+
+There are two sides to setting this up. **Part 1** is what you do inside Hypha. **Part 2** is what
+the other app's developer does. You can hand Part 2, or
+[`docs/integrations/external-signal-ingestion.md`](../../../../../../../../../docs/integrations/external-signal-ingestion.md),
+straight to them — it contains no Hypha-internal detail.
+
+---
+
+# Part 1 — What to do on the Hypha side
+
+## Step 1: Confirm the migration is applied
+
+The key table and the ownership columns ship in `0074_space_api_keys_and_signal_source.sql`.
+
+```bash
+pnpm --filter @hypha-platform/storage-postgres run migrate
+```
+
+Verify against the target database:
+
+```sql
+select table_name from information_schema.tables where table_name = 'space_api_keys';
+select column_name from information_schema.columns
+  where table_name = 'coherences' and column_name in ('source', 'external_id');
+```
+
+You want one row from the first query and two from the second. Nothing works before this.
+
+## Step 2: Set the ops secret
+
+Issuing keys is guarded by a single platform secret, `HYPHA_SPACE_API_KEY_OPS_SECRET`. Generate one:
+
+```bash
+openssl rand -base64 32
+```
+
+Set it where the app runs:
+
+- **Production / Preview:** Vercel project → Settings → Environment Variables (server-side, _not_
+  `NEXT_PUBLIC_`). **Redeploy** afterwards — env changes only reach new deployments.
+- **Local:** add it to `apps/web/.env` (the key already exists, unset, in `.env.template`).
+
+Until it is set, the ops endpoints answer `503 HYPHA_SPACE_API_KEY_OPS_SECRET is not configured`.
+
+Keep this secret to the ops team. It can mint write credentials for **every** space.
+
+## Step 3: Find the space slug
+
+It is the segment in the space URL: `https://app.hypha.earth/en/dho/**acme-dao**/coherence` →
+`acme-dao`. Everything below is scoped to that one space.
+
+## Step 4: Agree a `source` slug with the integrator
+
+`source` is a stable identifier for their app, e.g. `acaw-contest`. It is stamped on every signal the
+key writes, and it is what later proves they own those signals — they can only update and upvote
+rows carrying their own `source`.
+
+Rules: lowercase letters, numbers and hyphens, must start alphanumeric, 1–64 characters. **One active
+key per `source` per space.** Pick it once; changing it later orphans every signal already written
+under the old value.
+
+## Step 5: Issue the key
+
+```bash
+export HYPHA_SPACE_API_KEY_OPS_SECRET='<the secret from step 2>'
+
+curl -X POST https://app.hypha.earth/api/v1/ops/spaces/acme-dao/api-keys \
+  -H "x-hypha-ops-secret: $HYPHA_SPACE_API_KEY_OPS_SECRET" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "name": "ACAW contest app",
+    "source": "acaw-contest",
+    "scopes": ["signals:write", "signals:upvote"]
+  }'
+```
+
+`201 Created` — and this is the **only** time `apiKey` is ever returned:
+
+```json
+{
+  "key": {
+    "id": 12,
+    "spaceId": 42,
+    "name": "ACAW contest app",
+    "source": "acaw-contest",
+    "keyPrefix": "K3nQ7bTz",
+    "scopes": ["signals:write", "signals:upvote"],
+    "createdByPersonId": null,
+    "lastUsedAt": null,
+    "revokedAt": null,
+    "createdAt": "2026-07-27T12:00:00.000Z"
+  },
+  "apiKey": "hyk_K3nQ7bTz_x9f…",
+  "warning": "Store this key now — it is not recoverable. Never expose it in client-side code."
+}
+```
+
+Only a SHA-256 digest is stored. If the plaintext is lost, revoke the key and issue a new one —
+there is no recovery path.
+
+Grant `signals:write` alone if the app only files signals and should not vote.
+
+| Response | Meaning                                                                   |
+| -------- | ------------------------------------------------------------------------- |
+| `201`    | Key issued. Capture `apiKey` now.                                         |
+| `400`    | Bad `name`/`source`/`scopes` — see `details` (Zod flatten).               |
+| `401`    | Ops secret missing or wrong.                                              |
+| `404`    | No space with that slug.                                                  |
+| `409`    | An active key already exists for that `source`. Revoke it first (step 9). |
+| `503`    | `HYPHA_SPACE_API_KEY_OPS_SECRET` not configured on this deployment.       |
+
+## Step 6: Hand over the credentials
+
+Send the integrator, over a secure channel:
+
+| What                                   | Example                                                             |
+| -------------------------------------- | ------------------------------------------------------------------- |
+| Base URL                               | `https://app.hypha.earth`                                           |
+| Space slug                             | `acme-dao`                                                          |
+| API key                                | `hyk_K3nQ7bTz_x9f…`                                                 |
+| Their `source`                         | `acaw-contest` (informational — the server derives it from the key) |
+| Valid `progressStatus` / `board` slugs | see step 7                                                          |
+
+Tell them plainly: **the key is server-side only.** It grants write access to the space. Hypha spaces
+can be fully public, so anything reachable from a browser is effectively published.
+
+## Step 7: Give them the space's workflow slugs
+
+`progressStatus` and `board` must be slugs this space actually defines, or the create fails with
+`400 Unknown progress status …`. Both are optional — omitted, a signal lands on the space's first
+backlog status and default board.
+
+Defaults for a space that has never customised its workflow:
+
+- **statuses:** `backlog`, `todo`, `in_progress`, `blocked`, `done`
+- **boards:** `general`
+
+If the space has customised them, read the live config and pass the slugs along:
+
+```bash
+curl https://app.hypha.earth/api/v1/spaces/acme-dao/signal-workflow
+```
+
+Do this yourself rather than asking the integrator to: that endpoint is gated by space
+transparency, not by the API key, so a private space will refuse them.
+
+## Step 8: Verify end to end
+
+Post a test signal with the key you just issued:
+
+```bash
+export HYPHA_SPACE_API_KEY='hyk_K3nQ7bTz_x9f…'
+
+curl -X POST https://app.hypha.earth/api/v1/spaces/acme-dao/signals \
+  -H "x-hypha-api-key: $HYPHA_SPACE_API_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "title": "Integration smoke test",
+    "description": "Delete me once the board shows this.",
+    "type": "Insight",
+    "externalId": "smoke-test-1"
+  }'
+```
+
+Then check, in order:
+
+1. The response is `201` and carries a `url`. Open it — the signal should be on the board.
+2. `attributedTo` is `"space"` here (no `author` was sent), and the card shows the **space's name and
+   logo** as the author.
+3. Re-run the exact same command. You should get `200` and the _same_ `id` — idempotency works.
+4. Repeat with `"author": { "walletAddress": "<a real member's wallet>" }` and a new `externalId`.
+   Expect `attributedTo: "author"` and that member's name on the card.
+5. Archive or delete the test signals from the Hypha UI.
+
+If the board is empty but the API returned `201`, check that Coherence is not switched off for this
+deployment: it defaults **on**, but `NEXT_PUBLIC_ENABLE_COHERENCE=false` (or an `enable-coherence`
+toolbar override) hides the tab. The row is still in the database.
+
+For upvotes to mirror on-chain the space must be linked to an on-chain space (`web3SpaceId`).
+Unlinked spaces answer `409` on upvote calls; creating and updating signals still works.
+
+## Step 9: List, revoke, rotate
+
+```bash
+# Metadata only — never key material. Includes lastUsedAt, useful to confirm traffic.
+curl https://app.hypha.earth/api/v1/ops/spaces/acme-dao/api-keys \
+  -H "x-hypha-ops-secret: $HYPHA_SPACE_API_KEY_OPS_SECRET"
+
+# Revoke by key id. Takes effect immediately; the key then fails with 401.
+curl -X DELETE https://app.hypha.earth/api/v1/ops/spaces/acme-dao/api-keys/12 \
+  -H "x-hypha-ops-secret: $HYPHA_SPACE_API_KEY_OPS_SECRET"
+```
+
+**To rotate,** revoke the old key and issue a new one with the **same `source`** — ownership of
+existing signals is carried by `source`, not by the key id, so the app keeps its ability to update
+and vote on everything it filed before. There is no overlap window: coordinate the swap, because the
+old key stops working the moment it is revoked.
+
+Revoking is the correct response to a leaked key. Signals already written stay on the board.
+
+---
+
+# Part 2 — Integrating from another app
+
+## Authentication
+
+Every request carries the key:
+
+```http
+x-hypha-api-key: hyk_<prefix>_<secret>
+```
+
+`Authorization: Bearer <key>` is also accepted, for clients that only do bearer auth.
+
+The key is valid for **one space**. Presented against a different space it fails with `403`.
+
+## The three calls
+
+```http
+POST   /api/v1/spaces/{spaceSlug}/signals                          # create (idempotent)
+PATCH  /api/v1/spaces/{spaceSlug}/signals/{signalSlug}             # update your own
+PUT    /api/v1/spaces/{spaceSlug}/signals/{signalSlug}/upvotes     # record an upvote
+DELETE /api/v1/spaces/{spaceSlug}/signals/{signalSlug}/upvotes     # remove an upvote
+```
+
+## Create fields
+
+| Field            | Required | Notes                                                                                       |
+| ---------------- | -------- | ------------------------------------------------------------------------------------------- |
+| `title`          | **yes**  | 1–**50** characters. Board cards are sized for short titles — truncate, or you get a `400`. |
+| `description`    | **yes**  | 1–4000 characters.                                                                          |
+| `type`           | **yes**  | `Opportunity`, `Risk`, `Tension`, `Insight`.                                                |
+| `priority`       | no       | `critical`, `high`, `medium` (default), `low`.                                              |
+| `tags`           | no       | Free strings, max 50. `External Signal` is appended automatically.                          |
+| `externalId`     | no       | **Send it.** Your own record id — makes retries idempotent and updates possible.            |
+| `author`         | no       | `{ walletAddress }` or `{ email }`. Unknown or omitted → published as the space.            |
+| `progressStatus` | no       | A status slug the space defines. Ask Hypha which.                                           |
+| `board`          | no       | A board (swimlane) slug the space defines.                                                  |
+| `dueAt`          | no       | ISO 8601 timestamp, or `null`.                                                              |
+
+Bodies are strict: an unknown field (`prioriy`) is a `400`, never a silent drop. Assignees stay a
+Hypha-side concern and cannot be set here.
+
+## Attribution — who the board credits
+
+Name the person with the wallet or email **they use on Hypha**. If it matches, the signal is credited
+to that member. If it matches nobody, or you send no `author` at all, the signal is still created and
+credited to **the space itself**, appearing under the space's name and logo with no voting power.
+
+So ingestion never fails over an identity mismatch — but it also silently stops naming individuals.
+Every create response tells you which happened:
+
+```json
+{ "attributedTo": "author" }   // matched a Hypha member
+{ "attributedTo": "space" }    // published as the space
+```
+
+Log it. A run of `"space"` means your identity mapping has drifted, not that Hypha is broken.
+
+Upvotes are stricter: a voter **must** resolve to a real Hypha member with on-chain voting power,
+otherwise `422`. An upvote only means something as one member's weight.
+
+## A working client
+
+Server-side only. No dependencies beyond `fetch` (Node 18+).
+
+```ts
+// lib/hypha-signals.ts
+const BASE_URL = process.env.HYPHA_BASE_URL ?? 'https://app.hypha.earth';
+const SPACE_SLUG = requireEnv('HYPHA_SPACE_SLUG');
+const API_KEY = requireEnv('HYPHA_SPACE_API_KEY');
+
+function requireEnv(name: string): string {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`${name} is not set`);
+  return value;
+}
+
+export type SignalType = 'Opportunity' | 'Risk' | 'Tension' | 'Insight';
+export type SignalPriority = 'critical' | 'high' | 'medium' | 'low';
+export type AuthorRef = { walletAddress?: string; email?: string };
+
+export type PublishSignalInput = {
+  /** Your own record id. Makes retries safe and lets you update later. */
+  externalId: string;
+  title: string;
+  description: string;
+  type: SignalType;
+  priority?: SignalPriority;
+  tags?: string[];
+  progressStatus?: string;
+  board?: string;
+  dueAt?: string | null;
+  author?: AuthorRef;
+};
+
+export type PublishedSignal = {
+  id: number;
+  slug: string;
+  spaceSlug: string;
+  /** Deep link to the signal on the board — good for linking your users into Hypha. */
+  url: string;
+  attributedTo: 'author' | 'space';
+};
+
+export class HyphaSignalError extends Error {
+  constructor(message: string, readonly status: number, readonly body: string) {
+    super(message);
+    this.name = 'HyphaSignalError';
+  }
+
+  /** 5xx and 429 are worth retrying; a 4xx means fix the request. */
+  get retryable(): boolean {
+    return this.status >= 500 || this.status === 429;
+  }
+}
+
+async function call<T>(method: string, path: string, body?: unknown): Promise<T> {
+  const response = await fetch(`${BASE_URL}${path}`, {
+    method,
+    headers: {
+      'x-hypha-api-key': API_KEY,
+      ...(body === undefined ? {} : { 'Content-Type': 'application/json' }),
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+
+  const text = await response.text();
+  if (!response.ok) {
+    throw new HyphaSignalError(`Hypha ${method} ${path} failed with ${response.status}`, response.status, text);
+  }
+  return (text ? JSON.parse(text) : null) as T;
+}
+
+const signalsPath = `/api/v1/spaces/${SPACE_SLUG}/signals`;
+
+/**
+ * Create a signal, or return the existing one when this `externalId` was already
+ * sent. Safe to call again after a timeout.
+ */
+export function publishSignal(input: PublishSignalInput): Promise<PublishedSignal> {
+  return call<PublishedSignal>('POST', signalsPath, {
+    ...input,
+    title: input.title.slice(0, 50),
+  });
+}
+
+/** Patch a signal your app created. Omitted fields keep their stored values. */
+export function updateSignal(signalSlug: string, patch: Partial<Pick<PublishSignalInput, 'title' | 'description' | 'type' | 'priority' | 'tags' | 'progressStatus' | 'board' | 'dueAt'>> & { archived?: boolean }): Promise<{ signal: unknown }> {
+  return call('PATCH', `${signalsPath}/${signalSlug}`, patch);
+}
+
+/** Record (or re-allocate) one member's upvote. Requires `signals:upvote`. */
+export function upvoteSignal(signalSlug: string, walletAddress: string, votingPowerPercent?: number): Promise<{ upvotes: unknown }> {
+  return call('PUT', `${signalsPath}/${signalSlug}/upvotes`, {
+    voter: { walletAddress },
+    ...(votingPowerPercent === undefined ? {} : { votingPowerPercent }),
+  });
+}
+
+export function removeUpvote(signalSlug: string, walletAddress: string): Promise<{ upvotes: unknown }> {
+  const query = `?voter=${encodeURIComponent(walletAddress)}`;
+  return call('DELETE', `${signalsPath}/${signalSlug}/upvotes${query}`);
+}
+
+/** Retry transient failures with backoff. Never retries a 4xx. */
+export async function withRetry<T>(operation: () => Promise<T>, attempts = 3): Promise<T> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      return await operation();
+    } catch (error) {
+      lastError = error;
+      const retryable = !(error instanceof HyphaSignalError) || error.retryable;
+      if (!retryable || attempt === attempts) break;
+      await new Promise((resolve) => setTimeout(resolve, 2 ** attempt * 500));
+    }
+  }
+  throw lastError;
+}
+```
+
+### Calling it
+
+```ts
+import { publishSignal, withRetry } from '@/lib/hypha-signals';
+
+export async function onContestSubmission(submission: Submission) {
+  const signal = await withRetry(() =>
+    publishSignal({
+      externalId: `submission-${submission.id}`,
+      title: submission.headline,
+      description: submission.body,
+      type: 'Opportunity',
+      priority: submission.urgent ? 'high' : 'medium',
+      tags: ['Contest', submission.category],
+      author: { email: submission.authorEmail },
+    }),
+  );
+
+  if (signal.attributedTo === 'space') {
+    console.warn('Signal published as the space', {
+      submissionId: submission.id,
+      email: submission.authorEmail,
+    });
+  }
+
+  return signal.url; // link the user straight to the board
+}
+```
+
+### Python equivalent
+
+```python
+import os, json, urllib.request
+
+BASE_URL = os.environ.get("HYPHA_BASE_URL", "https://app.hypha.earth")
+SPACE_SLUG = os.environ["HYPHA_SPACE_SLUG"]
+API_KEY = os.environ["HYPHA_SPACE_API_KEY"]
+
+def publish_signal(payload: dict) -> dict:
+    url = f"{BASE_URL}/api/v1/spaces/{SPACE_SLUG}/signals"
+    request = urllib.request.Request(
+        url,
+        method="POST",
+        data=json.dumps(payload).encode(),
+        headers={"x-hypha-api-key": API_KEY, "Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(request) as response:
+        return json.loads(response.read())
+
+signal = publish_signal({
+    "externalId": "submission-42",
+    "title": "Riverside cleanup needs funding"[:50],
+    "description": "Twelve members flagged the riverside site this week.",
+    "type": "Opportunity",
+    "author": {"email": "member@example.org"},
+})
+print(signal["url"], signal["attributedTo"])
+```
+
+## Where to call it from
+
+Publish from your **server**, after your own write commits — a route handler, a queue worker, or a
+webhook. Two rules:
+
+- **Never fail a user action because Hypha was unreachable.** Enqueue and retry; the board is a
+  mirror, not your source of truth.
+- **Store the returned `slug`** against your record. You need it to update the signal or move it
+  through the workflow later.
+
+Because `externalId` makes creates idempotent, a worker can safely replay its queue.
+
+## Troubleshooting
+
+| Status | What it means                                                          | What to do                                                                                            |
+| ------ | ---------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `400`  | Validation failed, unknown field, or an undefined status/board slug    | Read `details`; check `title` ≤ 50 chars and that your `progressStatus`/`board` slugs match the space |
+| `401`  | Key missing, unknown, or revoked                                       | Check the header name and that ops has not revoked the key                                            |
+| `403`  | Key is for another space, lacks the scope, or the signal is not yours  | You can only touch signals your own `source` created                                                  |
+| `404`  | Space or signal not found                                              | Check the space slug and that you stored the right signal slug                                        |
+| `409`  | Signal is archived, or the space is not linked on-chain (upvotes only) | Nothing to retry; ask Hypha to link the space                                                         |
+| `422`  | Voter has no Hypha profile or no voting power                          | Prompt the user to connect their Hypha profile — do not retry                                         |
+| `500`  | Unexpected server failure                                              | Retry with backoff                                                                                    |
+
+Validation failures carry `{ "error": "Validation failed", "details": … }` (Zod flatten). Other
+errors are `{ "error": "…" }`.
+
+## Local testing
+
+Against a dev server, everything is identical with `BASE_URL=http://localhost:3000` — issue a key
+with the ops secret from `apps/web/.env`:
+
+```bash
+curl -X POST http://localhost:3000/api/v1/ops/spaces/<spaceSlug>/api-keys \
+  -H "x-hypha-ops-secret: $HYPHA_SPACE_API_KEY_OPS_SECRET" \
+  -H 'Content-Type: application/json' \
+  -d '{ "name": "local dev", "source": "local-dev", "scopes": ["signals:write"] }'
+```
+
+---
+
+## Related
+
+- [`docs/integrations/external-signal-ingestion.md`](../../../../../../../../../docs/integrations/external-signal-ingestion.md)
+  — the full integrator reference, safe to share outside the team.
+- Route handlers: `route.ts` (create), `[signalSlug]/route.ts` (update),
+  `[signalSlug]/upvotes/route.ts` (upvotes), `_lib/authorize-ingestion.ts` (key + attribution).
+- Key administration: `apps/web/src/app/api/v1/ops/spaces/[spaceSlug]/api-keys/`.

--- a/apps/web/src/app/api/v1/spaces/[spaceSlug]/signals/README.md
+++ b/apps/web/src/app/api/v1/spaces/[spaceSlug]/signals/README.md
@@ -1,511 +1,369 @@
-# Signals Ingestion API
+# Hypha Signals API — build spec for an AI coding agent
 
-Let a community's **own app** publish signals onto the Hypha **Signals Board** of one Space.
+**This file is written to be given to an AI coding agent** (Lovable, Cursor, Claude Code) that is
+building **the other app** — the community app that publishes signals into Hypha. It is a
+specification, not a tutorial: every rule is explicit, every field is bounded, and the expected
+implementation is given in full.
 
-Ingested signals are written into the same `coherences` table the board already reads, so they show
-up in the Coherence tab at `/{lang}/dho/{spaceSlug}/coherence` next to signals raised inside Hypha.
-There is no separate view and no sync step.
-
-**Base URL (production):** `https://app.hypha.earth`
-**Auth:** per-space API key, issued by Hypha ops
-**Scopes:** `signals:write` (create + update), `signals:upvote` (record + remove upvotes)
-
-```
-Community app ──x-hypha-api-key──▶ POST /api/v1/spaces/{spaceSlug}/signals
-                                      │
-                                      ├─ verify key + scope against this space
-                                      ├─ credit a known Hypha person, else the space
-                                      └─ insert into coherences (source = <your slug>)
-                                            │
-                                            ▼
-                                     Signals Board (existing UI)
-```
-
-There are two sides to setting this up. **Part 1** is what you do inside Hypha. **Part 2** is what
-the other app's developer does. You can hand Part 2, or
-[`docs/integrations/external-signal-ingestion.md`](../../../../../../../../../docs/integrations/external-signal-ingestion.md),
-straight to them — it contains no Hypha-internal detail.
+Humans wanting the narrative version: `docs/integrations/external-signal-ingestion.md`.
 
 ---
 
-# Part 1 — What to do on the Hypha side
+## 1. What you are building
 
-## Step 1: Confirm the migration is applied
+The app you are working on must publish **signals** to a Hypha Space's **Signals Board**.
 
-The key table and the ownership columns ship in `0074_space_api_keys_and_signal_source.sql`.
+A signal is one short post: a title, a description, a type, and optionally who raised it. One
+`POST` per signal. Once posted, it appears on that Space's board in Hypha, next to signals raised by
+members inside Hypha. There is nothing to sync and nothing to poll.
 
-```bash
-pnpm --filter @hypha-platform/storage-postgres run migrate
+You will build exactly two things:
+
+1. A **server-side function** that holds the Hypha API key and forwards signals to Hypha.
+2. A **client call** to that function, at the point in the app where a signal is produced.
+
+---
+
+## 2. Hard rules
+
+Violating any of these breaks the integration or leaks a credential.
+
+1. **The API key is a server-side secret.** Never put it in frontend code, never in a `VITE_*` or
+   `NEXT_PUBLIC_*` variable, never in a committed file, never in a client-side `fetch`. In a Lovable
+   app this means the key lives in a **Lovable Cloud / Supabase Edge Function secret** and every
+   Hypha call happens inside that Edge Function. A Hypha Space can be fully public, so a key
+   reachable from a browser is a published key.
+2. **Keep JWT verification enabled** on that Edge Function (Supabase's default). Otherwise anyone on
+   the internet can call it and spam the Space's board. Only signed-in users of your app may publish.
+3. **Always send `externalId`.** It is your own record id for the thing the signal describes. It
+   makes retries safe (see §5) and it is the only way to update the signal later.
+4. **`title` is limited to 50 characters.** Truncate before sending, or the request fails. The
+   description is where the detail goes.
+5. **`type` must be exactly one of** `Opportunity`, `Risk`, `Tension`, `Insight`. No other value is
+   accepted. Match case exactly.
+6. **Never invent fields.** The request body is strict — an unrecognised field (e.g. `prioriy`,
+   `authorName`, `spaceId`) fails the whole request with `400`.
+7. **Never retry a `4xx`.** A `4xx` means the request is wrong and will fail identically forever.
+   Retry only `5xx` and `429`, with backoff.
+8. **Never block or fail a user action because Hypha was unreachable.** Publishing is a mirror of
+   your own data, not your source of truth. Save your record first, then publish.
+
+---
+
+## 3. Configuration
+
+The human operating the app supplies these three values. Store them as **Edge Function secrets**.
+Do not hardcode them, and do not guess them.
+
+| Secret name           | Example                   | Notes                                        |
+| --------------------- | ------------------------- | -------------------------------------------- |
+| `HYPHA_BASE_URL`      | `https://app.hypha.earth` | Production Hypha                             |
+| `HYPHA_SPACE_SLUG`    | `acme-dao`                | Which Space the signals land in              |
+| `HYPHA_SPACE_API_KEY` | `hyk_K3nQ7bTz_x9f…`       | Per-Space key. Valid for that one Space only |
+
+If any is missing, fail fast with a clear error at startup of the function. Do not fall back to a
+placeholder and do not proceed.
+
+---
+
+## 4. The API contract
+
+### Create a signal
+
+```http
+POST {HYPHA_BASE_URL}/api/v1/spaces/{HYPHA_SPACE_SLUG}/signals
+x-hypha-api-key: {HYPHA_SPACE_API_KEY}
+Content-Type: application/json
 ```
 
-Verify against the target database:
-
-```sql
-select table_name from information_schema.tables where table_name = 'space_api_keys';
-select column_name from information_schema.columns
-  where table_name = 'coherences' and column_name in ('source', 'external_id');
-```
-
-You want one row from the first query and two from the second. Nothing works before this.
-
-## Step 2: Set the ops secret
-
-Issuing keys is guarded by a single platform secret, `HYPHA_SPACE_API_KEY_OPS_SECRET`. Generate one:
-
-```bash
-openssl rand -base64 32
-```
-
-Set it where the app runs:
-
-- **Production / Preview:** Vercel project → Settings → Environment Variables (server-side, _not_
-  `NEXT_PUBLIC_`). **Redeploy** afterwards — env changes only reach new deployments.
-- **Local:** add it to `apps/web/.env` (the key already exists, unset, in `.env.template`).
-
-Until it is set, the ops endpoints answer `503 HYPHA_SPACE_API_KEY_OPS_SECRET is not configured`.
-
-Keep this secret to the ops team. It can mint write credentials for **every** space.
-
-## Step 3: Find the space slug
-
-It is the segment in the space URL: `https://app.hypha.earth/en/dho/**acme-dao**/coherence` →
-`acme-dao`. Everything below is scoped to that one space.
-
-## Step 4: Agree a `source` slug with the integrator
-
-`source` is a stable identifier for their app, e.g. `acaw-contest`. It is stamped on every signal the
-key writes, and it is what later proves they own those signals — they can only update and upvote
-rows carrying their own `source`.
-
-Rules: lowercase letters, numbers and hyphens, must start alphanumeric, 1–64 characters. **One active
-key per `source` per space.** Pick it once; changing it later orphans every signal already written
-under the old value.
-
-## Step 5: Issue the key
-
-```bash
-export HYPHA_SPACE_API_KEY_OPS_SECRET='<the secret from step 2>'
-
-curl -X POST https://app.hypha.earth/api/v1/ops/spaces/acme-dao/api-keys \
-  -H "x-hypha-ops-secret: $HYPHA_SPACE_API_KEY_OPS_SECRET" \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "name": "ACAW contest app",
-    "source": "acaw-contest",
-    "scopes": ["signals:write", "signals:upvote"]
-  }'
-```
-
-`201 Created` — and this is the **only** time `apiKey` is ever returned:
+Body:
 
 ```json
 {
-  "key": {
-    "id": 12,
-    "spaceId": 42,
-    "name": "ACAW contest app",
-    "source": "acaw-contest",
-    "keyPrefix": "K3nQ7bTz",
-    "scopes": ["signals:write", "signals:upvote"],
-    "createdByPersonId": null,
-    "lastUsedAt": null,
-    "revokedAt": null,
-    "createdAt": "2026-07-27T12:00:00.000Z"
-  },
-  "apiKey": "hyk_K3nQ7bTz_x9f…",
-  "warning": "Store this key now — it is not recoverable. Never expose it in client-side code."
+  "externalId": "submission-42",
+  "title": "Riverside cleanup needs funding",
+  "description": "Twelve members flagged the riverside site this week.",
+  "type": "Opportunity",
+  "priority": "high",
+  "tags": ["Contest", "Fundraising"],
+  "author": { "email": "member@example.org" }
 }
 ```
 
-Only a SHA-256 digest is stored. If the plaintext is lost, revoke the key and issue a new one —
-there is no recovery path.
+| Field            | Required            | Type / allowed values                              | Limits                         |
+| ---------------- | ------------------- | -------------------------------------------------- | ------------------------------ |
+| `title`          | **yes**             | string                                             | 1–**50** chars — truncate      |
+| `description`    | **yes**             | string                                             | 1–4000 chars                   |
+| `type`           | **yes**             | `Opportunity` \| `Risk` \| `Tension` \| `Insight`  | exact case                     |
+| `externalId`     | _treat as required_ | string                                             | 1–200 chars, unique per signal |
+| `priority`       | no                  | `critical` \| `high` \| `medium` \| `low`          | defaults to `medium`           |
+| `tags`           | no                  | string[]                                           | max 50 items                   |
+| `author`         | no                  | `{ "walletAddress": "0x…" }` or `{ "email": "…" }` | see §6                         |
+| `dueAt`          | no                  | ISO 8601 string, or `null`                         | —                              |
+| `progressStatus` | no                  | a status slug the Space defines                    | ask the human; omit if unsure  |
+| `board`          | no                  | a board slug the Space defines                     | ask the human; omit if unsure  |
 
-Grant `signals:write` alone if the app only files signals and should not vote.
+Omit any optional field you have no real value for. Do not send `null` to mean "unset" (only `dueAt`
+accepts `null`).
 
-| Response | Meaning                                                                   |
-| -------- | ------------------------------------------------------------------------- |
-| `201`    | Key issued. Capture `apiKey` now.                                         |
-| `400`    | Bad `name`/`source`/`scopes` — see `details` (Zod flatten).               |
-| `401`    | Ops secret missing or wrong.                                              |
-| `404`    | No space with that slug.                                                  |
-| `409`    | An active key already exists for that `source`. Revoke it first (step 9). |
-| `503`    | `HYPHA_SPACE_API_KEY_OPS_SECRET` not configured on this deployment.       |
+**Response `201`** (created) or **`200`** (this `externalId` was already published):
 
-## Step 6: Hand over the credentials
-
-Send the integrator, over a secure channel:
-
-| What                                   | Example                                                             |
-| -------------------------------------- | ------------------------------------------------------------------- |
-| Base URL                               | `https://app.hypha.earth`                                           |
-| Space slug                             | `acme-dao`                                                          |
-| API key                                | `hyk_K3nQ7bTz_x9f…`                                                 |
-| Their `source`                         | `acaw-contest` (informational — the server derives it from the key) |
-| Valid `progressStatus` / `board` slugs | see step 7                                                          |
-
-Tell them plainly: **the key is server-side only.** It grants write access to the space. Hypha spaces
-can be fully public, so anything reachable from a browser is effectively published.
-
-## Step 7: Give them the space's workflow slugs
-
-`progressStatus` and `board` must be slugs this space actually defines, or the create fails with
-`400 Unknown progress status …`. Both are optional — omitted, a signal lands on the space's first
-backlog status and default board.
-
-Defaults for a space that has never customised its workflow:
-
-- **statuses:** `backlog`, `todo`, `in_progress`, `blocked`, `done`
-- **boards:** `general`
-
-If the space has customised them, read the live config and pass the slugs along:
-
-```bash
-curl https://app.hypha.earth/api/v1/spaces/acme-dao/signal-workflow
+```json
+{
+  "id": 501,
+  "slug": "coh-1a2b3c4d",
+  "spaceSlug": "acme-dao",
+  "url": "https://app.hypha.earth/en/dho/acme-dao/coherence?signal=coh-1a2b3c4d",
+  "attributedTo": "author",
+  "signal": { "…": "full record" }
+}
 ```
 
-Do this yourself rather than asking the integrator to: that endpoint is gated by space
-transparency, not by the API key, so a private space will refuse them.
+Store `slug` against your record — you need it to update the signal later. `url` deep-links to the
+signal on the board; show it to the user if useful.
 
-## Step 8: Verify end to end
+### Update a signal you created (optional)
 
-Post a test signal with the key you just issued:
-
-```bash
-export HYPHA_SPACE_API_KEY='hyk_K3nQ7bTz_x9f…'
-
-curl -X POST https://app.hypha.earth/api/v1/spaces/acme-dao/signals \
-  -H "x-hypha-api-key: $HYPHA_SPACE_API_KEY" \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "title": "Integration smoke test",
-    "description": "Delete me once the board shows this.",
-    "type": "Insight",
-    "externalId": "smoke-test-1"
-  }'
+```http
+PATCH {HYPHA_BASE_URL}/api/v1/spaces/{HYPHA_SPACE_SLUG}/signals/{slug}
 ```
 
-Then check, in order:
+Send only the fields that changed: `title`, `description`, `type`, `priority`, `tags`,
+`progressStatus`, `board`, `dueAt`, `archived`. You may only patch signals your own key created;
+anything else returns `403`.
 
-1. The response is `201` and carries a `url`. Open it — the signal should be on the board.
-2. `attributedTo` is `"space"` here (no `author` was sent), and the card shows the **space's name and
-   logo** as the author.
-3. Re-run the exact same command. You should get `200` and the _same_ `id` — idempotency works.
-4. Repeat with `"author": { "walletAddress": "<a real member's wallet>" }` and a new `externalId`.
-   Expect `attributedTo: "author"` and that member's name on the card.
-5. Archive or delete the test signals from the Hypha UI.
+### Upvotes (only build this if asked)
 
-If the board is empty but the API returned `201`, check that Coherence is not switched off for this
-deployment: it defaults **on**, but `NEXT_PUBLIC_ENABLE_COHERENCE=false` (or an `enable-coherence`
-toolbar override) hides the tab. The row is still in the database.
-
-For upvotes to mirror on-chain the space must be linked to an on-chain space (`web3SpaceId`).
-Unlinked spaces answer `409` on upvote calls; creating and updating signals still works.
-
-## Step 9: List, revoke, rotate
-
-```bash
-# Metadata only — never key material. Includes lastUsedAt, useful to confirm traffic.
-curl https://app.hypha.earth/api/v1/ops/spaces/acme-dao/api-keys \
-  -H "x-hypha-ops-secret: $HYPHA_SPACE_API_KEY_OPS_SECRET"
-
-# Revoke by key id. Takes effect immediately; the key then fails with 401.
-curl -X DELETE https://app.hypha.earth/api/v1/ops/spaces/acme-dao/api-keys/12 \
-  -H "x-hypha-ops-secret: $HYPHA_SPACE_API_KEY_OPS_SECRET"
+```http
+PUT    {…}/signals/{slug}/upvotes   body: { "voter": { "walletAddress": "0x…" }, "votingPowerPercent": 25 }
+DELETE {…}/signals/{slug}/upvotes?voter=0x…
 ```
 
-**To rotate,** revoke the old key and issue a new one with the **same `source`** — ownership of
-existing signals is carried by `source`, not by the key id, so the app keeps its ability to update
-and vote on everything it filed before. There is no overlap window: coordinate the swap, because the
-old key stops working the moment it is revoked.
-
-Revoking is the correct response to a leaked key. Signals already written stay on the board.
+Unlike authors, a voter **must** be an existing Hypha member with on-chain voting power, or you get
+`422`. Do not retry a `422`; surface "connect your Hypha profile" to the user instead.
 
 ---
 
-# Part 2 — Integrating from another app
+## 5. Idempotency — why `externalId` matters
 
-## Authentication
+`(Space, your app, externalId)` is unique in Hypha. Send the same `externalId` twice and the second
+call returns `200` with the signal that already exists, rather than creating a duplicate.
 
-Every request carries the key:
+This is what makes the integration safe: if a request times out, or a queue redelivers, or a user
+double-clicks, you can send the exact same payload again with no duplicate on the board. Use a stable
+id from your own database (`submission-42`, `idea-a1b2c3`), never a timestamp or a random value.
 
-```http
-x-hypha-api-key: hyk_<prefix>_<secret>
-```
+Without `externalId` every call creates a new signal and you can never update it.
 
-`Authorization: Bearer <key>` is also accepted, for clients that only do bearer auth.
+---
 
-The key is valid for **one space**. Presented against a different space it fails with `403`.
+## 6. Who gets credited on the board
 
-## The three calls
+`author` names the person who raised the signal, by the **wallet address or email they use on
+Hypha**:
 
-```http
-POST   /api/v1/spaces/{spaceSlug}/signals                          # create (idempotent)
-PATCH  /api/v1/spaces/{spaceSlug}/signals/{signalSlug}             # update your own
-PUT    /api/v1/spaces/{spaceSlug}/signals/{signalSlug}/upvotes     # record an upvote
-DELETE /api/v1/spaces/{spaceSlug}/signals/{signalSlug}/upvotes     # remove an upvote
-```
+- **It matches a Hypha member** → the signal is credited to that member. Response says
+  `"attributedTo": "author"`.
+- **It matches nobody, or you omit `author`** → the signal is still created, credited to **the Space
+  itself**, shown under the Space's name and logo. Response says `"attributedTo": "space"`.
 
-## Create fields
+So a wrong or unknown author never fails the request — it silently changes who is credited.
+Therefore: **log `attributedTo` on every create.** If it is `"space"` when you expected `"author"`,
+the app's email/wallet does not match that person's Hypha profile. That is a data problem to report,
+not an error to retry.
 
-| Field            | Required | Notes                                                                                       |
-| ---------------- | -------- | ------------------------------------------------------------------------------------------- |
-| `title`          | **yes**  | 1–**50** characters. Board cards are sized for short titles — truncate, or you get a `400`. |
-| `description`    | **yes**  | 1–4000 characters.                                                                          |
-| `type`           | **yes**  | `Opportunity`, `Risk`, `Tension`, `Insight`.                                                |
-| `priority`       | no       | `critical`, `high`, `medium` (default), `low`.                                              |
-| `tags`           | no       | Free strings, max 50. `External Signal` is appended automatically.                          |
-| `externalId`     | no       | **Send it.** Your own record id — makes retries idempotent and updates possible.            |
-| `author`         | no       | `{ walletAddress }` or `{ email }`. Unknown or omitted → published as the space.            |
-| `progressStatus` | no       | A status slug the space defines. Ask Hypha which.                                           |
-| `board`          | no       | A board (swimlane) slug the space defines.                                                  |
-| `dueAt`          | no       | ISO 8601 timestamp, or `null`.                                                              |
+If the app has no user identity at all, omit `author` — publishing as the Space is the intended
+behaviour, not a workaround.
 
-Bodies are strict: an unknown field (`prioriy`) is a `400`, never a silent drop. Assignees stay a
-Hypha-side concern and cannot be set here.
+---
 
-## Attribution — who the board credits
+## 7. Reference implementation
 
-Name the person with the wallet or email **they use on Hypha**. If it matches, the signal is credited
-to that member. If it matches nobody, or you send no `author` at all, the signal is still created and
-credited to **the space itself**, appearing under the space's name and logo with no voting power.
-
-So ingestion never fails over an identity mismatch — but it also silently stops naming individuals.
-Every create response tells you which happened:
-
-```json
-{ "attributedTo": "author" }   // matched a Hypha member
-{ "attributedTo": "space" }    // published as the space
-```
-
-Log it. A run of `"space"` means your identity mapping has drifted, not that Hypha is broken.
-
-Upvotes are stricter: a voter **must** resolve to a real Hypha member with on-chain voting power,
-otherwise `422`. An upvote only means something as one member's weight.
-
-## A working client
-
-Server-side only. No dependencies beyond `fetch` (Node 18+).
+### Edge Function — `supabase/functions/publish-signal/index.ts`
 
 ```ts
-// lib/hypha-signals.ts
-const BASE_URL = process.env.HYPHA_BASE_URL ?? 'https://app.hypha.earth';
-const SPACE_SLUG = requireEnv('HYPHA_SPACE_SLUG');
-const API_KEY = requireEnv('HYPHA_SPACE_API_KEY');
+const BASE_URL = Deno.env.get('HYPHA_BASE_URL') ?? 'https://app.hypha.earth';
+const SPACE_SLUG = Deno.env.get('HYPHA_SPACE_SLUG');
+const API_KEY = Deno.env.get('HYPHA_SPACE_API_KEY');
 
-function requireEnv(name: string): string {
-  const value = process.env[name]?.trim();
-  if (!value) throw new Error(`${name} is not set`);
-  return value;
-}
-
-export type SignalType = 'Opportunity' | 'Risk' | 'Tension' | 'Insight';
-export type SignalPriority = 'critical' | 'high' | 'medium' | 'low';
-export type AuthorRef = { walletAddress?: string; email?: string };
-
-export type PublishSignalInput = {
-  /** Your own record id. Makes retries safe and lets you update later. */
-  externalId: string;
-  title: string;
-  description: string;
-  type: SignalType;
-  priority?: SignalPriority;
-  tags?: string[];
-  progressStatus?: string;
-  board?: string;
-  dueAt?: string | null;
-  author?: AuthorRef;
+const CORS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
 };
 
-export type PublishedSignal = {
-  id: number;
-  slug: string;
-  spaceSlug: string;
-  /** Deep link to the signal on the board — good for linking your users into Hypha. */
-  url: string;
-  attributedTo: 'author' | 'space';
-};
+const SIGNAL_TYPES = ['Opportunity', 'Risk', 'Tension', 'Insight'] as const;
+type SignalType = (typeof SIGNAL_TYPES)[number];
 
-export class HyphaSignalError extends Error {
-  constructor(message: string, readonly status: number, readonly body: string) {
-    super(message);
-    this.name = 'HyphaSignalError';
-  }
-
-  /** 5xx and 429 are worth retrying; a 4xx means fix the request. */
-  get retryable(): boolean {
-    return this.status >= 500 || this.status === 429;
-  }
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...CORS, 'Content-Type': 'application/json' },
+  });
 }
 
-async function call<T>(method: string, path: string, body?: unknown): Promise<T> {
-  const response = await fetch(`${BASE_URL}${path}`, {
-    method,
+Deno.serve(async (request) => {
+  if (request.method === 'OPTIONS') return new Response('ok', { headers: CORS });
+  if (request.method !== 'POST') return json({ error: 'Use POST' }, 405);
+
+  if (!SPACE_SLUG || !API_KEY) {
+    console.error('Missing HYPHA_SPACE_SLUG or HYPHA_SPACE_API_KEY secret');
+    return json({ error: 'Signals publishing is not configured' }, 500);
+  }
+
+  let input: Record<string, unknown>;
+  try {
+    input = await request.json();
+  } catch {
+    return json({ error: 'Invalid JSON' }, 400);
+  }
+
+  const externalId = String(input.externalId ?? '').trim();
+  const title = String(input.title ?? '').trim();
+  const description = String(input.description ?? '').trim();
+  const type = String(input.type ?? '') as SignalType;
+
+  if (!externalId || !title || !description) {
+    return json({ error: 'externalId, title and description are required' }, 400);
+  }
+  if (!SIGNAL_TYPES.includes(type)) {
+    return json({ error: `type must be one of ${SIGNAL_TYPES.join(', ')}` }, 400);
+  }
+
+  // Build the payload explicitly. Never forward the caller's object wholesale:
+  // an unexpected field makes Hypha reject the whole request.
+  const payload: Record<string, unknown> = {
+    externalId,
+    title: title.slice(0, 50),
+    description: description.slice(0, 4000),
+    type,
+  };
+  if (input.priority) payload.priority = input.priority;
+  if (Array.isArray(input.tags) && input.tags.length > 0) {
+    payload.tags = input.tags.slice(0, 50);
+  }
+  if (input.author && typeof input.author === 'object') {
+    payload.author = input.author;
+  }
+
+  const response = await fetch(`${BASE_URL}/api/v1/spaces/${SPACE_SLUG}/signals`, {
+    method: 'POST',
     headers: {
       'x-hypha-api-key': API_KEY,
-      ...(body === undefined ? {} : { 'Content-Type': 'application/json' }),
+      'Content-Type': 'application/json',
     },
-    body: body === undefined ? undefined : JSON.stringify(body),
+    body: JSON.stringify(payload),
   });
 
   const text = await response.text();
   if (!response.ok) {
-    throw new HyphaSignalError(`Hypha ${method} ${path} failed with ${response.status}`, response.status, text);
+    // Log the detail server-side; do not leak Hypha internals to the browser.
+    console.error('Hypha rejected the signal', {
+      status: response.status,
+      externalId,
+      body: text,
+    });
+    const retryable = response.status >= 500 || response.status === 429;
+    return json({ error: 'Could not publish to Hypha', retryable }, retryable ? 503 : 400);
   }
-  return (text ? JSON.parse(text) : null) as T;
-}
 
-const signalsPath = `/api/v1/spaces/${SPACE_SLUG}/signals`;
-
-/**
- * Create a signal, or return the existing one when this `externalId` was already
- * sent. Safe to call again after a timeout.
- */
-export function publishSignal(input: PublishSignalInput): Promise<PublishedSignal> {
-  return call<PublishedSignal>('POST', signalsPath, {
-    ...input,
-    title: input.title.slice(0, 50),
-  });
-}
-
-/** Patch a signal your app created. Omitted fields keep their stored values. */
-export function updateSignal(signalSlug: string, patch: Partial<Pick<PublishSignalInput, 'title' | 'description' | 'type' | 'priority' | 'tags' | 'progressStatus' | 'board' | 'dueAt'>> & { archived?: boolean }): Promise<{ signal: unknown }> {
-  return call('PATCH', `${signalsPath}/${signalSlug}`, patch);
-}
-
-/** Record (or re-allocate) one member's upvote. Requires `signals:upvote`. */
-export function upvoteSignal(signalSlug: string, walletAddress: string, votingPowerPercent?: number): Promise<{ upvotes: unknown }> {
-  return call('PUT', `${signalsPath}/${signalSlug}/upvotes`, {
-    voter: { walletAddress },
-    ...(votingPowerPercent === undefined ? {} : { votingPowerPercent }),
-  });
-}
-
-export function removeUpvote(signalSlug: string, walletAddress: string): Promise<{ upvotes: unknown }> {
-  const query = `?voter=${encodeURIComponent(walletAddress)}`;
-  return call('DELETE', `${signalsPath}/${signalSlug}/upvotes${query}`);
-}
-
-/** Retry transient failures with backoff. Never retries a 4xx. */
-export async function withRetry<T>(operation: () => Promise<T>, attempts = 3): Promise<T> {
-  let lastError: unknown;
-  for (let attempt = 1; attempt <= attempts; attempt += 1) {
-    try {
-      return await operation();
-    } catch (error) {
-      lastError = error;
-      const retryable = !(error instanceof HyphaSignalError) || error.retryable;
-      if (!retryable || attempt === attempts) break;
-      await new Promise((resolve) => setTimeout(resolve, 2 ** attempt * 500));
-    }
+  const signal = JSON.parse(text);
+  if (signal.attributedTo === 'space') {
+    console.warn('Signal credited to the Space, not the author', {
+      externalId,
+      author: payload.author ?? null,
+    });
   }
-  throw lastError;
-}
+
+  return json({
+    slug: signal.slug,
+    url: signal.url,
+    attributedTo: signal.attributedTo,
+  });
+});
 ```
 
-### Calling it
+### Client call
 
 ```ts
-import { publishSignal, withRetry } from '@/lib/hypha-signals';
+import { supabase } from '@/integrations/supabase/client';
 
-export async function onContestSubmission(submission: Submission) {
-  const signal = await withRetry(() =>
-    publishSignal({
+export async function publishSignal(submission: { id: string; headline: string; body: string; authorEmail?: string }) {
+  const { data, error } = await supabase.functions.invoke('publish-signal', {
+    body: {
       externalId: `submission-${submission.id}`,
       title: submission.headline,
       description: submission.body,
       type: 'Opportunity',
-      priority: submission.urgent ? 'high' : 'medium',
-      tags: ['Contest', submission.category],
-      author: { email: submission.authorEmail },
-    }),
-  );
+      priority: 'medium',
+      ...(submission.authorEmail ? { author: { email: submission.authorEmail } } : {}),
+    },
+  });
 
-  if (signal.attributedTo === 'space') {
-    console.warn('Signal published as the space', {
-      submissionId: submission.id,
-      email: submission.authorEmail,
-    });
+  if (error) {
+    // Never surface this as a failure of the user's own action.
+    console.error('Publishing to Hypha failed', error);
+    return null;
   }
-
-  return signal.url; // link the user straight to the board
+  return data as { slug: string; url: string; attributedTo: string };
 }
 ```
 
-### Python equivalent
-
-```python
-import os, json, urllib.request
-
-BASE_URL = os.environ.get("HYPHA_BASE_URL", "https://app.hypha.earth")
-SPACE_SLUG = os.environ["HYPHA_SPACE_SLUG"]
-API_KEY = os.environ["HYPHA_SPACE_API_KEY"]
-
-def publish_signal(payload: dict) -> dict:
-    url = f"{BASE_URL}/api/v1/spaces/{SPACE_SLUG}/signals"
-    request = urllib.request.Request(
-        url,
-        method="POST",
-        data=json.dumps(payload).encode(),
-        headers={"x-hypha-api-key": API_KEY, "Content-Type": "application/json"},
-    )
-    with urllib.request.urlopen(request) as response:
-        return json.loads(response.read())
-
-signal = publish_signal({
-    "externalId": "submission-42",
-    "title": "Riverside cleanup needs funding"[:50],
-    "description": "Twelve members flagged the riverside site this week.",
-    "type": "Opportunity",
-    "author": {"email": "member@example.org"},
-})
-print(signal["url"], signal["attributedTo"])
-```
-
-## Where to call it from
-
-Publish from your **server**, after your own write commits — a route handler, a queue worker, or a
-webhook. Two rules:
-
-- **Never fail a user action because Hypha was unreachable.** Enqueue and retry; the board is a
-  mirror, not your source of truth.
-- **Store the returned `slug`** against your record. You need it to update the signal or move it
-  through the workflow later.
-
-Because `externalId` makes creates idempotent, a worker can safely replay its queue.
-
-## Troubleshooting
-
-| Status | What it means                                                          | What to do                                                                                            |
-| ------ | ---------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| `400`  | Validation failed, unknown field, or an undefined status/board slug    | Read `details`; check `title` ≤ 50 chars and that your `progressStatus`/`board` slugs match the space |
-| `401`  | Key missing, unknown, or revoked                                       | Check the header name and that ops has not revoked the key                                            |
-| `403`  | Key is for another space, lacks the scope, or the signal is not yours  | You can only touch signals your own `source` created                                                  |
-| `404`  | Space or signal not found                                              | Check the space slug and that you stored the right signal slug                                        |
-| `409`  | Signal is archived, or the space is not linked on-chain (upvotes only) | Nothing to retry; ask Hypha to link the space                                                         |
-| `422`  | Voter has no Hypha profile or no voting power                          | Prompt the user to connect their Hypha profile — do not retry                                         |
-| `500`  | Unexpected server failure                                              | Retry with backoff                                                                                    |
-
-Validation failures carry `{ "error": "Validation failed", "details": … }` (Zod flatten). Other
-errors are `{ "error": "…" }`.
-
-## Local testing
-
-Against a dev server, everything is identical with `BASE_URL=http://localhost:3000` — issue a key
-with the ops secret from `apps/web/.env`:
-
-```bash
-curl -X POST http://localhost:3000/api/v1/ops/spaces/<spaceSlug>/api-keys \
-  -H "x-hypha-ops-secret: $HYPHA_SPACE_API_KEY_OPS_SECRET" \
-  -H 'Content-Type: application/json' \
-  -d '{ "name": "local dev", "source": "local-dev", "scopes": ["signals:write"] }'
-```
+Call it **after** your own record is saved, and ignore its failure for the user's flow.
 
 ---
 
-## Related
+## 8. Errors
 
-- [`docs/integrations/external-signal-ingestion.md`](../../../../../../../../../docs/integrations/external-signal-ingestion.md)
-  — the full integrator reference, safe to share outside the team.
-- Route handlers: `route.ts` (create), `[signalSlug]/route.ts` (update),
-  `[signalSlug]/upvotes/route.ts` (upvotes), `_lib/authorize-ingestion.ts` (key + attribution).
-- Key administration: `apps/web/src/app/api/v1/ops/spaces/[spaceSlug]/api-keys/`.
+| Status        | Meaning                                                                                                          | Correct response                                |
+| ------------- | ---------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| `400`         | Validation failed, unknown field, `title` over 50 chars, or a `progressStatus`/`board` the Space does not define | Fix the payload. Never retry unchanged          |
+| `401`         | Key missing, wrong, or revoked                                                                                   | Stop. Ask the human to re-check the secret      |
+| `403`         | Key belongs to another Space, lacks the scope, or the signal is not yours                                        | Stop. Do not retry                              |
+| `404`         | Space slug wrong, or signal slug wrong                                                                           | Stop. Verify configuration                      |
+| `409`         | Signal is archived, or the Space is not linked on-chain (upvotes only)                                           | Stop. Not retryable                             |
+| `422`         | Voter has no Hypha profile or no voting power (upvotes only)                                                     | Prompt the user, do not retry                   |
+| `429` / `5xx` | Transient                                                                                                        | Retry with exponential backoff, max ~3 attempts |
+
+Validation failures return `{ "error": "Validation failed", "details": { … } }`. Read `details` — it
+names the offending field.
+
+---
+
+## 9. Definition of done
+
+Do not report the integration complete until all of these hold:
+
+- [ ] `HYPHA_SPACE_API_KEY` appears **only** in Edge Function secrets. Searching the frontend bundle
+      and the repository for `hyk_` returns nothing.
+- [ ] JWT verification is enabled on the Edge Function; an unauthenticated call is rejected.
+- [ ] Publishing a signal returns a `url`, and opening that URL shows the signal on the Hypha board.
+- [ ] Publishing the **same** `externalId` twice creates **one** signal on the board.
+- [ ] `title` longer than 50 characters is truncated by your code, not rejected by Hypha.
+- [ ] `attributedTo` is logged on every publish.
+- [ ] A forced Hypha failure (e.g. a bad key) does **not** break or roll back the user's own action.
+- [ ] No `4xx` is ever retried.
+
+---
+
+## 10. Prompt to paste into the AI agent
+
+> Integrate Hypha Signals into this app.
+>
+> Goal: when a user submits **\<the thing your app produces\>**, publish it as a signal to our Hypha
+> Space so it appears on our Signals Board.
+>
+> Follow the specification in this file exactly. Specifically:
+>
+> - Put the Hypha API key in an Edge Function secret. It must never reach the browser.
+> - Keep JWT verification on that function enabled.
+> - Send `externalId` set to our own record id so retries never duplicate.
+> - Truncate `title` to 50 characters.
+> - Use `type` from `Opportunity | Risk | Tension | Insight` only.
+> - Send `author` as `{ email }` using the email on the user's account, and log `attributedTo` from
+>   the response.
+> - Publish after our own save succeeds, and never fail the user's action if Hypha is down.
+>
+> Secrets I will provide: `HYPHA_BASE_URL`, `HYPHA_SPACE_SLUG`, `HYPHA_SPACE_API_KEY`.
+>
+> When done, walk me through the Definition of done checklist in §9.

--- a/apps/web/src/app/api/v1/spaces/[spaceSlug]/signals/README.md
+++ b/apps/web/src/app/api/v1/spaces/[spaceSlug]/signals/README.md
@@ -59,7 +59,7 @@ Do not hardcode them, and do not guess them.
 | --------------------- | ------------------------- | -------------------------------------------- |
 | `HYPHA_BASE_URL`      | `https://app.hypha.earth` | Production Hypha                             |
 | `HYPHA_SPACE_SLUG`    | `acme-dao`                | Which Space the signals land in              |
-| `HYPHA_SPACE_API_KEY` | `hyk_K3nQ7bTz_x9f…`       | Per-Space key. Valid for that one Space only |
+| `HYPHA_SPACE_API_KEY` | `hyk_<prefix>_<secret>`   | Per-Space key. Valid for that one Space only |
 
 If any is missing, fail fast with a clear error at startup of the function. Do not fall back to a
 placeholder and do not proceed.
@@ -182,7 +182,9 @@ behaviour, not a workaround.
 ### Edge Function — `supabase/functions/publish-signal/index.ts`
 
 ```ts
-const BASE_URL = Deno.env.get('HYPHA_BASE_URL') ?? 'https://app.hypha.earth';
+// No fallback for any of the three: guessing the host would publish a staging
+// app's signals into production, or fail with a confusing 404.
+const BASE_URL = Deno.env.get('HYPHA_BASE_URL');
 const SPACE_SLUG = Deno.env.get('HYPHA_SPACE_SLUG');
 const API_KEY = Deno.env.get('HYPHA_SPACE_API_KEY');
 
@@ -206,25 +208,32 @@ Deno.serve(async (request) => {
   if (request.method === 'OPTIONS') return new Response('ok', { headers: CORS });
   if (request.method !== 'POST') return json({ error: 'Use POST' }, 405);
 
-  if (!SPACE_SLUG || !API_KEY) {
-    console.error('Missing HYPHA_SPACE_SLUG or HYPHA_SPACE_API_KEY secret');
+  if (!BASE_URL || !SPACE_SLUG || !API_KEY) {
+    console.error('Missing a HYPHA_BASE_URL, HYPHA_SPACE_SLUG or HYPHA_SPACE_API_KEY secret');
     return json({ error: 'Signals publishing is not configured' }, 500);
   }
 
   let input: Record<string, unknown>;
   try {
-    input = await request.json();
+    const parsed = await request.json();
+    // `null` and arrays are valid JSON but not valid bodies; reading fields off
+    // them would throw or coerce into nonsense like "[object Object]".
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return json({ error: 'Body must be a JSON object' }, 400);
+    }
+    input = parsed as Record<string, unknown>;
   } catch {
     return json({ error: 'Invalid JSON' }, 400);
   }
 
-  const externalId = String(input.externalId ?? '').trim();
-  const title = String(input.title ?? '').trim();
-  const description = String(input.description ?? '').trim();
-  const type = String(input.type ?? '') as SignalType;
+  const str = (value: unknown) => (typeof value === 'string' ? value.trim() : '');
+  const externalId = str(input.externalId);
+  const title = str(input.title);
+  const description = str(input.description);
+  const type = str(input.type) as SignalType;
 
   if (!externalId || !title || !description) {
-    return json({ error: 'externalId, title and description are required' }, 400);
+    return json({ error: 'externalId, title and description must be non-empty strings' }, 400);
   }
   if (!SIGNAL_TYPES.includes(type)) {
     return json({ error: `type must be one of ${SIGNAL_TYPES.join(', ')}` }, 400);
@@ -238,13 +247,17 @@ Deno.serve(async (request) => {
     description: description.slice(0, 4000),
     type,
   };
-  if (input.priority) payload.priority = input.priority;
+  if (typeof input.priority === 'string') payload.priority = input.priority;
   if (Array.isArray(input.tags) && input.tags.length > 0) {
-    payload.tags = input.tags.slice(0, 50);
+    payload.tags = input.tags.filter((tag) => typeof tag === 'string').slice(0, 50);
   }
-  if (input.author && typeof input.author === 'object') {
+  if (input.author && typeof input.author === 'object' && !Array.isArray(input.author)) {
     payload.author = input.author;
   }
+  if (typeof input.progressStatus === 'string') payload.progressStatus = input.progressStatus;
+  if (typeof input.board === 'string') payload.board = input.board;
+  // `null` is meaningful here — it clears a due date — so pass it through.
+  if (input.dueAt === null || typeof input.dueAt === 'string') payload.dueAt = input.dueAt;
 
   const response = await fetch(`${BASE_URL}/api/v1/spaces/${SPACE_SLUG}/signals`, {
     method: 'POST',
@@ -256,22 +269,39 @@ Deno.serve(async (request) => {
   });
 
   const text = await response.text();
+  let body: Record<string, unknown> = {};
+  try {
+    body = JSON.parse(text);
+  } catch {
+    // Non-JSON body (a gateway error page); the status is all we can rely on.
+  }
+
   if (!response.ok) {
-    // Log the detail server-side; do not leak Hypha internals to the browser.
+    // Never log the raw body or the author: both carry the signal's content and
+    // the member's email or wallet, and function logs are widely readable.
     console.error('Hypha rejected the signal', {
       status: response.status,
       externalId,
-      body: text,
     });
     const retryable = response.status >= 500 || response.status === 429;
-    return json({ error: 'Could not publish to Hypha', retryable }, retryable ? 503 : 400);
+    // Pass the status through so the caller can tell "fix the payload" (400)
+    // from "connect your profile" (422) from "re-check the key" (401).
+    return json(
+      {
+        error: 'Could not publish to Hypha',
+        status: response.status,
+        retryable,
+        details: body.details ?? null,
+      },
+      retryable ? 503 : response.status,
+    );
   }
 
-  const signal = JSON.parse(text);
+  const signal = body;
   if (signal.attributedTo === 'space') {
     console.warn('Signal credited to the Space, not the author', {
       externalId,
-      author: payload.author ?? null,
+      authorProvided: Boolean(payload.author),
     });
   }
 
@@ -327,6 +357,10 @@ Call it **after** your own record is saved, and ignore its failure for the user'
 
 Validation failures return `{ "error": "Validation failed", "details": { … } }`. Read `details` — it
 names the offending field.
+
+The Edge Function above forwards Hypha's status and `details` to its own caller (as
+`{ error, status, retryable, details }`), so the client can tell a payload bug from a `422` that needs
+a user prompt. It deliberately does not forward the raw response body.
 
 ---
 

--- a/apps/web/src/app/api/v1/spaces/[spaceSlug]/signals/[signalSlug]/route.ts
+++ b/apps/web/src/app/api/v1/spaces/[spaceSlug]/signals/[signalSlug]/route.ts
@@ -3,7 +3,6 @@ import { ZodError } from 'zod';
 import {
   normalizeCoherence,
   schemaPatchIngestedSignal,
-  updateCoherenceBySlug,
   updateCoherenceSignalBySlug,
 } from '@hypha-platform/core/server';
 import { db } from '@hypha-platform/storage-postgres';
@@ -63,8 +62,9 @@ export async function PATCH(
     }
 
     // `updateCoherenceSignalBySlug` writes the full signal, so unspecified
-    // fields are carried over from the stored row rather than reset.
-    let updated = await updateCoherenceSignalBySlug(
+    // fields are carried over from the stored row rather than reset. Archiving
+    // rides along in the same write, so a patch can never land half-applied.
+    const updated = await updateCoherenceSignalBySlug(
       {
         slug: signalSlug,
         requesterPersonId: signal.creatorId,
@@ -80,16 +80,10 @@ export async function PATCH(
             : patch.progressStatus,
         board: patch.board === undefined ? signal.board : patch.board,
         assigneeIds: signal.assigneeIds,
+        ...(patch.archived !== undefined ? { archived: patch.archived } : {}),
       },
       { db },
     );
-
-    if (patch.archived !== undefined && patch.archived !== signal.archived) {
-      updated = await updateCoherenceBySlug(
-        { slug: signalSlug, archived: patch.archived },
-        { db },
-      );
-    }
 
     return NextResponse.json({
       id: updated.id,

--- a/apps/web/src/app/api/v1/spaces/[spaceSlug]/signals/[signalSlug]/route.ts
+++ b/apps/web/src/app/api/v1/spaces/[spaceSlug]/signals/[signalSlug]/route.ts
@@ -1,0 +1,114 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { ZodError } from 'zod';
+import {
+  normalizeCoherence,
+  schemaPatchIngestedSignal,
+  updateCoherenceBySlug,
+  updateCoherenceSignalBySlug,
+} from '@hypha-platform/core/server';
+import { db } from '@hypha-platform/storage-postgres';
+
+import {
+  authorizeIngestion,
+  loadOwnedSignal,
+} from '../_lib/authorize-ingestion';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+type Params = { spaceSlug: string; signalSlug: string };
+
+/**
+ * Update a signal this integration previously ingested. Signals created in the
+ * Hypha UI, or by another integration, are not writable through this route.
+ */
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<Params> },
+) {
+  const { spaceSlug, signalSlug } = await params;
+
+  try {
+    const authorized = await authorizeIngestion(
+      request,
+      spaceSlug,
+      'signals:write',
+    );
+    if ('response' in authorized) return authorized.response;
+    const { space, apiKey } = authorized.context;
+
+    const owned = await loadOwnedSignal({ signalSlug, space, apiKey });
+    if ('response' in owned) return owned.response;
+    const { signal } = owned;
+
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+    }
+
+    let patch: ReturnType<typeof schemaPatchIngestedSignal.parse>;
+    try {
+      patch = schemaPatchIngestedSignal.parse(body);
+    } catch (error) {
+      if (error instanceof ZodError) {
+        return NextResponse.json(
+          { error: 'Validation failed', details: error.flatten() },
+          { status: 400 },
+        );
+      }
+      throw error;
+    }
+
+    // `updateCoherenceSignalBySlug` writes the full signal, so unspecified
+    // fields are carried over from the stored row rather than reset.
+    let updated = await updateCoherenceSignalBySlug(
+      {
+        slug: signalSlug,
+        requesterPersonId: signal.creatorId,
+        type: patch.type ?? signal.type,
+        priority: patch.priority ?? signal.priority,
+        title: patch.title ?? signal.title,
+        description: patch.description ?? signal.description,
+        tags: patch.tags ?? signal.tags,
+        dueAt: patch.dueAt === undefined ? signal.dueAt : patch.dueAt,
+        progressStatus:
+          patch.progressStatus === undefined
+            ? signal.progressStatus
+            : patch.progressStatus,
+        board: patch.board === undefined ? signal.board : patch.board,
+        assigneeIds: signal.assigneeIds,
+      },
+      { db },
+    );
+
+    if (patch.archived !== undefined && patch.archived !== signal.archived) {
+      updated = await updateCoherenceBySlug(
+        { slug: signalSlug, archived: patch.archived },
+        { db },
+      );
+    }
+
+    return NextResponse.json({
+      id: updated.id,
+      slug: updated.slug,
+      spaceSlug: space.slug,
+      signal: normalizeCoherence(updated),
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (/^Unknown (progress status|board)/.test(message)) {
+      return NextResponse.json({ error: message }, { status: 400 });
+    }
+    console.error('Failed to update ingested signal:', {
+      spaceSlug,
+      signalSlug,
+      message,
+    });
+    return NextResponse.json(
+      { error: 'Failed to update signal' },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/src/app/api/v1/spaces/[spaceSlug]/signals/[signalSlug]/route.ts
+++ b/apps/web/src/app/api/v1/spaces/[spaceSlug]/signals/[signalSlug]/route.ts
@@ -12,6 +12,7 @@ import {
   authorizeIngestion,
   loadOwnedSignal,
 } from '../_lib/authorize-ingestion';
+import { withExternalTag } from '../_lib/external-signal-tag';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -71,7 +72,7 @@ export async function PATCH(
         priority: patch.priority ?? signal.priority,
         title: patch.title ?? signal.title,
         description: patch.description ?? signal.description,
-        tags: patch.tags ?? signal.tags,
+        tags: withExternalTag(patch.tags ?? signal.tags),
         dueAt: patch.dueAt === undefined ? signal.dueAt : patch.dueAt,
         progressStatus:
           patch.progressStatus === undefined

--- a/apps/web/src/app/api/v1/spaces/[spaceSlug]/signals/[signalSlug]/upvotes/route.ts
+++ b/apps/web/src/app/api/v1/spaces/[spaceSlug]/signals/[signalSlug]/upvotes/route.ts
@@ -1,0 +1,191 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { ZodError } from 'zod';
+import {
+  applyCoherenceUpvote,
+  applyCoherenceUpvoteRemoval,
+  schemaIngestedSignalUpvote,
+  type CoherenceUpvoteTarget,
+} from '@hypha-platform/core/server';
+import { db } from '@hypha-platform/storage-postgres';
+
+import {
+  authorizeIngestion,
+  loadOwnedSignal,
+  resolveSignalAuthor,
+} from '../../_lib/authorize-ingestion';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+type Params = { spaceSlug: string; signalSlug: string };
+
+/** Maps the shared upvote guards onto status codes for API callers. */
+const clientErrors: Array<{ pattern: RegExp; status: number }> = [
+  { pattern: /^Cannot vote on an archived signal/, status: 409 },
+  { pattern: /^Signal space is not linked to an on-chain space/, status: 409 },
+  { pattern: /^A linked wallet is required/, status: 422 },
+  { pattern: /^You have no voting power/, status: 422 },
+];
+
+function toErrorResponse(
+  error: unknown,
+  context: { spaceSlug: string; signalSlug: string; action: string },
+) {
+  const message = error instanceof Error ? error.message : String(error);
+  const match = clientErrors.find((candidate) =>
+    candidate.pattern.test(message),
+  );
+  if (match) {
+    return NextResponse.json({ error: message }, { status: match.status });
+  }
+  console.error(`Failed to ${context.action} ingested signal upvote:`, {
+    ...context,
+    message,
+  });
+  return NextResponse.json(
+    { error: `Failed to ${context.action} upvote` },
+    { status: 500 },
+  );
+}
+
+async function readJsonBody(request: NextRequest): Promise<unknown> {
+  try {
+    return await request.json();
+  } catch {
+    return undefined;
+  }
+}
+
+async function resolveContext(
+  request: NextRequest,
+  { spaceSlug, signalSlug }: Params,
+) {
+  const authorized = await authorizeIngestion(
+    request,
+    spaceSlug,
+    'signals:upvote',
+  );
+  if ('response' in authorized) return { response: authorized.response };
+  const { space, apiKey } = authorized.context;
+
+  const owned = await loadOwnedSignal({ signalSlug, space, apiKey });
+  if ('response' in owned) return { response: owned.response };
+
+  if (typeof space.web3SpaceId !== 'number') {
+    return {
+      response: NextResponse.json(
+        { error: 'Signal space is not linked to an on-chain space' },
+        { status: 409 },
+      ),
+    };
+  }
+
+  const target: CoherenceUpvoteTarget = {
+    id: owned.signal.id,
+    spaceId: owned.spaceId,
+    archived: owned.signal.archived,
+    web3SpaceId: space.web3SpaceId,
+  };
+
+  return { target };
+}
+
+/**
+ * Record an upvote on behalf of a community member who voted in the external
+ * app. Weight still comes from the space's on-chain voting power source, so an
+ * integration can allocate a share of what the member holds and never more.
+ */
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<Params> },
+) {
+  const resolvedParams = await params;
+
+  try {
+    const context = await resolveContext(request, resolvedParams);
+    if ('response' in context) return context.response;
+
+    let payload: ReturnType<typeof schemaIngestedSignalUpvote.parse>;
+    try {
+      payload = schemaIngestedSignalUpvote.parse(await readJsonBody(request));
+    } catch (error) {
+      if (error instanceof ZodError) {
+        return NextResponse.json(
+          { error: 'Validation failed', details: error.flatten() },
+          { status: 400 },
+        );
+      }
+      throw error;
+    }
+
+    const voter = await resolveSignalAuthor(payload.voter);
+    if (!voter?.id) {
+      return NextResponse.json(
+        {
+          error: `No Hypha person matches ${payload.voter.walletAddress}. The voter must have a Hypha profile with that wallet address.`,
+        },
+        { status: 422 },
+      );
+    }
+
+    const upvotes = await applyCoherenceUpvote(
+      {
+        coherence: context.target,
+        actor: voter,
+        votingPowerPercent: payload.votingPowerPercent,
+      },
+      { db },
+    );
+
+    return NextResponse.json({ upvotes });
+  } catch (error) {
+    return toErrorResponse(error, { ...resolvedParams, action: 'record' });
+  }
+}
+
+/** Remove a previously recorded upvote, e.g. when the member unallocates. */
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<Params> },
+) {
+  const resolvedParams = await params;
+
+  try {
+    const context = await resolveContext(request, resolvedParams);
+    if ('response' in context) return context.response;
+
+    // DELETE bodies are awkward for some clients, so `?voter=0x…` also works.
+    const body = await readJsonBody(request);
+    const walletAddress =
+      new URL(request.url).searchParams.get('voter')?.trim() ||
+      (body as { voter?: { walletAddress?: string } } | undefined)?.voter
+        ?.walletAddress;
+
+    if (!walletAddress) {
+      return NextResponse.json(
+        {
+          error:
+            'Identify the voter with a `voter` query parameter or a { voter: { walletAddress } } body.',
+        },
+        { status: 400 },
+      );
+    }
+
+    const voter = await resolveSignalAuthor({ walletAddress });
+    if (!voter?.id) {
+      return NextResponse.json(
+        { error: `No Hypha person matches ${walletAddress}.` },
+        { status: 422 },
+      );
+    }
+
+    const upvotes = await applyCoherenceUpvoteRemoval(
+      { coherence: context.target, actor: voter },
+      { db },
+    );
+
+    return NextResponse.json({ upvotes });
+  } catch (error) {
+    return toErrorResponse(error, { ...resolvedParams, action: 'remove' });
+  }
+}

--- a/apps/web/src/app/api/v1/spaces/[spaceSlug]/signals/[signalSlug]/upvotes/route.ts
+++ b/apps/web/src/app/api/v1/spaces/[spaceSlug]/signals/[signalSlug]/upvotes/route.ts
@@ -11,7 +11,7 @@ import { db } from '@hypha-platform/storage-postgres';
 import {
   authorizeIngestion,
   loadOwnedSignal,
-  resolveSignalAuthor,
+  resolvePersonRef,
 } from '../../_lib/authorize-ingestion';
 
 export const runtime = 'nodejs';
@@ -118,7 +118,9 @@ export async function PUT(
       throw error;
     }
 
-    const voter = await resolveSignalAuthor(payload.voter);
+    // Unlike authorship, a voter cannot fall back to the space: an upvote only
+    // means something as one member's weight, and upvotes are unique per person.
+    const voter = await resolvePersonRef(payload.voter);
     if (!voter?.id) {
       return NextResponse.json(
         {
@@ -171,7 +173,7 @@ export async function DELETE(
       );
     }
 
-    const voter = await resolveSignalAuthor({ walletAddress });
+    const voter = await resolvePersonRef({ walletAddress });
     if (!voter?.id) {
       return NextResponse.json(
         { error: `No Hypha person matches ${walletAddress}.` },

--- a/apps/web/src/app/api/v1/spaces/[spaceSlug]/signals/_lib/authorize-ingestion.ts
+++ b/apps/web/src/app/api/v1/spaces/[spaceSlug]/signals/_lib/authorize-ingestion.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import {
   authenticateSpaceApiKey,
+  ensureSpaceActorPerson,
   findCoherenceBySlug,
   findPersonByEmail,
   findPersonByWeb3Address,
@@ -57,32 +58,58 @@ export async function authorizeIngestion(
   return { context: { space, apiKey: auth.apiKey } };
 }
 
-export type SignalAuthorRef = {
+export type PersonRef = {
   walletAddress?: string;
   email?: string;
 };
 
+export type ResolvedSignalAuthor = {
+  personId: number;
+  /** True when the payload's author was unknown and the space stood in. */
+  attributedToSpace: boolean;
+};
+
 /**
- * Map an integration's identifier for a person onto an existing Hypha person.
- * Returns null when there is no match — signals are never attributed to a
- * placeholder, and ingestion never writes to the `people` table.
+ * Map an integration's identifier for someone onto an existing Hypha person.
+ * The wallet is tried first when both are given. Returns null when neither
+ * matches — no person is ever created to satisfy a lookup.
  */
-export async function resolveSignalAuthor(
-  author: SignalAuthorRef,
-): Promise<Person | null> {
-  if (author.walletAddress) {
+export async function resolvePersonRef(ref: PersonRef): Promise<Person | null> {
+  if (ref.walletAddress) {
     const byWallet = await findPersonByWeb3Address(
-      { address: author.walletAddress },
+      { address: ref.walletAddress },
       { db },
     );
     if (byWallet) return byWallet;
   }
 
-  if (author.email) {
-    return findPersonByEmail({ email: author.email }, { db });
+  if (ref.email) {
+    return findPersonByEmail({ email: ref.email }, { db });
   }
 
   return null;
+}
+
+/**
+ * Decide who an ingested signal is attributed to.
+ *
+ * An author Hypha already knows is used directly. When the author is omitted or
+ * matches nobody, the signal is attributed to the space itself, so an
+ * integration is never blocked by a contributor who has not linked the wallet or
+ * email the external app knows them by. The space actor holds no wallet and no
+ * membership, so the signal carries no voting power and cannot vote.
+ */
+export async function resolveSignalAuthorOrSpace(
+  author: PersonRef | undefined,
+  space: Space,
+): Promise<ResolvedSignalAuthor> {
+  const person = author ? await resolvePersonRef(author) : null;
+  if (person?.id) {
+    return { personId: person.id, attributedToSpace: false };
+  }
+
+  const spaceActor = await ensureSpaceActorPerson({ space }, { db });
+  return { personId: spaceActor.id, attributedToSpace: true };
 }
 
 /**
@@ -122,14 +149,4 @@ export async function loadOwnedSignal({
   }
 
   return { signal: normalizeCoherence(row), spaceId: row.spaceId };
-}
-
-export function authorNotFoundResponse(author: SignalAuthorRef) {
-  const identifier = author.walletAddress ?? author.email ?? 'the given author';
-  return NextResponse.json(
-    {
-      error: `No Hypha person matches ${identifier}. The author must have a Hypha profile with a matching wallet address or email before their signals can be ingested.`,
-    },
-    { status: 422 },
-  );
 }

--- a/apps/web/src/app/api/v1/spaces/[spaceSlug]/signals/_lib/authorize-ingestion.ts
+++ b/apps/web/src/app/api/v1/spaces/[spaceSlug]/signals/_lib/authorize-ingestion.ts
@@ -1,0 +1,135 @@
+import { NextResponse } from 'next/server';
+import {
+  authenticateSpaceApiKey,
+  findCoherenceBySlug,
+  findPersonByEmail,
+  findPersonByWeb3Address,
+  findSpaceBySlug,
+  normalizeCoherence,
+  type AuthenticatedSpaceApiKey,
+  type Person,
+  type SpaceApiKeyScope,
+} from '@hypha-platform/core/server';
+import { db } from '@hypha-platform/storage-postgres';
+
+type Space = NonNullable<Awaited<ReturnType<typeof findSpaceBySlug>>>;
+
+export type IngestionContext = {
+  space: Space;
+  apiKey: AuthenticatedSpaceApiKey;
+};
+
+/**
+ * Resolve the target space and verify the caller's integration key against it.
+ *
+ * Unlike the member-facing signal routes this deliberately does not consult
+ * space transparency: a key is a per-space grant, so a public space does not
+ * become writable and a private space stays writable by its own integration.
+ */
+export async function authorizeIngestion(
+  request: Request,
+  spaceSlug: string,
+  requiredScope: SpaceApiKeyScope,
+): Promise<{ context: IngestionContext } | { response: NextResponse }> {
+  const space = await findSpaceBySlug({ slug: spaceSlug }, { db });
+  if (!space) {
+    return {
+      response: NextResponse.json(
+        { error: 'Space not found' },
+        { status: 404 },
+      ),
+    };
+  }
+
+  const auth = await authenticateSpaceApiKey(
+    { request, spaceId: space.id, requiredScope },
+    { db },
+  );
+  if (!auth.ok) {
+    return {
+      response: NextResponse.json(
+        { error: auth.error },
+        { status: auth.status },
+      ),
+    };
+  }
+
+  return { context: { space, apiKey: auth.apiKey } };
+}
+
+export type SignalAuthorRef = {
+  walletAddress?: string;
+  email?: string;
+};
+
+/**
+ * Map an integration's identifier for a person onto an existing Hypha person.
+ * Returns null when there is no match — signals are never attributed to a
+ * placeholder, and ingestion never writes to the `people` table.
+ */
+export async function resolveSignalAuthor(
+  author: SignalAuthorRef,
+): Promise<Person | null> {
+  if (author.walletAddress) {
+    const byWallet = await findPersonByWeb3Address(
+      { address: author.walletAddress },
+      { db },
+    );
+    if (byWallet) return byWallet;
+  }
+
+  if (author.email) {
+    return findPersonByEmail({ email: author.email }, { db });
+  }
+
+  return null;
+}
+
+/**
+ * Load a signal and confirm the calling key owns it: same space, and written
+ * by the same integration `source`. Signals authored in the Hypha UI have no
+ * source, so they are never mutable through the ingestion API.
+ */
+export async function loadOwnedSignal({
+  signalSlug,
+  space,
+  apiKey,
+}: {
+  signalSlug: string;
+  space: Space;
+  apiKey: AuthenticatedSpaceApiKey;
+}) {
+  const row = await findCoherenceBySlug({ slug: signalSlug }, { db });
+  if (!row || row.spaceId !== space.id) {
+    return {
+      response: NextResponse.json(
+        { error: 'Signal not found' },
+        { status: 404 },
+      ),
+    };
+  }
+
+  if (row.source !== apiKey.source) {
+    return {
+      response: NextResponse.json(
+        {
+          error:
+            'This signal was not created by this integration, so it cannot be modified through the API.',
+        },
+        { status: 403 },
+      ),
+    };
+  }
+
+  return { signal: normalizeCoherence(row), spaceId: row.spaceId };
+}
+
+export function authorNotFoundResponse(author: SignalAuthorRef) {
+  const identifier = author.walletAddress ?? author.email ?? 'the given author';
+  return NextResponse.json(
+    {
+      error: `No Hypha person matches ${identifier}. The author must have a Hypha profile with a matching wallet address or email before their signals can be ingested.`,
+    },
+    { status: 422 },
+  );
+}

--- a/apps/web/src/app/api/v1/spaces/[spaceSlug]/signals/_lib/external-signal-tag.ts
+++ b/apps/web/src/app/api/v1/spaces/[spaceSlug]/signals/_lib/external-signal-tag.ts
@@ -1,0 +1,16 @@
+/** Marks every ingested signal so the board can filter on provenance. */
+export const EXTERNAL_SIGNAL_TAG = 'External Signal';
+
+/**
+ * Apply the provenance tag to a signal written by an integration.
+ *
+ * Used on update as well as creation: a patch replaces the whole tag list, so
+ * an integration editing tags would otherwise strip the marker off its own
+ * signal and make it indistinguishable from one authored in the Hypha UI.
+ */
+export function withExternalTag(tags: string[]): string[] {
+  const alreadyTagged = tags.some(
+    (tag) => tag.trim().toLowerCase() === EXTERNAL_SIGNAL_TAG.toLowerCase(),
+  );
+  return alreadyTagged ? tags : [...tags, EXTERNAL_SIGNAL_TAG];
+}

--- a/apps/web/src/app/api/v1/spaces/[spaceSlug]/signals/route.ts
+++ b/apps/web/src/app/api/v1/spaces/[spaceSlug]/signals/route.ts
@@ -5,6 +5,7 @@ import {
   createCoherence,
   findCoherenceBySourceExternalId,
   findSpaceActorPerson,
+  isUniqueViolation,
   normalizeCoherence,
   schemaIngestSignal,
   type Coherence,
@@ -53,6 +54,34 @@ function toIngestionResponse(
 }
 
 /**
+ * The `200` answer for an `externalId` this integration has already ingested,
+ * or null when it has not. Attribution is recovered by comparing the stored
+ * creator against the space actor, since the original payload is long gone.
+ */
+async function respondWithExistingSignal(
+  request: NextRequest,
+  key: { spaceId: number; source: string; externalId: string },
+  space: { slug: string },
+) {
+  const existing = await findCoherenceBySourceExternalId(key, { db });
+  if (!existing) return null;
+
+  const spaceActor = await findSpaceActorPerson(
+    { spaceId: key.spaceId },
+    { db },
+  );
+  return NextResponse.json(
+    toIngestionResponse(
+      request,
+      normalizeCoherence(existing),
+      space.slug,
+      existing.creatorId === spaceActor?.id ? 'space' : 'author',
+    ),
+    { status: 200 },
+  );
+}
+
+/**
  * Ingest a signal produced by a community's own app. The row lands in the same
  * `coherences` table the Signals Board reads, so it appears on the board with
  * no further work.
@@ -92,54 +121,58 @@ export async function POST(
       throw error;
     }
 
-    // Replay check first, so a repeated request neither writes nor creates the
-    // space actor person that attribution may fall back to.
-    if (payload.externalId) {
-      const existing = await findCoherenceBySourceExternalId(
-        {
+    const replayKey = payload.externalId
+      ? {
           spaceId: space.id,
           source: apiKey.source,
           externalId: payload.externalId,
-        },
-        { db },
-      );
-      if (existing) {
-        const spaceActor = await findSpaceActorPerson(
-          { spaceId: space.id },
-          { db },
-        );
-        return NextResponse.json(
-          toIngestionResponse(
-            request,
-            normalizeCoherence(existing),
-            space.slug,
-            existing.creatorId === spaceActor?.id ? 'space' : 'author',
-          ),
-          { status: 200 },
-        );
-      }
+        }
+      : null;
+
+    // Replay check first, so a repeated request neither writes nor creates the
+    // space actor person that attribution may fall back to.
+    if (replayKey) {
+      const replay = await respondWithExistingSignal(request, replayKey, space);
+      if (replay) return replay;
     }
 
     const author = await resolveSignalAuthorOrSpace(payload.author, space);
 
-    const created = await createCoherence(
-      {
-        creatorId: author.personId,
-        spaceId: space.id,
-        type: payload.type,
-        priority: payload.priority,
-        title: payload.title,
-        description: payload.description,
-        tags: withExternalTag(payload.tags),
-        archived: false,
-        dueAt: payload.dueAt,
-        progressStatus: payload.progressStatus,
-        board: payload.board,
-        source: apiKey.source,
-        externalId: payload.externalId ?? null,
-      },
-      { db },
-    );
+    let created: Awaited<ReturnType<typeof createCoherence>>;
+    try {
+      created = await createCoherence(
+        {
+          creatorId: author.personId,
+          spaceId: space.id,
+          type: payload.type,
+          priority: payload.priority,
+          title: payload.title,
+          description: payload.description,
+          tags: withExternalTag(payload.tags),
+          archived: false,
+          dueAt: payload.dueAt,
+          progressStatus: payload.progressStatus,
+          board: payload.board,
+          source: apiKey.source,
+          externalId: payload.externalId ?? null,
+        },
+        { db },
+      );
+    } catch (error) {
+      // Two retries can race past the replay check; the unique index is what
+      // actually makes ingestion idempotent, so honour it as a replay too. The
+      // lookup below is the real test of which constraint fired: any other one
+      // finds no row and falls through to the error response.
+      if (replayKey && isUniqueViolation(error)) {
+        const replay = await respondWithExistingSignal(
+          request,
+          replayKey,
+          space,
+        );
+        if (replay) return replay;
+      }
+      throw error;
+    }
 
     return NextResponse.json(
       toIngestionResponse(

--- a/apps/web/src/app/api/v1/spaces/[spaceSlug]/signals/route.ts
+++ b/apps/web/src/app/api/v1/spaces/[spaceSlug]/signals/route.ts
@@ -15,21 +15,12 @@ import {
   authorizeIngestion,
   resolveSignalAuthorOrSpace,
 } from './_lib/authorize-ingestion';
+import { withExternalTag } from './_lib/external-signal-tag';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 type Params = { spaceSlug: string };
-
-/** Marks every ingested signal so the board can filter on provenance. */
-const EXTERNAL_SIGNAL_TAG = 'External Signal';
-
-function withExternalTag(tags: string[]): string[] {
-  const alreadyTagged = tags.some(
-    (tag) => tag.trim().toLowerCase() === EXTERNAL_SIGNAL_TAG.toLowerCase(),
-  );
-  return alreadyTagged ? tags : [...tags, EXTERNAL_SIGNAL_TAG];
-}
 
 /**
  * Who the board credits for a signal: the reported author when Hypha knows

--- a/apps/web/src/app/api/v1/spaces/[spaceSlug]/signals/route.ts
+++ b/apps/web/src/app/api/v1/spaces/[spaceSlug]/signals/route.ts
@@ -1,0 +1,157 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { ZodError } from 'zod';
+import {
+  buildAiSignalNavigation,
+  createCoherence,
+  findCoherenceBySourceExternalId,
+  normalizeCoherence,
+  schemaIngestSignal,
+  type Coherence,
+} from '@hypha-platform/core/server';
+import { db } from '@hypha-platform/storage-postgres';
+
+import {
+  authorNotFoundResponse,
+  authorizeIngestion,
+  resolveSignalAuthor,
+} from './_lib/authorize-ingestion';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+type Params = { spaceSlug: string };
+
+/** Marks every ingested signal so the board can filter on provenance. */
+const EXTERNAL_SIGNAL_TAG = 'External Signal';
+
+function withExternalTag(tags: string[]): string[] {
+  const alreadyTagged = tags.some(
+    (tag) => tag.trim().toLowerCase() === EXTERNAL_SIGNAL_TAG.toLowerCase(),
+  );
+  return alreadyTagged ? tags : [...tags, EXTERNAL_SIGNAL_TAG];
+}
+
+function toIngestionResponse(
+  request: NextRequest,
+  signal: Coherence,
+  spaceSlug: string,
+) {
+  const signalSlug = signal.slug ?? '';
+  const { href } = buildAiSignalNavigation({
+    spaceSlug,
+    signalSlug,
+    signalTitle: signal.title,
+    roomId: signal.roomId,
+  });
+
+  return {
+    id: signal.id,
+    slug: signalSlug,
+    spaceSlug,
+    url: new URL(href, request.url).toString(),
+    signal,
+  };
+}
+
+/**
+ * Ingest a signal produced by a community's own app. The row lands in the same
+ * `coherences` table the Signals Board reads, so it appears on the board with
+ * no further work.
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<Params> },
+) {
+  const { spaceSlug } = await params;
+
+  try {
+    const authorized = await authorizeIngestion(
+      request,
+      spaceSlug,
+      'signals:write',
+    );
+    if ('response' in authorized) return authorized.response;
+    const { space, apiKey } = authorized.context;
+
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+    }
+
+    let payload: ReturnType<typeof schemaIngestSignal.parse>;
+    try {
+      payload = schemaIngestSignal.parse(body);
+    } catch (error) {
+      if (error instanceof ZodError) {
+        return NextResponse.json(
+          { error: 'Validation failed', details: error.flatten() },
+          { status: 400 },
+        );
+      }
+      throw error;
+    }
+
+    const author = await resolveSignalAuthor(payload.author);
+    if (!author?.id) {
+      return authorNotFoundResponse(payload.author);
+    }
+
+    if (payload.externalId) {
+      const existing = await findCoherenceBySourceExternalId(
+        {
+          spaceId: space.id,
+          source: apiKey.source,
+          externalId: payload.externalId,
+        },
+        { db },
+      );
+      if (existing) {
+        return NextResponse.json(
+          toIngestionResponse(
+            request,
+            normalizeCoherence(existing),
+            space.slug,
+          ),
+          { status: 200 },
+        );
+      }
+    }
+
+    const created = await createCoherence(
+      {
+        creatorId: author.id,
+        spaceId: space.id,
+        type: payload.type,
+        priority: payload.priority,
+        title: payload.title,
+        description: payload.description,
+        tags: withExternalTag(payload.tags),
+        archived: false,
+        dueAt: payload.dueAt,
+        progressStatus: payload.progressStatus,
+        board: payload.board,
+        source: apiKey.source,
+        externalId: payload.externalId ?? null,
+      },
+      { db },
+    );
+
+    return NextResponse.json(
+      toIngestionResponse(request, normalizeCoherence(created), space.slug),
+      { status: 201 },
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    // Workflow validation rejects unknown statuses and boards for the space.
+    if (/^Unknown (progress status|board)/.test(message)) {
+      return NextResponse.json({ error: message }, { status: 400 });
+    }
+    console.error('Failed to ingest signal:', { spaceSlug, message });
+    return NextResponse.json(
+      { error: 'Failed to ingest signal' },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/src/app/api/v1/spaces/[spaceSlug]/signals/route.ts
+++ b/apps/web/src/app/api/v1/spaces/[spaceSlug]/signals/route.ts
@@ -4,6 +4,7 @@ import {
   buildAiSignalNavigation,
   createCoherence,
   findCoherenceBySourceExternalId,
+  findSpaceActorPerson,
   normalizeCoherence,
   schemaIngestSignal,
   type Coherence,
@@ -11,9 +12,8 @@ import {
 import { db } from '@hypha-platform/storage-postgres';
 
 import {
-  authorNotFoundResponse,
   authorizeIngestion,
-  resolveSignalAuthor,
+  resolveSignalAuthorOrSpace,
 } from './_lib/authorize-ingestion';
 
 export const runtime = 'nodejs';
@@ -31,10 +31,17 @@ function withExternalTag(tags: string[]): string[] {
   return alreadyTagged ? tags : [...tags, EXTERNAL_SIGNAL_TAG];
 }
 
+/**
+ * Who the board credits for a signal: the reported author when Hypha knows
+ * them, otherwise the space itself.
+ */
+type Attribution = 'author' | 'space';
+
 function toIngestionResponse(
   request: NextRequest,
   signal: Coherence,
   spaceSlug: string,
+  attributedTo: Attribution,
 ) {
   const signalSlug = signal.slug ?? '';
   const { href } = buildAiSignalNavigation({
@@ -49,6 +56,7 @@ function toIngestionResponse(
     slug: signalSlug,
     spaceSlug,
     url: new URL(href, request.url).toString(),
+    attributedTo,
     signal,
   };
 }
@@ -93,11 +101,8 @@ export async function POST(
       throw error;
     }
 
-    const author = await resolveSignalAuthor(payload.author);
-    if (!author?.id) {
-      return authorNotFoundResponse(payload.author);
-    }
-
+    // Replay check first, so a repeated request neither writes nor creates the
+    // space actor person that attribution may fall back to.
     if (payload.externalId) {
       const existing = await findCoherenceBySourceExternalId(
         {
@@ -108,20 +113,27 @@ export async function POST(
         { db },
       );
       if (existing) {
+        const spaceActor = await findSpaceActorPerson(
+          { spaceId: space.id },
+          { db },
+        );
         return NextResponse.json(
           toIngestionResponse(
             request,
             normalizeCoherence(existing),
             space.slug,
+            existing.creatorId === spaceActor?.id ? 'space' : 'author',
           ),
           { status: 200 },
         );
       }
     }
 
+    const author = await resolveSignalAuthorOrSpace(payload.author, space);
+
     const created = await createCoherence(
       {
-        creatorId: author.id,
+        creatorId: author.personId,
         spaceId: space.id,
         type: payload.type,
         priority: payload.priority,
@@ -139,7 +151,12 @@ export async function POST(
     );
 
     return NextResponse.json(
-      toIngestionResponse(request, normalizeCoherence(created), space.slug),
+      toIngestionResponse(
+        request,
+        normalizeCoherence(created),
+        space.slug,
+        author.attributedToSpace ? 'space' : 'author',
+      ),
       { status: 201 },
     );
   } catch (error) {

--- a/docs/integrations/external-signal-ingestion.md
+++ b/docs/integrations/external-signal-ingestion.md
@@ -16,7 +16,7 @@ Community app
   ▼
 Hypha ingestion route
   ├─ verify per-space API key + scope
-  ├─ resolve the author to an existing Hypha person
+  ├─ credit a known Hypha person, else the space itself
   └─ insert into coherences (source = <your source slug>)
         │
         ▼
@@ -101,19 +101,35 @@ curl -X DELETE https://<hypha-host>/api/v1/ops/spaces/<spaceSlug>/api-keys/12 \
 
 ---
 
-## Authors must already exist in Hypha
+## Attribution: a known member, or the space itself
 
-A signal is attributed to a real Hypha person, so the board shows who raised it. Your app identifies
-that person by **wallet address** or **email**:
+The board shows who raised a signal. Your app names that person by **wallet address** or **email**:
 
 ```json
 "author": { "walletAddress": "0xAbC...123" }
 "author": { "email": "member@example.org" }
 ```
 
-If both are supplied, the wallet is tried first. If neither matches an existing Hypha profile the
-request fails with `422` and nothing is written — **ingestion never creates people**. Have your
-members connect the same wallet or use the same email on their Hypha profile first.
+If both are supplied, the wallet is tried first.
+
+When the author matches an existing Hypha profile, the signal is credited to that member. **When it
+matches nobody — or you omit `author` entirely — the signal is still created, credited to the space
+itself.** It appears on the board authored by the space, using the space's name and logo, and it
+carries **no voting power**: the space stands in as a publisher, not as a member, so it holds no
+tokens and cannot vote or be assigned work.
+
+Ingestion still **never creates member profiles**. The stand-in is a single non-human record per
+space, hidden from member directories and impossible to sign in as.
+
+Every create response says which of the two happened, so you can spot a broken identity mapping:
+
+```json
+{ "attributedTo": "author" }   // matched a Hypha member
+{ "attributedTo": "space" }    // published as the space
+```
+
+If you expect signals to be credited to individuals, have your members connect the same wallet or use
+the same email on their Hypha profile, then re-check `attributedTo`.
 
 ---
 
@@ -151,7 +167,7 @@ curl -X POST https://<hypha-host>/api/v1/spaces/acme-dao/signals \
 | `board` | no | A board (swimlane) slug configured for the space. Defaults to the space's default board. |
 | `dueAt` | no | ISO 8601 timestamp, or `null`. |
 | `externalId` | no | Your own record id. Strongly recommended — see idempotency below. |
-| `author` | yes | `{ walletAddress }` or `{ email }`. |
+| `author` | no | `{ walletAddress }` or `{ email }`. Omit, or send an unknown one, to publish as the space. |
 
 Unknown fields are rejected with `400`, so a typo fails loudly rather than being silently dropped.
 Assignees are Hypha person ids and stay a Hypha-side concern; they cannot be set through this API.
@@ -267,7 +283,7 @@ gets `422`. This mirrors Hypha's own upvote path exactly, since both call the sa
 | `403` | Key belongs to another space, lacks the required scope, or the signal is not yours. |
 | `404` | Space or signal not found. |
 | `409` | Signal is archived, or the space is not linked to an on-chain space (upvotes only). |
-| `422` | The author or voter has no matching Hypha profile, or the voter has no voting power. |
+| `422` | The voter has no matching Hypha profile, or no voting power. (Authors never fail — they fall back to the space.) |
 | `500` | Unexpected server error. |
 
 ---
@@ -276,8 +292,10 @@ gets `422`. This mirrors Hypha's own upvote path exactly, since both call the sa
 
 1. Ask Hypha for a key, choosing a stable `source` slug for your app.
 2. Store the key in server-side secrets only.
-3. Make sure your members' Hypha profiles carry the wallet address or email your app knows them by.
+3. Make sure your members' Hypha profiles carry the wallet address or email your app knows them by —
+   otherwise their signals are published as the space.
 4. Send `externalId` on every create so retries are safe and updates are possible.
 5. Treat ingestion as best-effort in your own flow: never fail a user action because Hypha was
    briefly unreachable — queue and retry instead.
-6. On `422`, surface a "connect your Hypha profile" prompt rather than retrying blindly.
+6. Watch `attributedTo` on creates; a run of `"space"` means your identity mapping has drifted.
+7. On `422` from an upvote, surface a "connect your Hypha profile" prompt rather than retrying blindly.

--- a/docs/integrations/external-signal-ingestion.md
+++ b/docs/integrations/external-signal-ingestion.md
@@ -10,7 +10,7 @@ separate view, no sync step.
 
 ## How it fits together
 
-```
+```text
 Community app
   │  POST /api/v1/spaces/{spaceSlug}/signals      (x-hypha-api-key)
   ▼
@@ -32,7 +32,7 @@ Hypha's own UI. That mirror is best-effort: if it fails, the vote is still recor
 
 Every request carries a **per-space API key**:
 
-```
+```http
 x-hypha-api-key: hyk_<prefix>_<secret>
 ```
 
@@ -76,18 +76,19 @@ Response (the only time `apiKey` is ever returned):
     "spaceId": 42,
     "name": "ACAW contest app",
     "source": "acaw-contest",
-    "keyPrefix": "K3nQ7bTz",
+    "keyPrefix": "<prefix>",
     "scopes": ["signals:write", "signals:upvote"],
     "revokedAt": null
   },
-  "apiKey": "hyk_K3nQ7bTz_...",
+  "apiKey": "hyk_<prefix>_<secret>",
   "warning": "Store this key now — it is not recoverable. Never expose it in client-side code."
 }
 ```
 
 `source` is a stable slug identifying your app. It is stamped on every signal the key writes and is
-what proves ownership when you later update or vote on those signals. One active key per `source`
-per space.
+what proves ownership when you later update or vote on those signals. One **active** key per `source`
+per space — so rotating a key means revoking the old one and issuing a replacement under the same
+`source`, which keeps ownership of everything it has already published.
 
 List metadata (never key material) and revoke:
 
@@ -98,6 +99,9 @@ curl https://<hypha-host>/api/v1/ops/spaces/<spaceSlug>/api-keys \
 curl -X DELETE https://<hypha-host>/api/v1/ops/spaces/<spaceSlug>/api-keys/12 \
   -H "x-hypha-ops-secret: $HYPHA_SPACE_API_KEY_OPS_SECRET"
 ```
+
+The list is paginated like every other Hypha list endpoint — `{ "data": [...], "pagination": {...} }`,
+with optional `?page=` and `?pageSize=`.
 
 ---
 
@@ -135,7 +139,7 @@ the same email on their Hypha profile, then re-check `attributedTo`.
 
 ## Create a signal
 
-```
+```http
 POST /api/v1/spaces/{spaceSlug}/signals
 ```
 
@@ -202,7 +206,7 @@ update it later. Send it.
 
 ## Update a signal you created
 
-```
+```http
 PATCH /api/v1/spaces/{spaceSlug}/signals/{signalSlug}
 ```
 
@@ -224,7 +228,7 @@ records, it does not administer the space's board.
 
 ## Record and remove upvotes
 
-```
+```http
 PUT    /api/v1/spaces/{spaceSlug}/signals/{signalSlug}/upvotes
 DELETE /api/v1/spaces/{spaceSlug}/signals/{signalSlug}/upvotes
 ```
@@ -269,6 +273,13 @@ Both return the recalculated upvote summary:
 holds**, read live from the space's on-chain voting power source — the same source Hypha uses to
 tally proposals. Your app cannot inflate anyone's weight; a voter with no voting power in the space
 gets `422`. This mirrors Hypha's own upvote path exactly, since both call the same code.
+
+**What the key is trusted with.** Hypha authenticates your app, not the individual voter: there is no
+per-vote wallet signature. A key with `signals:upvote` can therefore record an upvote for any member
+of its space, bounded by that member's real weight and by one vote per person. Establishing that a
+member actually intended the vote is your app's job — the same trust you place in it when it publishes
+signals on their behalf. Grant `signals:upvote` only to apps whose own authentication you rely on, and
+omit the scope entirely for apps that merely publish.
 
 ---
 

--- a/docs/integrations/external-signal-ingestion.md
+++ b/docs/integrations/external-signal-ingestion.md
@@ -1,0 +1,283 @@
+# External Signal Ingestion API
+
+Let a community's own app produce signals that land on the Hypha **Signals Board** for their Space.
+
+Signals written through this API go into the same `coherences` table the board reads, so they appear
+in the Coherence tab (`/{lang}/dho/{spaceSlug}/coherence`) alongside signals created in Hypha — no
+separate view, no sync step.
+
+---
+
+## How it fits together
+
+```
+Community app
+  │  POST /api/v1/spaces/{spaceSlug}/signals      (x-hypha-api-key)
+  ▼
+Hypha ingestion route
+  ├─ verify per-space API key + scope
+  ├─ resolve the author to an existing Hypha person
+  └─ insert into coherences (source = <your source slug>)
+        │
+        ▼
+   Signals Board (existing UI)
+```
+
+Upvotes additionally mirror to the Signals contract on Base, exactly as they do for votes cast in
+Hypha's own UI. That mirror is best-effort: if it fails, the vote is still recorded off-chain.
+
+---
+
+## Authentication
+
+Every request carries a **per-space API key**:
+
+```
+x-hypha-api-key: hyk_<prefix>_<secret>
+```
+
+An `Authorization: Bearer <key>` header also works, for clients that only support bearer auth.
+
+Key properties:
+
+| Property | Behaviour |
+| --- | --- |
+| Scope of validity | One space. A key presented against a different space is rejected with `403`. |
+| Storage | Only a SHA-256 digest is stored. The plaintext is shown once at issuance and is unrecoverable. |
+| Permissions | `signals:write` (create/update) and `signals:upvote` (record/remove upvotes), granted per key. |
+| Revocation | Immediate — a revoked key fails with `401`. |
+
+> **Server-side only.** The key grants write access to the space. Never ship it to a browser, a
+> mobile bundle, or any `NEXT_PUBLIC_` / `VITE_` variable. Hypha spaces can be fully public, so
+> anything reachable from the client is effectively published.
+
+### Getting a key
+
+Keys are issued by Hypha ops, not from the space UI — precisely because a public space's UI is
+readable by anyone. Ask Hypha to run:
+
+```bash
+curl -X POST https://<hypha-host>/api/v1/ops/spaces/<spaceSlug>/api-keys \
+  -H "x-hypha-ops-secret: $HYPHA_SPACE_API_KEY_OPS_SECRET" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "name": "ACAW contest app",
+    "source": "acaw-contest",
+    "scopes": ["signals:write", "signals:upvote"]
+  }'
+```
+
+Response (the only time `apiKey` is ever returned):
+
+```json
+{
+  "key": {
+    "id": 12,
+    "spaceId": 42,
+    "name": "ACAW contest app",
+    "source": "acaw-contest",
+    "keyPrefix": "K3nQ7bTz",
+    "scopes": ["signals:write", "signals:upvote"],
+    "revokedAt": null
+  },
+  "apiKey": "hyk_K3nQ7bTz_...",
+  "warning": "Store this key now — it is not recoverable. Never expose it in client-side code."
+}
+```
+
+`source` is a stable slug identifying your app. It is stamped on every signal the key writes and is
+what proves ownership when you later update or vote on those signals. One active key per `source`
+per space.
+
+List metadata (never key material) and revoke:
+
+```bash
+curl https://<hypha-host>/api/v1/ops/spaces/<spaceSlug>/api-keys \
+  -H "x-hypha-ops-secret: $HYPHA_SPACE_API_KEY_OPS_SECRET"
+
+curl -X DELETE https://<hypha-host>/api/v1/ops/spaces/<spaceSlug>/api-keys/12 \
+  -H "x-hypha-ops-secret: $HYPHA_SPACE_API_KEY_OPS_SECRET"
+```
+
+---
+
+## Authors must already exist in Hypha
+
+A signal is attributed to a real Hypha person, so the board shows who raised it. Your app identifies
+that person by **wallet address** or **email**:
+
+```json
+"author": { "walletAddress": "0xAbC...123" }
+"author": { "email": "member@example.org" }
+```
+
+If both are supplied, the wallet is tried first. If neither matches an existing Hypha profile the
+request fails with `422` and nothing is written — **ingestion never creates people**. Have your
+members connect the same wallet or use the same email on their Hypha profile first.
+
+---
+
+## Create a signal
+
+```
+POST /api/v1/spaces/{spaceSlug}/signals
+```
+
+```bash
+curl -X POST https://<hypha-host>/api/v1/spaces/acme-dao/signals \
+  -H "x-hypha-api-key: $HYPHA_SPACE_API_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "title": "Riverside cleanup needs funding",
+    "description": "Twelve members flagged the riverside site in this week'\''s round.",
+    "type": "Opportunity",
+    "priority": "high",
+    "tags": ["Impact Goals", "Fundraising"],
+    "externalId": "submission-42",
+    "author": { "walletAddress": "0xAbC0000000000000000000000000000000000123" }
+  }'
+```
+
+### Fields
+
+| Field | Required | Notes |
+| --- | --- | --- |
+| `title` | yes | 1–50 characters. The board cards are sized for short titles. |
+| `description` | yes | 1–4000 characters. |
+| `type` | yes | `Opportunity`, `Risk`, `Tension`, or `Insight`. |
+| `priority` | no | `critical`, `high`, `medium` (default), `low`. |
+| `tags` | no | Free-form strings, max 50. `External Signal` is added automatically. |
+| `progressStatus` | no | A status slug configured for the space (`backlog`, `todo`, …). Defaults to the space's first status. |
+| `board` | no | A board (swimlane) slug configured for the space. Defaults to the space's default board. |
+| `dueAt` | no | ISO 8601 timestamp, or `null`. |
+| `externalId` | no | Your own record id. Strongly recommended — see idempotency below. |
+| `author` | yes | `{ walletAddress }` or `{ email }`. |
+
+Unknown fields are rejected with `400`, so a typo fails loudly rather than being silently dropped.
+Assignees are Hypha person ids and stay a Hypha-side concern; they cannot be set through this API.
+
+`type` is limited to the four types Hypha's own signal editor can round-trip, which keeps every
+ingested signal fully editable by space members in the UI.
+
+### Response
+
+`201 Created`:
+
+```json
+{
+  "id": 501,
+  "slug": "coh-1a2b3c4d",
+  "spaceSlug": "acme-dao",
+  "url": "https://<hypha-host>/en/dho/acme-dao/coherence?signal=coh-1a2b3c4d",
+  "signal": { "...": "the full signal record" }
+}
+```
+
+`url` deep-links to the signal on the board — good for linking your users straight into Hypha.
+
+### Idempotency
+
+When you send `externalId`, the pair `(space, your source, externalId)` is unique. A retry with the
+same `externalId` returns **`200`** with the signal that already exists instead of creating a
+duplicate. Without `externalId` every POST creates a new signal, and you also lose the ability to
+update it later. Send it.
+
+---
+
+## Update a signal you created
+
+```
+PATCH /api/v1/spaces/{spaceSlug}/signals/{signalSlug}
+```
+
+```bash
+curl -X PATCH https://<hypha-host>/api/v1/spaces/acme-dao/signals/coh-1a2b3c4d \
+  -H "x-hypha-api-key: $HYPHA_SPACE_API_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{ "priority": "critical", "progressStatus": "in_progress" }'
+```
+
+A partial patch: omitted fields keep their stored values. `dueAt` distinguishes absent (unchanged)
+from explicit `null` (cleared). `archived: true` removes the signal from the default board view.
+
+Only signals whose `source` matches your key can be updated — signals raised by members in the
+Hypha UI, or by another integration, return `403`. This is intentional: your app mirrors its own
+records, it does not administer the space's board.
+
+---
+
+## Record and remove upvotes
+
+```
+PUT    /api/v1/spaces/{spaceSlug}/signals/{signalSlug}/upvotes
+DELETE /api/v1/spaces/{spaceSlug}/signals/{signalSlug}/upvotes
+```
+
+Requires the `signals:upvote` scope, and applies to your own signals only.
+
+```bash
+curl -X PUT https://<hypha-host>/api/v1/spaces/acme-dao/signals/coh-1a2b3c4d/upvotes \
+  -H "x-hypha-api-key: $HYPHA_SPACE_API_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "voter": { "walletAddress": "0xAbC0000000000000000000000000000000000123" },
+    "votingPowerPercent": 25
+  }'
+```
+
+Re-sending `PUT` for the same voter updates their allocation rather than adding a second vote.
+
+```bash
+# DELETE bodies are awkward in some clients, so a query parameter works too.
+curl -X DELETE "https://<hypha-host>/api/v1/spaces/acme-dao/signals/coh-1a2b3c4d/upvotes?voter=0xAbC0000000000000000000000000000000000123" \
+  -H "x-hypha-api-key: $HYPHA_SPACE_API_KEY"
+```
+
+Both return the recalculated upvote summary:
+
+```json
+{
+  "upvotes": {
+    "totalVotingPower": "250000000000000000000",
+    "upvoteCount": 1,
+    "tokenDecimals": 18,
+    "voters": [{ "personId": 3, "name": "Ada L", "votingPower": "250000000000000000000" }],
+    "myUpvote": { "votingPower": "250000000000000000000", "maxVotingPower": "1000000000000000000000" }
+  }
+}
+```
+
+### Weight is decided on-chain, not by your app
+
+`votingPowerPercent` (1–100, default 100) is a **share of the voting power that voter genuinely
+holds**, read live from the space's on-chain voting power source — the same source Hypha uses to
+tally proposals. Your app cannot inflate anyone's weight; a voter with no voting power in the space
+gets `422`. This mirrors Hypha's own upvote path exactly, since both call the same code.
+
+---
+
+## Status codes
+
+| Code | Meaning |
+| --- | --- |
+| `200` | Update, upvote, or idempotent create replay succeeded. |
+| `201` | Signal created. |
+| `400` | Malformed JSON, failed validation, unknown field, or a status/board slug the space does not define. |
+| `401` | Missing, unknown, or revoked API key. |
+| `403` | Key belongs to another space, lacks the required scope, or the signal is not yours. |
+| `404` | Space or signal not found. |
+| `409` | Signal is archived, or the space is not linked to an on-chain space (upvotes only). |
+| `422` | The author or voter has no matching Hypha profile, or the voter has no voting power. |
+| `500` | Unexpected server error. |
+
+---
+
+## Checklist for integrators
+
+1. Ask Hypha for a key, choosing a stable `source` slug for your app.
+2. Store the key in server-side secrets only.
+3. Make sure your members' Hypha profiles carry the wallet address or email your app knows them by.
+4. Send `externalId` on every create so retries are safe and updates are possible.
+5. Treat ingestion as best-effort in your own flow: never fail a user action because Hypha was
+   briefly unreachable — queue and retry instead.
+6. On `422`, surface a "connect your Hypha profile" prompt rather than retrying blindly.

--- a/packages/core/src/coherence/__tests__/apply-coherence-upvote.test.ts
+++ b/packages/core/src/coherence/__tests__/apply-coherence-upvote.test.ts
@@ -1,0 +1,196 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('next/server', () => ({
+  after: (callback: () => unknown) => {
+    void callback();
+  },
+}));
+vi.mock('../server/web3/get-member-voting-power', () => ({
+  getMemberVotingPower: vi.fn(),
+}));
+vi.mock('../server/web3/record-signal-upvote-onchain', () => ({
+  recordSignalUpvoteOnChain: vi.fn(),
+}));
+vi.mock('../server/coherence-upvotes', () => ({
+  EMPTY_COHERENCE_UPVOTE_SUMMARY: {
+    totalVotingPower: '0',
+    upvoteCount: 0,
+    tokenDecimals: 0,
+    voters: [],
+    myUpvote: null,
+  },
+  findCoherenceUpvoteSummaries: vi.fn().mockResolvedValue({}),
+  removeCoherenceUpvote: vi.fn(),
+  upsertCoherenceUpvote: vi.fn(),
+}));
+
+import {
+  applyCoherenceUpvote,
+  applyCoherenceUpvoteRemoval,
+  resolveVotingPowerPercent,
+  type CoherenceUpvoteTarget,
+} from '../server/apply-coherence-upvote';
+import {
+  removeCoherenceUpvote,
+  upsertCoherenceUpvote,
+} from '../server/coherence-upvotes';
+import { getMemberVotingPower } from '../server/web3/get-member-voting-power';
+import { recordSignalUpvoteOnChain } from '../server/web3/record-signal-upvote-onchain';
+
+const db = {} as never;
+const voter = '0x1111111111111111111111111111111111111111';
+
+const signal: CoherenceUpvoteTarget = {
+  id: 11,
+  spaceId: 5,
+  archived: false,
+  web3SpaceId: 77,
+};
+
+const actor = { id: 3, address: voter };
+
+const mockedVotingPower = vi.mocked(getMemberVotingPower);
+const mockedUpsert = vi.mocked(upsertCoherenceUpvote);
+const mockedRemove = vi.mocked(removeCoherenceUpvote);
+const mockedMirror = vi.mocked(recordSignalUpvoteOnChain);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedVotingPower.mockResolvedValue({
+    votingPower: 1000n,
+    votingPowerSource: 1,
+    tokenDecimals: 18,
+  });
+});
+
+describe('resolveVotingPowerPercent', () => {
+  it('defaults to the full 100% when missing or unparseable', () => {
+    expect(resolveVotingPowerPercent(undefined)).toBe(100);
+    expect(resolveVotingPowerPercent('not a number')).toBe(100);
+  });
+
+  it('clamps into 1..100 and truncates fractions', () => {
+    expect(resolveVotingPowerPercent(0)).toBe(1);
+    expect(resolveVotingPowerPercent(-20)).toBe(1);
+    expect(resolveVotingPowerPercent(250)).toBe(100);
+    expect(resolveVotingPowerPercent(42.9)).toBe(42);
+  });
+});
+
+describe('applyCoherenceUpvote', () => {
+  it('snapshots a share of the on-chain voting power', async () => {
+    await applyCoherenceUpvote(
+      { coherence: signal, actor, votingPowerPercent: 25 },
+      { db },
+    );
+
+    expect(mockedVotingPower).toHaveBeenCalledWith({
+      memberAddress: voter,
+      web3SpaceId: 77,
+    });
+    expect(mockedUpsert).toHaveBeenCalledWith(
+      {
+        coherenceId: 11,
+        personId: 3,
+        votingPower: '250',
+        maxVotingPower: '1000',
+        tokenDecimals: 18,
+      },
+      { db },
+    );
+  });
+
+  it('allocates at least one unit when the percentage rounds to zero', async () => {
+    mockedVotingPower.mockResolvedValue({
+      votingPower: 10n,
+      votingPowerSource: 2,
+      tokenDecimals: 0,
+    });
+
+    await applyCoherenceUpvote(
+      { coherence: signal, actor, votingPowerPercent: 1 },
+      { db },
+    );
+
+    expect(mockedUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({ votingPower: '1' }),
+      { db },
+    );
+  });
+
+  it('mirrors the upvote on-chain with the snapshotted amount', async () => {
+    await applyCoherenceUpvote({ coherence: signal, actor }, { db });
+
+    expect(mockedMirror).toHaveBeenCalledWith({
+      web3SpaceId: 77,
+      signalId: 11,
+      voter,
+      amount: 1000n,
+      kind: 'upvote',
+    });
+  });
+
+  it('refuses to vote on an archived signal', async () => {
+    await expect(
+      applyCoherenceUpvote(
+        { coherence: { ...signal, archived: true }, actor },
+        { db },
+      ),
+    ).rejects.toThrow('Cannot vote on an archived signal');
+    expect(mockedUpsert).not.toHaveBeenCalled();
+  });
+
+  it('refuses when the space has no on-chain id', async () => {
+    await expect(
+      applyCoherenceUpvote(
+        { coherence: { ...signal, web3SpaceId: null }, actor },
+        { db },
+      ),
+    ).rejects.toThrow('not linked to an on-chain space');
+  });
+
+  it('refuses when the actor has no linked wallet', async () => {
+    await expect(
+      applyCoherenceUpvote(
+        { coherence: signal, actor: { id: 3, address: null } },
+        { db },
+      ),
+    ).rejects.toThrow('A linked wallet is required');
+  });
+
+  it('refuses when the actor holds no voting power in the space', async () => {
+    mockedVotingPower.mockResolvedValue({
+      votingPower: 0n,
+      votingPowerSource: 1,
+      tokenDecimals: 18,
+    });
+
+    await expect(
+      applyCoherenceUpvote({ coherence: signal, actor }, { db }),
+    ).rejects.toThrow('no voting power');
+    expect(mockedUpsert).not.toHaveBeenCalled();
+  });
+});
+
+describe('applyCoherenceUpvoteRemoval', () => {
+  it('mirrors a removal when a row was actually deleted', async () => {
+    mockedRemove.mockResolvedValue(true);
+
+    await applyCoherenceUpvoteRemoval({ coherence: signal, actor }, { db });
+
+    expect(mockedMirror).toHaveBeenCalledWith({
+      web3SpaceId: 77,
+      signalId: 11,
+      voter,
+      kind: 'removal',
+    });
+  });
+
+  it('stays silent on-chain when there was nothing to remove', async () => {
+    mockedRemove.mockResolvedValue(false);
+
+    await applyCoherenceUpvoteRemoval({ coherence: signal, actor }, { db });
+
+    expect(mockedMirror).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/coherence/__tests__/apply-coherence-upvote.test.ts
+++ b/packages/core/src/coherence/__tests__/apply-coherence-upvote.test.ts
@@ -1,9 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('next/server', () => ({
-  after: (callback: () => unknown) => {
+  after: vi.fn((callback: () => unknown) => {
     void callback();
-  },
+  }),
 }));
 vi.mock('../server/web3/get-member-voting-power', () => ({
   getMemberVotingPower: vi.fn(),
@@ -23,6 +23,8 @@ vi.mock('../server/coherence-upvotes', () => ({
   removeCoherenceUpvote: vi.fn(),
   upsertCoherenceUpvote: vi.fn(),
 }));
+
+import { after } from 'next/server';
 
 import {
   applyCoherenceUpvote,
@@ -49,6 +51,7 @@ const signal: CoherenceUpvoteTarget = {
 
 const actor = { id: 3, address: voter };
 
+const mockedAfter = vi.mocked(after);
 const mockedVotingPower = vi.mocked(getMemberVotingPower);
 const mockedUpsert = vi.mocked(upsertCoherenceUpvote);
 const mockedRemove = vi.mocked(removeCoherenceUpvote);
@@ -119,6 +122,22 @@ describe('applyCoherenceUpvote', () => {
   });
 
   it('mirrors the upvote on-chain with the snapshotted amount', async () => {
+    await applyCoherenceUpvote({ coherence: signal, actor }, { db });
+
+    expect(mockedMirror).toHaveBeenCalledWith({
+      web3SpaceId: 77,
+      signalId: 11,
+      voter,
+      amount: 1000n,
+      kind: 'upvote',
+    });
+  });
+
+  it('still mirrors when `after` is unavailable outside a request scope', async () => {
+    mockedAfter.mockImplementationOnce(() => {
+      throw new Error('after() was called outside a request scope');
+    });
+
     await applyCoherenceUpvote({ coherence: signal, actor }, { db });
 
     expect(mockedMirror).toHaveBeenCalledWith({

--- a/packages/core/src/coherence/__tests__/ingest-signal-validation.test.ts
+++ b/packages/core/src/coherence/__tests__/ingest-signal-validation.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  schemaIngestSignal,
+  schemaIngestedSignalUpvote,
+  schemaPatchIngestedSignal,
+} from '../validation';
+
+const wallet = '0x1111111111111111111111111111111111111111';
+
+const validSignal = {
+  title: 'Riverside cleanup needs funding',
+  description: 'Twelve members flagged the riverside site this week.',
+  type: 'Opportunity',
+  author: { walletAddress: wallet },
+};
+
+describe('schemaIngestSignal', () => {
+  it('defaults priority and tags so a minimal payload is enough', () => {
+    const parsed = schemaIngestSignal.parse(validSignal);
+
+    expect(parsed.priority).toBe('medium');
+    expect(parsed.tags).toEqual([]);
+  });
+
+  it('requires an author identified by wallet or email', () => {
+    expect(() =>
+      schemaIngestSignal.parse({ ...validSignal, author: {} }),
+    ).toThrow(/walletAddress or email/);
+  });
+
+  it('accepts an email author', () => {
+    const parsed = schemaIngestSignal.parse({
+      ...validSignal,
+      author: { email: 'Member@Example.org' },
+    });
+    expect(parsed.author.email).toBe('Member@Example.org');
+  });
+
+  it('rejects a malformed wallet address', () => {
+    expect(() =>
+      schemaIngestSignal.parse({
+        ...validSignal,
+        author: { walletAddress: '0xnope' },
+      }),
+    ).toThrow();
+  });
+
+  it('rejects unknown fields so typos fail loudly', () => {
+    expect(() =>
+      schemaIngestSignal.parse({ ...validSignal, prioriy: 'high' }),
+    ).toThrow();
+  });
+
+  it('does not let an integration set Hypha-side assignees', () => {
+    expect(() =>
+      schemaIngestSignal.parse({ ...validSignal, assigneeIds: [1, 2] }),
+    ).toThrow();
+  });
+
+  it('rejects signal types the Hypha editor cannot round-trip', () => {
+    expect(() =>
+      schemaIngestSignal.parse({ ...validSignal, type: 'Proposal' }),
+    ).toThrow();
+  });
+
+  it('only accepts workflow slugs in the space slug format', () => {
+    expect(
+      schemaIngestSignal.parse({
+        ...validSignal,
+        progressStatus: 'in_progress',
+      }).progressStatus,
+    ).toBe('in_progress');
+    expect(() =>
+      schemaIngestSignal.parse({ ...validSignal, board: 'Not A Slug' }),
+    ).toThrow();
+  });
+
+  it('deduplicates tags case-insensitively', () => {
+    const parsed = schemaIngestSignal.parse({
+      ...validSignal,
+      tags: ['Governance', 'governance', 'Policy'],
+    });
+    expect(parsed.tags).toEqual(['Governance', 'Policy']);
+  });
+});
+
+describe('schemaPatchIngestedSignal', () => {
+  it('requires at least one field', () => {
+    expect(() => schemaPatchIngestedSignal.parse({})).toThrow(
+      /at least one field/,
+    );
+  });
+
+  it('leaves dueAt undefined when absent so a patch does not clear it', () => {
+    const parsed = schemaPatchIngestedSignal.parse({ priority: 'high' });
+    expect(parsed.dueAt).toBeUndefined();
+    expect(parsed.title).toBeUndefined();
+  });
+
+  it('distinguishes an explicit null dueAt as "clear it"', () => {
+    expect(schemaPatchIngestedSignal.parse({ dueAt: null }).dueAt).toBeNull();
+  });
+
+  it('parses an ISO dueAt into a Date', () => {
+    const parsed = schemaPatchIngestedSignal.parse({
+      dueAt: '2026-08-01T10:00:00.000Z',
+    });
+    expect(parsed.dueAt).toBeInstanceOf(Date);
+  });
+});
+
+describe('schemaIngestedSignalUpvote', () => {
+  it('requires a voter wallet', () => {
+    expect(() => schemaIngestedSignalUpvote.parse({})).toThrow();
+  });
+
+  it('accepts a percentage within 1..100', () => {
+    const parsed = schemaIngestedSignalUpvote.parse({
+      voter: { walletAddress: wallet },
+      votingPowerPercent: 25,
+    });
+    expect(parsed.votingPowerPercent).toBe(25);
+  });
+
+  it('rejects an out-of-range percentage', () => {
+    expect(() =>
+      schemaIngestedSignalUpvote.parse({
+        voter: { walletAddress: wallet },
+        votingPowerPercent: 150,
+      }),
+    ).toThrow();
+  });
+});

--- a/packages/core/src/coherence/__tests__/ingest-signal-validation.test.ts
+++ b/packages/core/src/coherence/__tests__/ingest-signal-validation.test.ts
@@ -23,10 +23,18 @@ describe('schemaIngestSignal', () => {
     expect(parsed.tags).toEqual([]);
   });
 
-  it('requires an author identified by wallet or email', () => {
+  it('requires a wallet or email when an author is given', () => {
     expect(() =>
       schemaIngestSignal.parse({ ...validSignal, author: {} }),
     ).toThrow(/walletAddress or email/);
+  });
+
+  it('allows omitting the author, to publish as the space', () => {
+    const parsed = schemaIngestSignal.parse({
+      ...validSignal,
+      author: undefined,
+    });
+    expect(parsed.author).toBeUndefined();
   });
 
   it('accepts an email author', () => {
@@ -34,7 +42,7 @@ describe('schemaIngestSignal', () => {
       ...validSignal,
       author: { email: 'Member@Example.org' },
     });
-    expect(parsed.author.email).toBe('Member@Example.org');
+    expect(parsed.author?.email).toBe('Member@Example.org');
   });
 
   it('rejects a malformed wallet address', () => {

--- a/packages/core/src/coherence/coherence-tags.ts
+++ b/packages/core/src/coherence/coherence-tags.ts
@@ -1,5 +1,6 @@
 export const COHERENCE_TAGS = [
   'AI Signal',
+  'External Signal',
   'Purpose',
   'North Star',
   'Vision',

--- a/packages/core/src/coherence/server/actions.ts
+++ b/packages/core/src/coherence/server/actions.ts
@@ -31,16 +31,11 @@ import {
 import type { SignalWorkflowConfig } from '../signal-workflow';
 import { assertCoherenceSpacePanelAuth } from './assert-coherence-space-panel-auth';
 import { normalizeCoherence } from './web3/normalize-coherence';
+import { findCoherenceForUpvote } from './coherence-upvotes';
 import {
-  EMPTY_COHERENCE_UPVOTE_SUMMARY,
-  findCoherenceForUpvote,
-  findCoherenceUpvoteSummaries,
-  removeCoherenceUpvote,
-  upsertCoherenceUpvote,
-} from './coherence-upvotes';
-import { getMemberVotingPower } from './web3/get-member-voting-power';
-import { recordSignalUpvoteOnChain } from './web3/record-signal-upvote-onchain';
-import { after } from 'next/server';
+  applyCoherenceUpvote,
+  applyCoherenceUpvoteRemoval,
+} from './apply-coherence-upvote';
 import type { CoherenceUpvoteSummary } from '../types';
 
 async function assertSignalWorkflowAccess({
@@ -200,20 +195,6 @@ async function resolveCoherenceUpvoteContext({
   return { self, coherence };
 }
 
-async function getCoherenceUpvoteSummary({
-  coherenceId,
-  viewerPersonId,
-}: {
-  coherenceId: number;
-  viewerPersonId: number;
-}): Promise<CoherenceUpvoteSummary> {
-  const summaries = await findCoherenceUpvoteSummaries(
-    { coherenceIds: [coherenceId], viewerPersonId },
-    { db },
-  );
-  return summaries[coherenceId] ?? EMPTY_COHERENCE_UPVOTE_SUMMARY;
-}
-
 /**
  * Upvote a signal with a share of the caller's proposal voting power.
  * Voting power is read from the space's on-chain voting power source and
@@ -230,15 +211,6 @@ export async function upvoteCoherenceAction(
     slug,
     authToken,
   });
-  if (coherence.archived) {
-    throw new Error('Cannot vote on an archived signal');
-  }
-  if (coherence.spaceId == null || coherence.web3SpaceId == null) {
-    throw new Error('Signal space is not linked to an on-chain space');
-  }
-  if (!self.address) {
-    throw new Error('A linked wallet is required to vote on signals');
-  }
   // Same membership rules as other signal interactions: Postgres membership
   // with an on-chain member/delegate fallback.
   await assertCoherenceSpacePanelAuth({
@@ -247,58 +219,10 @@ export async function upvoteCoherenceAction(
     requesterPersonId: self.id,
   });
 
-  // Default to 100 only for missing/non-numeric input; an explicit 0 falls
-  // through to the Math.max(1, ...) clamp below.
-  const rawPercent = Number(votingPowerPercent);
-  const percent = Math.min(
-    100,
-    Math.max(1, Number.isFinite(rawPercent) ? Math.trunc(rawPercent) : 100),
-  );
-
-  const { votingPower: maxVotingPower, tokenDecimals } =
-    await getMemberVotingPower({
-      memberAddress: self.address as `0x${string}`,
-      web3SpaceId: coherence.web3SpaceId,
-    });
-  if (maxVotingPower <= 0n) {
-    throw new Error('You have no voting power in this space');
-  }
-
-  let votingPower = (maxVotingPower * BigInt(percent)) / 100n;
-  if (votingPower <= 0n) {
-    votingPower = 1n;
-  }
-
-  await upsertCoherenceUpvote(
-    {
-      coherenceId: coherence.id,
-      personId: self.id,
-      votingPower: votingPower.toString(),
-      maxVotingPower: maxVotingPower.toString(),
-      tokenDecimals,
-    },
+  return applyCoherenceUpvote(
+    { coherence, actor: self, votingPowerPercent },
     { db },
   );
-
-  // Mirror the upvote to the Signals contract after the response is sent;
-  // best-effort and invisible to the user.
-  const web3SpaceId = coherence.web3SpaceId;
-  const voter = self.address as `0x${string}`;
-  const amount = votingPower;
-  after(() =>
-    recordSignalUpvoteOnChain({
-      web3SpaceId,
-      signalId: coherence.id,
-      voter,
-      amount,
-      kind: 'upvote',
-    }),
-  );
-
-  return getCoherenceUpvoteSummary({
-    coherenceId: coherence.id,
-    viewerPersonId: self.id,
-  });
 }
 
 /** Remove the caller's own upvote from a signal. */
@@ -317,30 +241,8 @@ export async function removeCoherenceUpvoteAction(
     authToken: authToken as string,
     requesterPersonId: self.id,
   });
-  const removed = await removeCoherenceUpvote(
-    { coherenceId: coherence.id, personId: self.id },
-    { db },
-  );
 
-  // Only mirror on-chain when a row was actually deleted; a no-op removal
-  // (e.g. double click) should not emit a removal event.
-  if (removed && coherence.web3SpaceId != null && self.address) {
-    const web3SpaceId = coherence.web3SpaceId;
-    const voter = self.address as `0x${string}`;
-    after(() =>
-      recordSignalUpvoteOnChain({
-        web3SpaceId,
-        signalId: coherence.id,
-        voter,
-        kind: 'removal',
-      }),
-    );
-  }
-
-  return getCoherenceUpvoteSummary({
-    coherenceId: coherence.id,
-    viewerPersonId: self.id,
-  });
+  return applyCoherenceUpvoteRemoval({ coherence, actor: self }, { db });
 }
 
 export async function getSignalWorkflowConfigAction(

--- a/packages/core/src/coherence/server/apply-coherence-upvote.ts
+++ b/packages/core/src/coherence/server/apply-coherence-upvote.ts
@@ -1,0 +1,163 @@
+import { after } from 'next/server';
+
+import type { DbConfig } from '../../server';
+import type { CoherenceUpvoteSummary } from '../types';
+import {
+  EMPTY_COHERENCE_UPVOTE_SUMMARY,
+  findCoherenceUpvoteSummaries,
+  removeCoherenceUpvote,
+  upsertCoherenceUpvote,
+} from './coherence-upvotes';
+import { getMemberVotingPower } from './web3/get-member-voting-power';
+import { recordSignalUpvoteOnChain } from './web3/record-signal-upvote-onchain';
+
+/** The signal being voted on, joined with its space's on-chain id. */
+export type CoherenceUpvoteTarget = {
+  id: number;
+  spaceId: number | null;
+  archived: boolean | null;
+  web3SpaceId: number | null;
+};
+
+/** Whoever the vote is attributed to, already resolved and authorized. */
+export type CoherenceUpvoteActor = {
+  id: number;
+  address?: string | null;
+};
+
+/**
+ * Mirror to the Signals contract once the response is on its way. Outside a
+ * request scope (scripts, tests) `after` is unavailable, so fall back to a
+ * detached call — either way the mirror is best-effort.
+ */
+function scheduleUpvoteMirror(
+  event: Parameters<typeof recordSignalUpvoteOnChain>[0],
+) {
+  try {
+    after(() => recordSignalUpvoteOnChain(event));
+  } catch {
+    void recordSignalUpvoteOnChain(event);
+  }
+}
+
+/** Clamp to 1..100; missing or non-numeric input means "use my full power". */
+export function resolveVotingPowerPercent(raw: unknown): number {
+  const parsed = Number(raw);
+  return Math.min(
+    100,
+    Math.max(1, Number.isFinite(parsed) ? Math.trunc(parsed) : 100),
+  );
+}
+
+export async function getCoherenceUpvoteSummary(
+  {
+    coherenceId,
+    viewerPersonId,
+  }: { coherenceId: number; viewerPersonId: number },
+  { db }: DbConfig,
+): Promise<CoherenceUpvoteSummary> {
+  const summaries = await findCoherenceUpvoteSummaries(
+    { coherenceIds: [coherenceId], viewerPersonId },
+    { db },
+  );
+  return summaries[coherenceId] ?? EMPTY_COHERENCE_UPVOTE_SUMMARY;
+}
+
+/**
+ * Record an upvote weighted by a share of the actor's on-chain voting power.
+ *
+ * Shared by the signed-in UI path and the community-app API path so both read
+ * voting power from the space's on-chain source — an integration can allocate
+ * a percentage of what a member actually holds, never more. Callers are
+ * responsible for authorizing the actor first.
+ */
+export async function applyCoherenceUpvote(
+  {
+    coherence,
+    actor,
+    votingPowerPercent,
+  }: {
+    coherence: CoherenceUpvoteTarget;
+    actor: CoherenceUpvoteActor;
+    votingPowerPercent?: number;
+  },
+  { db }: DbConfig,
+): Promise<CoherenceUpvoteSummary> {
+  if (coherence.archived) {
+    throw new Error('Cannot vote on an archived signal');
+  }
+  if (coherence.spaceId == null || coherence.web3SpaceId == null) {
+    throw new Error('Signal space is not linked to an on-chain space');
+  }
+  if (!actor.address) {
+    throw new Error('A linked wallet is required to vote on signals');
+  }
+
+  const percent = resolveVotingPowerPercent(votingPowerPercent);
+  const voter = actor.address as `0x${string}`;
+  const web3SpaceId = coherence.web3SpaceId;
+
+  const { votingPower: maxVotingPower, tokenDecimals } =
+    await getMemberVotingPower({ memberAddress: voter, web3SpaceId });
+  if (maxVotingPower <= 0n) {
+    throw new Error('You have no voting power in this space');
+  }
+
+  let votingPower = (maxVotingPower * BigInt(percent)) / 100n;
+  if (votingPower <= 0n) {
+    votingPower = 1n;
+  }
+
+  await upsertCoherenceUpvote(
+    {
+      coherenceId: coherence.id,
+      personId: actor.id,
+      votingPower: votingPower.toString(),
+      maxVotingPower: maxVotingPower.toString(),
+      tokenDecimals,
+    },
+    { db },
+  );
+
+  scheduleUpvoteMirror({
+    web3SpaceId,
+    signalId: coherence.id,
+    voter,
+    amount: votingPower,
+    kind: 'upvote',
+  });
+
+  return getCoherenceUpvoteSummary(
+    { coherenceId: coherence.id, viewerPersonId: actor.id },
+    { db },
+  );
+}
+
+/** Remove the actor's own upvote. Callers must authorize the actor first. */
+export async function applyCoherenceUpvoteRemoval(
+  {
+    coherence,
+    actor,
+  }: { coherence: CoherenceUpvoteTarget; actor: CoherenceUpvoteActor },
+  { db }: DbConfig,
+): Promise<CoherenceUpvoteSummary> {
+  const removed = await removeCoherenceUpvote(
+    { coherenceId: coherence.id, personId: actor.id },
+    { db },
+  );
+
+  // A no-op removal (e.g. a double click) should not emit a removal event.
+  if (removed && coherence.web3SpaceId != null && actor.address) {
+    scheduleUpvoteMirror({
+      web3SpaceId: coherence.web3SpaceId,
+      signalId: coherence.id,
+      voter: actor.address as `0x${string}`,
+      kind: 'removal',
+    });
+  }
+
+  return getCoherenceUpvoteSummary(
+    { coherenceId: coherence.id, viewerPersonId: actor.id },
+    { db },
+  );
+}

--- a/packages/core/src/coherence/server/index.ts
+++ b/packages/core/src/coherence/server/index.ts
@@ -1,6 +1,7 @@
 export * from '../lib';
 export * from './ai-signal-actions';
 export * from './actions';
+export * from './apply-coherence-upvote';
 export * from './coherence-upvotes';
 export * from './mutations';
 export * from './queries';

--- a/packages/core/src/coherence/server/mutations.ts
+++ b/packages/core/src/coherence/server/mutations.ts
@@ -199,6 +199,7 @@ export const updateCoherenceSignalBySlug = async (
     progressStatus,
     board,
     assigneeIds,
+    archived,
   } = rest;
   const row = await getCoherenceRowForTaskPatch({ slug }, { db });
   const nextProgressStatus = progressStatus ?? DEFAULT_SIGNAL_PROGRESS_STATUS;
@@ -234,6 +235,7 @@ export const updateCoherenceSignalBySlug = async (
       ...(assigneeIds !== undefined
         ? { assigneeIds: normalizeAssigneeIds(assigneeIds) }
         : {}),
+      ...(archived !== undefined ? { archived } : {}),
     })
     .where(eq(coherences.id, row.id))
     .returning();

--- a/packages/core/src/coherence/server/queries.ts
+++ b/packages/core/src/coherence/server/queries.ts
@@ -141,6 +141,32 @@ export const findCoherenceBySlug = async (
   };
 };
 
+/**
+ * Resolve a signal previously written by an integration, so a retried POST
+ * returns the original record instead of creating a duplicate.
+ */
+export const findCoherenceBySourceExternalId = async (
+  {
+    spaceId,
+    source,
+    externalId,
+  }: { spaceId: number; source: string; externalId: string },
+  { db }: DbConfig,
+): Promise<Coherence | null> => {
+  const [row] = await db
+    .select()
+    .from(coherences)
+    .where(
+      and(
+        eq(coherences.spaceId, spaceId),
+        eq(coherences.source, source),
+        eq(coherences.externalId, externalId),
+      ),
+    )
+    .limit(1);
+  return row ?? null;
+};
+
 type CheckCoherenceSlugExistsInput = {
   slug: string;
 };

--- a/packages/core/src/coherence/server/web3/normalize-coherence.ts
+++ b/packages/core/src/coherence/server/web3/normalize-coherence.ts
@@ -24,6 +24,8 @@ export function normalizeCoherence({
   progressStatus,
   board,
   assigneeIds,
+  source,
+  externalId,
   ...rest
 }: DbCoherence): Coherence {
   return {
@@ -50,6 +52,8 @@ export function normalizeCoherence({
     progressStatus: progressStatus?.trim() || DEFAULT_SIGNAL_PROGRESS_STATUS,
     board: board?.trim() || null,
     assigneeIds: normalizeAssigneeIds(assigneeIds),
+    source: source?.trim() || null,
+    externalId: externalId?.trim() || null,
     ...rest,
   };
 }

--- a/packages/core/src/coherence/types.ts
+++ b/packages/core/src/coherence/types.ts
@@ -49,6 +49,8 @@ export interface UpdateCoherenceSignalInput {
   progressStatus?: string | null;
   board?: string | null;
   assigneeIds?: number[];
+  /** Omit to leave the archived state alone; set it to change it in the same write. */
+  archived?: boolean;
 }
 
 export type UpdateCoherenceSignalBySlugInput = {

--- a/packages/core/src/coherence/types.ts
+++ b/packages/core/src/coherence/types.ts
@@ -22,6 +22,10 @@ export interface CreateCoherenceInput {
   progressStatus?: string | null;
   board?: string | null;
   assigneeIds?: number[];
+  /** `space_api_keys.source` when written by a community app integration. */
+  source?: string | null;
+  /** The integration's own identifier for the record, used for idempotency. */
+  externalId?: string | null;
 }
 
 export interface UpdateCoherenceInput {
@@ -103,6 +107,10 @@ export type Coherence = {
   progressStatus: string | null;
   board: string | null;
   assigneeIds: number[];
+  /** `space_api_keys.source` when written by a community app integration. */
+  source: string | null;
+  /** The integration's own identifier for the record. */
+  externalId: string | null;
   /** Present on list/detail API responses; not stored on the row itself. */
   upvotes?: CoherenceUpvoteSummary;
 };

--- a/packages/core/src/coherence/validation.ts
+++ b/packages/core/src/coherence/validation.ts
@@ -128,8 +128,9 @@ const evmAddressSchema = z
   .regex(/^0x[0-9a-fA-F]{40}$/, 'walletAddress must be an EVM address');
 
 /**
- * The author of an externally ingested signal must already exist in Hypha —
- * an integration identifies them by wallet or email, it never creates people.
+ * An integration identifies an author by wallet or email; it never creates
+ * people. When the author is omitted, or matches nobody in Hypha, the signal is
+ * attributed to the space itself.
  */
 const ingestedSignalAuthorSchema = z
   .object({
@@ -181,7 +182,8 @@ export const schemaIngestSignal = z
     dueAt: optionalDueAtSchema,
     /** The integration's own record id, used to make retries idempotent. */
     externalId: z.string().trim().min(1).max(200).optional(),
-    author: ingestedSignalAuthorSchema,
+    /** Omit to publish as the space rather than on behalf of a person. */
+    author: ingestedSignalAuthorSchema.optional(),
   })
   .strict();
 

--- a/packages/core/src/coherence/validation.ts
+++ b/packages/core/src/coherence/validation.ts
@@ -122,6 +122,96 @@ export const schemaPatchCoherenceTaskBySlug = z.object({
   priority: z.enum(COHERENCE_PRIORITIES).optional(),
 });
 
+const evmAddressSchema = z
+  .string()
+  .trim()
+  .regex(/^0x[0-9a-fA-F]{40}$/, 'walletAddress must be an EVM address');
+
+/**
+ * The author of an externally ingested signal must already exist in Hypha —
+ * an integration identifies them by wallet or email, it never creates people.
+ */
+const ingestedSignalAuthorSchema = z
+  .object({
+    walletAddress: evmAddressSchema.optional(),
+    email: z.string().trim().email().max(320).optional(),
+  })
+  .strict()
+  .refine((author) => Boolean(author.walletAddress || author.email), {
+    message: 'author requires either walletAddress or email',
+  });
+
+const workflowSlugSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(64)
+  .regex(/^[a-z0-9_]+$/)
+  .nullable()
+  .optional();
+
+/**
+ * Tri-state so a patch can leave a due date untouched (absent) or clear it
+ * (explicit null). The shared `optionalDueAtSchema` collapses both to null.
+ */
+const patchDueAtSchema = z
+  .union([z.string().datetime(), z.date(), z.null()])
+  .optional()
+  .transform((value) => {
+    if (value === undefined) return undefined;
+    if (value === null) return null;
+    const date = value instanceof Date ? value : new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date;
+  });
+
+/**
+ * Signal creation by a community app. Types are limited to the four the Hypha
+ * edit form can round-trip, so an ingested signal stays fully editable in the
+ * UI. Assignees are Hypha person ids and remain a Hypha-side concern.
+ */
+export const schemaIngestSignal = z
+  .object({
+    type: z.enum(COHERENCE_SIGNAL_TYPES),
+    priority: z.enum(COHERENCE_PRIORITIES).default('medium'),
+    title: z.string().trim().min(1).max(50),
+    description: z.string().trim().min(1).max(4000),
+    tags: coherenceTagsSchema,
+    progressStatus: workflowSlugSchema,
+    board: workflowSlugSchema,
+    dueAt: optionalDueAtSchema,
+    /** The integration's own record id, used to make retries idempotent. */
+    externalId: z.string().trim().min(1).max(200).optional(),
+    author: ingestedSignalAuthorSchema,
+  })
+  .strict();
+
+export const schemaPatchIngestedSignal = z
+  .object({
+    type: z.enum(COHERENCE_SIGNAL_TYPES).optional(),
+    priority: z.enum(COHERENCE_PRIORITIES).optional(),
+    title: z.string().trim().min(1).max(50).optional(),
+    description: z.string().trim().min(1).max(4000).optional(),
+    tags: coherenceTagsSchema.optional(),
+    archived: z.boolean().optional(),
+    progressStatus: workflowSlugSchema,
+    board: workflowSlugSchema,
+    dueAt: patchDueAtSchema,
+  })
+  .strict()
+  .refine(
+    (patch) => Object.values(patch).some((value) => value !== undefined),
+    {
+      message: 'Provide at least one field to update',
+    },
+  );
+
+export const schemaIngestedSignalUpvote = z
+  .object({
+    voter: z.object({ walletAddress: evmAddressSchema }).strict(),
+    votingPowerPercent: z.number().int().min(1).max(100).optional(),
+  })
+  .strict();
+
 const signalStatusCategorySchema = z.enum([
   'backlog',
   'active',

--- a/packages/core/src/common/server/index.ts
+++ b/packages/core/src/common/server/index.ts
@@ -19,6 +19,7 @@ export * from './webhooks';
 export * from './route-handlers';
 
 export * from './extract-revert-reason';
+export * from './unique-violation';
 
 export * from './encrypt-aes';
 export * from './encrypt-matrix-token';

--- a/packages/core/src/common/server/unique-violation.ts
+++ b/packages/core/src/common/server/unique-violation.ts
@@ -1,0 +1,33 @@
+/**
+ * Recognise a Postgres unique-constraint violation (SQLSTATE 23505).
+ *
+ * Any check-then-insert has a window where a concurrent request inserts first,
+ * so the constraint — not the check — is what actually guarantees uniqueness.
+ * Callers use this to turn the resulting error into the same answer the check
+ * would have produced, rather than a 500.
+ *
+ * Pass `constraint` to narrow to one index when a table has several, so an
+ * unrelated violation is not mistaken for the expected one.
+ */
+export function isUniqueViolation(
+  error: unknown,
+  constraint?: string,
+): boolean {
+  const candidate = error as {
+    code?: string;
+    constraint?: string;
+    cause?: unknown;
+  } | null;
+  if (!candidate || typeof candidate !== 'object') return false;
+
+  if (candidate.code === '23505') {
+    return constraint
+      ? Boolean(candidate.constraint?.includes(constraint))
+      : true;
+  }
+
+  // Drizzle wraps driver errors, so the SQLSTATE can sit one level down.
+  return candidate.cause
+    ? isUniqueViolation(candidate.cause, constraint)
+    : false;
+}

--- a/packages/core/src/common/server/unique-violation.ts
+++ b/packages/core/src/common/server/unique-violation.ts
@@ -6,8 +6,8 @@
  * Callers use this to turn the resulting error into the same answer the check
  * would have produced, rather than a 500.
  *
- * Pass `constraint` to narrow to one index when a table has several, so an
- * unrelated violation is not mistaken for the expected one.
+ * Pass the full `constraint` name to narrow to one index when a table has
+ * several, so an unrelated violation is not mistaken for the expected one.
  */
 export function isUniqueViolation(
   error: unknown,
@@ -21,9 +21,7 @@ export function isUniqueViolation(
   if (!candidate || typeof candidate !== 'object') return false;
 
   if (candidate.code === '23505') {
-    return constraint
-      ? Boolean(candidate.constraint?.includes(constraint))
-      : true;
+    return constraint ? candidate.constraint === constraint : true;
   }
 
   // Drizzle wraps driver errors, so the SQLSTATE can sit one level down.

--- a/packages/core/src/people/server/__tests__/space-actor-person.test.ts
+++ b/packages/core/src/people/server/__tests__/space-actor-person.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@hypha-platform/storage-postgres', () => ({
+  people: { id: 'people.id', sub: 'people.sub' },
+}));
+
+import {
+  ensureSpaceActorPerson,
+  spaceActorSub,
+  type SpaceActorSource,
+} from '../space-actor-person';
+
+const space: SpaceActorSource = {
+  id: 5,
+  slug: 'riverside',
+  title: 'Riverside DAO',
+  logoUrl: 'https://cdn.example.org/riverside.png',
+};
+
+type Row = Record<string, unknown> & { id: number };
+
+/**
+ * Minimal stand-in for the Drizzle chains this module uses. Predicates are
+ * opaque, so `actors` holds only the space actor rows a select could match,
+ * while `takenSlugs` models slugs owned by unrelated people.
+ */
+function createFakeDb() {
+  const state = {
+    actors: [] as Row[],
+    takenSlugs: new Set<string>(),
+    inserted: [] as Record<string, unknown>[],
+    updated: [] as Record<string, unknown>[],
+  };
+
+  const db = {
+    select: () => ({
+      from: () => ({
+        where: () => ({ limit: () => state.actors.slice(0, 1) }),
+      }),
+    }),
+    insert: () => ({
+      values: (values: Record<string, unknown>) => ({
+        onConflictDoNothing: () => ({
+          returning: () => {
+            state.inserted.push(values);
+            if (state.takenSlugs.has(String(values.slug))) return [];
+            const row: Row = { ...values, id: 900 + state.actors.length };
+            state.actors.push(row);
+            return [row];
+          },
+        }),
+      }),
+    }),
+    update: () => ({
+      set: (values: Record<string, unknown>) => ({
+        where: () => ({
+          returning: () => {
+            state.updated.push(values);
+            const next = { ...state.actors[0], ...values } as Row;
+            state.actors[0] = next;
+            return [next];
+          },
+        }),
+      }),
+    }),
+  };
+
+  return { db: db as never, state };
+}
+
+let fake: ReturnType<typeof createFakeDb>;
+
+beforeEach(() => {
+  fake = createFakeDb();
+});
+
+describe('ensureSpaceActorPerson', () => {
+  it('creates a person that stands for the space', async () => {
+    const actor = await ensureSpaceActorPerson({ space }, { db: fake.db });
+
+    expect(actor.id).toBe(900);
+    expect(fake.state.inserted).toHaveLength(1);
+    expect(fake.state.inserted[0]).toMatchObject({
+      sub: 'space:5',
+      slug: 'space-riverside',
+      name: 'Riverside DAO',
+      avatarUrl: 'https://cdn.example.org/riverside.png',
+    });
+  });
+
+  it('leaves the actor without a wallet or email, so it holds no voting power', async () => {
+    await ensureSpaceActorPerson({ space }, { db: fake.db });
+
+    const values = fake.state.inserted[0] ?? {};
+    expect(values.address).toBeUndefined();
+    expect(values.email).toBeUndefined();
+  });
+
+  it('cannot be signed in as, because its sub is not a Privy subject', () => {
+    expect(spaceActorSub(5)).toBe('space:5');
+    expect(spaceActorSub(5).startsWith('did:privy:')).toBe(false);
+  });
+
+  it('reuses the actor on later signals instead of creating another', async () => {
+    const first = await ensureSpaceActorPerson({ space }, { db: fake.db });
+    const second = await ensureSpaceActorPerson({ space }, { db: fake.db });
+
+    expect(second.id).toBe(first.id);
+    expect(fake.state.inserted).toHaveLength(1);
+  });
+
+  it('qualifies the slug with the space id when a member already holds it', async () => {
+    fake.state.takenSlugs.add('space-riverside');
+
+    const actor = await ensureSpaceActorPerson({ space }, { db: fake.db });
+
+    expect(fake.state.inserted.map((values) => values.slug)).toEqual([
+      'space-riverside',
+      'space-riverside-5',
+    ]);
+    expect(actor.slug).toBe('space-riverside-5');
+  });
+
+  it('refreshes the label after the space is renamed', async () => {
+    await ensureSpaceActorPerson({ space }, { db: fake.db });
+
+    const actor = await ensureSpaceActorPerson(
+      { space: { ...space, title: 'Riverside Collective' } },
+      { db: fake.db },
+    );
+
+    expect(actor.name).toBe('Riverside Collective');
+    expect(fake.state.updated).toHaveLength(1);
+  });
+
+  it('does not write when nothing about the space changed', async () => {
+    await ensureSpaceActorPerson({ space }, { db: fake.db });
+    await ensureSpaceActorPerson({ space }, { db: fake.db });
+
+    expect(fake.state.updated).toHaveLength(0);
+  });
+});

--- a/packages/core/src/people/server/index.ts
+++ b/packages/core/src/people/server/index.ts
@@ -1,3 +1,4 @@
 export * from './queries';
 export * from './mutations';
 export * from './resolve-person-from-auth-token';
+export * from './space-actor-person';

--- a/packages/core/src/people/server/queries.ts
+++ b/packages/core/src/people/server/queries.ts
@@ -179,6 +179,26 @@ export const findPeopleByWeb3Addresses = async (
   return dbPeople.map(mapToDomainPerson);
 };
 
+export type FindPersonByEmailInput = {
+  email: string;
+};
+export const findPersonByEmail = async (
+  { email }: FindPersonByEmailInput,
+  { db }: DbConfig,
+) => {
+  const normalized = email.trim().toLowerCase();
+  if (!normalized) return null;
+
+  const [person] = await db
+    .select()
+    .from(people)
+    .where(eq(sql`lower(${people.email})`, normalized))
+    .limit(1);
+  if (!person) return null;
+
+  return mapToDomainPerson(person);
+};
+
 export type FindPersonBySpaceIdInput = { spaceId: number };
 export type FindPersonBySpaceIdConfig = {
   db: DatabaseInstance;

--- a/packages/core/src/people/server/queries.ts
+++ b/packages/core/src/people/server/queries.ts
@@ -10,12 +10,20 @@ import {
   spaces,
   documents,
 } from '@hypha-platform/storage-postgres';
-import { sql, eq, inArray, and } from 'drizzle-orm';
+import { sql, eq, inArray, and, notLike, or, isNull } from 'drizzle-orm';
 import invariant from 'tiny-invariant';
 import { DatabaseInstance, DbConfig } from '../../server';
+import { SPACE_ACTOR_SUB_PREFIX } from './space-actor-person';
 
 const nullToUndefined = <T>(value: T | null): T | undefined =>
   value === null ? undefined : value;
+
+/**
+ * Keep the pseudo-people that represent spaces out of human-facing directories.
+ * They exist only to own signals a space authored on an integration's behalf.
+ */
+const isHumanPerson = () =>
+  or(isNull(people.sub), notLike(people.sub, `${SPACE_ACTOR_SUB_PREFIX}%`));
 
 export const getDefaultFields = () => {
   return {
@@ -77,6 +85,7 @@ export const findAllPeople = async (config: FindAllPeopleConfig) => {
   const dbPeople = (await db
     .select(getDefaultFields())
     .from(people)
+    .where(isHumanPerson())
     .limit(pageSize)
     .offset(offset)) as ResultRow[];
 
@@ -120,7 +129,8 @@ export const findAllPeopleWithoutPagination = async ({
       address: people.address,
       leadImageUrl: people.leadImageUrl,
     })
-    .from(people)) as ResultRow[];
+    .from(people)
+    .where(isHumanPerson())) as ResultRow[];
 
   return dbPeople.map(mapToDomainPerson);
 };

--- a/packages/core/src/people/server/space-actor-person.ts
+++ b/packages/core/src/people/server/space-actor-person.ts
@@ -1,0 +1,107 @@
+import { people } from '@hypha-platform/storage-postgres';
+import type { Person as DbPerson } from '@hypha-platform/storage-postgres';
+import { eq } from 'drizzle-orm';
+
+import type { DbConfig } from '../../server';
+
+/**
+ * `people.sub` marker for the pseudo-person that represents a space itself.
+ *
+ * A space needs a row in `people` to own a signal, because `coherences
+ * .creator_id` is a non-null foreign key. Privy subjects look like
+ * `did:privy:…`, so this prefix can never collide with a real user, and a
+ * space actor can never be authenticated as.
+ */
+export const SPACE_ACTOR_SUB_PREFIX = 'space:';
+
+export function spaceActorSub(spaceId: number): string {
+  return `${SPACE_ACTOR_SUB_PREFIX}${spaceId}`;
+}
+
+/** Space descriptor needed to present the space as an author on the board. */
+export type SpaceActorSource = {
+  id: number;
+  slug: string;
+  title: string;
+  logoUrl?: string | null;
+};
+
+export const findSpaceActorPerson = async (
+  { spaceId }: { spaceId: number },
+  { db }: DbConfig,
+): Promise<DbPerson | null> => {
+  const [row] = await db
+    .select()
+    .from(people)
+    .where(eq(people.sub, spaceActorSub(spaceId)))
+    .limit(1);
+  return row ?? null;
+};
+
+/**
+ * Get — creating on first use — the person row that represents a space.
+ *
+ * Used when an integration reports an author Hypha does not know, so the
+ * signal is attributed to the space rather than being rejected or pinned on an
+ * unrelated member. The row carries no wallet address and no email, so it
+ * holds no voting power and cannot be notified or signed in as.
+ */
+export const ensureSpaceActorPerson = async (
+  { space }: { space: SpaceActorSource },
+  { db }: DbConfig,
+): Promise<DbPerson> => {
+  const existing = await findSpaceActorPerson({ spaceId: space.id }, { db });
+  if (existing) {
+    return syncSpaceActorPerson({ actor: existing, space }, { db });
+  }
+
+  const baseSlug = `space-${space.slug}`;
+  // `people.slug` is unique and a real member could already hold the plain
+  // form, so fall back to a space-id-qualified slug. `onConflictDoNothing`
+  // also absorbs a concurrent request creating the same actor.
+  for (const slug of [baseSlug, `${baseSlug}-${space.id}`]) {
+    const [created] = await db
+      .insert(people)
+      .values({
+        sub: spaceActorSub(space.id),
+        slug,
+        name: space.title,
+        nickname: space.title,
+        avatarUrl: space.logoUrl ?? null,
+      })
+      .onConflictDoNothing()
+      .returning();
+    if (created) return created;
+
+    const raced = await findSpaceActorPerson({ spaceId: space.id }, { db });
+    if (raced) return raced;
+  }
+
+  throw new Error(
+    `Failed to create the space actor person for spaceId=${space.id}`,
+  );
+};
+
+/** Keep the board label truthful after a space is renamed or re-branded. */
+async function syncSpaceActorPerson(
+  { actor, space }: { actor: DbPerson; space: SpaceActorSource },
+  { db }: DbConfig,
+): Promise<DbPerson> {
+  const nextAvatarUrl = space.logoUrl ?? null;
+  if (actor.name === space.title && actor.avatarUrl === nextAvatarUrl) {
+    return actor;
+  }
+
+  const [updated] = await db
+    .update(people)
+    .set({
+      name: space.title,
+      nickname: space.title,
+      avatarUrl: nextAvatarUrl,
+      updatedAt: new Date(),
+    })
+    .where(eq(people.id, actor.id))
+    .returning();
+
+  return updated ?? actor;
+}

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -36,7 +36,12 @@ export * from './coherence/signal-workflow';
 export {
   schemaPatchCoherenceTaskBySlug,
   schemaSignalWorkflowConfig,
+  schemaIngestSignal,
+  schemaPatchIngestedSignal,
+  schemaIngestedSignalUpvote,
 } from './coherence/validation';
+export * from './space-api-key/server';
+export * from './space-api-key';
 export * from './schedule/server';
 export * from './schedule';
 export * from './pipeline/server';

--- a/packages/core/src/space-api-key/__tests__/authenticate-space-api-key.test.ts
+++ b/packages/core/src/space-api-key/__tests__/authenticate-space-api-key.test.ts
@@ -1,0 +1,217 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../server/queries', () => ({
+  findActiveSpaceApiKeyByHash: vi.fn(),
+}));
+vi.mock('../server/mutations', () => ({
+  touchSpaceApiKeyLastUsed: vi.fn(),
+}));
+
+import {
+  generateSpaceApiKey,
+  hashSpaceApiKey,
+  safeEqualHashes,
+  SPACE_API_KEY_PREFIX,
+} from '../generate-api-key';
+import {
+  authenticateSpaceApiKey,
+  SPACE_API_KEY_HEADER,
+} from '../server/authenticate-space-api-key';
+import { findActiveSpaceApiKeyByHash } from '../server/queries';
+import { touchSpaceApiKeyLastUsed } from '../server/mutations';
+
+const db = {} as never;
+
+function keyRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 7,
+    spaceId: 42,
+    name: 'Contest app',
+    source: 'contest-app',
+    keyPrefix: 'abcd1234',
+    keyHash: 'unset',
+    scopes: ['signals:write'],
+    createdByPersonId: null,
+    lastUsedAt: null,
+    revokedAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+function requestWithKey(key: string, header = SPACE_API_KEY_HEADER) {
+  return new Request('https://hypha.test/api/v1/spaces/acme/signals', {
+    method: 'POST',
+    headers: { [header]: key },
+  });
+}
+
+describe('generateSpaceApiKey', () => {
+  it('produces a namespaced key whose digest matches the plaintext', () => {
+    const { plaintext, prefix, hash } = generateSpaceApiKey();
+
+    expect(plaintext.startsWith(`${SPACE_API_KEY_PREFIX}_${prefix}_`)).toBe(
+      true,
+    );
+    expect(hash).toBe(hashSpaceApiKey(plaintext));
+    expect(hash).toHaveLength(64);
+  });
+
+  it('never repeats a key', () => {
+    const keys = new Set(
+      Array.from({ length: 50 }, () => generateSpaceApiKey().plaintext),
+    );
+    expect(keys.size).toBe(50);
+  });
+
+  it('ignores surrounding whitespace when hashing', () => {
+    const { plaintext, hash } = generateSpaceApiKey();
+    expect(hashSpaceApiKey(`  ${plaintext}\n`)).toBe(hash);
+  });
+});
+
+describe('safeEqualHashes', () => {
+  it('rejects digests of differing length instead of throwing', () => {
+    expect(safeEqualHashes('abc', 'abcd')).toBe(false);
+  });
+
+  it('accepts identical digests', () => {
+    const hash = hashSpaceApiKey('hyk_test_key');
+    expect(safeEqualHashes(hash, hash)).toBe(true);
+  });
+});
+
+describe('authenticateSpaceApiKey', () => {
+  const mockedLookup = vi.mocked(findActiveSpaceApiKeyByHash);
+  const mockedTouch = vi.mocked(touchSpaceApiKeyLastUsed);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('authenticates a valid key and records its use', async () => {
+    const { plaintext, hash } = generateSpaceApiKey();
+    mockedLookup.mockResolvedValue(keyRow({ keyHash: hash }) as never);
+
+    const result = await authenticateSpaceApiKey(
+      {
+        request: requestWithKey(plaintext),
+        spaceId: 42,
+        requiredScope: 'signals:write',
+      },
+      { db },
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      apiKey: { id: 7, spaceId: 42, source: 'contest-app' },
+    });
+    expect(mockedLookup).toHaveBeenCalledWith({ keyHash: hash }, { db });
+    expect(mockedTouch).toHaveBeenCalledWith({ id: 7 }, { db });
+  });
+
+  it('accepts the key as a bearer token too', async () => {
+    const { plaintext, hash } = generateSpaceApiKey();
+    mockedLookup.mockResolvedValue(keyRow({ keyHash: hash }) as never);
+
+    const request = new Request('https://hypha.test/x', {
+      method: 'POST',
+      headers: { authorization: `Bearer ${plaintext}` },
+    });
+
+    const result = await authenticateSpaceApiKey(
+      { request, spaceId: 42, requiredScope: 'signals:write' },
+      { db },
+    );
+
+    expect(result.ok).toBe(true);
+  });
+
+  it('returns 401 when no key is presented', async () => {
+    const request = new Request('https://hypha.test/x', { method: 'POST' });
+
+    const result = await authenticateSpaceApiKey(
+      { request, spaceId: 42, requiredScope: 'signals:write' },
+      { db },
+    );
+
+    expect(result).toMatchObject({ ok: false, status: 401 });
+    expect(mockedLookup).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 for an unknown or revoked key', async () => {
+    // The query filters out revoked rows, so both cases surface as no row.
+    mockedLookup.mockResolvedValue(null);
+
+    const result = await authenticateSpaceApiKey(
+      {
+        request: requestWithKey(generateSpaceApiKey().plaintext),
+        spaceId: 42,
+        requiredScope: 'signals:write',
+      },
+      { db },
+    );
+
+    expect(result).toMatchObject({ ok: false, status: 401 });
+    expect(mockedTouch).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when the key belongs to another space', async () => {
+    const { plaintext, hash } = generateSpaceApiKey();
+    mockedLookup.mockResolvedValue(
+      keyRow({ keyHash: hash, spaceId: 99 }) as never,
+    );
+
+    const result = await authenticateSpaceApiKey(
+      {
+        request: requestWithKey(plaintext),
+        spaceId: 42,
+        requiredScope: 'signals:write',
+      },
+      { db },
+    );
+
+    expect(result).toMatchObject({ ok: false, status: 403 });
+    expect(mockedTouch).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when the key lacks the required scope', async () => {
+    const { plaintext, hash } = generateSpaceApiKey();
+    mockedLookup.mockResolvedValue(
+      keyRow({ keyHash: hash, scopes: ['signals:write'] }) as never,
+    );
+
+    const result = await authenticateSpaceApiKey(
+      {
+        request: requestWithKey(plaintext),
+        spaceId: 42,
+        requiredScope: 'signals:upvote',
+      },
+      { db },
+    );
+
+    expect(result).toMatchObject({ ok: false, status: 403 });
+    if (!result.ok) {
+      expect(result.error).toContain('signals:upvote');
+    }
+  });
+
+  it('rejects a row whose stored digest does not match the presented key', async () => {
+    const { plaintext } = generateSpaceApiKey();
+    mockedLookup.mockResolvedValue(
+      keyRow({ keyHash: hashSpaceApiKey('a-different-key') }) as never,
+    );
+
+    const result = await authenticateSpaceApiKey(
+      {
+        request: requestWithKey(plaintext),
+        spaceId: 42,
+        requiredScope: 'signals:write',
+      },
+      { db },
+    );
+
+    expect(result).toMatchObject({ ok: false, status: 401 });
+  });
+});

--- a/packages/core/src/space-api-key/__tests__/authenticate-space-api-key.test.ts
+++ b/packages/core/src/space-api-key/__tests__/authenticate-space-api-key.test.ts
@@ -4,7 +4,7 @@ vi.mock('../server/queries', () => ({
   findActiveSpaceApiKeyByHash: vi.fn(),
 }));
 vi.mock('../server/mutations', () => ({
-  touchSpaceApiKeyLastUsed: vi.fn(),
+  touchSpaceApiKeyLastUsed: vi.fn().mockResolvedValue(undefined),
 }));
 
 import {
@@ -109,6 +109,26 @@ describe('authenticateSpaceApiKey', () => {
     });
     expect(mockedLookup).toHaveBeenCalledWith({ keyHash: hash }, { db });
     expect(mockedTouch).toHaveBeenCalledWith({ id: 7 }, { db });
+  });
+
+  it('authenticates even when recording usage fails', async () => {
+    const { plaintext, hash } = generateSpaceApiKey();
+    mockedLookup.mockResolvedValue(keyRow({ keyHash: hash }) as never);
+    mockedTouch.mockRejectedValueOnce(new Error('database unavailable'));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = await authenticateSpaceApiKey(
+      {
+        request: requestWithKey(plaintext),
+        spaceId: 42,
+        requiredScope: 'signals:write',
+      },
+      { db },
+    );
+
+    expect(result.ok).toBe(true);
+    await vi.waitFor(() => expect(warn).toHaveBeenCalled());
+    warn.mockRestore();
   });
 
   it('accepts the key as a bearer token too', async () => {

--- a/packages/core/src/space-api-key/generate-api-key.ts
+++ b/packages/core/src/space-api-key/generate-api-key.ts
@@ -14,6 +14,20 @@ export type GeneratedSpaceApiKey = {
   hash: string;
 };
 
+/**
+ * Digest a key for storage, and for resolving it on each authenticated request.
+ *
+ * SHA-256 rather than a slow KDF (bcrypt/scrypt/argon2) is deliberate. A key is
+ * 32 bytes from `randomBytes` — 256 bits of entropy, never human-chosen — so
+ * there is no guessable keyspace for a slow hash to defend: recovering the
+ * plaintext from a leaked digest is infeasible at any iteration count, and
+ * precomputation does not apply to random input. Per-record salting would also
+ * make the digest unindexable, and authentication resolves a key *by* this
+ * value, so every request would degrade into scanning candidate rows.
+ *
+ * CodeQL flags this as `js/insufficient-password-hash`; the rule assumes a
+ * user-chosen password, which this is not.
+ */
 export function hashSpaceApiKey(plaintext: string): string {
   return createHash('sha256').update(plaintext.trim(), 'utf8').digest('hex');
 }

--- a/packages/core/src/space-api-key/generate-api-key.ts
+++ b/packages/core/src/space-api-key/generate-api-key.ts
@@ -1,0 +1,42 @@
+import { createHash, randomBytes, timingSafeEqual } from 'node:crypto';
+
+/** Namespace marker so a leaked key is recognisable as a Hypha space key. */
+export const SPACE_API_KEY_PREFIX = 'hyk';
+
+const SECRET_BYTES = 32;
+const PREFIX_CHARS = 8;
+
+export type GeneratedSpaceApiKey = {
+  /** Shown to the integrator exactly once; never persisted. */
+  plaintext: string;
+  /** Leading segment, safe to display in lists and logs. */
+  prefix: string;
+  hash: string;
+};
+
+export function hashSpaceApiKey(plaintext: string): string {
+  return createHash('sha256').update(plaintext.trim(), 'utf8').digest('hex');
+}
+
+/**
+ * Compare two hex digests without leaking length or content through timing.
+ * Both inputs are digests, so a length mismatch already means "not equal".
+ */
+export function safeEqualHashes(a: string, b: string): boolean {
+  const bufferA = Buffer.from(a, 'utf8');
+  const bufferB = Buffer.from(b, 'utf8');
+  if (bufferA.length !== bufferB.length) return false;
+  return timingSafeEqual(bufferA, bufferB);
+}
+
+/** `hyk_<8-char public prefix>_<43-char secret>`. */
+export function generateSpaceApiKey(): GeneratedSpaceApiKey {
+  const prefix = randomBytes(16)
+    .toString('base64url')
+    .replace(/[^a-zA-Z0-9]/g, '')
+    .slice(0, PREFIX_CHARS);
+  const secret = randomBytes(SECRET_BYTES).toString('base64url');
+  const plaintext = `${SPACE_API_KEY_PREFIX}_${prefix}_${secret}`;
+
+  return { plaintext, prefix, hash: hashSpaceApiKey(plaintext) };
+}

--- a/packages/core/src/space-api-key/index.ts
+++ b/packages/core/src/space-api-key/index.ts
@@ -1,0 +1,3 @@
+export * from './generate-api-key';
+export * from './types';
+export * from './validation';

--- a/packages/core/src/space-api-key/server/authenticate-space-api-key.ts
+++ b/packages/core/src/space-api-key/server/authenticate-space-api-key.ts
@@ -1,0 +1,101 @@
+import type { DbConfig } from '../../server';
+import { hashSpaceApiKey, safeEqualHashes } from '../generate-api-key';
+import type { SpaceApiKeyScope } from '../types';
+import { findActiveSpaceApiKeyByHash } from './queries';
+import { touchSpaceApiKeyLastUsed } from './mutations';
+
+export const SPACE_API_KEY_HEADER = 'x-hypha-api-key';
+
+export type AuthenticatedSpaceApiKey = {
+  id: number;
+  spaceId: number;
+  name: string;
+  source: string;
+  scopes: SpaceApiKeyScope[];
+};
+
+export type SpaceApiKeyAuthResult =
+  | { ok: true; apiKey: AuthenticatedSpaceApiKey }
+  | { ok: false; status: 401 | 403; error: string };
+
+export function readSpaceApiKeyFromRequest(
+  request: Request,
+): string | undefined {
+  const explicit = request.headers.get(SPACE_API_KEY_HEADER)?.trim();
+  if (explicit) return explicit;
+
+  const bearer = request.headers
+    .get('authorization')
+    ?.replace(/^Bearer\s+/i, '')
+    .trim();
+  return bearer || undefined;
+}
+
+/**
+ * Verify an inbound integration key against a single space and scope.
+ *
+ * The lookup is by SHA-256 digest, so no secret is ever used in a SQL
+ * comparison; the digests are then re-compared with a timing-safe check.
+ * A key issued for another space is rejected even though digests are globally
+ * unique, so a key can never be replayed against a space it does not own.
+ */
+export async function authenticateSpaceApiKey(
+  {
+    request,
+    spaceId,
+    requiredScope,
+  }: {
+    request: Request;
+    spaceId: number;
+    requiredScope: SpaceApiKeyScope;
+  },
+  { db }: DbConfig,
+): Promise<SpaceApiKeyAuthResult> {
+  const presented = readSpaceApiKeyFromRequest(request);
+  if (!presented) {
+    return {
+      ok: false,
+      status: 401,
+      error: `Missing API key. Send it in the ${SPACE_API_KEY_HEADER} header.`,
+    };
+  }
+
+  const presentedHash = hashSpaceApiKey(presented);
+  const row = await findActiveSpaceApiKeyByHash(
+    { keyHash: presentedHash },
+    { db },
+  );
+  if (!row || !safeEqualHashes(row.keyHash, presentedHash)) {
+    return { ok: false, status: 401, error: 'Invalid or revoked API key.' };
+  }
+
+  if (row.spaceId !== spaceId) {
+    return {
+      ok: false,
+      status: 403,
+      error: 'This API key is not valid for this space.',
+    };
+  }
+
+  const scopes = (row.scopes ?? []) as SpaceApiKeyScope[];
+  if (!scopes.includes(requiredScope)) {
+    return {
+      ok: false,
+      status: 403,
+      error: `This API key is missing the "${requiredScope}" scope.`,
+    };
+  }
+
+  await touchSpaceApiKeyLastUsed({ id: row.id }, { db });
+
+  return {
+    ok: true,
+    apiKey: {
+      id: row.id,
+      spaceId: row.spaceId,
+      name: row.name,
+      source: row.source,
+      scopes,
+    },
+  };
+}

--- a/packages/core/src/space-api-key/server/authenticate-space-api-key.ts
+++ b/packages/core/src/space-api-key/server/authenticate-space-api-key.ts
@@ -86,7 +86,14 @@ export async function authenticateSpaceApiKey(
     };
   }
 
-  await touchSpaceApiKeyLastUsed({ id: row.id }, { db });
+  // Telemetry, not an auth input: never make a valid key fail, or pay for a
+  // serialized write, because of it.
+  void touchSpaceApiKeyLastUsed({ id: row.id }, { db }).catch((error) => {
+    console.warn('Failed to record API key usage', {
+      keyId: row.id,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  });
 
   return {
     ok: true,

--- a/packages/core/src/space-api-key/server/index.ts
+++ b/packages/core/src/space-api-key/server/index.ts
@@ -1,0 +1,3 @@
+export * from './authenticate-space-api-key';
+export * from './mutations';
+export * from './queries';

--- a/packages/core/src/space-api-key/server/mutations.ts
+++ b/packages/core/src/space-api-key/server/mutations.ts
@@ -1,0 +1,104 @@
+import { spaceApiKeys } from '@hypha-platform/storage-postgres';
+import { and, eq, isNull } from 'drizzle-orm';
+
+import type { DbConfig } from '../../server';
+import { generateSpaceApiKey } from '../generate-api-key';
+import type { SpaceApiKeyScope, SpaceApiKeySummary } from '../types';
+
+export type CreateSpaceApiKeyInput = {
+  spaceId: number;
+  name: string;
+  source: string;
+  scopes: SpaceApiKeyScope[];
+  createdByPersonId?: number | null;
+};
+
+export type CreateSpaceApiKeyResult = {
+  key: SpaceApiKeySummary;
+  /** Returned exactly once — it cannot be recovered from the database. */
+  plaintext: string;
+};
+
+export const createSpaceApiKey = async (
+  {
+    spaceId,
+    name,
+    source,
+    scopes,
+    createdByPersonId = null,
+  }: CreateSpaceApiKeyInput,
+  { db }: DbConfig,
+): Promise<CreateSpaceApiKeyResult> => {
+  const { plaintext, prefix, hash } = generateSpaceApiKey();
+
+  const [row] = await db
+    .insert(spaceApiKeys)
+    .values({
+      spaceId,
+      name: name.trim(),
+      source: source.trim(),
+      keyPrefix: prefix,
+      keyHash: hash,
+      scopes,
+      createdByPersonId,
+    })
+    .returning();
+
+  if (!row) {
+    throw new Error(`Failed to persist API key for spaceId=${spaceId}`);
+  }
+
+  // Built field by field so the digest can never leak into a response.
+  return {
+    key: {
+      id: row.id,
+      spaceId: row.spaceId,
+      name: row.name,
+      source: row.source,
+      keyPrefix: row.keyPrefix,
+      scopes: row.scopes as SpaceApiKeyScope[],
+      createdByPersonId: row.createdByPersonId,
+      lastUsedAt: row.lastUsedAt,
+      revokedAt: row.revokedAt,
+      createdAt: row.createdAt,
+    },
+    plaintext,
+  };
+};
+
+/** @returns true when an active key was revoked by this call. */
+export const revokeSpaceApiKey = async (
+  { id, spaceId }: { id: number; spaceId: number },
+  { db }: DbConfig,
+): Promise<boolean> => {
+  const revoked = await db
+    .update(spaceApiKeys)
+    .set({ revokedAt: new Date(), updatedAt: new Date() })
+    .where(
+      and(
+        eq(spaceApiKeys.id, id),
+        eq(spaceApiKeys.spaceId, spaceId),
+        isNull(spaceApiKeys.revokedAt),
+      ),
+    )
+    .returning();
+  return revoked.length > 0;
+};
+
+/**
+ * Record that a key was just used. Best-effort: a failure here must never
+ * fail the request that the key authorised.
+ */
+export const touchSpaceApiKeyLastUsed = async (
+  { id }: { id: number },
+  { db }: DbConfig,
+): Promise<void> => {
+  try {
+    await db
+      .update(spaceApiKeys)
+      .set({ lastUsedAt: new Date() })
+      .where(eq(spaceApiKeys.id, id));
+  } catch (error) {
+    console.error('touchSpaceApiKeyLastUsed:', error);
+  }
+};

--- a/packages/core/src/space-api-key/server/queries.ts
+++ b/packages/core/src/space-api-key/server/queries.ts
@@ -1,0 +1,76 @@
+import { spaceApiKeys } from '@hypha-platform/storage-postgres';
+import { and, desc, eq, isNull } from 'drizzle-orm';
+
+import type { DbConfig } from '../../server';
+import type { SpaceApiKeyScope, SpaceApiKeySummary } from '../types';
+
+/** Columns safe to hand back to callers — deliberately excludes `keyHash`. */
+const summaryColumns = {
+  id: spaceApiKeys.id,
+  spaceId: spaceApiKeys.spaceId,
+  name: spaceApiKeys.name,
+  source: spaceApiKeys.source,
+  keyPrefix: spaceApiKeys.keyPrefix,
+  scopes: spaceApiKeys.scopes,
+  createdByPersonId: spaceApiKeys.createdByPersonId,
+  lastUsedAt: spaceApiKeys.lastUsedAt,
+  revokedAt: spaceApiKeys.revokedAt,
+  createdAt: spaceApiKeys.createdAt,
+};
+
+function toSummary(row: {
+  id: number;
+  spaceId: number;
+  name: string;
+  source: string;
+  keyPrefix: string;
+  scopes: string[];
+  createdByPersonId: number | null;
+  lastUsedAt: Date | null;
+  revokedAt: Date | null;
+  createdAt: Date;
+}): SpaceApiKeySummary {
+  return { ...row, scopes: row.scopes as SpaceApiKeyScope[] };
+}
+
+/**
+ * Look up a non-revoked key by its SHA-256 digest. Callers must still verify
+ * the digest with a timing-safe comparison and check the space and scopes.
+ */
+export const findActiveSpaceApiKeyByHash = async (
+  { keyHash }: { keyHash: string },
+  { db }: DbConfig,
+) => {
+  const [row] = await db
+    .select()
+    .from(spaceApiKeys)
+    .where(
+      and(eq(spaceApiKeys.keyHash, keyHash), isNull(spaceApiKeys.revokedAt)),
+    )
+    .limit(1);
+  return row ?? null;
+};
+
+export const listSpaceApiKeys = async (
+  { spaceId }: { spaceId: number },
+  { db }: DbConfig,
+): Promise<SpaceApiKeySummary[]> => {
+  const rows = await db
+    .select(summaryColumns)
+    .from(spaceApiKeys)
+    .where(eq(spaceApiKeys.spaceId, spaceId))
+    .orderBy(desc(spaceApiKeys.createdAt));
+  return rows.map(toSummary);
+};
+
+export const findSpaceApiKeyById = async (
+  { id, spaceId }: { id: number; spaceId: number },
+  { db }: DbConfig,
+): Promise<SpaceApiKeySummary | null> => {
+  const [row] = await db
+    .select(summaryColumns)
+    .from(spaceApiKeys)
+    .where(and(eq(spaceApiKeys.id, id), eq(spaceApiKeys.spaceId, spaceId)))
+    .limit(1);
+  return row ? toSummary(row) : null;
+};

--- a/packages/core/src/space-api-key/types.ts
+++ b/packages/core/src/space-api-key/types.ts
@@ -1,0 +1,24 @@
+export const SPACE_API_KEY_SCOPES = [
+  'signals:write',
+  'signals:upvote',
+] as const;
+
+export type SpaceApiKeyScope = (typeof SPACE_API_KEY_SCOPES)[number];
+
+/** Key metadata safe to return over the wire — never includes the digest. */
+export type SpaceApiKeySummary = {
+  id: number;
+  spaceId: number;
+  name: string;
+  source: string;
+  keyPrefix: string;
+  scopes: SpaceApiKeyScope[];
+  createdByPersonId: number | null;
+  lastUsedAt: Date | null;
+  revokedAt: Date | null;
+  createdAt: Date;
+};
+
+export function isSpaceApiKeyScope(value: string): value is SpaceApiKeyScope {
+  return (SPACE_API_KEY_SCOPES as readonly string[]).includes(value);
+}

--- a/packages/core/src/space-api-key/validation.ts
+++ b/packages/core/src/space-api-key/validation.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+import { SPACE_API_KEY_SCOPES } from './types';
+
+export const spaceApiKeySourceSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(64)
+  .regex(
+    /^[a-z0-9][a-z0-9-]*$/,
+    'Source must be lowercase letters, numbers and hyphens',
+  );
+
+export const schemaCreateSpaceApiKey = z.object({
+  name: z.string().trim().min(1).max(120),
+  source: spaceApiKeySourceSchema,
+  scopes: z.array(z.enum(SPACE_API_KEY_SCOPES)).min(1).max(10),
+});

--- a/packages/storage-postgres/migrations/0074_space_api_keys_and_signal_source.sql
+++ b/packages/storage-postgres/migrations/0074_space_api_keys_and_signal_source.sql
@@ -1,0 +1,45 @@
+CREATE TABLE IF NOT EXISTS "space_api_keys" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"space_id" integer NOT NULL,
+	"name" text NOT NULL,
+	"source" varchar(64) NOT NULL,
+	"key_prefix" varchar(16) NOT NULL,
+	"key_hash" text NOT NULL,
+	"scopes" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"created_by_person_id" integer,
+	"last_used_at" timestamp with time zone,
+	"revoked_at" timestamp with time zone,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'space_api_keys_space_id_spaces_id_fk'
+  ) THEN
+    ALTER TABLE "space_api_keys" ADD CONSTRAINT "space_api_keys_space_id_spaces_id_fk" FOREIGN KEY ("space_id") REFERENCES "public"."spaces"("id") ON DELETE cascade ON UPDATE no action;
+  END IF;
+END $$;
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'space_api_keys_created_by_person_id_people_id_fk'
+  ) THEN
+    ALTER TABLE "space_api_keys" ADD CONSTRAINT "space_api_keys_created_by_person_id_people_id_fk" FOREIGN KEY ("created_by_person_id") REFERENCES "public"."people"("id") ON DELETE set null ON UPDATE no action;
+  END IF;
+END $$;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "space_api_keys_key_hash_unique" ON "space_api_keys" USING btree ("key_hash");
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "space_api_keys_space_source_unique" ON "space_api_keys" USING btree ("space_id","source");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "space_api_keys_space_revoked_idx" ON "space_api_keys" USING btree ("space_id","revoked_at");
+--> statement-breakpoint
+ALTER TABLE "coherences" ADD COLUMN IF NOT EXISTS "source" text;
+--> statement-breakpoint
+ALTER TABLE "coherences" ADD COLUMN IF NOT EXISTS "external_id" text;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "coherences_space_source_external_id_unique" ON "coherences" USING btree ("space_id","source","external_id")
+  WHERE "space_id" IS NOT NULL AND "source" IS NOT NULL AND "external_id" IS NOT NULL;

--- a/packages/storage-postgres/migrations/0074_space_api_keys_and_signal_source.sql
+++ b/packages/storage-postgres/migrations/0074_space_api_keys_and_signal_source.sql
@@ -33,7 +33,10 @@ END $$;
 --> statement-breakpoint
 CREATE UNIQUE INDEX IF NOT EXISTS "space_api_keys_key_hash_unique" ON "space_api_keys" USING btree ("key_hash");
 --> statement-breakpoint
-CREATE UNIQUE INDEX IF NOT EXISTS "space_api_keys_space_source_unique" ON "space_api_keys" USING btree ("space_id","source");
+DROP INDEX IF EXISTS "space_api_keys_space_source_unique";
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "space_api_keys_space_source_unique" ON "space_api_keys" USING btree ("space_id","source")
+  WHERE "revoked_at" IS NULL;
 --> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "space_api_keys_space_revoked_idx" ON "space_api_keys" USING btree ("space_id","revoked_at");
 --> statement-breakpoint

--- a/packages/storage-postgres/migrations/meta/_journal.json
+++ b/packages/storage-postgres/migrations/meta/_journal.json
@@ -519,6 +519,13 @@
       "when": 1784000000004,
       "tag": "0073_deal_account_manager_fk_validate",
       "breakpoints": true
+    },
+    {
+      "idx": 74,
+      "version": "7",
+      "when": 1784000000005,
+      "tag": "0074_space_api_keys_and_signal_source",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/storage-postgres/src/schema/coherence.ts
+++ b/packages/storage-postgres/src/schema/coherence.ts
@@ -39,6 +39,10 @@ export const coherences = pgTable(
     progressStatus: text('progress_status'),
     board: text('board'),
     assigneeIds: jsonb('assignee_ids').$type<number[]>().notNull().default([]),
+    /** `space_api_keys.source` when the signal arrived from a community app. */
+    source: text('source'),
+    /** The external app's own identifier for the record, used for idempotency. */
+    externalId: text('external_id'),
     ...commonDateFields,
   },
   (table) => [
@@ -67,6 +71,11 @@ export const coherences = pgTable(
       .on(table.spaceId, table.dueAt)
       .where(sql`${table.dueAt} IS NOT NULL AND ${table.archived} = false`),
     index('coherences_assignee_ids_idx').using('gin', table.assigneeIds),
+    uniqueIndex('coherences_space_source_external_id_unique')
+      .on(table.spaceId, table.source, table.externalId)
+      .where(
+        sql`${table.spaceId} IS NOT NULL AND ${table.source} IS NOT NULL AND ${table.externalId} IS NOT NULL`,
+      ),
   ],
 );
 

--- a/packages/storage-postgres/src/schema/index.ts
+++ b/packages/storage-postgres/src/schema/index.ts
@@ -37,6 +37,7 @@ import {
 import { deals } from './deal';
 import { pipelineSavedViews } from './pipeline-saved-view';
 import { pipelineUserSettings } from './pipeline-user-settings';
+import { spaceApiKeys } from './space-api-key';
 
 export { SPACE_FLAGS } from './flags';
 export { CATEGORIES } from './categories';
@@ -62,6 +63,7 @@ export * from './space-scheduled-item';
 export * from './deal';
 export * from './pipeline-saved-view';
 export * from './pipeline-user-settings';
+export * from './space-api-key';
 
 export const schema = {
   documents,
@@ -97,4 +99,5 @@ export const schema = {
   deals,
   pipelineSavedViews,
   pipelineUserSettings,
+  spaceApiKeys,
 };

--- a/packages/storage-postgres/src/schema/space-api-key.ts
+++ b/packages/storage-postgres/src/schema/space-api-key.ts
@@ -9,7 +9,7 @@ import {
   uniqueIndex,
   varchar,
 } from 'drizzle-orm/pg-core';
-import { InferInsertModel, InferSelectModel } from 'drizzle-orm';
+import { InferInsertModel, InferSelectModel, sql } from 'drizzle-orm';
 import { commonDateFields } from './shared';
 import { spaces } from './space';
 import { people } from './people';
@@ -47,10 +47,12 @@ export const spaceApiKeys = pgTable(
   },
   (table) => [
     uniqueIndex('space_api_keys_key_hash_unique').on(table.keyHash),
-    uniqueIndex('space_api_keys_space_source_unique').on(
-      table.spaceId,
-      table.source,
-    ),
+    // Active keys only: `source` is stamped onto every signal the key writes, so
+    // rotating a key has to reuse it. Spanning revoked rows would make issuing a
+    // replacement impossible without breaking ownership of past signals.
+    uniqueIndex('space_api_keys_space_source_unique')
+      .on(table.spaceId, table.source)
+      .where(sql`${table.revokedAt} IS NULL`),
     index('space_api_keys_space_revoked_idx').on(
       table.spaceId,
       table.revokedAt,

--- a/packages/storage-postgres/src/schema/space-api-key.ts
+++ b/packages/storage-postgres/src/schema/space-api-key.ts
@@ -1,0 +1,62 @@
+import {
+  index,
+  integer,
+  jsonb,
+  pgTable,
+  serial,
+  text,
+  timestamp,
+  uniqueIndex,
+  varchar,
+} from 'drizzle-orm/pg-core';
+import { InferInsertModel, InferSelectModel } from 'drizzle-orm';
+import { commonDateFields } from './shared';
+import { spaces } from './space';
+import { people } from './people';
+
+/**
+ * Credentials that let a community's own app write into a single space
+ * (currently signals). Only the SHA-256 digest of the key is stored — the
+ * plaintext is shown once at issuance and cannot be recovered afterwards.
+ *
+ * Deliberately has no RLS read policy: key rows are never selected by any
+ * member-facing route, because a space can be fully public.
+ */
+export const spaceApiKeys = pgTable(
+  'space_api_keys',
+  {
+    id: serial('id').primaryKey(),
+    spaceId: integer('space_id')
+      .notNull()
+      .references(() => spaces.id, { onDelete: 'cascade' }),
+    /** Human label for the integration, e.g. "ACAW contest app". */
+    name: text('name').notNull(),
+    /** Stable slug stamped onto every signal the key writes. */
+    source: varchar('source', { length: 64 }).notNull(),
+    /** Leading segment of the plaintext key, for identifying it in lists and logs. */
+    keyPrefix: varchar('key_prefix', { length: 16 }).notNull(),
+    keyHash: text('key_hash').notNull(),
+    scopes: jsonb('scopes').$type<string[]>().notNull().default([]),
+    createdByPersonId: integer('created_by_person_id').references(
+      () => people.id,
+      { onDelete: 'set null' },
+    ),
+    lastUsedAt: timestamp('last_used_at', { withTimezone: true }),
+    revokedAt: timestamp('revoked_at', { withTimezone: true }),
+    ...commonDateFields,
+  },
+  (table) => [
+    uniqueIndex('space_api_keys_key_hash_unique').on(table.keyHash),
+    uniqueIndex('space_api_keys_space_source_unique').on(
+      table.spaceId,
+      table.source,
+    ),
+    index('space_api_keys_space_revoked_idx').on(
+      table.spaceId,
+      table.revokedAt,
+    ),
+  ],
+);
+
+export type SpaceApiKey = InferSelectModel<typeof spaceApiKeys>;
+export type NewSpaceApiKey = InferInsertModel<typeof spaceApiKeys>;


### PR DESCRIPTION
## Summary

Communities run their own apps, but their signals had nowhere to land in Hypha. The Signals Board's write side is `'use server'` actions holding a Privy user token — there was no inbound API at all.

This adds **per-space API keys** so a community app can create, update, and record upvotes on signals over REST. Rows are written straight into the `coherences` table the board already reads, so ingested signals show up in the Coherence tab with **no board changes**.

```
Community app ──x-hypha-api-key──▶ POST /api/v1/spaces/{slug}/signals
                                      │
                                      ├─ verify key + scope against this space
                                      ├─ credit a known person, else the space
                                      └─ insert into coherences (source = <app slug>)
                                            │
                                            ▼
                                     Signals Board (existing UI)
```

Backend only — no admin UI for key management, deliberately (see below).

## Key decisions

**Keys are ops-issued, not space-issued.** Some Hypha spaces are completely public, so anyone able to read a space would be able to read its write credentials if issuance lived in the space UI. Issuance therefore sits under the existing ops namespace behind a new `HYPHA_SPACE_API_KEY_OPS_SECRET`. Only a SHA-256 digest is stored; the plaintext is returned exactly once and is unrecoverable.

**An unknown author publishes as the space.** An integration identifies the author by wallet address or email. A match is credited to that member. No match — or no `author` at all — still creates the signal, credited to the space itself, appearing on the board under the space's name and logo. An external app cannot be expected to know which wallet or email someone linked to Hypha, so a profile mismatch the space does not control should not cost it the signal.

The space acts through one pseudo-person per space, created on first use because `coherences.creator_id` is a non-null foreign key. It has no wallet, email, or membership, so it holds **no voting power**, cannot vote, and cannot be signed in as (its `sub` is `space:<id>`, never a Privy subject). It is filtered out of the member directories. Every create response reports `attributedTo: "author" | "space"` so integrators can spot a broken identity mapping.

Voters are the exception and still require a real match (`422`): an upvote only means something as one member's on-chain weight, and upvotes are unique per person, so a shared stand-in would collapse every anonymous vote into one weightless row.

**Ownership via `(space_id, source, external_id)`.** This unique index does double duty: it makes a retried `POST` idempotent (returns the original signal with `200` instead of duplicating), and it proves which integration owns a signal. An app can only update and vote on what it created — signals raised by members in the UI return `403`.

**Upvote weight is still decided on-chain.** `upvoteCoherenceAction` was carrying identity resolution, on-chain voting power, and the Signals contract mirror in one function. The part after identity resolution is extracted into `applyCoherenceUpvote`, now shared by the Privy path and the API path. So `votingPowerPercent` is a share of what the member *genuinely holds* according to the space's on-chain voting power source — an integration cannot inflate anyone's weight — and the on-chain mirror behaves identically either way.

## Endpoints

| Endpoint | Scope | Notes |
|---|---|---|
| `POST /api/v1/spaces/{slug}/signals` | `signals:write` | Idempotent on `externalId`; auto-tags `External Signal`; returns a board deep link |
| `PATCH /api/v1/spaces/{slug}/signals/{signalSlug}` | `signals:write` | Partial; own signals only |
| `PUT`/`DELETE /api/v1/spaces/{slug}/signals/{signalSlug}/upvotes` | `signals:upvote` | Own signals only |
| `POST`/`GET /api/v1/ops/spaces/{slug}/api-keys` | ops secret | Issue (plaintext once) / list metadata only |
| `DELETE /api/v1/ops/spaces/{slug}/api-keys/{keyId}` | ops secret | Revoke |

Request bodies are `.strict()`, so a typo like `prioriy` fails with `400` rather than being silently dropped. `type` is limited to the four types Hypha's own editor can round-trip, which keeps every ingested signal fully editable by members.

## Migration

`0074_space_api_keys_and_signal_source.sql` — new `space_api_keys` table, plus nullable `source` / `external_id` on `coherences` and the partial unique index. Hand-written with `IF NOT EXISTS` guards to match the convention from 0054 onward (the drizzle snapshots stop at 0053, so `drizzle-kit generate` re-emits already-applied tables and cannot be used here).

No migration is needed for space attribution: the stand-in is an ordinary `people` row.

## Test plan

- [x] `pnpm --filter @hypha-platform/core test` — 571 pass (one unrelated pre-existing failure: `call-camera-access.test.ts`, `navigator is not defined`, also failing on `main`). New: 12 key auth/generation tests, 11 `applyCoherenceUpvote` tests, 17 ingestion validation tests, 7 space-actor tests (lazy create, reuse, slug collision, rename refresh, no wallet/email).
- [x] `pnpm build` — full monorepo green; all five new routes register as dynamic handlers.
- [x] `pnpm lint` and `pnpm format:check` — clean, no new warnings.
- [ ] **Needs a reviewer with a database:** issue a key for a sandbox space, `POST` a signal with a wallet nobody owns, and confirm it renders on the Signals Board authored by the space with no voting power; then `POST` one with a real member's wallet and confirm it is credited to them; then upvote and confirm the weight matches the member's on-chain voting power. I verified the read path statically — the board filters only on `space_id` and `archived = false`, with no creator or membership filter — but could not run it end-to-end locally (no DB URL in this working copy).

## Follow-ups (deliberately out of scope)

Admin UI for key management (blocked on the public-space concern above), per-key rate limiting, and auto-creating real member profiles from external payloads.

📄 Integrator brief: `docs/integrations/external-signal-ingestion.md`

Made with [Cursor](https://cursor.com)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ops-only per-space API key management (create/list/revoke) secured by an ops secret.
  * Added External Signal ingestion for community integrations: idempotent create, signal patching, and upvote/remove.
  * Added the “External Signal” tag and persisted integration identifiers (source/externalId) for signals.
* **Documentation**
  * Added the external-signal ingestion integration guide.
  * Updated ops-secret env template and feature-flag documentation with rollback guidance.
* **Tests**
  * Added coverage for ingestion validation and coherence upvote apply/removal behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->