### PR TITLE
fix(storage-evm): correct OSwaps pricing math, close EOSIO parity gaps, add tests

### DIFF
--- a/packages/storage-evm/contracts/mocks/MockBadDecimalsERC20.sol
+++ b/packages/storage-evm/contracts/mocks/MockBadDecimalsERC20.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import '@openzeppelin/contracts/token/ERC20/ERC20.sol';
+
+/**
+ * @dev ERC20 whose `decimals()` misbehaves, to check that callers reading token
+ *      metadata degrade gracefully. Modes:
+ *      0 — returns a nonsensically large value
+ *      1 — returns fewer than 32 bytes, so the result cannot be ABI-decoded
+ *      2 — reverts
+ */
+contract MockBadDecimalsERC20 is ERC20 {
+  uint8 public mode;
+
+  constructor(uint8 mode_) ERC20('Bad', 'BAD') {
+    mode = mode_;
+  }
+
+  function mint(address to, uint256 amount) public {
+    _mint(to, amount);
+  }
+
+  function decimals() public view override returns (uint8) {
+    uint8 m = mode;
+    if (m == 0) {
+      // Report 999, which no real token uses, via a wider return type.
+      assembly {
+        mstore(0, 999)
+        return(0, 32)
+      }
+    }
+    if (m == 1) {
+      assembly {
+        mstore(0, 6)
+        return(0, 4)
+      }
+    }
+    revert('MockBadDecimalsERC20: no decimals');
+  }
+}

--- a/packages/storage-evm/contracts/mocks/MockFeeOnTransferERC20.sol
+++ b/packages/storage-evm/contracts/mocks/MockFeeOnTransferERC20.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import '@openzeppelin/contracts/token/ERC20/ERC20.sol';
+
+/**
+ * @dev ERC20 that burns a fee on every transfer, so the recipient receives less
+ *      than the sender sent. Used to verify that balance-based accounting
+ *      rejects fee-on-transfer tokens instead of mispricing them.
+ */
+contract MockFeeOnTransferERC20 is ERC20 {
+  uint8 private _decimals;
+  uint256 public feeBps;
+
+  constructor(
+    string memory name,
+    string memory symbol,
+    uint8 decimals_,
+    uint256 feeBps_
+  ) ERC20(name, symbol) {
+    _decimals = decimals_;
+    feeBps = feeBps_;
+  }
+
+  function decimals() public view override returns (uint8) {
+    return _decimals;
+  }
+
+  function mint(address to, uint256 amount) public {
+    _mint(to, amount);
+  }
+
+  function setFeeBps(uint256 feeBps_) external {
+    feeBps = feeBps_;
+  }
+
+  function _update(address from, address to, uint256 value) internal override {
+    if (from != address(0) && to != address(0) && feeBps > 0) {
+      uint256 fee = (value * feeBps) / 10_000;
+      if (fee > 0) {
+        super._update(from, address(0), fee);
+        super._update(from, to, value - fee);
+        return;
+      }
+    }
+    super._update(from, to, value);
+  }
+}

--- a/packages/storage-evm/contracts/mocks/MockNoDecimalsERC20.sol
+++ b/packages/storage-evm/contracts/mocks/MockNoDecimalsERC20.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/**
+ * @dev Minimal ERC20-like token that deliberately does NOT implement
+ *      `decimals()`. Used to verify that callers reading token metadata degrade
+ *      gracefully instead of reverting.
+ */
+contract MockNoDecimalsERC20 {
+  mapping(address => uint256) public balanceOf;
+  mapping(address => mapping(address => uint256)) public allowance;
+  uint256 public totalSupply;
+
+  event Transfer(address indexed from, address indexed to, uint256 value);
+  event Approval(address indexed owner, address indexed spender, uint256 value);
+
+  function mint(address to, uint256 amount) external {
+    balanceOf[to] += amount;
+    totalSupply += amount;
+    emit Transfer(address(0), to, amount);
+  }
+
+  function approve(address spender, uint256 amount) external returns (bool) {
+    allowance[msg.sender][spender] = amount;
+    emit Approval(msg.sender, spender, amount);
+    return true;
+  }
+
+  function transfer(address to, uint256 amount) external returns (bool) {
+    _transfer(msg.sender, to, amount);
+    return true;
+  }
+
+  function transferFrom(
+    address from,
+    address to,
+    uint256 amount
+  ) external returns (bool) {
+    uint256 allowed = allowance[from][msg.sender];
+    require(allowed >= amount, 'insufficient allowance');
+    if (allowed != type(uint256).max) {
+      allowance[from][msg.sender] = allowed - amount;
+    }
+    _transfer(from, to, amount);
+    return true;
+  }
+
+  function _transfer(address from, address to, uint256 amount) private {
+    require(balanceOf[from] >= amount, 'insufficient balance');
+    balanceOf[from] -= amount;
+    balanceOf[to] += amount;
+    emit Transfer(from, to, amount);
+  }
+}

--- a/packages/storage-evm/contracts/mocks/MockReentrantERC20.sol
+++ b/packages/storage-evm/contracts/mocks/MockReentrantERC20.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import '@openzeppelin/contracts/token/ERC20/ERC20.sol';
+
+/**
+ * @dev ERC20 that re-enters a target contract while it is mid-transfer. Used to
+ *      verify that reentrancy guards on the target actually hold.
+ *
+ *      Arm it with the call to attempt, then trigger a transfer out of `target`.
+ *      The re-entrant call's outcome is recorded rather than bubbled, so a test
+ *      can assert that the guard rejected it while the outer call still
+ *      completed normally.
+ */
+contract MockReentrantERC20 is ERC20 {
+  uint8 private _decimals;
+
+  address public target;
+  bytes public payload;
+  bool public armed;
+
+  bool public reentryAttempted;
+  bool public reentrySucceeded;
+
+  constructor(
+    string memory name,
+    string memory symbol,
+    uint8 decimals_
+  ) ERC20(name, symbol) {
+    _decimals = decimals_;
+  }
+
+  function decimals() public view override returns (uint8) {
+    return _decimals;
+  }
+
+  function mint(address to, uint256 amount) public {
+    _mint(to, amount);
+  }
+
+  function arm(address target_, bytes calldata payload_) external {
+    target = target_;
+    payload = payload_;
+    armed = true;
+    reentryAttempted = false;
+    reentrySucceeded = false;
+  }
+
+  function _update(address from, address to, uint256 value) internal override {
+    // Re-enter while the target is paying out, i.e. inside its own call frame.
+    if (armed && from == target) {
+      armed = false;
+      reentryAttempted = true;
+      // solhint-disable-next-line avoid-low-level-calls
+      (bool ok, ) = target.call(payload);
+      reentrySucceeded = ok;
+    }
+    super._update(from, to, value);
+  }
+}

--- a/packages/storage-evm/contracts/seedsexample/ISeedsEcosystem.sol
+++ b/packages/storage-evm/contracts/seedsexample/ISeedsEcosystem.sol
@@ -31,6 +31,8 @@ interface IOSwaps {
   // Admin functions
   function init(address manager) external;
 
+  function setManager(address newManager) external;
+
   function freeze(uint64 tokenId, string calldata symbol) external;
 
   function unfreeze(uint64 tokenId, string calldata symbol) external;
@@ -49,9 +51,38 @@ interface IOSwaps {
     uint64[] calldata tokenIdList
   ) external view returns (PoolStatus[] memory);
 
-  function assets(uint64 tokenId) external view returns (AssetInfo memory);
+  /**
+   * @dev Use getAsset rather than the auto-generated `assets` mapping getter.
+   * The mapping getter returns AssetInfo's members as flat values, which is not
+   * ABI-compatible with a struct return once the struct contains dynamic types.
+   */
+  function getAsset(uint64 tokenId) external view returns (AssetInfo memory);
 
-  function config() external view returns (Config memory);
+  function getTokenIds() external view returns (uint64[] memory);
+
+  function getAssetCount() external view returns (uint256);
+
+  function liquidityTokens(uint64 tokenId) external view returns (address);
+
+  function tokenIdByAddress(address token) external view returns (uint64);
+
+  function config()
+    external
+    view
+    returns (address manager, bytes32 chainId, uint64 lastTokenId);
+
+  // Quotes
+  function quoteExactIn(
+    uint64 inTokenId,
+    uint64 outTokenId,
+    uint256 inAmount
+  ) external view returns (uint256 outAmount);
+
+  function quoteExactOut(
+    uint64 inTokenId,
+    uint64 outTokenId,
+    uint256 outAmount
+  ) external view returns (uint256 inAmount);
 
   // Liquidity
   function addLiquidity(
@@ -72,7 +103,8 @@ interface IOSwaps {
     address recipient,
     uint64 inTokenId,
     uint64 outTokenId,
-    uint256 inAmount
+    uint256 inAmount,
+    uint256 minOutAmount
   ) external returns (uint256 outAmount);
 
   function swapExactOut(
@@ -84,12 +116,23 @@ interface IOSwaps {
   ) external returns (uint256 inAmount);
 
   // Events
+  event ManagerUpdated(
+    address indexed previousManager,
+    address indexed newManager
+  );
   event AssetCreated(
     uint64 indexed tokenId,
     address indexed tokenContract,
     string symbol
   );
+  event AssetForgotten(uint64 indexed tokenId, address indexed tokenContract);
   event AssetFrozen(uint64 indexed tokenId, bool frozen);
+  event WeightUpdated(
+    uint64 indexed tokenId,
+    uint256 previousWeight,
+    uint256 newWeight,
+    bool priceChanged
+  );
   event LiquidityAdded(
     address indexed account,
     uint64 indexed tokenId,
@@ -105,7 +148,7 @@ interface IOSwaps {
   event TokenSwapped(
     address indexed sender,
     address indexed recipient,
-    uint64 inTokenId,
+    uint64 indexed inTokenId,
     uint64 outTokenId,
     uint256 inAmount,
     uint256 outAmount

--- a/packages/storage-evm/contracts/seedsexample/OSwaps.EOSIO-PARITY.md
+++ b/packages/storage-evm/contracts/seedsexample/OSwaps.EOSIO-PARITY.md
@@ -4,8 +4,7 @@ This document answers a specific question: the Solidity `OSwaps.sol` in this fol
 Antelope/EOSIO `oswaps` contract designed by Chuck for the Seeds ecosystem. **How faithful is it?**
 
 It is written to be read start to finish by a human. For the mechanical contract reference — every
-function, parameter, revert, and the code a UI needs — see
-[`OSwaps.docs.md`](./OSwaps.docs.md).
+function, parameter, revert, and what a UI needs — see [`OSwaps.docs.md`](./OSwaps.docs.md).
 
 The sources compared are all in this directory:
 
@@ -16,37 +15,42 @@ The sources compared are all in this directory:
 | `OSwaps.sol`          | The Solidity port under review                                                 |
 | `ISeedsEcosystem.sol` | Solidity interface declarations for the port                                   |
 
+> **A note on history.** An earlier revision of this port reproduced the protocol's economics
+> faithfully but implemented the arithmetic with hand-written Taylor series that were badly wrong for
+> large trades, and it had drifted from the original on several smaller points. That analysis, and
+> the remediation it recommended, has been carried out — the contract in this folder is the corrected
+> version. §7 records what changed and why, because "which version am I reading?" is otherwise a
+> confusing question to answer from the diff alone.
+
 ---
 
 ## 1. The short answer
 
-**The economic model is faithfully reproduced. The numerical implementation of it is not.**
+**The economic model and the protocol's safety rules are faithfully reproduced. The numerics are
+now equivalent to the original's, and a small number of deliberate deviations exist where the EVM
+demands them.**
 
-Every action in the original has a counterpart, and the parts that matter conceptually — the
-Balancer invariant, single-sided liquidity with weight adjustment, the "weight zero means hold the
-price" convention, the freeze-on-reprice safety rule, manager-gated withdrawal, LIQ receipt tokens
-issued 1:1 — all survive the translation intact and behave the same way. Someone who understood the
-original protocol will recognise this contract and will not be surprised by how it behaves.
+Every action in the original has a counterpart. The parts that matter conceptually — the Balancer
+invariant, single-sided liquidity with weight adjustment, the "weight zero means hold the price"
+convention, the freeze-on-reprice safety rule, manager-gated withdrawal, the symbol typo guard, LIQ
+receipt tokens issued 1:1 and not tradeable peer-to-peer — all survive the translation intact and
+behave the same way. Someone who understood the original protocol will recognise this contract and
+will not be surprised by how it behaves.
 
-The EOSIO version's rearchitecting for EVM is also mostly well judged. The original's most awkward
-feature — a two-action "prep then transfer" choreography needed because EOSIO tokens push rather
-than pull — is correctly collapsed into ordinary pull-based functions, which is what an EVM port
-should do.
+The rearchitecting for EVM is well judged. The original's most awkward feature — a two-action "prep
+then transfer" choreography needed because EOSIO tokens push rather than pull — is correctly
+collapsed into ordinary pull-based functions, which is what an EVM port should do.
 
-What did not survive is the arithmetic. The original called the C standard library's `log()` and
-`exp()` on IEEE doubles: accurate to roughly 15 significant digits across the whole useful domain.
-The port substitutes hand-written Taylor series that are accurate for small trades, visibly wrong
-for large ones, and mathematically divergent past a hard boundary. The pool prices correctly for
-trades up to roughly 40–50% of the relevant pool balance and misprices or reverts beyond that. Nobody
-can steal from it outright — out-of-range trades revert, and we could not construct a profitable
-standalone attack — but the two swap directions are _not_ equally safe: `swapExactIn` errs in the
-pool's favour, while `swapExactOut` errs against it and can break the invariant by as much as 16.8% on
-a single large trade, at liquidity providers' expense. That is a real functional gap any production
-use has to close.
+On arithmetic, the port now matches the original's behaviour rather than its literal instruction
+sequence. The original called the C standard library's `log()` and `exp()` on IEEE doubles, accurate
+to roughly 15 significant digits across the whole useful domain. The port uses PRBMath's fixed-point
+`pow`, which is accurate to better than 1e-10 relative across the same domain and has no practical
+trade-size ceiling. This is a substitution of primitive, not of formula: the algebra is the same.
 
-Beyond the math, a handful of smaller divergences are worth knowing about, and one of them —
-`emergencyWithdraw` — is a departure from the original's _trust model_ rather than its mechanics,
-which makes it the most philosophically significant change in the port.
+Four deliberate deviations remain, each because the EVM makes the original's choice unsafe or
+unreachable: a `minOutAmount` slippage floor on the exact-in swap, an exact pull instead of
+overpay-and-refund on the exact-out swap, reentrancy guards, and outright rejection of
+fee-on-transfer tokens. All four are additions of safety, not changes of economics.
 
 A caveat on the baseline: `oswaps.hpp` describes itself as a Proof of Concept and lists exchange
 fees, liquidity metering, and multichain operation as deliberately unimplemented. The Solidity port
@@ -57,25 +61,26 @@ are against the original as written, not against a hypothetical finished protoco
 
 ## 2. Action-by-action mapping
 
-| EOSIO action                                               | Solidity                                       | Fidelity                                                 |
-| ---------------------------------------------------------- | ---------------------------------------------- | -------------------------------------------------------- |
-| `createasseta(actor, chain, contract, symbol, meta)`       | `createAsset(tokenContract, symbol, metadata)` | Close. `chain` dropped; LIQ precision and naming changed |
-| `forgetasset(actor, token_id, memo)`                       | `forgetAsset(tokenId)`                         | Partial. Does not clean up the LIQ token                 |
-| `querypool(token_id_list)`                                 | `queryPool(tokenIdList)`                       | Faithful                                                 |
-| `freeze(actor, token_id, symbol)`                          | `freeze(tokenId, symbol)`                      | Faithful, including the symbol typo guard                |
-| `unfreeze(actor, token_id, symbol)`                        | `unfreeze(tokenId, symbol)`                    | Faithful                                                 |
-| `init(manager, chain)`                                     | `init(manager)`                                | Partial. One-shot; no manager rotation                   |
-| `addliqprep` + `ontransfer`                                | `addLiquidity(tokenId, amount, weight)`        | Correctly collapsed. One dropped guard                   |
-| `exprepfrom` + `ontransfer`                                | `swapExactIn(...)`                             | Correctly collapsed. Math differs                        |
-| `exprepto` + `ontransfer`                                  | `swapExactOut(..., maxInAmount)`               | Correctly collapsed and improved                         |
-| `withdraw(account, token_id, amount, weight)`              | `withdraw(account, tokenId, amount, weight)`   | Faithful, including the unusual auth model               |
-| `transfer(from, to, quantity, memo)` (LIQ, p2p-restricted) | `LiquidityToken` plain ERC-20                  | **Diverges.** Restriction lost                           |
-| `retire(quantity, memo)`                                   | `LiquidityToken.burnFrom`                      | Equivalent                                               |
-| `ontransfer` fallback for unsolicited transfers            | —                                              | Naturally not applicable                                 |
-| `save_transaction` / `txx` singleton                       | —                                              | Correctly eliminated                                     |
-| `reset()`                                                  | —                                              | Missing                                                  |
-| `resetacct(account)`                                       | —                                              | Not applicable — no internal balance tables              |
-| —                                                          | `emergencyWithdraw(token, amount)`             | **Added.** No counterpart in the original                |
+| EOSIO action                                               | Solidity                                       | Fidelity                                      |
+| ---------------------------------------------------------- | ---------------------------------------------- | --------------------------------------------- |
+| `init(manager, chain)`                                     | `init(manager)` + `setManager(newManager)`     | Faithful. `chain` dropped; rotation preserved |
+| `createasseta(actor, chain, contract, symbol, meta)`       | `createAsset(tokenContract, symbol, metadata)` | Close. `chain` dropped; LIQ naming changed    |
+| `forgetasset(actor, token_id, memo)`                       | `forgetAsset(tokenId)`                         | Improved. Gated on a zero balance             |
+| `querypool(token_id_list)`                                 | `queryPool(tokenIdList)`                       | Faithful                                      |
+| `freeze(actor, token_id, symbol)`                          | `freeze(tokenId, symbol)`                      | Faithful, including the symbol typo guard     |
+| `unfreeze(actor, token_id, symbol)`                        | `unfreeze(tokenId, symbol)`                    | Faithful                                      |
+| `addliqprep` + `ontransfer`                                | `addLiquidity(tokenId, amount, weight)`        | Correctly collapsed                           |
+| `exprepfrom` + `ontransfer`                                | `swapExactIn(..., minOutAmount)`               | Correctly collapsed; slippage floor added     |
+| `exprepto` + `ontransfer`                                  | `swapExactOut(..., maxInAmount)`               | Correctly collapsed and improved              |
+| `withdraw(account, token_id, amount, weight)`              | `withdraw(account, tokenId, amount, weight)`   | Faithful, including the unusual auth model    |
+| `transfer(from, to, quantity, memo)` (LIQ, p2p-restricted) | `LiquidityToken`, p2p blocked                  | Faithful                                      |
+| `retire(quantity, memo)`                                   | `LiquidityToken.burnFrom`                      | Equivalent                                    |
+| `ontransfer` fallback for unsolicited transfers            | —                                              | Naturally not applicable                      |
+| `save_transaction` / `txx` singleton                       | —                                              | Correctly eliminated                          |
+| `reset()`                                                  | —                                              | Missing. Was explicitly test-only             |
+| `resetacct(account)`                                       | —                                              | Not applicable — no internal balance tables   |
+| —                                                          | `quoteExactIn` / `quoteExactOut`               | **Added.** Views, no economic effect          |
+| —                                                          | `getAsset` / `getTokenIds` / `getAssetCount`   | **Added.** Views, no economic effect          |
 
 ---
 
@@ -92,9 +97,17 @@ out_bal_after = llround(out_bal_before * exp(lnc));
 computed_amt  = out_bal_before - out_bal_after;
 ```
 
-and the port computes the same expression in fixed point. `swapExactOut` likewise mirrors the
-original's inverted form with `wOut/wIn`. Setting aside the accuracy of `ln` and `exp` themselves,
-the algebra is a correct transcription.
+The port computes the same quantity as a single fractional power, rearranged so the base exceeds one
+and the exponent is positive:
+
+```solidity
+UD60x18 ratio  = ud(inBalAfter).div(ud(inBalBefore));
+UD60x18 factor = ratio.pow(ud(wIn).div(ud(wOut)));
+uint256 outBalAfter = ud(outBalBefore).div(factor).unwrap();
+```
+
+`x^y` and `exp(y * ln(x))` are the same function; the original decomposed it that way because that is
+what `libm` offers. `swapExactOut` likewise mirrors the original's inverted form with `wOut/wIn`.
 
 ### Single-sided liquidity and the weight convention
 
@@ -107,8 +120,8 @@ new_weight = a->weight * (1.0 - float(amount64) / bal_before);   // withdraw
 ```
 
 The port rearranges these to avoid fractional intermediates —
-`weight * (balBefore + amount) / balBefore` — which is algebraically identical and the right way to
-do it in integer arithmetic.
+`weight * (balBefore ± amount) / balBefore`, via `Math.mulDiv` so the numerator cannot overflow —
+which is algebraically identical and the right way to do it in integer arithmetic.
 
 ### Freeze-on-reprice
 
@@ -123,6 +136,21 @@ That compound-assignment idiom means "stay as you were if weight is zero, otherw
 The port expresses the same logic as `if (weight != 0) { active = false; }`. Equivalent in both
 branches. This rule is also why bootstrapping a new asset requires two `unfreeze` calls — an
 initially counterintuitive sequence that is inherited from the original, not introduced here.
+
+### The zero-weight guard
+
+The original refuses to compute a price-preserving weight when there is nothing to preserve:
+
+```cpp
+if(new_weight == 0.0) {
+  check(bal_before > 0, "zero weight requires existing balance");
+  new_weight = a->weight * (1.0 + float(amount64)/bal_before);
+}
+```
+
+The port asserts the same precondition with the same meaning
+(`Zero weight requires existing balance`), so a first deposit must establish a price explicitly
+rather than silently leaving the weight at zero.
 
 ### The symbol confirmation guard
 
@@ -147,18 +175,58 @@ if (!has_auth(get_self())) {
 ```
 
 The port reaches the same outcome directly, with the pool calling `burnFrom` on the LIQ token
-without consulting allowances. Different mechanism, same trust model — this is faithful, and worth
-saying explicitly because it looks like an EVM-specific liberty and is not.
+without consulting allowances. Different mechanism, same trust model — worth saying explicitly
+because it looks like an EVM-specific liberty and is not.
+
+### Manager rotation
+
+The original gates reconfiguration on the incumbent manager rather than the owner:
+
+```cpp
+bool reconfig = configset.exists();
+if(reconfig) { require_auth(cfg.manager); } else { require_auth2(get_self().value, "owner"_n.value); }
+```
+
+with the header stating the intent: "The manager account may transfer authority to a replacement
+manager account." The port splits this into `init` (owner, once) and `setManager` (incumbent
+manager), which is the same two-case authorisation expressed as two functions.
+
+### LIQ receipts are not tradeable
+
+The original explicitly blocked peer-to-peer trade in liquidity receipts, routing every transfer
+through the contract:
+
+```cpp
+check( from == get_self() || to == get_self(),
+       "oswaps token transfers must be to/from contract");
+// should this no-p2p restriction be under manager config control?
+```
+
+The comment shows this was a considered design decision with a known open question. The port enforces
+the same rule in `LiquidityToken._update`, permitting mint, burn, and any transfer involving the pool,
+and rejecting account-to-account moves. The open question is left open — making the restriction
+manager-configurable would be a protocol change, not a port decision.
+
+### LIQ precision follows the underlying token
+
+The original matched the LIQ token's precision to the underlying token's, reading it from the token's
+own stats table:
+
+```cpp
+auto liq_sym = eosio::symbol(liq_sym_code, ast->supply.symbol.precision());
+```
+
+The port reads `decimals()` from the ERC-20 and passes it to `LiquidityToken`, so 1 USDC deposited
+shows as 1.0 LIQ rather than as a raw `1e6` against an 18-decimal token. Tokens that do not answer,
+or answer nonsensically, fall back to 18.
 
 ### Other faithful details
 
-The strict `bal_before > amount` check on withdrawal, so the pool can never be emptied through that
-path. New assets starting inactive with zero weight. `querypool` reverting on an unknown id rather
-than skipping it. Permissionless asset creation and permissionless deposits. LIQ minted 1:1 with the
-nominal deposit rather than as a proportional share. Reading pool balances live rather than tracking
-them internally. No exchange fees. And no minimum-output guard on the exact-in swap — the original
-had none either, so the port is faithful here even though the omission is far more dangerous on a
-public EVM mempool than on Antelope.
+The strict `bal_before > amount` check on withdrawal for a live asset, so a tradeable pool can never
+be emptied. New assets starting inactive with zero weight. `querypool` reverting on an unknown id
+rather than skipping it. Permissionless asset creation and permissionless deposits. LIQ minted 1:1
+with the nominal deposit rather than as a proportional share. Reading pool balances live rather than
+tracking them internally. No exchange fees.
 
 ---
 
@@ -188,8 +256,8 @@ uint64_t in_bal_before = acin->balance.amount - quantity.amount;
 On EVM, `transferFrom` makes all of this unnecessary. The port reads the balance before pulling
 funds, which is the natural inversion and is correct. Three prep actions, a transient singleton, a
 transaction-introspection routine, and the entire dispatch layer collapse into three ordinary
-functions. This is the right call and it is executed cleanly — the elimination of `save_transaction`
-and the `txx` table is a genuine simplification rather than a lost feature.
+functions. The elimination of `save_transaction` and the `txx` table is a genuine simplification
+rather than a lost feature.
 
 ### Replacing the surplus refund with an exact pull
 
@@ -203,14 +271,32 @@ check(in_surplus >= 0, "insufficient amount transferred in");
 ```
 
 `swapExactOut` instead computes the exact input, checks it against a caller-supplied `maxInAmount`,
-and pulls precisely that. This is strictly better: no overpayment, no refund transfer, no
-round-trip. The `maxInAmount` parameter is a genuine addition with no original counterpart, and it
-is the right idiom for EVM.
+and pulls precisely that. Strictly better: no overpayment, no refund transfer, no round-trip. The
+`maxInAmount` parameter has no original counterpart and is the right idiom for EVM.
+
+### A slippage floor on the exact-in swap
+
+The original had no minimum-output parameter, and on Antelope it did not need one — there is no
+public mempool in which to front-run a pending action. On EVM, a swap with no output floor is
+sandwichable by construction. `swapExactIn` therefore takes `minOutAmount`.
+
+This is the one place where the port adds a parameter that changes the caller's contract rather than
+just its plumbing, and it is a deliberate departure: reproducing the original's omission literally
+would reproduce a vulnerability that only exists in the new execution environment.
 
 ### Reentrancy protection
 
 `nonReentrant` on all three value-moving functions. There is no analogous hazard in the EOSIO model,
-so this is a necessary EVM-specific addition.
+so this is a necessary EVM-specific addition. A test drives a malicious ERC-20 that re-enters the
+pool mid-payout and confirms the guard rejects it.
+
+### Rejecting fee-on-transfer and rebasing tokens
+
+Both implementations read pool balances live rather than tracking them, which means a token whose
+balance changes for reasons other than the pool's own transfers will misprice persistently. Antelope
+tokens do not behave this way, so the original never had to consider it. The port verifies after each
+inbound transfer that the balance moved by exactly the stated amount, and reverts
+`Unexpected balance change` otherwise. This closes a failure mode the original could not have.
 
 ### Dropping the chain plumbing
 
@@ -221,299 +307,164 @@ of cross-chain operation, but only ever accepted `"Telos"`:
 check(chain == chain_name, "currently only Telos chain supported");
 ```
 
-Dropping this from a single-chain EVM deployment is reasonable. The port does leave a vestige behind,
-which is discussed below.
+Dropping this from a single-chain EVM deployment is reasonable. `config.chainId` is retained and set
+to `block.chainid`, preserving the original's record of its home chain; like the original's
+`chain_id` in practice, nothing reads it.
 
 ---
 
-## 5. Divergences that are regressions
+## 5. Remaining divergences
 
-Ordered by significance.
+None of these are regressions in behaviour, but they are differences worth knowing about.
 
-### 5.1 The arithmetic — the port's central weakness
+### 5.1 `forgetAsset` is stricter than the original
 
-Covered in detail in §6. This is the one item that would block production use.
-
-### 5.2 `emergencyWithdraw` breaks the original trust model
-
-This has no counterpart in the original and is the port's sharpest philosophical departure. Chuck's
-header is unusually explicit that the owner is meant to be powerless after setup:
-
-> The contract account owner permission should be a "cold" multisig which is used once for
-> uploading the contract and once for specifying a manager account. **It has no operational role
-> after that**, however for test purposes the `reset` action is implemented.
-
-The port gives the owner a permanent, unrestricted ability to move any token out of the pool:
-
-```solidity
-function emergencyWithdraw(address token, uint256 amount) external onlyOwner {
-  require(IERC20(token).transfer(owner(), amount), 'Transfer failed');
-}
-```
-
-No timelock, no event, no restriction to registered assets, no cap. Depositors are fully exposed to
-the owner key. This inverts a designed property of the protocol — that the operational role sits with
-a governance-controlled manager while the owner stays cold — and it should be either removed or
-narrowed and timelocked before anyone is asked to supply liquidity.
-
-### 5.3 LIQ tokens lost their precision
-
-The original deliberately matched the LIQ token's precision to the underlying token's, reading it
-from the token's own stats table:
-
-```cpp
-auto liq_sym = eosio::symbol(liq_sym_code, ast->supply.symbol.precision());
-```
-
-The port's `LiquidityToken` is a plain OpenZeppelin ERC-20, so it always has 18 decimals, while LIQ
-is still minted 1:1 against the raw deposit. Deposit 1 USDC and you receive `1e6` base units of an
-18-decimal token — displayed naively, `0.000000000001 LIQ`. The accounting still works because mint
-and burn are symmetric, but every display path has to special-case it. Since the original did the
-work to get this right, the loss is a straightforward regression.
-
-The naming scheme also changed. The original generated base-26 alphabetic suffixes via `sym_from_id`
-(`LIQA`, `LIQB`, … `LIQAA`) because Antelope symbol codes must be uppercase letters. The port uses
-decimal (`LIQ1`, `LIQ2`). Cosmetic, and arguably clearer, but a difference worth noting since it
-changes how these tokens appear in wallets.
-
-### 5.4 LIQ receipts became freely tradeable
-
-The original explicitly blocked peer-to-peer trade in liquidity receipts, routing every transfer
-through the contract:
-
-```cpp
-check( from == get_self() || to == get_self(),
-       "oswaps token transfers must be to/from contract");
-// should this no-p2p restriction be under manager config control?
-```
-
-The comment shows this was a considered design decision with a known open question, not an accident.
-The port's `LiquidityToken` is an unrestricted ERC-20, so receipts can be traded, lent, or used as
-collateral. Combined with the fact that `withdraw` burns from whatever address the manager names,
-this changes who can be made whole: the manager must now check current LIQ balances rather than
-assuming the depositor still holds the receipt.
-
-### 5.5 A dropped guard lets weights be silently zero
-
-The original refuses to compute a price-preserving weight when there is nothing to preserve:
-
-```cpp
-if(new_weight == 0.0) {
-  check(bal_before > 0, "zero weight requires existing balance");
-  new_weight = a->weight * (1.0 + float(amount64)/bal_before);
-}
-```
-
-The port folds that condition into the `if` instead of asserting it:
-
-```solidity
-if (weight == 0 && balBefore > 0) {
-  newWeight = (assets[tokenId].weight * (balBefore + amount)) / balBefore;
-}
-```
-
-When `balBefore == 0`, the original reverts with a clear message; the port silently leaves the weight
-at zero. Since the weight is a divisor in the pricing math, every later swap out of that asset then
-fails with a division-by-zero panic, and the asset stays bricked until a manager reprices it. A
-deliberate guard was converted into a silent failure mode — one of those small transcription
-slips that produces a confusing bug much later.
-
-### 5.6 `init` cannot rotate the manager
-
-The original supports reconfiguration, gating it on the incumbent manager:
-
-```cpp
-bool reconfig = configset.exists();
-if(reconfig) { require_auth(cfg.manager); } else { require_auth2(get_self().value, "owner"_n.value); }
-```
-
-The header states the intent: "The manager account may transfer authority to a replacement manager
-account." The port's `init` reverts on any second call, so the manager is fixed forever at
-deployment. Losing that key permanently disables freeze, unfreeze, withdraw, and forgetAsset — and
-because withdrawal is manager-only, it permanently traps all liquidity. This is a designed capability
-that was dropped, and it matters more here than it did on Antelope.
-
-### 5.7 `forgetAsset` does not finish the job
-
-The original also erases the LIQ token's stats rows, and flags the remaining untidiness in a
-comment:
+The original erased the LIQ token's stats rows and flagged the remaining untidiness in a comment:
 
 ```cpp
 // should we check for zero balance before destroying LIQ token?
 // accounts table has stranded ram & data which could create weirdness
 ```
 
-The port deletes only the asset record, leaving `liquidityTokens[tokenId]` populated and the id in
-the `tokenIds` array, with the LIQ token still live and mintable-in-principle. As in the original
-there is no zero-balance check, so any remaining pool balance becomes unreachable — except that here
-`emergencyWithdraw` provides a recovery path the original lacked. Roughly as untidy as the original,
-in slightly different places.
+The port answers that open question with "yes": `forgetAsset` requires a zero pool balance and
+clears every mapping and the id list entry. The original's stranded-balance scenario cannot occur.
 
-### 5.8 `reset` and validation dropped
+Making that reachable required one change with no counterpart in the original. The original forbade
+emptying an asset unconditionally (`bal_before > amount`), which would have made a funded asset
+impossible to retire once the zero-balance gate was added. The port keeps the strict check while the
+asset is **active** and relaxes it to `>=` while the asset is **frozen** — a frozen asset is not
+tradeable, so a zero balance cannot produce an undefined price. Retirement is therefore
+freeze → drain → forget.
 
-`reset()` and `resetacct()` are gone. `resetacct` is genuinely inapplicable — the port has no
-internal balance tables — and `reset` was explicitly "for test purposes," so this is minor. Worth
-noting only because `emergencyWithdraw` appears to have been introduced in their place while granting
-much broader powers than either.
+The alternative would have been an owner-level rescue hatch, which the original design explicitly
+withholds (see §6). Relaxing the drain rule for non-tradeable assets seemed the smaller deviation.
 
-The port also validates less at asset creation. The original had to stat the token's supply to read
-its precision, which incidentally proved the token existed:
+### 5.2 LIQ token naming
+
+The original generated base-26 alphabetic suffixes via `sym_from_id` (`LIQA`, `LIQB`, … `LIQAA`)
+because Antelope symbol codes must be uppercase letters. The port uses decimal (`LIQ1`, `LIQ2`).
+Cosmetic, and arguably clearer, but it changes how these tokens appear in wallets.
+
+### 5.3 `reset` is gone
+
+`reset()` and `resetacct()` are absent. `resetacct` is genuinely inapplicable — the port has no
+internal balance tables — and `reset` was explicitly "for test purposes." Minor.
+
+### 5.4 Less validation at asset creation
+
+The original had to stat the token's supply to read its precision, which incidentally proved the
+token existed:
 
 ```cpp
 auto ast = astattable.require_find(symbol.raw(), "can't stat symbol");
 ```
 
-`createAsset` checks only that the address is not the pool itself. It does not verify the target is a
-contract, does not detect duplicate registration, and never reads the token's real symbol or
-decimals — the `symbol` argument is an unchecked label. On Antelope, RAM costs also made spamming the
-asset table expensive; on EVM only gas limits it.
+The port checks that the address is not the pool, is not zero, has code, and is not already
+registered — but does not prove the target is a real ERC-20, and never validates the `symbol`
+argument against the token, which remains an unchecked label. On Antelope, RAM costs also made
+spamming the asset table expensive; on EVM only gas limits it, so registration remains a
+griefing surface and a UI needs an allowlist.
 
-### 5.9 A vestigial `chainId`
+Note also that "has code" no longer distinguishes contracts from accounts as cleanly as it once did:
+under EIP-7702 an ordinary account can carry a delegation designator and so report a non-empty
+code size. The check catches obvious mistakes, not all of them.
 
-With the chain plumbing removed, one fragment was left behind in a broken state:
+### 5.5 Quote and enumeration views were added
 
-```solidity
-config.chainId = blockhash(block.number - 1);
-```
-
-In the original, `chain_id` held the actual Telos chain id and indexed the asset table for future
-cross-chain identification. Here it is set to a block hash — not a chain identifier by any
-definition — and never read again. If the field is kept it should be `block.chainid`; otherwise it
-should be deleted along with the rest of the multichain scaffolding.
-
----
-
-## 6. The arithmetic, in detail
-
-This deserves its own section because it is the gap between "faithful port" and "production ready."
-
-### What the original did
-
-EOSIO contracts have the C standard library. `oswaps.cpp` uses `log()` and `exp()` on IEEE
-double-precision floats — roughly 15 to 16 significant digits, valid across the entire useful
-domain, with no trade-size constraint arising from the math itself. Weights are stored as `float`.
-
-### What the port does
-
-Solidity has no floating point, so the port implements both functions from scratch in 18-decimal
-fixed point: a 10-term Taylor series for `ln` expanded about `x = 1`, and a 20-term Taylor series
-for `exp`.
-
-The `ln` choice is the problem. A Taylor expansion of `ln(x)` about `x = 1` converges only for
-`0 < x < 2`, and slowly near the edges. The argument here is
-`inBalAfter / inBalBefore = 1 + inAmount / inBalBefore`, so the series' domain limit translates
-directly into a limit on **trade size as a fraction of the input-side pool balance.** At `x = 2` —
-a trade equal to the entire input balance — the series has not converged; beyond it, it diverges and
-produces garbage.
-
-### Measured error
-
-Comparing the port's fixed-point result against exact arithmetic, at equal weights. The two swap
-directions feed `ln` different ratios, so they have different envelopes — and, importantly, **their
-errors point in opposite directions.**
-
-`swapExactIn`, where the constraint is trade size against the input-side balance. Errors here
-underpay the trader, so the pool gains:
-
-| Trade size vs input balance | `ln` argument | Error in output | Verdict     |
-| --------------------------- | ------------- | --------------- | ----------- |
-| 1% – 30%                    | 1.01 – 1.30   | < 0.0001%       | Accurate    |
-| 40%                         | 1.40          | −0.0007%        | Accurate    |
-| 50%                         | 1.50          | −0.0061%        | Acceptable  |
-| 60%                         | 1.60          | −0.036%         | Degraded    |
-| 75%                         | 1.75          | −0.30%          | Degraded    |
-| 90%                         | 1.90          | −1.75%          | Badly wrong |
-| 100%                        | 2.00          | −4.87%          | Badly wrong |
-| 125%                        | 2.25          | −51%            | Badly wrong |
-| ≥ 150%                      | ≥ 2.50        | —               | Reverts     |
-
-`swapExactOut`, where the constraint is the requested output against the output-side balance. Errors
-here undercharge the trader, so the pool loses:
-
-| Output vs output balance | `ln` argument | Error in required input | Invariant `V` change |
-| ------------------------ | ------------- | ----------------------- | -------------------- |
-| 1% – 25%                 | 0.99 – 0.75   | < 0.0001%               | ~0                   |
-| 33%                      | 0.67          | −0.0002%                | −0.00002%            |
-| 40%                      | 0.60          | −0.0015%                | −0.0001%             |
-| 50%                      | 0.50          | −0.017%                 | −0.008%              |
-| 60%                      | 0.40          | −0.12%                  | −0.06%               |
-| 75%                      | 0.25          | −1.67%                  | −1.26%               |
-| 90%                      | 0.10          | −18.7%                  | −16.8%               |
-
-The weight ratio constrains things independently, because the exponent is `-(wIn/wOut) * ln(ratio)`
-and `exp` also loses accuracy for large arguments. At a 10% trade size, weight ratios up to about
-50:1 remain accurate; at 100:1 and beyond the call reverts. Note also that the port's `_exp` returns
-badly wrong values for arguments below about −8 — `exp(-10)` evaluates to roughly `13.4` instead of
-`0.0000454` — which is what causes those reverts.
-
-### How bad is it, exactly
-
-**No standalone extraction is possible.** Inputs outside the convergent domain revert rather than
-executing: when the series diverges, the computed post-swap balance exceeds the pre-swap balance and
-the subtraction underflows, which Solidity 0.8 turns into a panic. Within the executable range, we
-swept 525 `swapExactOut` configurations — weight ratios from 0.02 to 50, pool imbalance from 1:100 to
-100:1, output sizes from 1% to 99% — and found no combination in which a caller can buy the output for
-less than its pre-trade spot value. There is no self-contained way to profit off the mispricing,
-because the curve price for any non-trivial trade remains worse than spot even after the error.
-
-**But `swapExactOut` does leak liquidity-provider value.** It breaks the invariant downward, by up to
-16.8% of `V` on a single large trade. Unlike the exact-in direction, where the approximation error
-accrues to the pool, here it accrues to the counterparty. That value is real, and it is captured by
-whoever was going to arbitrage the pool anyway. This is the part of the math problem that costs
-someone money rather than merely producing a wrong number, and it is why the two directions should not
-be treated as equally safe.
-
-**Small trades are genuinely fine.** Below 30% of the relevant balance the error is under one part in
-a million in both directions, well inside any sane slippage tolerance. A pool that is large relative
-to typical trade size behaves correctly.
-
-### Recommendation
-
-Replace `_ln` and `_exp` with an audited fixed-point library — `PRBMath` or solmate's
-`FixedPointMathLib` — both of which provide full-domain `ln` and `exp` with far better accuracy and
-comparable or lower gas. That removes the trade-size ceiling, eliminates the envelope reverts, and
-brings the port back in line with the original's numerical behaviour.
-
-There is a real tension here worth naming: swapping in a library moves the code _further_ from a
-literal transcription of Chuck's C++ while moving it _closer_ to the protocol's actual intended
-behaviour. Our view is that fidelity means reproducing intended behaviour, and Chuck's use of
-`log()`/`exp()` was a use of the best available primitive rather than a design choice in favour of
-truncated series. But it is a judgement call and should be made deliberately rather than by default.
+`quoteExactIn`, `quoteExactOut`, `getAsset`, `getTokenIds`, and `getAssetCount` have no counterparts
+in the original, which exposed its tables directly to off-chain readers — an affordance EVM does not
+provide. They are views with no economic effect. The quote views share the exact code path used by
+the swaps, so they cannot drift from execution.
 
 ---
 
-## 7. Verdict
+## 6. The trust model
 
-| Dimension                                                                         | Assessment                                                                                                  |
-| --------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| Economic model (invariant, weights, single-sided liquidity)                       | Faithful                                                                                                    |
-| Action coverage                                                                   | Complete, apart from `reset`                                                                                |
-| Semantic rules (freeze-on-reprice, weight-zero, symbol guard, manager-gated exit) | Faithful                                                                                                    |
-| EVM rearchitecting (pull vs push, exact-pull swap, reentrancy)                    | Well judged, an improvement                                                                                 |
-| Numerical accuracy                                                                | **Materially worse.** Reliable only below ~40–50% of pool balance; `swapExactOut` leaks LP value above that |
-| Trust model                                                                       | **Diverges.** `emergencyWithdraw` contradicts the stated cold-owner design                                  |
-| LIQ token behaviour                                                               | Diverges on precision and on transfer restrictions                                                          |
-| Operational completeness                                                          | Gaps: no manager rotation, incomplete `forgetAsset`, a dropped guard                                        |
-| Production readiness                                                              | Not ready. No tests, no deploy script, unresolved math                                                      |
+Worth its own section, because it is the dimension on which a port is easiest to get wrong without
+changing a single formula.
+
+Chuck's header is unusually explicit that the owner is meant to be powerless after setup:
+
+> The contract account owner permission should be a "cold" multisig which is used once for
+> uploading the contract and once for specifying a manager account. **It has no operational role
+> after that**, however for test purposes the `reset` action is implemented.
+
+The port honours this. `owner` can call `init` once and nothing else; there is no owner-level
+withdrawal, no pause, and no upgrade path. Every operational power — freeze, unfreeze, withdraw,
+forgetAsset, and rotation of the role itself — sits with `manager`, which the incumbent manager can
+hand on but the owner cannot reclaim.
+
+That concentration is the protocol's own design, not an artefact of the port, and it has a sharp
+consequence that any deployment has to confront directly: **liquidity providers cannot exit without
+the manager.** A lost or hostile manager key traps every deposit. On Antelope the manager was
+expected to be a governance-controlled account; the EVM equivalent is a multisig or a Hypha space
+`Executor`, and an EOA manager would be a serious misconfiguration rather than a mere inconvenience.
+
+An earlier revision of the port granted the owner an unrestricted `emergencyWithdraw`. That inverted
+the designed property above — it made depositors trust the owner key rather than the manager
+governance — and it has been removed. The zero-balance gate on `forgetAsset` removes the failure mode
+it was ostensibly there to rescue.
+
+---
+
+## 7. What changed from the earlier revision
+
+For readers who saw the previous analysis of this port. Each item was a divergence from the original
+or an EVM-specific hazard; all are now closed.
+
+| Item                                                                                               | Resolution                                                          |
+| -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| Taylor-series `_ln`/`_exp`: up to 4.9% error on exact-in, and a 16.8% invariant break on exact-out | Replaced with PRBMath `UD60x18.pow`; error now below 1e-10 relative |
+| Hard trade-size ceiling — trades ≥ 150% of the input balance reverted                              | Gone. 100× the pool balance prices correctly at equal weights       |
+| `emergencyWithdraw` gave the owner an unrestricted drain                                           | Removed                                                             |
+| `addLiquidity` silently left the weight at zero on an empty pool                                   | Restored the original's explicit guard                              |
+| No manager rotation — a lost key trapped all liquidity permanently                                 | Added `setManager`, gated on the incumbent manager                  |
+| `swapExactIn` had no slippage floor                                                                | Added `minOutAmount`                                                |
+| LIQ decimals always 18, regardless of the underlying                                               | Read from the token, with an 18 fallback                            |
+| LIQ freely transferable, unlike the original                                                       | Peer-to-peer transfers blocked, matching the original               |
+| `forgetAsset` left mappings populated and could strand balances                                    | Full cleanup, gated on a zero balance                               |
+| `config.chainId` was set to a block hash                                                           | Set to `block.chainid`                                              |
+| `IOSwaps.assets` was ABI-incompatible with the real getter                                         | Interface now declares `getAsset`, which returns a real struct      |
+| Zero weight caused a division-by-zero panic deep in the math                                       | Named precondition: `Input/Output weight not set`                   |
+| `inTokenId == outTokenId` was not rejected                                                         | Rejected with `Same token`                                          |
+| The same token could be registered twice, sharing one balance                                      | Rejected with `Token already registered`                            |
+| Raw `require(token.transfer(...))`, breaking on non-standard ERC-20s                               | `SafeERC20` throughout                                              |
+| Fee-on-transfer and rebasing tokens mispriced silently                                             | Rejected with `Unexpected balance change`                           |
+| Weight changes emitted no event                                                                    | `WeightUpdated`; `forgetAsset` and manager changes also emit now    |
+| Dead `onlyActive` modifier                                                                         | Removed                                                             |
+| No tests, no deploy script                                                                         | 85-case suite in `test/OSwaps.test.ts`; `scripts/oswaps.deploy.ts`  |
+
+The one judgement call worth restating. Replacing the Taylor series moves the code _further_ from a
+literal transcription of Chuck's C++ while moving it _closer_ to the protocol's intended behaviour.
+Our view is that fidelity means reproducing intended behaviour, and that `log()`/`exp()` on doubles
+was Chuck's use of the best available primitive rather than a design preference for truncated series.
+A fixed-point `pow` is the closest EVM equivalent of that primitive.
+
+---
+
+## 8. Verdict
+
+| Dimension                                                                         | Assessment                                                                 |
+| --------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| Economic model (invariant, weights, single-sided liquidity)                       | Faithful                                                                   |
+| Action coverage                                                                   | Complete, apart from the test-only `reset`                                 |
+| Semantic rules (freeze-on-reprice, weight-zero, symbol guard, manager-gated exit) | Faithful                                                                   |
+| EVM rearchitecting (pull vs push, exact-pull swap, reentrancy, slippage floor)    | Well judged; an improvement                                                |
+| Numerical accuracy                                                                | Equivalent to the original. < 1e-10 relative error, no practical trade cap |
+| Trust model                                                                       | Faithful. Owner is powerless after `init`; all power sits with the manager |
+| LIQ token behaviour                                                               | Faithful on precision, 1:1 issuance, and the no-p2p restriction            |
+| Operational completeness                                                          | Complete: rotation, full `forgetAsset`, no stranded balances               |
+| Production readiness                                                              | **Unaudited.** Tested and deployable, but not reviewed by a third party    |
 
 **Summary for the original question.** As a description of the oSwaps protocol, the port is
-accurate — it implements Chuck's design, keeps its non-obvious safety rules, and translates the
-EOSIO-specific plumbing into idiomatic EVM correctly. As an implementation of that protocol, it is
-a proof of concept whose pricing math is only trustworthy for trades that are small relative to pool
-size, whose exact-out direction quietly transfers value from liquidity providers to counterparties on
-large trades, and which grants the deployer a fund-recovery power the original design deliberately
-withheld.
+accurate: it implements Chuck's design, keeps its non-obvious safety rules, preserves its trust
+model, and translates the EOSIO-specific plumbing into idiomatic EVM correctly. As an implementation
+of that protocol, its numerics now match the original's across the full useful domain, and the
+handful of places where it departs from the original are all additions of safety that the EVM's
+execution model demands — a slippage floor, reentrancy guards, rejection of tokens whose balances
+move on their own, and a drain rule that makes asset retirement possible without giving the owner a
+key to the pool.
 
-Prioritised remediation, if this is to go anywhere:
-
-1. Replace the Taylor-series math with an audited fixed-point library.
-2. Remove or timelock `emergencyWithdraw`.
-3. Add a test suite — there is currently none, and the math has never been exercised.
-4. Restore the dropped `bal_before > 0` guard in `addLiquidity`.
-5. Add manager rotation.
-6. Add a `minOutAmount` parameter to `swapExactIn`. Absent in the original too, but MEV on a public
-   EVM mempool makes it necessary here in a way it was not on Antelope.
-7. Match LIQ decimals to the underlying token, and decide deliberately whether to restore the
-   peer-to-peer transfer restriction.
-8. Complete `forgetAsset`, or gate it on a zero pool balance.
-9. Fix or delete the vestigial `config.chainId`.
+The remaining gap to production is not fidelity but assurance: the contract is unaudited, and its
+entire operational surface depends on one manager address whose governance a deployment has to choose
+deliberately.

--- a/packages/storage-evm/contracts/seedsexample/OSwaps.EOSIO-PARITY.md
+++ b/packages/storage-evm/contracts/seedsexample/OSwaps.EOSIO-PARITY.md
@@ -1,0 +1,519 @@
+# OSwaps: How Close Is the Solidity Port to Chuck's Original Protocol?
+
+This document answers a specific question: the Solidity `OSwaps.sol` in this folder is a port of the
+Antelope/EOSIO `oswaps` contract designed by Chuck for the Seeds ecosystem. **How faithful is it?**
+
+It is written to be read start to finish by a human. For the mechanical contract reference — every
+function, parameter, revert, and the code a UI needs — see
+[`OSwaps.docs.md`](./OSwaps.docs.md).
+
+The sources compared are all in this directory:
+
+| File                  | What it is                                                                     |
+| --------------------- | ------------------------------------------------------------------------------ |
+| `oswaps.hpp`          | Chuck's original header, with the protocol's design intent in its doc comments |
+| `oswaps.cpp`          | The original EOSIO/Antelope implementation                                     |
+| `OSwaps.sol`          | The Solidity port under review                                                 |
+| `ISeedsEcosystem.sol` | Solidity interface declarations for the port                                   |
+
+---
+
+## 1. The short answer
+
+**The economic model is faithfully reproduced. The numerical implementation of it is not.**
+
+Every action in the original has a counterpart, and the parts that matter conceptually — the
+Balancer invariant, single-sided liquidity with weight adjustment, the "weight zero means hold the
+price" convention, the freeze-on-reprice safety rule, manager-gated withdrawal, LIQ receipt tokens
+issued 1:1 — all survive the translation intact and behave the same way. Someone who understood the
+original protocol will recognise this contract and will not be surprised by how it behaves.
+
+The EOSIO version's rearchitecting for EVM is also mostly well judged. The original's most awkward
+feature — a two-action "prep then transfer" choreography needed because EOSIO tokens push rather
+than pull — is correctly collapsed into ordinary pull-based functions, which is what an EVM port
+should do.
+
+What did not survive is the arithmetic. The original called the C standard library's `log()` and
+`exp()` on IEEE doubles: accurate to roughly 15 significant digits across the whole useful domain.
+The port substitutes hand-written Taylor series that are accurate for small trades, visibly wrong
+for large ones, and mathematically divergent past a hard boundary. The pool prices correctly for
+trades up to roughly 40–50% of the relevant pool balance and misprices or reverts beyond that. Nobody
+can steal from it outright — out-of-range trades revert, and we could not construct a profitable
+standalone attack — but the two swap directions are _not_ equally safe: `swapExactIn` errs in the
+pool's favour, while `swapExactOut` errs against it and can break the invariant by as much as 16.8% on
+a single large trade, at liquidity providers' expense. That is a real functional gap any production
+use has to close.
+
+Beyond the math, a handful of smaller divergences are worth knowing about, and one of them —
+`emergencyWithdraw` — is a departure from the original's _trust model_ rather than its mechanics,
+which makes it the most philosophically significant change in the port.
+
+A caveat on the baseline: `oswaps.hpp` describes itself as a Proof of Concept and lists exchange
+fees, liquidity metering, and multichain operation as deliberately unimplemented. The Solidity port
+omits all three too, so on those points it is faithful to what actually existed. Judgements below
+are against the original as written, not against a hypothetical finished protocol.
+
+---
+
+## 2. Action-by-action mapping
+
+| EOSIO action                                               | Solidity                                       | Fidelity                                                 |
+| ---------------------------------------------------------- | ---------------------------------------------- | -------------------------------------------------------- |
+| `createasseta(actor, chain, contract, symbol, meta)`       | `createAsset(tokenContract, symbol, metadata)` | Close. `chain` dropped; LIQ precision and naming changed |
+| `forgetasset(actor, token_id, memo)`                       | `forgetAsset(tokenId)`                         | Partial. Does not clean up the LIQ token                 |
+| `querypool(token_id_list)`                                 | `queryPool(tokenIdList)`                       | Faithful                                                 |
+| `freeze(actor, token_id, symbol)`                          | `freeze(tokenId, symbol)`                      | Faithful, including the symbol typo guard                |
+| `unfreeze(actor, token_id, symbol)`                        | `unfreeze(tokenId, symbol)`                    | Faithful                                                 |
+| `init(manager, chain)`                                     | `init(manager)`                                | Partial. One-shot; no manager rotation                   |
+| `addliqprep` + `ontransfer`                                | `addLiquidity(tokenId, amount, weight)`        | Correctly collapsed. One dropped guard                   |
+| `exprepfrom` + `ontransfer`                                | `swapExactIn(...)`                             | Correctly collapsed. Math differs                        |
+| `exprepto` + `ontransfer`                                  | `swapExactOut(..., maxInAmount)`               | Correctly collapsed and improved                         |
+| `withdraw(account, token_id, amount, weight)`              | `withdraw(account, tokenId, amount, weight)`   | Faithful, including the unusual auth model               |
+| `transfer(from, to, quantity, memo)` (LIQ, p2p-restricted) | `LiquidityToken` plain ERC-20                  | **Diverges.** Restriction lost                           |
+| `retire(quantity, memo)`                                   | `LiquidityToken.burnFrom`                      | Equivalent                                               |
+| `ontransfer` fallback for unsolicited transfers            | —                                              | Naturally not applicable                                 |
+| `save_transaction` / `txx` singleton                       | —                                              | Correctly eliminated                                     |
+| `reset()`                                                  | —                                              | Missing                                                  |
+| `resetacct(account)`                                       | —                                              | Not applicable — no internal balance tables              |
+| —                                                          | `emergencyWithdraw(token, amount)`             | **Added.** No counterpart in the original                |
+
+---
+
+## 3. What was reproduced correctly
+
+### The pricing model
+
+The invariant, the exponent structure, and the direction of every term match. The original computes:
+
+```cpp
+lc  = log((double)in_bal_after / in_bal_before);
+lnc = -(ain->weight / aout->weight * lc);
+out_bal_after = llround(out_bal_before * exp(lnc));
+computed_amt  = out_bal_before - out_bal_after;
+```
+
+and the port computes the same expression in fixed point. `swapExactOut` likewise mirrors the
+original's inverted form with `wOut/wIn`. Setting aside the accuracy of `ln` and `exp` themselves,
+the algebra is a correct transcription.
+
+### Single-sided liquidity and the weight convention
+
+The heart of the protocol. `weight = 0` means "recompute my weight so the price does not move," and
+both implementations use the same algebra. The original:
+
+```cpp
+new_weight = a->weight * (1.0 + float(amount64) / bal_before);   // deposit
+new_weight = a->weight * (1.0 - float(amount64) / bal_before);   // withdraw
+```
+
+The port rearranges these to avoid fractional intermediates —
+`weight * (balBefore + amount) / balBefore` — which is algebraically identical and the right way to
+do it in integer arithmetic.
+
+### Freeze-on-reprice
+
+A subtle rule, and the port gets it exactly right. In the original, a non-zero weight argument means
+the operator is deliberately changing the price, and the asset is frozen until a manager reviews it:
+
+```cpp
+s.active &= (ap.weight == 0.0);
+```
+
+That compound-assignment idiom means "stay as you were if weight is zero, otherwise go inactive."
+The port expresses the same logic as `if (weight != 0) { active = false; }`. Equivalent in both
+branches. This rule is also why bootstrapping a new asset requires two `unfreeze` calls — an
+initially counterintuitive sequence that is inherited from the original, not introduced here.
+
+### The symbol confirmation guard
+
+`freeze` and `unfreeze` both take a redundant `symbol` argument that must match what is stored. The
+original's rationale, from the header, is to "minimize errors in manually-entered transaction data."
+The port keeps it, comparing by `keccak256`. Easy to mistake for dead weight and drop; it was
+correctly retained.
+
+### Manager-gated withdrawal, including the surprising part
+
+`withdraw` is manager-only in both, so liquidity providers cannot exit on their own initiative.
+More surprisingly, in both implementations the manager can burn a provider's LIQ receipts _without
+that provider's consent_. In the original this is not stated outright but follows from the
+authorisation logic: `withdraw` sends an inline LIQ transfer authorised by the contract's own
+`active` permission, and the transfer handler only demands the sender's authority when the contract
+is not already authorised:
+
+```cpp
+if (!has_auth(get_self())) {
+  require_auth( from ); // only needed if we enable p2p LIQ transfers
+}
+```
+
+The port reaches the same outcome directly, with the pool calling `burnFrom` on the LIQ token
+without consulting allowances. Different mechanism, same trust model — this is faithful, and worth
+saying explicitly because it looks like an EVM-specific liberty and is not.
+
+### Other faithful details
+
+The strict `bal_before > amount` check on withdrawal, so the pool can never be emptied through that
+path. New assets starting inactive with zero weight. `querypool` reverting on an unknown id rather
+than skipping it. Permissionless asset creation and permissionless deposits. LIQ minted 1:1 with the
+nominal deposit rather than as a proportional share. Reading pool balances live rather than tracking
+them internally. No exchange fees. And no minimum-output guard on the exact-in swap — the original
+had none either, so the port is faithful here even though the omission is far more dangerous on a
+public EVM mempool than on Antelope.
+
+---
+
+## 4. Adaptations that are correct and well judged
+
+### Collapsing prep-and-transfer into direct calls
+
+The original's most distinctive structural feature exists to work around an EOSIO constraint: token
+transfers are _pushed_ to the recipient, so a contract cannot pull tokens and cannot know why a
+transfer arrived. Chuck's solution was a compound transaction — a "prep" action stating intent,
+immediately followed by the transfer — with `save_transaction` serialising and inspecting the whole
+transaction to verify the pairing:
+
+```cpp
+check(final_action.name == "transfer"_n, "final action must be token transfer");
+check(should_be_this_action.name == entry && should_be_this_action.account == get_self(),
+      "prep action must be next-to-last in transaction ");
+```
+
+The `ontransfer` handler then re-read the stored transaction, dispatched on the prep action's type,
+and had to _back out_ the transfer that had already happened to recover the pre-transfer balance:
+
+```cpp
+uint64_t in_bal_before = acin->balance.amount - quantity.amount;
+```
+
+On EVM, `transferFrom` makes all of this unnecessary. The port reads the balance before pulling
+funds, which is the natural inversion and is correct. Three prep actions, a transient singleton, a
+transaction-introspection routine, and the entire dispatch layer collapse into three ordinary
+functions. This is the right call and it is executed cleanly — the elimination of `save_transaction`
+and the `txx` table is a genuine simplification rather than a lost feature.
+
+### Replacing the surplus refund with an exact pull
+
+Because EOSIO could not pull funds, `exprepto` (exact output) required the sender to transfer _at
+least_ enough and then refunded the difference:
+
+```cpp
+in_surplus = quantity.amount - computed_amt;
+check(in_surplus >= 0, "insufficient amount transferred in");
+// ... later: transfer overpayment back to sender
+```
+
+`swapExactOut` instead computes the exact input, checks it against a caller-supplied `maxInAmount`,
+and pulls precisely that. This is strictly better: no overpayment, no refund transfer, no
+round-trip. The `maxInAmount` parameter is a genuine addition with no original counterpart, and it
+is the right idiom for EVM.
+
+### Reentrancy protection
+
+`nonReentrant` on all three value-moving functions. There is no analogous hazard in the EOSIO model,
+so this is a necessary EVM-specific addition.
+
+### Dropping the chain plumbing
+
+The original carried `chain` parameters and a `chain_code` index on the asset table in anticipation
+of cross-chain operation, but only ever accepted `"Telos"`:
+
+```cpp
+check(chain == chain_name, "currently only Telos chain supported");
+```
+
+Dropping this from a single-chain EVM deployment is reasonable. The port does leave a vestige behind,
+which is discussed below.
+
+---
+
+## 5. Divergences that are regressions
+
+Ordered by significance.
+
+### 5.1 The arithmetic — the port's central weakness
+
+Covered in detail in §6. This is the one item that would block production use.
+
+### 5.2 `emergencyWithdraw` breaks the original trust model
+
+This has no counterpart in the original and is the port's sharpest philosophical departure. Chuck's
+header is unusually explicit that the owner is meant to be powerless after setup:
+
+> The contract account owner permission should be a "cold" multisig which is used once for
+> uploading the contract and once for specifying a manager account. **It has no operational role
+> after that**, however for test purposes the `reset` action is implemented.
+
+The port gives the owner a permanent, unrestricted ability to move any token out of the pool:
+
+```solidity
+function emergencyWithdraw(address token, uint256 amount) external onlyOwner {
+  require(IERC20(token).transfer(owner(), amount), 'Transfer failed');
+}
+```
+
+No timelock, no event, no restriction to registered assets, no cap. Depositors are fully exposed to
+the owner key. This inverts a designed property of the protocol — that the operational role sits with
+a governance-controlled manager while the owner stays cold — and it should be either removed or
+narrowed and timelocked before anyone is asked to supply liquidity.
+
+### 5.3 LIQ tokens lost their precision
+
+The original deliberately matched the LIQ token's precision to the underlying token's, reading it
+from the token's own stats table:
+
+```cpp
+auto liq_sym = eosio::symbol(liq_sym_code, ast->supply.symbol.precision());
+```
+
+The port's `LiquidityToken` is a plain OpenZeppelin ERC-20, so it always has 18 decimals, while LIQ
+is still minted 1:1 against the raw deposit. Deposit 1 USDC and you receive `1e6` base units of an
+18-decimal token — displayed naively, `0.000000000001 LIQ`. The accounting still works because mint
+and burn are symmetric, but every display path has to special-case it. Since the original did the
+work to get this right, the loss is a straightforward regression.
+
+The naming scheme also changed. The original generated base-26 alphabetic suffixes via `sym_from_id`
+(`LIQA`, `LIQB`, … `LIQAA`) because Antelope symbol codes must be uppercase letters. The port uses
+decimal (`LIQ1`, `LIQ2`). Cosmetic, and arguably clearer, but a difference worth noting since it
+changes how these tokens appear in wallets.
+
+### 5.4 LIQ receipts became freely tradeable
+
+The original explicitly blocked peer-to-peer trade in liquidity receipts, routing every transfer
+through the contract:
+
+```cpp
+check( from == get_self() || to == get_self(),
+       "oswaps token transfers must be to/from contract");
+// should this no-p2p restriction be under manager config control?
+```
+
+The comment shows this was a considered design decision with a known open question, not an accident.
+The port's `LiquidityToken` is an unrestricted ERC-20, so receipts can be traded, lent, or used as
+collateral. Combined with the fact that `withdraw` burns from whatever address the manager names,
+this changes who can be made whole: the manager must now check current LIQ balances rather than
+assuming the depositor still holds the receipt.
+
+### 5.5 A dropped guard lets weights be silently zero
+
+The original refuses to compute a price-preserving weight when there is nothing to preserve:
+
+```cpp
+if(new_weight == 0.0) {
+  check(bal_before > 0, "zero weight requires existing balance");
+  new_weight = a->weight * (1.0 + float(amount64)/bal_before);
+}
+```
+
+The port folds that condition into the `if` instead of asserting it:
+
+```solidity
+if (weight == 0 && balBefore > 0) {
+  newWeight = (assets[tokenId].weight * (balBefore + amount)) / balBefore;
+}
+```
+
+When `balBefore == 0`, the original reverts with a clear message; the port silently leaves the weight
+at zero. Since the weight is a divisor in the pricing math, every later swap out of that asset then
+fails with a division-by-zero panic, and the asset stays bricked until a manager reprices it. A
+deliberate guard was converted into a silent failure mode — one of those small transcription
+slips that produces a confusing bug much later.
+
+### 5.6 `init` cannot rotate the manager
+
+The original supports reconfiguration, gating it on the incumbent manager:
+
+```cpp
+bool reconfig = configset.exists();
+if(reconfig) { require_auth(cfg.manager); } else { require_auth2(get_self().value, "owner"_n.value); }
+```
+
+The header states the intent: "The manager account may transfer authority to a replacement manager
+account." The port's `init` reverts on any second call, so the manager is fixed forever at
+deployment. Losing that key permanently disables freeze, unfreeze, withdraw, and forgetAsset — and
+because withdrawal is manager-only, it permanently traps all liquidity. This is a designed capability
+that was dropped, and it matters more here than it did on Antelope.
+
+### 5.7 `forgetAsset` does not finish the job
+
+The original also erases the LIQ token's stats rows, and flags the remaining untidiness in a
+comment:
+
+```cpp
+// should we check for zero balance before destroying LIQ token?
+// accounts table has stranded ram & data which could create weirdness
+```
+
+The port deletes only the asset record, leaving `liquidityTokens[tokenId]` populated and the id in
+the `tokenIds` array, with the LIQ token still live and mintable-in-principle. As in the original
+there is no zero-balance check, so any remaining pool balance becomes unreachable — except that here
+`emergencyWithdraw` provides a recovery path the original lacked. Roughly as untidy as the original,
+in slightly different places.
+
+### 5.8 `reset` and validation dropped
+
+`reset()` and `resetacct()` are gone. `resetacct` is genuinely inapplicable — the port has no
+internal balance tables — and `reset` was explicitly "for test purposes," so this is minor. Worth
+noting only because `emergencyWithdraw` appears to have been introduced in their place while granting
+much broader powers than either.
+
+The port also validates less at asset creation. The original had to stat the token's supply to read
+its precision, which incidentally proved the token existed:
+
+```cpp
+auto ast = astattable.require_find(symbol.raw(), "can't stat symbol");
+```
+
+`createAsset` checks only that the address is not the pool itself. It does not verify the target is a
+contract, does not detect duplicate registration, and never reads the token's real symbol or
+decimals — the `symbol` argument is an unchecked label. On Antelope, RAM costs also made spamming the
+asset table expensive; on EVM only gas limits it.
+
+### 5.9 A vestigial `chainId`
+
+With the chain plumbing removed, one fragment was left behind in a broken state:
+
+```solidity
+config.chainId = blockhash(block.number - 1);
+```
+
+In the original, `chain_id` held the actual Telos chain id and indexed the asset table for future
+cross-chain identification. Here it is set to a block hash — not a chain identifier by any
+definition — and never read again. If the field is kept it should be `block.chainid`; otherwise it
+should be deleted along with the rest of the multichain scaffolding.
+
+---
+
+## 6. The arithmetic, in detail
+
+This deserves its own section because it is the gap between "faithful port" and "production ready."
+
+### What the original did
+
+EOSIO contracts have the C standard library. `oswaps.cpp` uses `log()` and `exp()` on IEEE
+double-precision floats — roughly 15 to 16 significant digits, valid across the entire useful
+domain, with no trade-size constraint arising from the math itself. Weights are stored as `float`.
+
+### What the port does
+
+Solidity has no floating point, so the port implements both functions from scratch in 18-decimal
+fixed point: a 10-term Taylor series for `ln` expanded about `x = 1`, and a 20-term Taylor series
+for `exp`.
+
+The `ln` choice is the problem. A Taylor expansion of `ln(x)` about `x = 1` converges only for
+`0 < x < 2`, and slowly near the edges. The argument here is
+`inBalAfter / inBalBefore = 1 + inAmount / inBalBefore`, so the series' domain limit translates
+directly into a limit on **trade size as a fraction of the input-side pool balance.** At `x = 2` —
+a trade equal to the entire input balance — the series has not converged; beyond it, it diverges and
+produces garbage.
+
+### Measured error
+
+Comparing the port's fixed-point result against exact arithmetic, at equal weights. The two swap
+directions feed `ln` different ratios, so they have different envelopes — and, importantly, **their
+errors point in opposite directions.**
+
+`swapExactIn`, where the constraint is trade size against the input-side balance. Errors here
+underpay the trader, so the pool gains:
+
+| Trade size vs input balance | `ln` argument | Error in output | Verdict     |
+| --------------------------- | ------------- | --------------- | ----------- |
+| 1% – 30%                    | 1.01 – 1.30   | < 0.0001%       | Accurate    |
+| 40%                         | 1.40          | −0.0007%        | Accurate    |
+| 50%                         | 1.50          | −0.0061%        | Acceptable  |
+| 60%                         | 1.60          | −0.036%         | Degraded    |
+| 75%                         | 1.75          | −0.30%          | Degraded    |
+| 90%                         | 1.90          | −1.75%          | Badly wrong |
+| 100%                        | 2.00          | −4.87%          | Badly wrong |
+| 125%                        | 2.25          | −51%            | Badly wrong |
+| ≥ 150%                      | ≥ 2.50        | —               | Reverts     |
+
+`swapExactOut`, where the constraint is the requested output against the output-side balance. Errors
+here undercharge the trader, so the pool loses:
+
+| Output vs output balance | `ln` argument | Error in required input | Invariant `V` change |
+| ------------------------ | ------------- | ----------------------- | -------------------- |
+| 1% – 25%                 | 0.99 – 0.75   | < 0.0001%               | ~0                   |
+| 33%                      | 0.67          | −0.0002%                | −0.00002%            |
+| 40%                      | 0.60          | −0.0015%                | −0.0001%             |
+| 50%                      | 0.50          | −0.017%                 | −0.008%              |
+| 60%                      | 0.40          | −0.12%                  | −0.06%               |
+| 75%                      | 0.25          | −1.67%                  | −1.26%               |
+| 90%                      | 0.10          | −18.7%                  | −16.8%               |
+
+The weight ratio constrains things independently, because the exponent is `-(wIn/wOut) * ln(ratio)`
+and `exp` also loses accuracy for large arguments. At a 10% trade size, weight ratios up to about
+50:1 remain accurate; at 100:1 and beyond the call reverts. Note also that the port's `_exp` returns
+badly wrong values for arguments below about −8 — `exp(-10)` evaluates to roughly `13.4` instead of
+`0.0000454` — which is what causes those reverts.
+
+### How bad is it, exactly
+
+**No standalone extraction is possible.** Inputs outside the convergent domain revert rather than
+executing: when the series diverges, the computed post-swap balance exceeds the pre-swap balance and
+the subtraction underflows, which Solidity 0.8 turns into a panic. Within the executable range, we
+swept 525 `swapExactOut` configurations — weight ratios from 0.02 to 50, pool imbalance from 1:100 to
+100:1, output sizes from 1% to 99% — and found no combination in which a caller can buy the output for
+less than its pre-trade spot value. There is no self-contained way to profit off the mispricing,
+because the curve price for any non-trivial trade remains worse than spot even after the error.
+
+**But `swapExactOut` does leak liquidity-provider value.** It breaks the invariant downward, by up to
+16.8% of `V` on a single large trade. Unlike the exact-in direction, where the approximation error
+accrues to the pool, here it accrues to the counterparty. That value is real, and it is captured by
+whoever was going to arbitrage the pool anyway. This is the part of the math problem that costs
+someone money rather than merely producing a wrong number, and it is why the two directions should not
+be treated as equally safe.
+
+**Small trades are genuinely fine.** Below 30% of the relevant balance the error is under one part in
+a million in both directions, well inside any sane slippage tolerance. A pool that is large relative
+to typical trade size behaves correctly.
+
+### Recommendation
+
+Replace `_ln` and `_exp` with an audited fixed-point library — `PRBMath` or solmate's
+`FixedPointMathLib` — both of which provide full-domain `ln` and `exp` with far better accuracy and
+comparable or lower gas. That removes the trade-size ceiling, eliminates the envelope reverts, and
+brings the port back in line with the original's numerical behaviour.
+
+There is a real tension here worth naming: swapping in a library moves the code _further_ from a
+literal transcription of Chuck's C++ while moving it _closer_ to the protocol's actual intended
+behaviour. Our view is that fidelity means reproducing intended behaviour, and Chuck's use of
+`log()`/`exp()` was a use of the best available primitive rather than a design choice in favour of
+truncated series. But it is a judgement call and should be made deliberately rather than by default.
+
+---
+
+## 7. Verdict
+
+| Dimension                                                                         | Assessment                                                                                                  |
+| --------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| Economic model (invariant, weights, single-sided liquidity)                       | Faithful                                                                                                    |
+| Action coverage                                                                   | Complete, apart from `reset`                                                                                |
+| Semantic rules (freeze-on-reprice, weight-zero, symbol guard, manager-gated exit) | Faithful                                                                                                    |
+| EVM rearchitecting (pull vs push, exact-pull swap, reentrancy)                    | Well judged, an improvement                                                                                 |
+| Numerical accuracy                                                                | **Materially worse.** Reliable only below ~40–50% of pool balance; `swapExactOut` leaks LP value above that |
+| Trust model                                                                       | **Diverges.** `emergencyWithdraw` contradicts the stated cold-owner design                                  |
+| LIQ token behaviour                                                               | Diverges on precision and on transfer restrictions                                                          |
+| Operational completeness                                                          | Gaps: no manager rotation, incomplete `forgetAsset`, a dropped guard                                        |
+| Production readiness                                                              | Not ready. No tests, no deploy script, unresolved math                                                      |
+
+**Summary for the original question.** As a description of the oSwaps protocol, the port is
+accurate — it implements Chuck's design, keeps its non-obvious safety rules, and translates the
+EOSIO-specific plumbing into idiomatic EVM correctly. As an implementation of that protocol, it is
+a proof of concept whose pricing math is only trustworthy for trades that are small relative to pool
+size, whose exact-out direction quietly transfers value from liquidity providers to counterparties on
+large trades, and which grants the deployer a fund-recovery power the original design deliberately
+withheld.
+
+Prioritised remediation, if this is to go anywhere:
+
+1. Replace the Taylor-series math with an audited fixed-point library.
+2. Remove or timelock `emergencyWithdraw`.
+3. Add a test suite — there is currently none, and the math has never been exercised.
+4. Restore the dropped `bal_before > 0` guard in `addLiquidity`.
+5. Add manager rotation.
+6. Add a `minOutAmount` parameter to `swapExactIn`. Absent in the original too, but MEV on a public
+   EVM mempool makes it necessary here in a way it was not on Antelope.
+7. Match LIQ decimals to the underlying token, and decide deliberately whether to restore the
+   peer-to-peer transfer restriction.
+8. Complete `forgetAsset`, or gate it on a zero pool balance.
+9. Fix or delete the vestigial `config.chainId`.

--- a/packages/storage-evm/contracts/seedsexample/OSwaps.docs.md
+++ b/packages/storage-evm/contracts/seedsexample/OSwaps.docs.md
@@ -1,0 +1,607 @@
+# OSwaps — Contract Reference
+
+Complete functional reference for `contracts/seedsexample/OSwaps.sol`.
+
+**Audience:** an engineer or AI agent implementing a UI against this contract. Everything needed to
+build a working interface is here: the full external surface, the role model, the bootstrap
+sequence, the pricing math (with a bit-exact TypeScript port for off-chain quoting), the revert
+catalogue, and the behavioural traps that will otherwise cost you a day of debugging.
+
+> **Status: not deployed.** OSwaps is a reference port of the Antelope/EOSIO `oswaps` contract. It
+> has no entry in `contracts/addresses.txt`, no deploy script, no tests, and is excluded from
+> `wagmi.config.ts` so it does not appear in `packages/core/src/generated.ts`. Any UI work must
+> begin by deploying it to a local or test network. Read the "Known defects" section before
+> building anything — several items change what the UI must do.
+>
+> For how faithfully this reproduces the original protocol, see
+> [`OSwaps.EOSIO-PARITY.md`](./OSwaps.EOSIO-PARITY.md).
+
+---
+
+## 1. What the contract does
+
+OSwaps is a multi-token liquidity pool. A single contract instance holds balances of many ERC-20
+tokens and prices swaps between any two of them using the Balancer constant-value invariant:
+
+```
+V = B1^W1 * B2^W2 * ... * Bn^Wn
+```
+
+where `Bi` is the pool's balance of token `i` and `Wi` is that token's weight. `V` is held constant
+across a swap, which determines the output amount.
+
+In the small-trade limit (negligible slippage, and there are no fees at all here), swapping `Qi` of
+token `i` yields:
+
+```
+Qj = Qi * (Bj / Bi) * (Wi / Wj)
+```
+
+Two properties distinguish this from Uniswap-style pools and drive most of the UI design:
+
+**Liquidity is single-sided.** You deposit one token, not a pair. To keep the price of that token
+unchanged, the contract raises its weight in proportion to the balance increase, so the ratio
+`B/W` — which is what sets the price — stays fixed. That is what `weight = 0` means in
+`addLiquidity` and `withdraw`: "recompute the weight for me so the price does not move."
+
+**Weights are only meaningful as ratios.** The pricing math uses `wIn / wOut` and nothing else, so
+the absolute scale is arbitrary and no normalisation is enforced or required. Weights do not sum to
+
+1. `1e18` is a convenient unit but the contract does not care.
+
+---
+
+## 2. Roles and authorisation
+
+| Role      | How it is set                        | Powers                                                                  |
+| --------- | ------------------------------------ | ----------------------------------------------------------------------- |
+| `owner`   | Deployer, via OpenZeppelin `Ownable` | `init`, `emergencyWithdraw`                                             |
+| `manager` | Set once by `owner` via `init`       | `freeze`, `unfreeze`, `forgetAsset`, `withdraw`                         |
+| anyone    | —                                    | `createAsset`, `addLiquidity`, `swapExactIn`, `swapExactOut`, all views |
+
+Two things to internalise before designing screens:
+
+**Liquidity providers cannot withdraw their own liquidity.** `withdraw` is `onlyManager`. An LP
+deposits permissionlessly and receives LIQ receipt tokens, but exit is entirely at the manager's
+discretion. This is faithful to the original design, not an oversight. Do not build a "remove
+liquidity" button for ordinary users — build a manager console.
+
+**`emergencyWithdraw` lets the owner move any token out of the pool at any time.** It is
+unrestricted and permanent. Any UI that surfaces pool balances to depositors should disclose this.
+
+`manager` is `address(0)` until `init` is called, so all manager functions revert before
+initialisation. `init` can only be called once and there is no way to rotate the manager
+afterwards — if the manager key is lost, freeze/unfreeze/withdraw/forgetAsset are permanently
+unavailable.
+
+---
+
+## 3. State model
+
+```solidity
+struct Config {
+  address manager;      // set once via init()
+  bytes32 chainId;      // vestigial, never read (see Known defects #7)
+  uint64  lastTokenId;  // monotonically increasing; last id issued by createAsset
+}
+
+struct AssetInfo {
+  uint64  tokenId;
+  address contractAddress; // the ERC-20
+  string  symbol;          // free-form label, NOT read from the token
+  bool    active;          // false = swaps and deposits blocked
+  string  metadata;        // free-form, intended for JSON
+  uint256 weight;          // Balancer weight; only the ratio to other weights matters
+}
+```
+
+| Storage           | Type                           | Notes                                                 |
+| ----------------- | ------------------------------ | ----------------------------------------------------- |
+| `config`          | `Config`                       | public getter returns 3 flat values                   |
+| `assets`          | `mapping(uint64 => AssetInfo)` | public getter returns 6 flat values, **not** a struct |
+| `liquidityTokens` | `mapping(uint64 => address)`   | the `LiquidityToken` deployed for each asset          |
+| `tokenIds`        | `uint64[]`                     | append-only, never pruned, **no length getter**       |
+
+Pool balances are not stored. Every read and every price calculation calls
+`IERC20(token).balanceOf(address(this))` live. This has a direct consequence: **any token
+transferred to the contract address becomes pool liquidity with no LIQ issued against it.** A
+donation silently improves the price for everyone and is unrecoverable by the sender.
+
+### Enumerating assets
+
+`tokenIds` is public but Solidity only generates an element getter, not a length getter, so you
+cannot iterate it without knowing its size. Use one of these instead:
+
+1. **Preferred:** read `config().lastTokenId` and loop `1..lastTokenId`, calling `assets(i)` and
+   skipping entries whose `symbol` is empty (empty means never created, or deleted by
+   `forgetAsset`). Ids are assigned sequentially from 1, so this is complete.
+2. Index `AssetCreated` events. Note that `forgetAsset` emits nothing, so an event-only index will
+   show deleted assets as live. Cross-check against `assets(i)`.
+
+---
+
+## 4. Lifecycle — the bootstrap sequence
+
+This is the single most important section for a UI implementer. A newly created asset is **inactive
+with zero weight**, and the obvious call order does not work. The required sequence is:
+
+```mermaid
+sequenceDiagram
+  participant O as owner
+  participant M as manager
+  participant LP as liquidity provider
+  participant C as OSwaps
+
+  O->>C: init(manager)
+  LP->>C: createAsset(token, symbol, meta)
+  Note over C: active = false, weight = 0
+  M->>C: unfreeze(tokenId, symbol)
+  Note over C: active = true
+  LP->>C: approve + addLiquidity(id, amount, weight != 0)
+  Note over C: weight set, active = false again
+  M->>C: unfreeze(tokenId, symbol)
+  Note over C: active = true — now swappable
+```
+
+Why each step is necessary:
+
+- `createAsset` always sets `active = false` and `weight = 0`.
+- `addLiquidity` requires `active || amount == 0`, so a deposit into a fresh asset reverts with
+  `Token is frozen`. The manager must `unfreeze` first.
+- The **first** deposit must pass a non-zero `weight`. Passing `weight = 0` on an empty pool leaves
+  the weight at zero (see Known defects #1), and a zero weight makes every swap _out of_ that token
+  revert with a division-by-zero panic.
+- Passing a non-zero `weight` deliberately freezes the asset, because a non-zero weight means the
+  price changed and the original protocol requires manager review before trading resumes. So a
+  second `unfreeze` is needed.
+
+Repeat `createAsset` → `unfreeze` → `addLiquidity` → `unfreeze` for each token. At least two assets
+must be live before any swap is possible.
+
+---
+
+## 5. External function reference
+
+### `init(address manager)`
+
+`onlyOwner`. One-shot. Sets the manager. Reverts `Already initialized` if `config.manager` is
+already non-zero. There is no manager rotation, and passing `address(0)` is not rejected but would
+permanently brick all manager functions.
+
+### `createAsset(address tokenContract, string symbol, string metadata) → uint64 tokenId`
+
+Permissionless. Increments `config.lastTokenId`, registers the asset with `active = false` and
+`weight = 0`, appends to `tokenIds`, and deploys a fresh `LiquidityToken` (see §7) whose name and
+symbol are both `"LIQ" + tokenId` (e.g. `LIQ1`).
+
+Reverts only on `tokenContract == address(this)` (`Cannot be oswaps`). Notably it does **not**
+verify that `tokenContract` is a contract or an ERC-20, does not check for duplicate registration
+of the same token, and does not read the token's real symbol or decimals — the `symbol` argument is
+a free-form label used solely for the confirmation check in `freeze`/`unfreeze`.
+
+Because it is permissionless and deploys a contract per call, it is a gas-griefing surface: anyone
+can register unlimited junk assets and inflate `lastTokenId`, which lengthens the enumeration loop
+in §3. A UI should treat unfamiliar assets as untrusted and maintain an allowlist.
+
+Emits `AssetCreated(tokenId, tokenContract, symbol)`.
+
+### `forgetAsset(uint64 tokenId)`
+
+`onlyManager`. Deletes `assets[tokenId]`. Reverts `Token not found` if the symbol is empty.
+
+Incompletely implemented — it leaves `liquidityTokens[tokenId]` populated, leaves the id in
+`tokenIds`, does not destroy or freeze the LIQ token, and does not check that the pool balance is
+zero. **Any pool balance of a forgotten asset becomes permanently unreachable** except through
+`emergencyWithdraw`, because every other path requires a live asset record. Emits no event, so
+event-based indexers will not notice. A UI should confirm destructively and warn about the trapped
+balance.
+
+### `freeze(uint64 tokenId, string symbol)` / `unfreeze(uint64 tokenId, string symbol)`
+
+`onlyManager`. Sets `active` false/true. The `symbol` argument must equal the stored symbol exactly
+(compared by `keccak256`) — it is a typo guard, mirroring the original protocol. Reverts
+`Token not found` or `Symbol mismatch`. Both emit `AssetFrozen(tokenId, frozen)`.
+
+### `queryPool(uint64[] tokenIdList) → PoolStatus[]`
+
+View. Returns `{ tokenId, balance, weight }` per requested id, with `balance` read live from the
+token. **Reverts `Token not found` if any single id in the list is unregistered or forgotten**, so
+never pass unvalidated ids — one bad entry fails the whole batch. Filter first using the
+enumeration in §3.
+
+This is the primary read for a UI. It gives you everything needed to compute prices client-side.
+
+### `addLiquidity(uint64 tokenId, uint256 amount, uint256 weight)`
+
+Permissionless, `nonReentrant`. Requires prior `approve` of `amount` to the OSwaps address.
+
+1. Requires the asset to exist and `active || amount == 0`.
+2. Pulls `amount` via `transferFrom`.
+3. Sets the weight: if `weight != 0` it is used verbatim; if `weight == 0` **and** the pre-deposit
+   balance was non-zero, the weight is scaled to preserve price as
+   `w_new = w_old * (balBefore + amount) / balBefore`.
+4. If `weight != 0`, sets `active = false`.
+5. If `amount > 0`, mints `amount` LIQ 1:1 to the caller and emits
+   `LiquidityAdded(caller, tokenId, amount, amount)`.
+
+Two supported modes worth exposing separately in a UI:
+
+- **Deposit at current price** — `weight = 0`, `amount > 0`, existing balance non-zero. Price
+  unchanged, asset stays tradeable, no manager action needed.
+- **Reprice without depositing** — `amount = 0`, `weight != 0`. Allowed even while frozen, since
+  the `active || amount == 0` check passes. This is how a manager adjusts a price. It freezes the
+  asset and emits **no event at all** (the `LiquidityAdded` emit is inside `if (amount > 0)`), so
+  weight changes are invisible to indexers. Poll `assets(id).weight` instead.
+
+### `withdraw(address account, uint64 tokenId, uint256 amount, uint256 weight)`
+
+`onlyManager`, `nonReentrant`. The mirror of `addLiquidity`.
+
+Requires `balBefore > amount` — strictly greater, so the pool can never be fully drained through
+this path. Weight handling mirrors deposit: `weight == 0` scales to
+`w_new = w_old * (balBefore - amount) / balBefore` to hold price; non-zero sets it verbatim and
+freezes the asset. Burns `amount` LIQ from `account` — **without allowance**, since the pool owns
+the LIQ token — then transfers `amount` of the underlying to `account`.
+
+The LIQ burn reverts if `account` holds less than `amount`, which is the only thing tying a
+withdrawal to an actual deposit. Because LIQ is freely transferable (Known defects #4), the manager
+must verify `account` still holds its receipts before calling.
+
+Emits `LiquidityWithdrawn(account, tokenId, amount, amount)`.
+
+### `swapExactIn(address recipient, uint64 inTokenId, uint64 outTokenId, uint256 inAmount) → uint256 outAmount`
+
+Permissionless, `nonReentrant`. Requires prior `approve` of `inAmount`.
+
+Both assets must exist and be `active`. Reads both balances, requires `inBalBefore > 0`, pulls
+`inAmount`, computes the output via the Balancer formula (§6), requires
+`0 < outAmount < outBalBefore`, transfers the output to `recipient`, emits `TokenSwapped`.
+
+> **There is no minimum-output parameter.** The caller has no on-chain slippage protection and the
+> transaction is fully sandwichable in a public mempool. Any UI must compute an expected output,
+> show the user a tolerance, and — since the contract cannot enforce it — wrap the call in a router
+> or multicall that checks the received amount and reverts, or accept the exposure explicitly.
+> `swapExactOut` does have a `maxInAmount` guard; this asymmetry is real, not a documentation error.
+
+`inTokenId == outTokenId` is not rejected. It will either revert on the output-amount check or
+return a self-swap at a loss. Block it in the UI.
+
+### `swapExactOut(address recipient, uint64 inTokenId, uint64 outTokenId, uint256 outAmount, uint256 maxInAmount) → uint256 inAmount`
+
+Permissionless, `nonReentrant`. Requires prior `approve` of at least `maxInAmount`.
+
+Same validation, plus `outBalBefore > outAmount` (`Insufficient output balance`). Computes the
+required input, reverts `Excessive input amount` if it exceeds `maxInAmount`, then pulls exactly
+`inAmount` and sends `outAmount`. Because the exact amount is pulled, no refund path is needed.
+
+### `emergencyWithdraw(address token, uint256 amount)`
+
+`onlyOwner`. Transfers any amount of any token to the owner. No timelock, no event, no restriction
+to registered assets. This is the contract's largest trust assumption.
+
+---
+
+## 6. Pricing math and off-chain quoting
+
+### The formulas
+
+`swapExactIn` solves for the output balance:
+
+```
+outBalAfter = outBalBefore * (inBalAfter / inBalBefore) ^ (-wIn / wOut)
+outAmount   = outBalBefore - outBalAfter
+```
+
+`swapExactOut` solves for the input balance:
+
+```
+inBalAfter = inBalBefore * (outBalAfter / outBalBefore) ^ (-wOut / wIn)
+inAmount   = inBalAfter - inBalBefore
+```
+
+Both are evaluated as `exp(exponent * ln(ratio))` using **hand-rolled Taylor series** in
+18-decimal fixed point: a 10-term series for `ln` and a 20-term series for `exp`. This is the
+critical implementation detail, because those series have a limited domain of convergence.
+
+### Accuracy envelope — measured
+
+`_ln` is a Taylor expansion about `x = 1`, which converges only for `0 < x < 2` and slowly near the
+edges. Each swap direction feeds it a different ratio, so the two functions have **different
+envelopes and opposite error directions.** Both matter.
+
+**`swapExactIn`.** The ratio is `inBalAfter / inBalBefore = 1 + inAmount / inBalBefore`, so the
+constraint is trade size as a fraction of the **input**-side balance. Errors here _underpay the
+trader_, meaning the pool gains:
+
+| `inAmount` vs input pool balance | Error     | Verdict     |
+| -------------------------------- | --------- | ----------- |
+| 1% – 30%                         | < 0.0001% | Accurate    |
+| 40%                              | −0.0007%  | Accurate    |
+| 50%                              | −0.0061%  | Acceptable  |
+| 60%                              | −0.036%   | Degraded    |
+| 75%                              | −0.30%    | Degraded    |
+| 90%                              | −1.75%    | Badly wrong |
+| 100%                             | −4.87%    | Badly wrong |
+| 125%                             | −51%      | Badly wrong |
+| ≥ 150%                           | —         | Reverts     |
+
+**`swapExactOut`.** The ratio is `outBalAfter / outBalBefore = 1 − outAmount / outBalBefore`, so the
+constraint is the requested output as a fraction of the **output**-side balance. Errors here run the
+other way — they _undercharge the trader_, so the pool loses:
+
+| `outAmount` vs output pool balance | Error in required input | Invariant `V` change | Verdict     |
+| ---------------------------------- | ----------------------- | -------------------- | ----------- |
+| 1% – 25%                           | < 0.0001%               | ~0                   | Accurate    |
+| 33%                                | −0.0002%                | −0.00002%            | Accurate    |
+| 40%                                | −0.0015%                | −0.0001%             | Accurate    |
+| 50%                                | −0.017%                 | −0.008%              | Degraded    |
+| 60%                                | −0.12%                  | −0.06%               | Degraded    |
+| 75%                                | −1.67%                  | −1.26%               | Badly wrong |
+| 90%                                | −18.7%                  | −16.8%               | Badly wrong |
+| ≥ 100%                             | —                       | —                    | Reverts     |
+
+The weight ratio constrains things independently, because the exponent is `-(wIn/wOut) * ln(ratio)`
+and `_exp` also diverges for large arguments. At a 10% trade size, ratios up to `wIn/wOut ≈ 50` stay
+accurate; `≈ 100` and above revert.
+
+Three conclusions that should shape the UI directly:
+
+**No standalone theft is possible, but `swapExactOut` leaks LP value.** Out-of-range inputs revert
+rather than executing, because the diverging series makes a subtraction underflow, which Solidity 0.8
+turns into a panic. And across 525 executable `swapExactOut` configurations — weight ratios from 0.02
+to 50, pool imbalance from 1:100 to 100:1, output sizes from 1% to 99% — no combination lets a caller
+buy the output for less than its pre-trade spot value, so there is no self-contained drain. What
+`swapExactOut` _does_ do is break the invariant downward, by as much as 16.8% of `V` on a single
+large trade. That value is real and is captured by whoever was going to arbitrage the pool anyway, at
+the expense of liquidity providers.
+
+**Cap `swapExactOut` harder than `swapExactIn`.** Its accurate range is narrower (roughly 40% of the
+output balance versus 50% of the input balance) and its errors point against the pool rather than for
+it. Treat 40% as the safe ceiling for exact-out and 50% for exact-in, warn up to 75%, and block
+beyond that.
+
+**Present the caps as liquidity limits.** "This pool does not have enough liquidity for that trade"
+is accurate and reads naturally. Anchor the check on the correct side of the pool for each direction
+— input balance for exact-in, output balance for exact-out — since confusing the two will let bad
+trades through.
+
+### Bit-exact TypeScript port for quoting
+
+There is no `quote` view function on the contract, and simulating via `eth_call` requires the caller
+to already hold the balance and allowance — awkward for a quote on a form the user has not funded
+yet. Replicate the math instead. Truncation must match Solidity exactly, so use `BigInt` throughout
+and never `Number`. JavaScript `BigInt` division truncates toward zero, matching Solidity `int256`
+division, and unary minus binds tighter than division in both languages, so the expressions below
+are faithful line for line.
+
+```ts
+const ONE = 10n ** 18n;
+
+/** Mirrors OSwaps._ln — 10-term Taylor series about x = 1, 18-decimal fixed point. */
+function ln(x: bigint): bigint {
+  if (x <= 0n) throw new Error('ln: x must be positive');
+  const diff = x - ONE;
+  if (diff === 0n) return 0n;
+  let result = diff;
+  let term = diff;
+  for (let i = 2n; i <= 10n; i++) {
+    term = (term * diff) / ONE;
+    if (i % 2n === 0n) result -= term / i;
+    else result += term / i;
+  }
+  return result;
+}
+
+/** Mirrors OSwaps._exp — 20-term Taylor series, 18-decimal fixed point. */
+function exp(x: bigint): bigint {
+  let result = ONE;
+  let term = ONE;
+  for (let i = 1n; i <= 20n; i++) {
+    term = (term * x) / (i * ONE);
+    result += term;
+    if (term === 0n) break;
+  }
+  return result;
+}
+
+/** Mirrors swapExactIn. Returns null where the contract would revert. */
+export function quoteExactIn(inBalBefore: bigint, inAmount: bigint, outBalBefore: bigint, wIn: bigint, wOut: bigint): bigint | null {
+  if (inBalBefore === 0n || wOut === 0n) return null;
+  const ratio = ((inBalBefore + inAmount) * ONE) / inBalBefore;
+  const exponent = -(wIn * ln(ratio)) / wOut;
+  const outBalAfter = (outBalBefore * exp(exponent)) / ONE;
+  if (outBalAfter > outBalBefore) return null; // would underflow and revert
+  const outAmount = outBalBefore - outBalAfter;
+  if (outAmount === 0n || outAmount >= outBalBefore) return null;
+  return outAmount;
+}
+
+/** Mirrors swapExactOut. Returns null where the contract would revert. */
+export function quoteExactOut(inBalBefore: bigint, outBalBefore: bigint, outAmount: bigint, wIn: bigint, wOut: bigint): bigint | null {
+  if (inBalBefore === 0n || wIn === 0n || outBalBefore <= outAmount) return null;
+  const ratio = ((outBalBefore - outAmount) * ONE) / outBalBefore;
+  const exponent = -(wOut * ln(ratio)) / wIn;
+  const inBalAfter = (inBalBefore * exp(exponent)) / ONE;
+  if (inBalAfter < inBalBefore) return null;
+  return inBalAfter - inBalBefore;
+}
+```
+
+To also surface how much the approximation is costing the user, compute the exact value with
+floating point and show the gap:
+
+```ts
+export function exactQuoteOut(inBalBefore: bigint, inAmount: bigint, outBalBefore: bigint, wIn: bigint, wOut: bigint): number {
+  const ib = Number(inBalBefore),
+    ob = Number(outBalBefore);
+  return ob - ob * Math.pow((ib + Number(inAmount)) / ib, -(Number(wIn) / Number(wOut)));
+}
+```
+
+A gap beyond a fraction of a percent means the trade is outside the reliable envelope.
+
+---
+
+## 7. The LIQ receipt token
+
+`createAsset` deploys one `LiquidityToken` per asset — a minimal `ERC20 + Ownable` whose owner is
+the OSwaps contract, exposing `mint(to, amount)` and `burnFrom(from, amount)`, both `onlyOwner`.
+Note that `burnFrom` does **not** consult allowances despite the name; the pool burns unilaterally.
+
+LIQ is minted 1:1 against the raw deposited amount and burned 1:1 against the raw withdrawn amount.
+It therefore represents a **nominal claim on units deposited, not a proportional share of the
+pool.** Two consequences:
+
+- Total LIQ supply does not track the pool balance. Swaps, donations, and `emergencyWithdraw` all
+  change the balance without changing LIQ supply. Never render LIQ as a percentage of the pool.
+- **LIQ always has 18 decimals regardless of the underlying token.** Depositing 1 USDC (`1e6` raw)
+  mints `1e6` base units of an 18-decimal token, which renders as `0.000000000001 LIQ`. Format LIQ
+  balances using the _underlying token's_ decimals to get a number that means anything to a user,
+  and never assume LIQ decimals match the asset. See Known defects #3.
+
+---
+
+## 8. Events
+
+| Event                                                                                                                       | Emitted by                             | Indexed                    |
+| --------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- | -------------------------- |
+| `AssetCreated(uint64 tokenId, address tokenContract, string symbol)`                                                        | `createAsset`                          | `tokenId`, `tokenContract` |
+| `AssetFrozen(uint64 tokenId, bool frozen)`                                                                                  | `freeze`, `unfreeze`                   | `tokenId`                  |
+| `LiquidityAdded(address account, uint64 tokenId, uint256 amount, uint256 liqTokensMinted)`                                  | `addLiquidity`, only when `amount > 0` | `account`, `tokenId`       |
+| `LiquidityWithdrawn(address account, uint64 tokenId, uint256 amount, uint256 liqTokensBurned)`                              | `withdraw`                             | `account`, `tokenId`       |
+| `TokenSwapped(address sender, address recipient, uint64 inTokenId, uint64 outTokenId, uint256 inAmount, uint256 outAmount)` | both swaps                             | `sender`, `recipient`      |
+
+Gaps to plan around: `forgetAsset` and `emergencyWithdraw` emit nothing; weight changes emit
+nothing; and `inTokenId`/`outTokenId` on `TokenSwapped` are **not** indexed, so per-pair filtering
+must happen client-side after fetching by sender or recipient.
+
+---
+
+## 9. Revert catalogue
+
+| Message                                            | Source                                                                       |
+| -------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `Only manager`                                     | manager-gated function called by another address                             |
+| `Already initialized`                              | second `init`                                                                |
+| `Token not found`                                  | `freeze`, `unfreeze`, `forgetAsset`, `queryPool`, `addLiquidity`, `withdraw` |
+| `Symbol mismatch`                                  | `freeze`/`unfreeze` symbol argument does not match stored                    |
+| `Cannot be oswaps`                                 | `createAsset` with the pool's own address                                    |
+| `Token is frozen`                                  | `addLiquidity` with `amount > 0` on an inactive asset                        |
+| `Input token not found` / `Output token not found` | swaps with an unregistered id                                                |
+| `Input token frozen` / `Output token frozen`       | swaps on an inactive asset                                                   |
+| `Zero input balance`                               | swaps when the input side holds nothing                                      |
+| `Insufficient output balance`                      | `swapExactOut` with `outAmount >= outBalBefore`                              |
+| `Insufficient balance`                             | `withdraw` with `amount >= balBefore`                                        |
+| `Invalid output amount`                            | computed output is 0 or ≥ pool balance — usually the math envelope           |
+| `Excessive input amount`                           | `swapExactOut` computed input above `maxInAmount`                            |
+| `Transfer failed`                                  | an ERC-20 returned `false`                                                   |
+| `ln: x must be positive`                           | ratio underflowed to 0                                                       |
+| `Ownable*`                                         | OpenZeppelin owner errors                                                    |
+| Panic `0x11` (arithmetic overflow/underflow)       | diverging Taylor series — trade far outside the envelope                     |
+| Panic `0x12` (division by zero)                    | swapping out of an asset whose weight is 0                                   |
+
+Map the last three to human-readable guidance. Panic `0x11` in practice means "trade too large for
+this pool"; `0x12` means "this asset was never priced."
+
+---
+
+## 10. Known defects a UI must work around
+
+None of these are fixed in the contract as it stands.
+
+The **pricing-math envelope in §6 is the most consequential constraint** and is not repeated here:
+both swap directions misprice outside a limited trade-size range, with `swapExactOut` erring against
+the pool. Implement those caps first. The items below are the remaining issues, ordered by how much
+they affect UI work.
+
+**1. `addLiquidity` can silently leave weight at zero.** With `weight = 0` on an empty pool, the
+original EOSIO contract reverts (`"zero weight requires existing balance"`); this port instead
+skips the branch and leaves the weight at 0. Every later swap _out of_ that asset then reverts with
+a division-by-zero panic and the asset is unusable until a manager repriced it. **Mitigation:**
+require a non-zero weight in the form whenever the current pool balance is zero, and flag any asset
+with `weight == 0` as misconfigured.
+
+**2. `swapExactIn` has no minimum-output parameter.** No on-chain slippage protection, fully
+sandwichable. **Mitigation:** enforce tolerance client-side and prefer `swapExactOut` (which has
+`maxInAmount`) wherever the flow allows a fixed output.
+
+**3. LIQ decimals do not match the underlying.** Always 18. **Mitigation:** format with the
+underlying token's decimals, as described in §7.
+
+**4. LIQ is freely transferable.** The original restricted LIQ to transfers involving the contract
+only, blocking peer-to-peer trade in receipts. This port uses a plain ERC-20. **Mitigation:** the
+manager console must check current LIQ balances before `withdraw`, since the holder may not be the
+depositor.
+
+**5. `IOSwaps.assets` in `ISeedsEcosystem.sol` is ABI-incompatible.** The interface declares
+`returns (AssetInfo memory)`, but a public mapping getter returns six flat values. Because
+`AssetInfo` contains dynamic `string` members, the struct encoding carries an extra offset word — 11
+words versus 10 — so decoding the real return through this interface throws. **Mitigation:** do not
+use `IOSwaps` for `assets`; generate types from the compiled artifact at
+`artifacts/contracts/seedsexample/OSwaps.sol/OSwaps.json`. The rest of `IOSwaps` is accurate, and
+`config()` happens to be compatible because `Config` is entirely static.
+
+**6. `forgetAsset` leaves state behind and traps balances.** See §5. **Mitigation:** warn
+destructively; treat empty-symbol ids as deleted when enumerating.
+
+**7. `config.chainId` is meaningless.** It is set once in the constructor to
+`blockhash(block.number - 1)` — a block hash, not a chain identifier — and never read anywhere. In
+the original it held the real Telos chain id to support future cross-chain asset identification.
+**Mitigation:** ignore the field. Do not display it.
+
+**8. No safety for non-standard ERC-20s.** Transfers use raw `require(token.transfer(...))` rather
+than `SafeERC20`, so tokens that return no value on transfer will revert on ABI decoding. And
+because all accounting is balance-based, **fee-on-transfer and rebasing tokens will mis-price
+persistently.** **Mitigation:** allowlist assets; exclude fee-on-transfer and rebasing tokens.
+
+**9. `createAsset` is unvalidated and permissionless.** No check that the target is a contract, no
+duplicate detection, no verification of the `symbol` label against the token. Junk assets inflate
+`lastTokenId`. **Mitigation:** maintain an allowlist; never trust the stored `symbol` — read the
+real one from the token contract.
+
+**10. `onlyActive` modifier is dead code.** Declared and never applied; the same check is inlined at
+each call site. Harmless, but do not read its presence as evidence of a guard.
+
+---
+
+## 11. Minimum viable UI
+
+A suggested scope, in dependency order.
+
+**Read layer.** Enumerate assets (§3), then `queryPool` over the valid ids for balances and
+weights. Resolve real symbol and decimals from each token contract, not from the stored label.
+Derive the marginal price of `i` against `j` as `(Bj/Wj) / (Bi/Wi)`.
+
+**Swap form.** Token in, token out, amount, direction (exact-in or exact-out). Quote with the
+functions in §6. Enforce the per-direction trade-size caps from §6, checking against the input
+balance for exact-in and the output balance for exact-out. Show output, effective price, slippage
+against the marginal price, and the approximation gap. Two transactions: `approve`, then the swap.
+Block `inTokenId == outTokenId` and any asset that is inactive or zero-weight.
+
+**Liquidity form.** Deposit only, with the price-preserving path (`weight = 0`) as the default and a
+non-zero weight required when the pool is empty. Make clear that withdrawal requires the manager,
+and that LIQ is a nominal receipt rather than a pool share.
+
+**Manager console.** Freeze/unfreeze (with the symbol confirmation), withdraw to an address, reprice
+via `addLiquidity(id, 0, newWeight)`, and `forgetAsset` behind a destructive confirmation. Surface
+which assets are frozen and why — an asset frozen by a reprice needs an explicit unfreeze before
+trading resumes, and that is the state users will most often get stuck in.
+
+---
+
+## 12. Before building
+
+Recommended prerequisites, in order:
+
+1. Add a deploy script and a Hardhat test suite. The contract has neither, and no test has ever
+   exercised the math.
+2. Decide whether to keep the Taylor-series math. Replacing `_ln`/`_exp` with an audited
+   fixed-point library (`PRBMath`, `solmate`'s `FixedPointMathLib`) removes the trade-size cap and
+   the whole class of envelope reverts, at the cost of diverging further from a literal port. This
+   is the highest-value change and it needs an explicit decision — see
+   [`OSwaps.EOSIO-PARITY.md`](./OSwaps.EOSIO-PARITY.md) §6.
+3. Add `quoteExactIn` / `quoteExactOut` view functions so the UI is not maintaining a parallel
+   implementation of the pricing math.
+4. Add `getTokenIds()` and a `minOutAmount` parameter on `swapExactIn`.
+5. Add the contract to `wagmi.config.ts` so typed bindings land in
+   `packages/core/src/generated.ts` and the UI is not hand-writing ABIs.

--- a/packages/storage-evm/contracts/seedsexample/OSwaps.docs.md
+++ b/packages/storage-evm/contracts/seedsexample/OSwaps.docs.md
@@ -4,14 +4,14 @@ Complete functional reference for `contracts/seedsexample/OSwaps.sol`.
 
 **Audience:** an engineer or AI agent implementing a UI against this contract. Everything needed to
 build a working interface is here: the full external surface, the role model, the bootstrap
-sequence, the pricing math (with a bit-exact TypeScript port for off-chain quoting), the revert
-catalogue, and the behavioural traps that will otherwise cost you a day of debugging.
+sequence, the pricing math and its measured accuracy, the revert catalogue, and the behavioural
+traps that will otherwise cost you a day of debugging.
 
 > **Status: not deployed.** OSwaps is a reference port of the Antelope/EOSIO `oswaps` contract. It
-> has no entry in `contracts/addresses.txt`, no deploy script, no tests, and is excluded from
-> `wagmi.config.ts` so it does not appear in `packages/core/src/generated.ts`. Any UI work must
-> begin by deploying it to a local or test network. Read the "Known defects" section before
-> building anything — several items change what the UI must do.
+> has no entry in `contracts/addresses.txt` and is excluded from `wagmi.config.ts`, so it does not
+> appear in `packages/core/src/generated.ts`. It does now have a deploy script
+> (`scripts/oswaps.deploy.ts`) and a test suite (`test/OSwaps.test.ts`, 85 cases). Any UI work must
+> begin by deploying it to a local or test network.
 >
 > For how faithfully this reproduces the original protocol, see
 > [`OSwaps.EOSIO-PARITY.md`](./OSwaps.EOSIO-PARITY.md).
@@ -37,7 +37,7 @@ token `i` yields:
 Qj = Qi * (Bj / Bi) * (Wi / Wj)
 ```
 
-Two properties distinguish this from Uniswap-style pools and drive most of the UI design:
+Two properties distinguish this from Uniswap-style pools and drive most of the UI design.
 
 **Liquidity is single-sided.** You deposit one token, not a pair. To keep the price of that token
 unchanged, the contract raises its weight in proportion to the balance increase, so the ratio
@@ -55,24 +55,23 @@ the absolute scale is arbitrary and no normalisation is enforced or required. We
 
 | Role      | How it is set                        | Powers                                                                  |
 | --------- | ------------------------------------ | ----------------------------------------------------------------------- |
-| `owner`   | Deployer, via OpenZeppelin `Ownable` | `init`, `emergencyWithdraw`                                             |
-| `manager` | Set once by `owner` via `init`       | `freeze`, `unfreeze`, `forgetAsset`, `withdraw`                         |
+| `owner`   | Deployer, via OpenZeppelin `Ownable` | `init` only, and only once                                              |
+| `manager` | `init`, then rotated by `setManager` | `freeze`, `unfreeze`, `forgetAsset`, `withdraw`, `setManager`           |
 | anyone    | —                                    | `createAsset`, `addLiquidity`, `swapExactIn`, `swapExactOut`, all views |
 
-Two things to internalise before designing screens:
+**The owner cannot move funds.** There is no owner-level withdrawal path. Once `init` has run, the
+owner has no remaining powers at all, which matches the original protocol's design intent that the
+owner key is cold and has no operational role.
 
 **Liquidity providers cannot withdraw their own liquidity.** `withdraw` is `onlyManager`. An LP
 deposits permissionlessly and receives LIQ receipt tokens, but exit is entirely at the manager's
 discretion. This is faithful to the original design, not an oversight. Do not build a "remove
 liquidity" button for ordinary users — build a manager console.
 
-**`emergencyWithdraw` lets the owner move any token out of the pool at any time.** It is
-unrestricted and permanent. Any UI that surfaces pool balances to depositors should disclose this.
-
-`manager` is `address(0)` until `init` is called, so all manager functions revert before
-initialisation. `init` can only be called once and there is no way to rotate the manager
-afterwards — if the manager key is lost, freeze/unfreeze/withdraw/forgetAsset are permanently
-unavailable.
+`manager` is `address(0)` until `init` is called, so every manager function reverts before
+initialisation. `init` rejects the zero address and can only be called once; after that the
+incumbent manager hands over via `setManager`, so the role is recoverable through governance but not
+through the owner.
 
 ---
 
@@ -80,14 +79,14 @@ unavailable.
 
 ```solidity
 struct Config {
-  address manager;      // set once via init()
-  bytes32 chainId;      // vestigial, never read (see Known defects #7)
+  address manager;      // set by init, rotated by setManager
+  bytes32 chainId;      // block.chainid at deployment; informational, never read
   uint64  lastTokenId;  // monotonically increasing; last id issued by createAsset
 }
 
 struct AssetInfo {
   uint64  tokenId;
-  address contractAddress; // the ERC-20
+  address contractAddress; // the ERC-20; address(0) means "no such asset"
   string  symbol;          // free-form label, NOT read from the token
   bool    active;          // false = swaps and deposits blocked
   string  metadata;        // free-form, intended for JSON
@@ -95,28 +94,29 @@ struct AssetInfo {
 }
 ```
 
-| Storage           | Type                           | Notes                                                 |
-| ----------------- | ------------------------------ | ----------------------------------------------------- |
-| `config`          | `Config`                       | public getter returns 3 flat values                   |
-| `assets`          | `mapping(uint64 => AssetInfo)` | public getter returns 6 flat values, **not** a struct |
-| `liquidityTokens` | `mapping(uint64 => address)`   | the `LiquidityToken` deployed for each asset          |
-| `tokenIds`        | `uint64[]`                     | append-only, never pruned, **no length getter**       |
+| Storage            | Type                           | Read it via                                     |
+| ------------------ | ------------------------------ | ----------------------------------------------- |
+| `config`           | `Config`                       | `config()` — returns 3 flat values              |
+| `assets`           | `mapping(uint64 => AssetInfo)` | **`getAsset(id)`**, not the `assets` getter     |
+| `liquidityTokens`  | `mapping(uint64 => address)`   | `liquidityTokens(id)`                           |
+| `tokenIdByAddress` | `mapping(address => uint64)`   | `tokenIdByAddress(token)`; 0 means unregistered |
+| `_tokenIds`        | `uint64[]` (private)           | `getTokenIds()`, `getAssetCount()`              |
 
-Pool balances are not stored. Every read and every price calculation calls
+Use `getAsset(id)` rather than the auto-generated `assets(id)` getter. A public mapping getter
+returns the struct members as separate values, whereas `getAsset` returns a real struct — and
+because `AssetInfo` contains dynamic `string` members those two encodings differ, so a client typed
+against one cannot decode the other. `getAsset` is what `IOSwaps` in `ISeedsEcosystem.sol` declares.
+
+**Pool balances are not stored.** Every read and every price calculation calls
 `IERC20(token).balanceOf(address(this))` live. This has a direct consequence: **any token
 transferred to the contract address becomes pool liquidity with no LIQ issued against it.** A
 donation silently improves the price for everyone and is unrecoverable by the sender.
 
 ### Enumerating assets
 
-`tokenIds` is public but Solidity only generates an element getter, not a length getter, so you
-cannot iterate it without knowing its size. Use one of these instead:
-
-1. **Preferred:** read `config().lastTokenId` and loop `1..lastTokenId`, calling `assets(i)` and
-   skipping entries whose `symbol` is empty (empty means never created, or deleted by
-   `forgetAsset`). Ids are assigned sequentially from 1, so this is complete.
-2. Index `AssetCreated` events. Note that `forgetAsset` emits nothing, so an event-only index will
-   show deleted assets as live. Cross-check against `assets(i)`.
+Call `getTokenIds()`. It returns exactly the live ids — `forgetAsset` prunes the array — so there is
+no filtering to do and no need to walk `1..lastTokenId`. `getAssetCount()` gives the length if you
+only need a count. Ids are never reused: `lastTokenId` only increases, even across `forgetAsset`.
 
 ---
 
@@ -148,9 +148,9 @@ Why each step is necessary:
 - `createAsset` always sets `active = false` and `weight = 0`.
 - `addLiquidity` requires `active || amount == 0`, so a deposit into a fresh asset reverts with
   `Token is frozen`. The manager must `unfreeze` first.
-- The **first** deposit must pass a non-zero `weight`. Passing `weight = 0` on an empty pool leaves
-  the weight at zero (see Known defects #1), and a zero weight makes every swap _out of_ that token
-  revert with a division-by-zero panic.
+- The **first** deposit must pass a non-zero `weight`. Passing `weight = 0` while the pool balance
+  is zero reverts with `Zero weight requires existing balance`, because there is no existing price
+  to preserve.
 - Passing a non-zero `weight` deliberately freezes the asset, because a non-zero weight means the
   price changed and the original protocol requires manager review before trading resumes. So a
   second `unfreeze` is needed.
@@ -158,43 +158,56 @@ Why each step is necessary:
 Repeat `createAsset` → `unfreeze` → `addLiquidity` → `unfreeze` for each token. At least two assets
 must be live before any swap is possible.
 
+Retiring an asset is the mirror image: `freeze` → `withdraw` the full balance → `forgetAsset`. A
+live asset cannot be emptied (its price would be undefined), so the freeze comes first.
+
 ---
 
 ## 5. External function reference
 
 ### `init(address manager)`
 
-`onlyOwner`. One-shot. Sets the manager. Reverts `Already initialized` if `config.manager` is
-already non-zero. There is no manager rotation, and passing `address(0)` is not rejected but would
-permanently brick all manager functions.
+`onlyOwner`, one-shot. Sets the manager. Reverts `Already initialized` on a second call and
+`Zero manager` on `address(0)`. Emits `ManagerUpdated(address(0), manager)`.
+
+### `setManager(address newManager)`
+
+`onlyManager`. Hands the manager role to another address. Reverts `Zero manager` on `address(0)`.
+The owner cannot call this — only the incumbent manager can. Emits
+`ManagerUpdated(previous, newManager)`.
 
 ### `createAsset(address tokenContract, string symbol, string metadata) → uint64 tokenId`
 
 Permissionless. Increments `config.lastTokenId`, registers the asset with `active = false` and
-`weight = 0`, appends to `tokenIds`, and deploys a fresh `LiquidityToken` (see §7) whose name and
-symbol are both `"LIQ" + tokenId` (e.g. `LIQ1`).
+`weight = 0`, appends to the id list, and deploys a fresh `LiquidityToken` (see §7) whose name and
+symbol are both `"LIQ" + tokenId` (e.g. `LIQ1`) and whose decimals match the underlying token.
 
-Reverts only on `tokenContract == address(this)` (`Cannot be oswaps`). Notably it does **not**
-verify that `tokenContract` is a contract or an ERC-20, does not check for duplicate registration
-of the same token, and does not read the token's real symbol or decimals — the `symbol` argument is
-a free-form label used solely for the confirmation check in `freeze`/`unfreeze`.
+Reverts on the pool's own address (`Cannot be oswaps`), `address(0)` (`Zero token address`), an
+address with no code (`Token is not a contract`), and a token that is already registered
+(`Token already registered`).
 
-Because it is permissionless and deploys a contract per call, it is a gas-griefing surface: anyone
-can register unlimited junk assets and inflate `lastTokenId`, which lengthens the enumeration loop
-in §3. A UI should treat unfamiliar assets as untrusted and maintain an allowlist.
+It does **not** verify that the target is a real ERC-20 and does not read the token's actual symbol:
+the `symbol` argument is a free-form label used only for the confirmation check in
+`freeze`/`unfreeze`. Because it is permissionless and deploys a contract per call, it remains a
+gas-griefing surface — anyone can register unlimited junk assets. A UI should treat unfamiliar
+assets as untrusted, maintain an allowlist, and read the real symbol and decimals from the token
+contract rather than from the stored label.
 
 Emits `AssetCreated(tokenId, tokenContract, symbol)`.
 
 ### `forgetAsset(uint64 tokenId)`
 
-`onlyManager`. Deletes `assets[tokenId]`. Reverts `Token not found` if the symbol is empty.
+`onlyManager`. Removes the asset completely: prunes the id list, and clears `assets`,
+`liquidityTokens`, and `tokenIdByAddress`. The id is never reissued, and the token may be
+re-registered afterwards under a new id.
 
-Incompletely implemented — it leaves `liquidityTokens[tokenId]` populated, leaves the id in
-`tokenIds`, does not destroy or freeze the LIQ token, and does not check that the pool balance is
-zero. **Any pool balance of a forgotten asset becomes permanently unreachable** except through
-`emergencyWithdraw`, because every other path requires a live asset record. Emits no event, so
-event-based indexers will not notice. A UI should confirm destructively and warn about the trapped
-balance.
+**Requires the pool balance to be exactly zero** (`Pool balance not zero`), so no balance can be
+stranded. Reaching zero requires freezing the asset first, since a live asset cannot be fully
+drained. Emits `AssetForgotten(tokenId, tokenContract)`.
+
+Note that the LIQ token contract itself is not destroyed — it remains on chain, but the pool loses
+its reference and nothing can mint or burn it again. Any LIQ still outstanding when the asset is
+forgotten becomes a dead balance, so drain to the receipt holders before retiring an asset.
 
 ### `freeze(uint64 tokenId, string symbol)` / `unfreeze(uint64 tokenId, string symbol)`
 
@@ -205,66 +218,77 @@ balance.
 ### `queryPool(uint64[] tokenIdList) → PoolStatus[]`
 
 View. Returns `{ tokenId, balance, weight }` per requested id, with `balance` read live from the
-token. **Reverts `Token not found` if any single id in the list is unregistered or forgotten**, so
-never pass unvalidated ids — one bad entry fails the whole batch. Filter first using the
-enumeration in §3.
+token. **Reverts `Token not found` if any single id in the list is unregistered**, so one bad entry
+fails the whole batch — pass ids from `getTokenIds()`.
 
-This is the primary read for a UI. It gives you everything needed to compute prices client-side.
+This is the primary read for a UI dashboard.
+
+### `getTokenIds() → uint64[]` / `getAssetCount() → uint256` / `getAsset(uint64) → AssetInfo`
+
+Views. See §3.
+
+### `quoteExactIn(uint64 inTokenId, uint64 outTokenId, uint256 inAmount) → uint256 outAmount`
+
+### `quoteExactOut(uint64 inTokenId, uint64 outTokenId, uint256 outAmount) → uint256 inAmount`
+
+Views. Price a swap without executing it. They apply exactly the same validation and exactly the
+same math as the swap functions, so a successful quote means the swap will succeed at that price in
+the same block, and a failing quote reverts with the same message the swap would. Neither requires
+the caller to hold a balance or an allowance, so they are safe to call against an unfunded form.
+
+Use these rather than reimplementing the math off-chain.
 
 ### `addLiquidity(uint64 tokenId, uint256 amount, uint256 weight)`
 
 Permissionless, `nonReentrant`. Requires prior `approve` of `amount` to the OSwaps address.
 
 1. Requires the asset to exist and `active || amount == 0`.
-2. Pulls `amount` via `transferFrom`.
-3. Sets the weight: if `weight != 0` it is used verbatim; if `weight == 0` **and** the pre-deposit
-   balance was non-zero, the weight is scaled to preserve price as
+2. Pulls `amount` via `safeTransferFrom`, then checks the balance rose by exactly `amount`.
+3. Sets the weight: if `weight != 0` it is used verbatim; if `weight == 0` the pre-deposit balance
+   must be non-zero and the weight is scaled to preserve price as
    `w_new = w_old * (balBefore + amount) / balBefore`.
 4. If `weight != 0`, sets `active = false`.
-5. If `amount > 0`, mints `amount` LIQ 1:1 to the caller and emits
-   `LiquidityAdded(caller, tokenId, amount, amount)`.
+5. Emits `WeightUpdated`, then — if `amount > 0` — mints `amount` LIQ 1:1 to the caller and emits
+   `LiquidityAdded`.
 
 Two supported modes worth exposing separately in a UI:
 
 - **Deposit at current price** — `weight = 0`, `amount > 0`, existing balance non-zero. Price
-  unchanged, asset stays tradeable, no manager action needed.
+  unchanged, asset stays tradeable, no manager action needed. This is the normal path.
 - **Reprice without depositing** — `amount = 0`, `weight != 0`. Allowed even while frozen, since
   the `active || amount == 0` check passes. This is how a manager adjusts a price. It freezes the
-  asset and emits **no event at all** (the `LiquidityAdded` emit is inside `if (amount > 0)`), so
-  weight changes are invisible to indexers. Poll `assets(id).weight` instead.
+  asset.
 
 ### `withdraw(address account, uint64 tokenId, uint256 amount, uint256 weight)`
 
 `onlyManager`, `nonReentrant`. The mirror of `addLiquidity`.
 
-Requires `balBefore > amount` — strictly greater, so the pool can never be fully drained through
-this path. Weight handling mirrors deposit: `weight == 0` scales to
+While the asset is **active**, requires `balBefore > amount` — strictly greater, so a tradeable
+asset can never be emptied. While it is **frozen**, `balBefore >= amount` is allowed, which is what
+makes the freeze-drain-forget retirement path possible.
+
+Weight handling mirrors deposit: `weight == 0` scales to
 `w_new = w_old * (balBefore - amount) / balBefore` to hold price; non-zero sets it verbatim and
 freezes the asset. Burns `amount` LIQ from `account` — **without allowance**, since the pool owns
 the LIQ token — then transfers `amount` of the underlying to `account`.
 
-The LIQ burn reverts if `account` holds less than `amount`, which is the only thing tying a
-withdrawal to an actual deposit. Because LIQ is freely transferable (Known defects #4), the manager
-must verify `account` still holds its receipts before calling.
+The LIQ burn reverts (`ERC20InsufficientBalance`) if `account` holds less than `amount`, which is
+the only thing tying a withdrawal to an actual deposit. Since LIQ cannot be traded peer-to-peer, the
+holder is always the original depositor.
 
-Emits `LiquidityWithdrawn(account, tokenId, amount, amount)`.
+Emits `WeightUpdated` and `LiquidityWithdrawn`.
 
-### `swapExactIn(address recipient, uint64 inTokenId, uint64 outTokenId, uint256 inAmount) → uint256 outAmount`
+### `swapExactIn(address recipient, uint64 inTokenId, uint64 outTokenId, uint256 inAmount, uint256 minOutAmount) → uint256 outAmount`
 
 Permissionless, `nonReentrant`. Requires prior `approve` of `inAmount`.
 
-Both assets must exist and be `active`. Reads both balances, requires `inBalBefore > 0`, pulls
-`inAmount`, computes the output via the Balancer formula (§6), requires
-`0 < outAmount < outBalBefore`, transfers the output to `recipient`, emits `TokenSwapped`.
+Validates both sides (§9), computes the output via the Balancer formula (§6), requires
+`0 < outAmount < outBalBefore` and `outAmount >= minOutAmount`, pulls `inAmount`, checks the balance
+rose by exactly that, transfers the output to `recipient`, and emits `TokenSwapped`.
 
-> **There is no minimum-output parameter.** The caller has no on-chain slippage protection and the
-> transaction is fully sandwichable in a public mempool. Any UI must compute an expected output,
-> show the user a tolerance, and — since the contract cannot enforce it — wrap the call in a router
-> or multicall that checks the received amount and reverts, or accept the exposure explicitly.
-> `swapExactOut` does have a `maxInAmount` guard; this asymmetry is real, not a documentation error.
-
-`inTokenId == outTokenId` is not rejected. It will either revert on the output-amount check or
-return a self-swap at a loss. Block it in the UI.
+`minOutAmount` is the caller's slippage floor. Pass a real value: `0` disables the protection and
+leaves the transaction sandwichable in a public mempool. The usual pattern is
+`quoteExactIn(...) * (1 - tolerance)`.
 
 ### `swapExactOut(address recipient, uint64 inTokenId, uint64 outTokenId, uint256 outAmount, uint256 maxInAmount) → uint256 inAmount`
 
@@ -274,171 +298,83 @@ Same validation, plus `outBalBefore > outAmount` (`Insufficient output balance`)
 required input, reverts `Excessive input amount` if it exceeds `maxInAmount`, then pulls exactly
 `inAmount` and sends `outAmount`. Because the exact amount is pulled, no refund path is needed.
 
-### `emergencyWithdraw(address token, uint256 amount)`
-
-`onlyOwner`. Transfers any amount of any token to the owner. No timelock, no event, no restriction
-to registered assets. This is the contract's largest trust assumption.
-
 ---
 
-## 6. Pricing math and off-chain quoting
+## 6. Pricing math
 
 ### The formulas
 
-`swapExactIn` solves for the output balance:
+`swapExactIn` solves for the output balance; `swapExactOut` solves for the input balance:
 
 ```
-outBalAfter = outBalBefore * (inBalAfter / inBalBefore) ^ (-wIn / wOut)
-outAmount   = outBalBefore - outBalAfter
+outBalAfter = outBalBefore * (inBalAfter  / inBalBefore)  ^ (-wIn / wOut)
+inBalAfter  = inBalBefore  * (outBalAfter / outBalBefore) ^ (-wOut / wIn)
 ```
 
-`swapExactOut` solves for the input balance:
+Both are evaluated with **PRBMath's `UD60x18.pow`** in 18-decimal fixed point. Each is algebraically
+rearranged so the base is always greater than one and the exponent is always positive, which keeps
+every intermediate value unsigned:
 
 ```
-inBalAfter = inBalBefore * (outBalAfter / outBalBefore) ^ (-wOut / wIn)
-inAmount   = inBalAfter - inBalBefore
+outBalAfter = outBalBefore / (inBalAfter / inBalBefore) ^ ( wIn / wOut)
+inBalAfter  = inBalBefore  * (outBalBefore / outBalAfter) ^ (wOut / wIn)
 ```
 
-Both are evaluated as `exp(exponent * ln(ratio))` using **hand-rolled Taylor series** in
-18-decimal fixed point: a 10-term series for `ln` and a 20-term series for `exp`. This is the
-critical implementation detail, because those series have a limited domain of convergence.
+Truncation is biased so the leftover wei stays in the pool: the retained output balance rounds up,
+and the charged input rounds up.
 
-### Accuracy envelope — measured
+### Accuracy — measured
 
-`_ln` is a Taylor expansion about `x = 1`, which converges only for `0 < x < 2` and slowly near the
-edges. Each swap direction feeds it a different ratio, so the two functions have **different
-envelopes and opposite error directions.** Both matter.
+Measured against double-precision reference arithmetic. Relative error on the quoted amount:
 
-**`swapExactIn`.** The ratio is `inBalAfter / inBalBefore = 1 + inAmount / inBalBefore`, so the
-constraint is trade size as a fraction of the **input**-side balance. Errors here _underpay the
-trader_, meaning the pool gains:
+| Conditions                                                             | Relative error |
+| ---------------------------------------------------------------------- | -------------- |
+| Equal weights, trades from 1e-5× to 10× the pool balance               | < 1e-11        |
+| Weight ratios up to 100:1, trades from 0.1% to 50% of the pool balance | < 1e-10        |
+| Weight ratios up to 50:1 including dust-sized trades                   | < 1e-9         |
 
-| `inAmount` vs input pool balance | Error     | Verdict     |
-| -------------------------------- | --------- | ----------- |
-| 1% – 30%                         | < 0.0001% | Accurate    |
-| 40%                              | −0.0007%  | Accurate    |
-| 50%                              | −0.0061%  | Acceptable  |
-| 60%                              | −0.036%   | Degraded    |
-| 75%                              | −0.30%    | Degraded    |
-| 90%                              | −1.75%    | Badly wrong |
-| 100%                             | −4.87%    | Badly wrong |
-| 125%                             | −51%      | Badly wrong |
-| ≥ 150%                           | —         | Reverts     |
+The bound is loosest for very small trades, where the ratio handed to `pow` sits closest to 1 and
+relative precision is worst — but the absolute amounts there are correspondingly tiny.
 
-**`swapExactOut`.** The ratio is `outBalAfter / outBalBefore = 1 − outAmount / outBalBefore`, so the
-constraint is the requested output as a fraction of the **output**-side balance. Errors here run the
-other way — they _undercharge the trader_, so the pool loses:
+The residual error has **no guaranteed sign**, so a single swap can in principle move the invariant
+`V` either way. The measured worst-case drop is below **1e-12 of pool value per swap**, which is
+enforced by a test. Extracting anything meaningful would take on the order of 1e10 swaps, costing
+vastly more in gas than it could yield.
 
-| `outAmount` vs output pool balance | Error in required input | Invariant `V` change | Verdict     |
-| ---------------------------------- | ----------------------- | -------------------- | ----------- |
-| 1% – 25%                           | < 0.0001%               | ~0                   | Accurate    |
-| 33%                                | −0.0002%                | −0.00002%            | Accurate    |
-| 40%                                | −0.0015%                | −0.0001%             | Accurate    |
-| 50%                                | −0.017%                 | −0.008%              | Degraded    |
-| 60%                                | −0.12%                  | −0.06%               | Degraded    |
-| 75%                                | −1.67%                  | −1.26%               | Badly wrong |
-| 90%                                | −18.7%                  | −16.8%               | Badly wrong |
-| ≥ 100%                             | —                       | —                    | Reverts     |
+### Domain limit
 
-The weight ratio constrains things independently, because the exponent is `-(wIn/wOut) * ln(ratio)`
-and `_exp` also diverges for large arguments. At a 10% trade size, ratios up to `wIn/wOut ≈ 50` stay
-accurate; `≈ 100` and above revert.
+`pow` requires `log2(base) * exponent < 192`. In practice:
 
-Three conclusions that should shape the UI directly:
+- **At or near equal weights there is effectively no trade-size ceiling.** Trades of 1×, 10×, and
+  100× the pool balance all price correctly. (A very large input buys almost the whole output side
+  but never all of it, so the pool cannot be emptied by a swap.)
+- **Extreme weight ratios cap the trade size.** At `wIn/wOut = 50` the ceiling sits above 13× the
+  input balance; a 20× trade reverts. At `wIn/wOut = 192` and above, even a doubling of the input
+  balance is out of range.
 
-**No standalone theft is possible, but `swapExactOut` leaks LP value.** Out-of-range inputs revert
-rather than executing, because the diverging series makes a subtraction underflow, which Solidity 0.8
-turns into a panic. And across 525 executable `swapExactOut` configurations — weight ratios from 0.02
-to 50, pool imbalance from 1:100 to 100:1, output sizes from 1% to 99% — no combination lets a caller
-buy the output for less than its pre-trade spot value, so there is no self-contained drain. What
-`swapExactOut` _does_ do is break the invariant downward, by as much as 16.8% of `V` on a single
-large trade. That value is real and is captured by whoever was going to arbitrage the pool anyway, at
-the expense of liquidity providers.
+Both limits are far outside anything a real pool would see, but surface the revert as "trade too
+large for this pool" rather than as a raw PRBMath error.
 
-**Cap `swapExactOut` harder than `swapExactIn`.** Its accurate range is narrower (roughly 40% of the
-output balance versus 50% of the input balance) and its errors point against the pool rather than for
-it. Treat 40% as the safe ceiling for exact-out and 50% for exact-in, warn up to 75%, and block
-beyond that.
+### Off-chain price display
 
-**Present the caps as liquidity limits.** "This pool does not have enough liquidity for that trade"
-is accurate and reads naturally. Anchor the check on the correct side of the pool for each direction
-— input balance for exact-in, output balance for exact-out — since confusing the two will let bad
-trades through.
-
-### Bit-exact TypeScript port for quoting
-
-There is no `quote` view function on the contract, and simulating via `eth_call` requires the caller
-to already hold the balance and allowance — awkward for a quote on a form the user has not funded
-yet. Replicate the math instead. Truncation must match Solidity exactly, so use `BigInt` throughout
-and never `Number`. JavaScript `BigInt` division truncates toward zero, matching Solidity `int256`
-division, and unary minus binds tighter than division in both languages, so the expressions below
-are faithful line for line.
+Use `quoteExactIn` / `quoteExactOut` for the actual numbers. Compute these client-side only for
+display:
 
 ```ts
-const ONE = 10n ** 18n;
-
-/** Mirrors OSwaps._ln — 10-term Taylor series about x = 1, 18-decimal fixed point. */
-function ln(x: bigint): bigint {
-  if (x <= 0n) throw new Error('ln: x must be positive');
-  const diff = x - ONE;
-  if (diff === 0n) return 0n;
-  let result = diff;
-  let term = diff;
-  for (let i = 2n; i <= 10n; i++) {
-    term = (term * diff) / ONE;
-    if (i % 2n === 0n) result -= term / i;
-    else result += term / i;
-  }
-  return result;
+/** Marginal (spot) price of `out` denominated in `in`. */
+export function spotPrice(inBal: bigint, wIn: bigint, outBal: bigint, wOut: bigint): number {
+  return Number(inBal) / Number(wIn) / (Number(outBal) / Number(wOut));
 }
 
-/** Mirrors OSwaps._exp — 20-term Taylor series, 18-decimal fixed point. */
-function exp(x: bigint): bigint {
-  let result = ONE;
-  let term = ONE;
-  for (let i = 1n; i <= 20n; i++) {
-    term = (term * x) / (i * ONE);
-    result += term;
-    if (term === 0n) break;
-  }
-  return result;
-}
-
-/** Mirrors swapExactIn. Returns null where the contract would revert. */
-export function quoteExactIn(inBalBefore: bigint, inAmount: bigint, outBalBefore: bigint, wIn: bigint, wOut: bigint): bigint | null {
-  if (inBalBefore === 0n || wOut === 0n) return null;
-  const ratio = ((inBalBefore + inAmount) * ONE) / inBalBefore;
-  const exponent = -(wIn * ln(ratio)) / wOut;
-  const outBalAfter = (outBalBefore * exp(exponent)) / ONE;
-  if (outBalAfter > outBalBefore) return null; // would underflow and revert
-  const outAmount = outBalBefore - outBalAfter;
-  if (outAmount === 0n || outAmount >= outBalBefore) return null;
-  return outAmount;
-}
-
-/** Mirrors swapExactOut. Returns null where the contract would revert. */
-export function quoteExactOut(inBalBefore: bigint, outBalBefore: bigint, outAmount: bigint, wIn: bigint, wOut: bigint): bigint | null {
-  if (inBalBefore === 0n || wIn === 0n || outBalBefore <= outAmount) return null;
-  const ratio = ((outBalBefore - outAmount) * ONE) / outBalBefore;
-  const exponent = -(wOut * ln(ratio)) / wIn;
-  const inBalAfter = (inBalBefore * exp(exponent)) / ONE;
-  if (inBalAfter < inBalBefore) return null;
-  return inBalAfter - inBalBefore;
+/** Price impact of a quote, as a fraction: 0.01 means the trade paid 1% over spot. */
+export function priceImpact(inAmount: bigint, outAmount: bigint, spot: number): number {
+  const effective = Number(inAmount) / Number(outAmount);
+  return effective / spot - 1;
 }
 ```
 
-To also surface how much the approximation is costing the user, compute the exact value with
-floating point and show the gap:
-
-```ts
-export function exactQuoteOut(inBalBefore: bigint, inAmount: bigint, outBalBefore: bigint, wIn: bigint, wOut: bigint): number {
-  const ib = Number(inBalBefore),
-    ob = Number(outBalBefore);
-  return ob - ob * Math.pow((ib + Number(inAmount)) / ib, -(Number(wIn) / Number(wOut)));
-}
-```
-
-A gap beyond a fraction of a percent means the trade is outside the reliable envelope.
+Both are for presentation, so `Number` is fine. Never use `Number` to derive an amount you then
+send on chain.
 
 ---
 
@@ -448,32 +384,40 @@ A gap beyond a fraction of a percent means the trade is outside the reliable env
 the OSwaps contract, exposing `mint(to, amount)` and `burnFrom(from, amount)`, both `onlyOwner`.
 Note that `burnFrom` does **not** consult allowances despite the name; the pool burns unilaterally.
 
-LIQ is minted 1:1 against the raw deposited amount and burned 1:1 against the raw withdrawn amount.
-It therefore represents a **nominal claim on units deposited, not a proportional share of the
-pool.** Two consequences:
+Three properties to design around:
 
-- Total LIQ supply does not track the pool balance. Swaps, donations, and `emergencyWithdraw` all
-  change the balance without changing LIQ supply. Never render LIQ as a percentage of the pool.
-- **LIQ always has 18 decimals regardless of the underlying token.** Depositing 1 USDC (`1e6` raw)
-  mints `1e6` base units of an 18-decimal token, which renders as `0.000000000001 LIQ`. Format LIQ
-  balances using the _underlying token's_ decimals to get a number that means anything to a user,
-  and never assume LIQ decimals match the asset. See Known defects #3.
+**Decimals match the underlying token.** Deposit 1 USDC and your LIQ1 balance reads as 1.0 at 6
+decimals. For a token that does not expose `decimals()`, or reports something nonsensical, LIQ falls
+back to 18.
+
+**LIQ is a nominal claim on units deposited, not a proportional share of the pool.** It is minted
+1:1 against the raw deposited amount and burned 1:1 against the raw withdrawn amount. Total supply
+does not track the pool balance, because swaps and donations change the balance without changing
+supply. Never render LIQ as a percentage of the pool.
+
+**Peer-to-peer transfers are blocked.** Every transfer must involve the pool address; account-to-
+account moves revert with `LIQ: transfers must involve pool`. This mirrors the original protocol and
+means the receipt holder is always the original depositor. Do not build a transfer UI for LIQ.
 
 ---
 
 ## 8. Events
 
-| Event                                                                                                                       | Emitted by                             | Indexed                    |
-| --------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- | -------------------------- |
-| `AssetCreated(uint64 tokenId, address tokenContract, string symbol)`                                                        | `createAsset`                          | `tokenId`, `tokenContract` |
-| `AssetFrozen(uint64 tokenId, bool frozen)`                                                                                  | `freeze`, `unfreeze`                   | `tokenId`                  |
-| `LiquidityAdded(address account, uint64 tokenId, uint256 amount, uint256 liqTokensMinted)`                                  | `addLiquidity`, only when `amount > 0` | `account`, `tokenId`       |
-| `LiquidityWithdrawn(address account, uint64 tokenId, uint256 amount, uint256 liqTokensBurned)`                              | `withdraw`                             | `account`, `tokenId`       |
-| `TokenSwapped(address sender, address recipient, uint64 inTokenId, uint64 outTokenId, uint256 inAmount, uint256 outAmount)` | both swaps                             | `sender`, `recipient`      |
+| Event                                                                                                                       | Emitted by                             | Indexed                            |
+| --------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- | ---------------------------------- |
+| `ManagerUpdated(address previousManager, address newManager)`                                                               | `init`, `setManager`                   | both                               |
+| `AssetCreated(uint64 tokenId, address tokenContract, string symbol)`                                                        | `createAsset`                          | `tokenId`, `tokenContract`         |
+| `AssetForgotten(uint64 tokenId, address tokenContract)`                                                                     | `forgetAsset`                          | `tokenId`, `tokenContract`         |
+| `AssetFrozen(uint64 tokenId, bool frozen)`                                                                                  | `freeze`, `unfreeze`                   | `tokenId`                          |
+| `WeightUpdated(uint64 tokenId, uint256 previousWeight, uint256 newWeight, bool priceChanged)`                               | `addLiquidity`, `withdraw`             | `tokenId`                          |
+| `LiquidityAdded(address account, uint64 tokenId, uint256 amount, uint256 liqTokensMinted)`                                  | `addLiquidity`, only when `amount > 0` | `account`, `tokenId`               |
+| `LiquidityWithdrawn(address account, uint64 tokenId, uint256 amount, uint256 liqTokensBurned)`                              | `withdraw`                             | `account`, `tokenId`               |
+| `TokenSwapped(address sender, address recipient, uint64 inTokenId, uint64 outTokenId, uint256 inAmount, uint256 outAmount)` | both swaps                             | `sender`, `recipient`, `inTokenId` |
 
-Gaps to plan around: `forgetAsset` and `emergencyWithdraw` emit nothing; weight changes emit
-nothing; and `inTokenId`/`outTokenId` on `TokenSwapped` are **not** indexed, so per-pair filtering
-must happen client-side after fetching by sender or recipient.
+Every state change emits something, so an event-only indexer can stay consistent. Two things to note:
+`WeightUpdated` fires on every `addLiquidity` and `withdraw`, including price-holding ones (read
+`priceChanged` to distinguish a deliberate reprice from an automatic rescale); and only `inTokenId`
+is indexed on `TokenSwapped`, so filtering by output token must happen client-side.
 
 ---
 
@@ -481,86 +425,68 @@ must happen client-side after fetching by sender or recipient.
 
 | Message                                            | Source                                                                       |
 | -------------------------------------------------- | ---------------------------------------------------------------------------- |
-| `Only manager`                                     | manager-gated function called by another address                             |
+| `Only manager`                                     | manager-gated function called by another address, including by the owner     |
 | `Already initialized`                              | second `init`                                                                |
+| `Zero manager`                                     | `init` or `setManager` with `address(0)`                                     |
 | `Token not found`                                  | `freeze`, `unfreeze`, `forgetAsset`, `queryPool`, `addLiquidity`, `withdraw` |
 | `Symbol mismatch`                                  | `freeze`/`unfreeze` symbol argument does not match stored                    |
 | `Cannot be oswaps`                                 | `createAsset` with the pool's own address                                    |
+| `Zero token address`                               | `createAsset` with `address(0)`                                              |
+| `Token is not a contract`                          | `createAsset` with an address that has no code                               |
+| `Token already registered`                         | `createAsset` with a token that already has an id                            |
+| `Pool balance not zero`                            | `forgetAsset` before the asset has been drained                              |
 | `Token is frozen`                                  | `addLiquidity` with `amount > 0` on an inactive asset                        |
-| `Input token not found` / `Output token not found` | swaps with an unregistered id                                                |
-| `Input token frozen` / `Output token frozen`       | swaps on an inactive asset                                                   |
-| `Zero input balance`                               | swaps when the input side holds nothing                                      |
+| `Zero weight requires existing balance`            | `addLiquidity` with `weight = 0` while the pool balance is zero              |
+| `Unexpected balance change`                        | fee-on-transfer or rebasing token detected mid-transfer                      |
+| `Zero amount`                                      | `withdraw` or a swap with a zero amount                                      |
+| `Zero recipient`                                   | swap to `address(0)`                                                         |
+| `Same token`                                       | swap or quote with `inTokenId == outTokenId`                                 |
+| `Input token not found` / `Output token not found` | swaps or quotes with an unregistered id                                      |
+| `Input token frozen` / `Output token frozen`       | swaps or quotes on an inactive asset                                         |
+| `Input weight not set` / `Output weight not set`   | the asset was never priced                                                   |
+| `Zero input balance` / `Zero output balance`       | the pool holds nothing on that side                                          |
 | `Insufficient output balance`                      | `swapExactOut` with `outAmount >= outBalBefore`                              |
-| `Insufficient balance`                             | `withdraw` with `amount >= balBefore`                                        |
-| `Invalid output amount`                            | computed output is 0 or ≥ pool balance — usually the math envelope           |
+| `Insufficient balance`                             | `withdraw` beyond what the asset holds                                       |
+| `Invalid output amount` / `Invalid input amount`   | the computed amount is 0, or the output is ≥ the pool balance                |
+| `Insufficient output amount`                       | `swapExactIn` output below `minOutAmount`                                    |
 | `Excessive input amount`                           | `swapExactOut` computed input above `maxInAmount`                            |
-| `Transfer failed`                                  | an ERC-20 returned `false`                                                   |
-| `ln: x must be positive`                           | ratio underflowed to 0                                                       |
-| `Ownable*`                                         | OpenZeppelin owner errors                                                    |
-| Panic `0x11` (arithmetic overflow/underflow)       | diverging Taylor series — trade far outside the envelope                     |
-| Panic `0x12` (division by zero)                    | swapping out of an asset whose weight is 0                                   |
-
-Map the last three to human-readable guidance. Panic `0x11` in practice means "trade too large for
-this pool"; `0x12` means "this asset was never priced."
+| `LIQ: transfers must involve pool`                 | attempted peer-to-peer LIQ transfer                                          |
+| `ERC20InsufficientBalance` (custom)                | `withdraw` when `account` holds too little LIQ                               |
+| `ERC20InsufficientAllowance` (custom)              | caller has not approved the pool                                             |
+| `OwnableUnauthorizedAccount` (custom)              | non-owner called `init`                                                      |
+| `PRBMath_UD60x18_Exp2_InputTooBig` (custom)        | trade beyond the exponent domain — see §6                                    |
 
 ---
 
-## 10. Known defects a UI must work around
+## 10. Constraints a UI must handle
 
-None of these are fixed in the contract as it stands.
+The math envelope is no longer one of them: both directions are accurate across any realistic trade
+size, and there is no trade-size cap to enforce. What remains:
 
-The **pricing-math envelope in §6 is the most consequential constraint** and is not repeated here:
-both swap directions misprice outside a limited trade-size range, with `swapExactOut` erring against
-the pool. Implement those caps first. The items below are the remaining issues, ordered by how much
-they affect UI work.
+**1. Withdrawal is manager-gated.** LPs deposit permissionlessly and cannot exit on their own.
+Surface this prominently before anyone deposits, and build a manager console for the exit path.
 
-**1. `addLiquidity` can silently leave weight at zero.** With `weight = 0` on an empty pool, the
-original EOSIO contract reverts (`"zero weight requires existing balance"`); this port instead
-skips the branch and leaves the weight at 0. Every later swap _out of_ that asset then reverts with
-a division-by-zero panic and the asset is unusable until a manager repriced it. **Mitigation:**
-require a non-zero weight in the form whenever the current pool balance is zero, and flag any asset
-with `weight == 0` as misconfigured.
+**2. Assets frozen by a reprice need an explicit unfreeze.** This is the state users will most often
+get stuck in. When an asset is inactive, say why — a fresh asset awaiting its first deposit and an
+asset frozen by a deliberate reprice look identical in `active`, but the second has a non-zero
+weight. Use that to distinguish them.
 
-**2. `swapExactIn` has no minimum-output parameter.** No on-chain slippage protection, fully
-sandwichable. **Mitigation:** enforce tolerance client-side and prefer `swapExactOut` (which has
-`maxInAmount`) wherever the flow allows a fixed output.
+**3. `createAsset` is permissionless and its `symbol` is an unchecked label.** Maintain an
+allowlist. Read the real symbol and decimals from the token contract, never from `AssetInfo.symbol`.
 
-**3. LIQ decimals do not match the underlying.** Always 18. **Mitigation:** format with the
-underlying token's decimals, as described in §7.
+**4. Donations to the contract address become liquidity with no receipt.** Balances are read live, so
+a stray transfer improves the price for everyone and cannot be recovered. Never present the pool
+address as a deposit address.
 
-**4. LIQ is freely transferable.** The original restricted LIQ to transfers involving the contract
-only, blocking peer-to-peer trade in receipts. This port uses a plain ERC-20. **Mitigation:** the
-manager console must check current LIQ balances before `withdraw`, since the holder may not be the
-depositor.
+**5. Fee-on-transfer and rebasing tokens are rejected, not supported.** `addLiquidity` and both swaps
+verify that the pool balance moved by exactly the stated amount and revert with
+`Unexpected balance change` otherwise. Filter these tokens out at registration time so users do not
+meet the error later.
 
-**5. `IOSwaps.assets` in `ISeedsEcosystem.sol` is ABI-incompatible.** The interface declares
-`returns (AssetInfo memory)`, but a public mapping getter returns six flat values. Because
-`AssetInfo` contains dynamic `string` members, the struct encoding carries an extra offset word — 11
-words versus 10 — so decoding the real return through this interface throws. **Mitigation:** do not
-use `IOSwaps` for `assets`; generate types from the compiled artifact at
-`artifacts/contracts/seedsexample/OSwaps.sol/OSwaps.json`. The rest of `IOSwaps` is accurate, and
-`config()` happens to be compatible because `Config` is entirely static.
+**6. LIQ is not transferable and not a pool share.** See §7.
 
-**6. `forgetAsset` leaves state behind and traps balances.** See §5. **Mitigation:** warn
-destructively; treat empty-symbol ids as deleted when enumerating.
-
-**7. `config.chainId` is meaningless.** It is set once in the constructor to
-`blockhash(block.number - 1)` — a block hash, not a chain identifier — and never read anywhere. In
-the original it held the real Telos chain id to support future cross-chain asset identification.
-**Mitigation:** ignore the field. Do not display it.
-
-**8. No safety for non-standard ERC-20s.** Transfers use raw `require(token.transfer(...))` rather
-than `SafeERC20`, so tokens that return no value on transfer will revert on ABI decoding. And
-because all accounting is balance-based, **fee-on-transfer and rebasing tokens will mis-price
-persistently.** **Mitigation:** allowlist assets; exclude fee-on-transfer and rebasing tokens.
-
-**9. `createAsset` is unvalidated and permissionless.** No check that the target is a contract, no
-duplicate detection, no verification of the `symbol` label against the token. Junk assets inflate
-`lastTokenId`. **Mitigation:** maintain an allowlist; never trust the stored `symbol` — read the
-real one from the token contract.
-
-**10. `onlyActive` modifier is dead code.** Declared and never applied; the same check is inlined at
-each call site. Harmless, but do not read its presence as evidence of a guard.
+**7. `minOutAmount` defaults to nothing.** The contract accepts `0`. Compute a real floor from
+`quoteExactIn` and a user-visible tolerance.
 
 ---
 
@@ -568,40 +494,33 @@ each call site. Harmless, but do not read its presence as evidence of a guard.
 
 A suggested scope, in dependency order.
 
-**Read layer.** Enumerate assets (§3), then `queryPool` over the valid ids for balances and
-weights. Resolve real symbol and decimals from each token contract, not from the stored label.
-Derive the marginal price of `i` against `j` as `(Bj/Wj) / (Bi/Wi)`.
+**Read layer.** `getTokenIds()`, then `queryPool` over them for balances and weights. Resolve real
+symbol and decimals from each token contract, not from the stored label. Derive the marginal price of
+`i` against `j` as `(Bj/Wj) / (Bi/Wi)`.
 
-**Swap form.** Token in, token out, amount, direction (exact-in or exact-out). Quote with the
-functions in §6. Enforce the per-direction trade-size caps from §6, checking against the input
-balance for exact-in and the output balance for exact-out. Show output, effective price, slippage
-against the marginal price, and the approximation gap. Two transactions: `approve`, then the swap.
-Block `inTokenId == outTokenId` and any asset that is inactive or zero-weight.
+**Swap form.** Token in, token out, amount, direction. Quote with `quoteExactIn` / `quoteExactOut`.
+Show output, effective price, and price impact against the marginal price. Set `minOutAmount` or
+`maxInAmount` from the user's tolerance — never leave them at 0 and `MaxUint256`. Two transactions:
+`approve`, then the swap. Block any asset that is inactive or zero-weight; the contract will reject
+`inTokenId == outTokenId` for you.
 
 **Liquidity form.** Deposit only, with the price-preserving path (`weight = 0`) as the default and a
 non-zero weight required when the pool is empty. Make clear that withdrawal requires the manager,
-and that LIQ is a nominal receipt rather than a pool share.
+and that LIQ is a non-transferable nominal receipt rather than a pool share.
 
 **Manager console.** Freeze/unfreeze (with the symbol confirmation), withdraw to an address, reprice
-via `addLiquidity(id, 0, newWeight)`, and `forgetAsset` behind a destructive confirmation. Surface
-which assets are frozen and why — an asset frozen by a reprice needs an explicit unfreeze before
-trading resumes, and that is the state users will most often get stuck in.
+via `addLiquidity(id, 0, newWeight)`, rotate the manager, and the freeze-drain-forget retirement
+sequence behind a destructive confirmation. Surface which assets are frozen and why.
 
 ---
 
-## 12. Before building
+## 12. Before deploying anything
 
-Recommended prerequisites, in order:
-
-1. Add a deploy script and a Hardhat test suite. The contract has neither, and no test has ever
-   exercised the math.
-2. Decide whether to keep the Taylor-series math. Replacing `_ln`/`_exp` with an audited
-   fixed-point library (`PRBMath`, `solmate`'s `FixedPointMathLib`) removes the trade-size cap and
-   the whole class of envelope reverts, at the cost of diverging further from a literal port. This
-   is the highest-value change and it needs an explicit decision — see
-   [`OSwaps.EOSIO-PARITY.md`](./OSwaps.EOSIO-PARITY.md) §6.
-3. Add `quoteExactIn` / `quoteExactOut` view functions so the UI is not maintaining a parallel
-   implementation of the pricing math.
-4. Add `getTokenIds()` and a `minOutAmount` parameter on `swapExactIn`.
-5. Add the contract to `wagmi.config.ts` so typed bindings land in
+1. **Get an audit.** The contract is unaudited reference code. The pricing math is now delegated to
+   PRBMath, but the surrounding accounting, the manager trust model, and the weight-rescaling
+   arithmetic have only been reviewed internally.
+2. **Decide the manager's governance.** Every operational power sits with one address and there is no
+   owner override. A Hypha space `Executor` or a multisig is the sensible target; an EOA is not.
+3. **Add the contract to `wagmi.config.ts`** so typed bindings land in
    `packages/core/src/generated.ts` and the UI is not hand-writing ABIs.
+4. **Decide the asset allowlist policy.** Registration is permissionless; presentation should not be.

--- a/packages/storage-evm/contracts/seedsexample/OSwaps.sol
+++ b/packages/storage-evm/contracts/seedsexample/OSwaps.sol
@@ -3,23 +3,36 @@ pragma solidity ^0.8.20;
 
 import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 import '@openzeppelin/contracts/token/ERC20/ERC20.sol';
+import '@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol';
+import '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
 import '@openzeppelin/contracts/access/Ownable.sol';
 import '@openzeppelin/contracts/utils/ReentrancyGuard.sol';
+import '@openzeppelin/contracts/utils/math/Math.sol';
+import { UD60x18, ud } from '@prb/math/src/UD60x18.sol';
 
 /**
  * @title OSwaps
- * @dev Multi-token liquidity pool implementing Balancer invariant formula
+ * @dev Multi-token liquidity pool implementing the Balancer invariant formula.
  *
- * The OSwaps contract implements a token conversion service based on a
- * multilateral token pool using the "balancer" invariant V = B1^W1 * B2^W2 * ... * Bn^Wn
+ * Port of the Antelope/EOSIO `oswaps` contract. It implements a token conversion
+ * service over a multilateral token pool using the "balancer" invariant
+ * V = B1^W1 * B2^W2 * ... * Bn^Wn.
  *
  * Features:
  * - Add liquidity with single-sided deposits
  * - Withdraw liquidity
  * - Token swaps between any pool tokens
  * - Dynamic weight adjustment during liquidity changes
+ *
+ * Weights are meaningful only as ratios: the pricing math uses wIn/wOut, so the
+ * absolute scale is arbitrary and weights are not normalised to sum to 1.
+ *
+ * See OSwaps.docs.md for the full contract reference and OSwaps.EOSIO-PARITY.md
+ * for a comparison against the original Antelope implementation.
  */
 contract OSwaps is Ownable, ReentrancyGuard {
+  using SafeERC20 for IERC20;
+
   // ============ Structs ============
 
   struct AssetInfo {
@@ -28,7 +41,7 @@ contract OSwaps is Ownable, ReentrancyGuard {
     string symbol;
     bool active;
     string metadata;
-    uint256 weight; // Stored as fixed point with 18 decimals (1.0 = 1e18)
+    uint256 weight;
   }
 
   struct PoolStatus {
@@ -53,16 +66,32 @@ contract OSwaps is Ownable, ReentrancyGuard {
   // tokenId => LIQ token contract
   mapping(uint64 => address) public liquidityTokens;
 
-  // Track all token IDs
-  uint64[] public tokenIds;
+  // ERC-20 address => tokenId, 0 when unregistered. Prevents double registration
+  // of the same token, which would give two asset records one shared balance.
+  mapping(address => uint64) public tokenIdByAddress;
 
-  // Events
+  // Registered token ids, pruned by forgetAsset
+  uint64[] private _tokenIds;
+
+  // tokenId => index into _tokenIds, for O(1) removal
+  mapping(uint64 => uint256) private _tokenIdIndex;
+
+  // ============ Events ============
+
+  event ManagerUpdated(address indexed previousManager, address indexed newManager);
   event AssetCreated(
     uint64 indexed tokenId,
     address indexed tokenContract,
     string symbol
   );
+  event AssetForgotten(uint64 indexed tokenId, address indexed tokenContract);
   event AssetFrozen(uint64 indexed tokenId, bool frozen);
+  event WeightUpdated(
+    uint64 indexed tokenId,
+    uint256 previousWeight,
+    uint256 newWeight,
+    bool priceChanged
+  );
   event LiquidityAdded(
     address indexed account,
     uint64 indexed tokenId,
@@ -78,7 +107,7 @@ contract OSwaps is Ownable, ReentrancyGuard {
   event TokenSwapped(
     address indexed sender,
     address indexed recipient,
-    uint64 inTokenId,
+    uint64 indexed inTokenId,
     uint64 outTokenId,
     uint256 inAmount,
     uint256 outAmount
@@ -91,34 +120,53 @@ contract OSwaps is Ownable, ReentrancyGuard {
     _;
   }
 
-  modifier onlyActive(uint64 tokenId) {
-    require(assets[tokenId].active, 'Token is frozen');
+  modifier assetExists(uint64 tokenId) {
+    require(assets[tokenId].contractAddress != address(0), 'Token not found');
     _;
   }
 
   // ============ Constructor ============
 
   constructor() Ownable(msg.sender) {
-    config.chainId = blockhash(block.number - 1);
+    // Informational only, mirroring the original contract's chain_id field. The
+    // original recorded the home chain to support future cross-chain assets.
+    config.chainId = bytes32(block.chainid);
     config.lastTokenId = 0;
   }
 
   // ============ Admin Functions ============
 
   /**
-   * @dev Initialize the contract with manager
-   * @param manager The manager address
+   * @dev Set the initial manager. Callable once by the owner; afterwards the
+   * manager rotates itself via setManager.
    */
   function init(address manager) external onlyOwner {
     require(config.manager == address(0), 'Already initialized');
+    require(manager != address(0), 'Zero manager');
     config.manager = manager;
+    emit ManagerUpdated(address(0), manager);
   }
 
   /**
-   * @dev Freeze a token (prevent swaps)
+   * @dev Transfer manager authority. The original protocol allowed the incumbent
+   * manager to hand over to a replacement; this is that path.
    */
-  function freeze(uint64 tokenId, string calldata symbol) external onlyManager {
-    require(bytes(assets[tokenId].symbol).length > 0, 'Token not found');
+  function setManager(address newManager) external onlyManager {
+    require(newManager != address(0), 'Zero manager');
+    address previous = config.manager;
+    config.manager = newManager;
+    emit ManagerUpdated(previous, newManager);
+  }
+
+  /**
+   * @dev Freeze a token, blocking swaps and deposits.
+   * @param symbol Must match the stored symbol. A guard against mistyped ids,
+   * carried over from the original protocol.
+   */
+  function freeze(
+    uint64 tokenId,
+    string calldata symbol
+  ) external onlyManager assetExists(tokenId) {
     require(
       keccak256(bytes(assets[tokenId].symbol)) == keccak256(bytes(symbol)),
       'Symbol mismatch'
@@ -128,13 +176,12 @@ contract OSwaps is Ownable, ReentrancyGuard {
   }
 
   /**
-   * @dev Unfreeze a token (allow swaps)
+   * @dev Unfreeze a token, allowing swaps and deposits.
    */
   function unfreeze(
     uint64 tokenId,
     string calldata symbol
-  ) external onlyManager {
-    require(bytes(assets[tokenId].symbol).length > 0, 'Token not found');
+  ) external onlyManager assetExists(tokenId) {
     require(
       keccak256(bytes(assets[tokenId].symbol)) == keccak256(bytes(symbol)),
       'Symbol mismatch'
@@ -146,7 +193,11 @@ contract OSwaps is Ownable, ReentrancyGuard {
   // ============ Asset Management ============
 
   /**
-   * @dev Create a new asset entry and corresponding LIQ token
+   * @dev Register an ERC-20 in the pool and deploy its LIQ receipt token.
+   *
+   * The asset starts inactive with zero weight, matching the original protocol.
+   * A manager must unfreeze it before the first deposit, and that first deposit
+   * must carry a non-zero weight to establish a price.
    */
   function createAsset(
     address tokenContract,
@@ -154,6 +205,9 @@ contract OSwaps is Ownable, ReentrancyGuard {
     string calldata metadata
   ) external returns (uint64 tokenId) {
     require(tokenContract != address(this), 'Cannot be oswaps');
+    require(tokenContract != address(0), 'Zero token address');
+    require(tokenContract.code.length > 0, 'Token is not a contract');
+    require(tokenIdByAddress[tokenContract] == 0, 'Token already registered');
 
     config.lastTokenId++;
     tokenId = config.lastTokenId;
@@ -167,18 +221,21 @@ contract OSwaps is Ownable, ReentrancyGuard {
       weight: 0
     });
 
-    tokenIds.push(tokenId);
+    tokenIdByAddress[tokenContract] = tokenId;
+    _tokenIdIndex[tokenId] = _tokenIds.length;
+    _tokenIds.push(tokenId);
 
-    // Create LIQ token
     string memory liqSymbol = string(
       abi.encodePacked('LIQ', _uint64ToString(tokenId))
     );
-    LiquidityToken liqToken = new LiquidityToken(
-      liqSymbol,
-      liqSymbol,
-      address(this)
+    liquidityTokens[tokenId] = address(
+      new LiquidityToken(
+        liqSymbol,
+        liqSymbol,
+        _readDecimals(tokenContract),
+        address(this)
+      )
     );
-    liquidityTokens[tokenId] = address(liqToken);
 
     emit AssetCreated(tokenId, tokenContract, symbol);
 
@@ -186,33 +243,58 @@ contract OSwaps is Ownable, ReentrancyGuard {
   }
 
   /**
-   * @dev Remove an asset from the pool
+   * @dev Remove an asset from the pool.
+   *
+   * Requires the pool balance to be zero. The original left stranded balances
+   * behind; because this contract has no owner-level rescue hatch, a non-empty
+   * asset must be drained through withdraw first or its balance would become
+   * permanently unreachable.
    */
-  function forgetAsset(uint64 tokenId) external onlyManager {
-    require(bytes(assets[tokenId].symbol).length > 0, 'Token not found');
+  function forgetAsset(
+    uint64 tokenId
+  ) external onlyManager assetExists(tokenId) {
+    address tokenContract = assets[tokenId].contractAddress;
+    require(
+      IERC20(tokenContract).balanceOf(address(this)) == 0,
+      'Pool balance not zero'
+    );
+
+    uint256 index = _tokenIdIndex[tokenId];
+    uint256 lastIndex = _tokenIds.length - 1;
+    if (index != lastIndex) {
+      uint64 movedId = _tokenIds[lastIndex];
+      _tokenIds[index] = movedId;
+      _tokenIdIndex[movedId] = index;
+    }
+    _tokenIds.pop();
+
+    delete _tokenIdIndex[tokenId];
+    delete tokenIdByAddress[tokenContract];
+    delete liquidityTokens[tokenId];
     delete assets[tokenId];
+
+    emit AssetForgotten(tokenId, tokenContract);
   }
 
   // ============ Query Functions ============
 
   /**
-   * @dev Query pool status for given token IDs
+   * @dev Pool balances and weights for the given token ids. Reverts if any id in
+   * the list is unregistered.
    */
   function queryPool(
     uint64[] calldata tokenIdList
   ) external view returns (PoolStatus[] memory) {
     PoolStatus[] memory statuses = new PoolStatus[](tokenIdList.length);
 
-    for (uint i = 0; i < tokenIdList.length; i++) {
+    for (uint256 i = 0; i < tokenIdList.length; i++) {
       uint64 tokenId = tokenIdList[i];
-      require(bytes(assets[tokenId].symbol).length > 0, 'Token not found');
-
       address tokenContract = assets[tokenId].contractAddress;
-      uint256 balance = IERC20(tokenContract).balanceOf(address(this));
+      require(tokenContract != address(0), 'Token not found');
 
       statuses[i] = PoolStatus({
         tokenId: tokenId,
-        balance: balance,
+        balance: IERC20(tokenContract).balanceOf(address(this)),
         weight: assets[tokenId].weight
       });
     }
@@ -220,44 +302,118 @@ contract OSwaps is Ownable, ReentrancyGuard {
     return statuses;
   }
 
+  /**
+   * @dev All registered token ids. Forgotten ids are pruned, so this is the
+   * authoritative enumeration.
+   */
+  function getTokenIds() external view returns (uint64[] memory) {
+    return _tokenIds;
+  }
+
+  function getAssetCount() external view returns (uint256) {
+    return _tokenIds.length;
+  }
+
+  /**
+   * @dev The full asset record as a struct. The auto-generated `assets` getter
+   * returns flat values, which is not ABI-compatible with a struct return.
+   */
+  function getAsset(uint64 tokenId) external view returns (AssetInfo memory) {
+    return assets[tokenId];
+  }
+
+  /**
+   * @dev Output amount for a given input, without executing the swap.
+   */
+  function quoteExactIn(
+    uint64 inTokenId,
+    uint64 outTokenId,
+    uint256 inAmount
+  ) external view returns (uint256 outAmount) {
+    (uint256 inBalBefore, uint256 outBalBefore) = _requireSwappable(
+      inTokenId,
+      outTokenId,
+      inAmount
+    );
+    outAmount = _computeBalancerOut(
+      inBalBefore,
+      inBalBefore + inAmount,
+      outBalBefore,
+      assets[inTokenId].weight,
+      assets[outTokenId].weight
+    );
+    require(outAmount > 0 && outAmount < outBalBefore, 'Invalid output amount');
+  }
+
+  /**
+   * @dev Input amount required for a given output, without executing the swap.
+   */
+  function quoteExactOut(
+    uint64 inTokenId,
+    uint64 outTokenId,
+    uint256 outAmount
+  ) external view returns (uint256 inAmount) {
+    (uint256 inBalBefore, uint256 outBalBefore) = _requireSwappable(
+      inTokenId,
+      outTokenId,
+      outAmount
+    );
+    require(outBalBefore > outAmount, 'Insufficient output balance');
+    inAmount = _computeBalancerIn(
+      inBalBefore,
+      outBalBefore,
+      outBalBefore - outAmount,
+      assets[inTokenId].weight,
+      assets[outTokenId].weight
+    );
+    require(inAmount > 0, 'Invalid input amount');
+  }
+
   // ============ Liquidity Functions ============
 
   /**
-   * @dev Add liquidity to pool
-   * @param tokenId Token ID to add
-   * @param amount Amount to add
-   * @param weight New weight (0 to maintain price)
+   * @dev Add liquidity to the pool.
+   * @param weight New balancer weight, or 0 to recompute a weight that leaves
+   * the price unchanged. A non-zero weight changes the price and therefore
+   * freezes the asset until a manager unfreezes it.
+   *
+   * Passing amount = 0 with a non-zero weight reprices the asset without a
+   * deposit, and is permitted while the asset is frozen.
    */
   function addLiquidity(
     uint64 tokenId,
     uint256 amount,
     uint256 weight
-  ) external nonReentrant {
-    require(bytes(assets[tokenId].symbol).length > 0, 'Token not found');
+  ) external nonReentrant assetExists(tokenId) {
     require(assets[tokenId].active || amount == 0, 'Token is frozen');
 
     address tokenContract = assets[tokenId].contractAddress;
     uint256 balBefore = IERC20(tokenContract).balanceOf(address(this));
 
-    // Transfer tokens to pool
-    require(
-      IERC20(tokenContract).transferFrom(msg.sender, address(this), amount),
-      'Transfer failed'
-    );
+    if (amount > 0) {
+      IERC20(tokenContract).safeTransferFrom(msg.sender, address(this), amount);
+      // Balance-based accounting cannot price fee-on-transfer or rebasing
+      // tokens, so reject them rather than misprice the pool.
+      require(
+        IERC20(tokenContract).balanceOf(address(this)) == balBefore + amount,
+        'Unexpected balance change'
+      );
+    }
 
-    // Calculate new weight
+    uint256 previousWeight = assets[tokenId].weight;
     uint256 newWeight = weight;
-    if (weight == 0 && balBefore > 0) {
-      // Maintain price: w_new = w_old * (1 + amount/balance)
-      newWeight = (assets[tokenId].weight * (balBefore + amount)) / balBefore;
+    if (weight == 0) {
+      require(balBefore > 0, 'Zero weight requires existing balance');
+      // Maintain price: w_new = w_old * (balance + amount) / balance
+      newWeight = Math.mulDiv(previousWeight, balBefore + amount, balBefore);
     }
 
     assets[tokenId].weight = newWeight;
     if (weight != 0) {
-      assets[tokenId].active = false; // Freeze if price changed
+      assets[tokenId].active = false;
     }
+    emit WeightUpdated(tokenId, previousWeight, newWeight, weight != 0);
 
-    // Mint LIQ tokens
     if (amount > 0) {
       LiquidityToken(liquidityTokens[tokenId]).mint(msg.sender, amount);
       emit LiquidityAdded(msg.sender, tokenId, amount, amount);
@@ -265,41 +421,47 @@ contract OSwaps is Ownable, ReentrancyGuard {
   }
 
   /**
-   * @dev Withdraw liquidity from pool
-   * @param account Account to receive tokens
-   * @param tokenId Token ID to withdraw
-   * @param amount Amount to withdraw
-   * @param weight New weight (0 to maintain price)
+   * @dev Withdraw liquidity from the pool. Manager-only, matching the original
+   * protocol: liquidity providers cannot exit on their own initiative.
+   * @param weight New balancer weight, or 0 to hold the price.
    */
   function withdraw(
     address account,
     uint64 tokenId,
     uint256 amount,
     uint256 weight
-  ) external onlyManager nonReentrant {
-    require(bytes(assets[tokenId].symbol).length > 0, 'Token not found');
+  ) external onlyManager nonReentrant assetExists(tokenId) {
+    require(amount > 0, 'Zero amount');
 
     address tokenContract = assets[tokenId].contractAddress;
     uint256 balBefore = IERC20(tokenContract).balanceOf(address(this));
-    require(balBefore > amount, 'Insufficient balance');
+    if (assets[tokenId].active) {
+      // A tradeable asset must keep a non-zero balance or its price is
+      // undefined. The original enforced this unconditionally.
+      require(balBefore > amount, 'Insufficient balance');
+    } else {
+      // A frozen asset cannot be traded, so it may be drained completely. This
+      // is what makes forgetAsset reachable: freeze, drain, forget. Without it,
+      // a funded asset could never be retired and would need an owner-level
+      // rescue hatch, which the original design deliberately withheld.
+      require(balBefore >= amount, 'Insufficient balance');
+    }
 
-    // Calculate new weight
+    uint256 previousWeight = assets[tokenId].weight;
     uint256 newWeight = weight;
     if (weight == 0) {
-      // Maintain price: w_new = w_old * (1 - amount/balance)
-      newWeight = (assets[tokenId].weight * (balBefore - amount)) / balBefore;
+      // Maintain price: w_new = w_old * (balance - amount) / balance
+      newWeight = Math.mulDiv(previousWeight, balBefore - amount, balBefore);
     }
 
     assets[tokenId].weight = newWeight;
     if (weight != 0) {
-      assets[tokenId].active = false; // Freeze if price changed
+      assets[tokenId].active = false;
     }
+    emit WeightUpdated(tokenId, previousWeight, newWeight, weight != 0);
 
-    // Burn LIQ tokens from account
     LiquidityToken(liquidityTokens[tokenId]).burnFrom(account, amount);
-
-    // Transfer tokens out
-    require(IERC20(tokenContract).transfer(account, amount), 'Transfer failed');
+    IERC20(tokenContract).safeTransfer(account, amount);
 
     emit LiquidityWithdrawn(account, tokenId, amount, amount);
   }
@@ -307,59 +469,44 @@ contract OSwaps is Ownable, ReentrancyGuard {
   // ============ Swap Functions ============
 
   /**
-   * @dev Swap tokens with exact input amount
-   * @param recipient Recipient of output tokens
-   * @param inTokenId Input token ID
-   * @param outTokenId Output token ID
-   * @param inAmount Exact input amount
-   * @return outAmount Computed output amount
+   * @dev Swap an exact input amount for a computed output.
+   * @param minOutAmount Slippage floor. The original protocol had no equivalent;
+   * it is required here because EVM transactions are visible in a public mempool
+   * before execution.
    */
   function swapExactIn(
     address recipient,
     uint64 inTokenId,
     uint64 outTokenId,
-    uint256 inAmount
+    uint256 inAmount,
+    uint256 minOutAmount
   ) external nonReentrant returns (uint256 outAmount) {
-    require(
-      bytes(assets[inTokenId].symbol).length > 0,
-      'Input token not found'
-    );
-    require(
-      bytes(assets[outTokenId].symbol).length > 0,
-      'Output token not found'
-    );
-    require(assets[inTokenId].active, 'Input token frozen');
-    require(assets[outTokenId].active, 'Output token frozen');
-
-    address inContract = assets[inTokenId].contractAddress;
-    address outContract = assets[outTokenId].contractAddress;
-
-    uint256 inBalBefore = IERC20(inContract).balanceOf(address(this));
-    uint256 outBalBefore = IERC20(outContract).balanceOf(address(this));
-    require(inBalBefore > 0, 'Zero input balance');
-
-    // Transfer input tokens
-    require(
-      IERC20(inContract).transferFrom(msg.sender, address(this), inAmount),
-      'Transfer failed'
+    require(recipient != address(0), 'Zero recipient');
+    (uint256 inBalBefore, uint256 outBalBefore) = _requireSwappable(
+      inTokenId,
+      outTokenId,
+      inAmount
     );
 
-    // Balancer formula: out_bal_after = out_bal_before * (in_bal_after/in_bal_before)^(-w_in/w_out)
-    uint256 inBalAfter = inBalBefore + inAmount;
     outAmount = _computeBalancerOut(
       inBalBefore,
-      inBalAfter,
+      inBalBefore + inAmount,
       outBalBefore,
       assets[inTokenId].weight,
       assets[outTokenId].weight
     );
-
     require(outAmount > 0 && outAmount < outBalBefore, 'Invalid output amount');
+    require(outAmount >= minOutAmount, 'Insufficient output amount');
 
-    // Transfer output tokens
+    address inContract = assets[inTokenId].contractAddress;
+    IERC20(inContract).safeTransferFrom(msg.sender, address(this), inAmount);
     require(
-      IERC20(outContract).transfer(recipient, outAmount),
-      'Transfer failed'
+      IERC20(inContract).balanceOf(address(this)) == inBalBefore + inAmount,
+      'Unexpected balance change'
+    );
+    IERC20(assets[outTokenId].contractAddress).safeTransfer(
+      recipient,
+      outAmount
     );
 
     emit TokenSwapped(
@@ -370,18 +517,13 @@ contract OSwaps is Ownable, ReentrancyGuard {
       inAmount,
       outAmount
     );
-
-    return outAmount;
   }
 
   /**
-   * @dev Swap tokens with exact output amount
-   * @param recipient Recipient of output tokens
-   * @param inTokenId Input token ID
-   * @param outTokenId Output token ID
-   * @param outAmount Exact output amount
-   * @param maxInAmount Maximum input amount willing to pay
-   * @return inAmount Computed input amount
+   * @dev Swap a computed input amount for an exact output.
+   * @param maxInAmount Cap on the input actually pulled. The original required
+   * the sender to overpay and refunded the surplus; pulling the exact amount
+   * makes the refund unnecessary.
    */
   function swapExactOut(
     address recipient,
@@ -390,47 +532,33 @@ contract OSwaps is Ownable, ReentrancyGuard {
     uint256 outAmount,
     uint256 maxInAmount
   ) external nonReentrant returns (uint256 inAmount) {
-    require(
-      bytes(assets[inTokenId].symbol).length > 0,
-      'Input token not found'
+    require(recipient != address(0), 'Zero recipient');
+    (uint256 inBalBefore, uint256 outBalBefore) = _requireSwappable(
+      inTokenId,
+      outTokenId,
+      outAmount
     );
-    require(
-      bytes(assets[outTokenId].symbol).length > 0,
-      'Output token not found'
-    );
-    require(assets[inTokenId].active, 'Input token frozen');
-    require(assets[outTokenId].active, 'Output token frozen');
-
-    address inContract = assets[inTokenId].contractAddress;
-    address outContract = assets[outTokenId].contractAddress;
-
-    uint256 inBalBefore = IERC20(inContract).balanceOf(address(this));
-    uint256 outBalBefore = IERC20(outContract).balanceOf(address(this));
-    require(inBalBefore > 0, 'Zero input balance');
     require(outBalBefore > outAmount, 'Insufficient output balance');
 
-    // Balancer formula: in_bal_after = in_bal_before * (out_bal_after/out_bal_before)^(-w_out/w_in)
-    uint256 outBalAfter = outBalBefore - outAmount;
     inAmount = _computeBalancerIn(
       inBalBefore,
       outBalBefore,
-      outBalAfter,
+      outBalBefore - outAmount,
       assets[inTokenId].weight,
       assets[outTokenId].weight
     );
-
+    require(inAmount > 0, 'Invalid input amount');
     require(inAmount <= maxInAmount, 'Excessive input amount');
 
-    // Transfer input tokens
+    address inContract = assets[inTokenId].contractAddress;
+    IERC20(inContract).safeTransferFrom(msg.sender, address(this), inAmount);
     require(
-      IERC20(inContract).transferFrom(msg.sender, address(this), inAmount),
-      'Transfer failed'
+      IERC20(inContract).balanceOf(address(this)) == inBalBefore + inAmount,
+      'Unexpected balance change'
     );
-
-    // Transfer output tokens
-    require(
-      IERC20(outContract).transfer(recipient, outAmount),
-      'Transfer failed'
+    IERC20(assets[outTokenId].contractAddress).safeTransfer(
+      recipient,
+      outAmount
     );
 
     emit TokenSwapped(
@@ -441,15 +569,47 @@ contract OSwaps is Ownable, ReentrancyGuard {
       inAmount,
       outAmount
     );
-
-    return inAmount;
   }
 
   // ============ Internal Helpers ============
 
   /**
-   * @dev Compute output amount using Balancer formula
-   * Uses natural logarithm approximation for gas efficiency
+   * @dev Shared validation for both swap directions and both quote views.
+   * @return inBalBefore Pool balance of the input token
+   * @return outBalBefore Pool balance of the output token
+   */
+  function _requireSwappable(
+    uint64 inTokenId,
+    uint64 outTokenId,
+    uint256 amount
+  ) internal view returns (uint256 inBalBefore, uint256 outBalBefore) {
+    require(inTokenId != outTokenId, 'Same token');
+    require(amount > 0, 'Zero amount');
+
+    AssetInfo storage assetIn = assets[inTokenId];
+    AssetInfo storage assetOut = assets[outTokenId];
+    require(assetIn.contractAddress != address(0), 'Input token not found');
+    require(assetOut.contractAddress != address(0), 'Output token not found');
+    require(assetIn.active, 'Input token frozen');
+    require(assetOut.active, 'Output token frozen');
+    require(assetIn.weight > 0, 'Input weight not set');
+    require(assetOut.weight > 0, 'Output weight not set');
+
+    inBalBefore = IERC20(assetIn.contractAddress).balanceOf(address(this));
+    outBalBefore = IERC20(assetOut.contractAddress).balanceOf(address(this));
+    require(inBalBefore > 0, 'Zero input balance');
+    require(outBalBefore > 0, 'Zero output balance');
+  }
+
+  /**
+   * @dev Output amount from the Balancer invariant.
+   *
+   *   outBalAfter = outBalBefore * (inBalAfter / inBalBefore) ^ (-wIn / wOut)
+   *               = outBalBefore / (inBalAfter / inBalBefore) ^ (wIn / wOut)
+   *
+   * Expressed as a division by a base-greater-than-one power so every operand
+   * stays positive. The original used C `log()` and `exp()` on doubles; this uses
+   * PRBMath's fixed-point `pow`, which is accurate across the whole domain.
    */
   function _computeBalancerOut(
     uint256 inBalBefore,
@@ -458,21 +618,22 @@ contract OSwaps is Ownable, ReentrancyGuard {
     uint256 wIn,
     uint256 wOut
   ) internal pure returns (uint256) {
-    // out_bal_after = out_bal_before * (in_bal_after/in_bal_before)^(-w_in/w_out)
-    // Simplified: out_bal_after = out_bal_before * exp(-(w_in/w_out) * ln(in_bal_after/in_bal_before))
+    UD60x18 ratio = ud(inBalAfter).div(ud(inBalBefore));
+    UD60x18 factor = ratio.pow(ud(wIn).div(ud(wOut)));
 
-    // Calculate ratio with precision
-    uint256 ratio = (inBalAfter * 1e18) / inBalBefore;
-    int256 lnRatio = _ln(int256(ratio));
-    int256 exponent = -(int256(wIn) * lnRatio) / int256(wOut);
-    uint256 expResult = uint256(_exp(exponent));
-
-    uint256 outBalAfter = (outBalBefore * expResult) / 1e18;
+    uint256 outBalAfter = ud(outBalBefore).div(factor).unwrap();
+    // Keep truncation dust in the pool rather than handing it to the trader.
+    if (outBalAfter < outBalBefore) {
+      outBalAfter += 1;
+    }
     return outBalBefore - outBalAfter;
   }
 
   /**
-   * @dev Compute input amount using Balancer formula
+   * @dev Input amount from the Balancer invariant.
+   *
+   *   inBalAfter = inBalBefore * (outBalAfter / outBalBefore) ^ (-wOut / wIn)
+   *              = inBalBefore * (outBalBefore / outBalAfter) ^ (wOut / wIn)
    */
   function _computeBalancerIn(
     uint256 inBalBefore,
@@ -481,67 +642,37 @@ contract OSwaps is Ownable, ReentrancyGuard {
     uint256 wIn,
     uint256 wOut
   ) internal pure returns (uint256) {
-    // in_bal_after = in_bal_before * (out_bal_after/out_bal_before)^(-w_out/w_in)
+    UD60x18 invRatio = ud(outBalBefore).div(ud(outBalAfter));
+    UD60x18 factor = invRatio.pow(ud(wOut).div(ud(wIn)));
 
-    uint256 ratio = (outBalAfter * 1e18) / outBalBefore;
-    int256 lnRatio = _ln(int256(ratio));
-    int256 exponent = -(int256(wOut) * lnRatio) / int256(wIn);
-    uint256 expResult = uint256(_exp(exponent));
-
-    uint256 inBalAfter = (inBalBefore * expResult) / 1e18;
-    return inBalAfter - inBalBefore;
+    uint256 inBalAfter = ud(inBalBefore).mul(factor).unwrap();
+    // Charge the trader the truncation dust rather than the pool, and never
+    // quote a free swap when the computed delta truncates to nothing.
+    if (inBalAfter <= inBalBefore) {
+      return 1;
+    }
+    return inBalAfter - inBalBefore + 1;
   }
 
   /**
-   * @dev Natural logarithm approximation (ln)
-   * Input: x in fixed point (1e18 = 1.0)
-   * Output: ln(x) in fixed point
+   * @dev The token's own precision, so the LIQ receipt reads in the same units
+   * as the deposit. Defaults to 18 for tokens that do not answer.
+   *
+   * Uses a raw staticcall rather than try/catch because `createAsset` accepts an
+   * arbitrary address: a call that succeeds but returns undecodable data makes
+   * try/catch revert in a way the catch clause cannot absorb.
    */
-  function _ln(int256 x) internal pure returns (int256) {
-    require(x > 0, 'ln: x must be positive');
-
-    // Taylor series approximation around x=1
-    // ln(x) ≈ (x-1) - (x-1)^2/2 + (x-1)^3/3 - ...
-    int256 one = 1e18;
-    int256 diff = x - one;
-
-    if (diff == 0) return 0;
-
-    // For better accuracy, use: ln(x) = ln(x/1) when x close to 1
-    int256 result = diff;
-    int256 term = diff;
-
-    for (uint i = 2; i <= 10; i++) {
-      term = (term * diff) / one;
-      if (i % 2 == 0) {
-        result -= term / int256(i);
-      } else {
-        result += term / int256(i);
+  function _readDecimals(address token) private view returns (uint8) {
+    (bool ok, bytes memory data) = token.staticcall(
+      abi.encodeWithSelector(IERC20Metadata.decimals.selector)
+    );
+    if (ok && data.length >= 32) {
+      uint256 value = abi.decode(data, (uint256));
+      if (value <= 36) {
+        return uint8(value);
       }
     }
-
-    return result;
-  }
-
-  /**
-   * @dev Exponential function approximation (e^x)
-   * Input: x in fixed point (1e18 = 1.0)
-   * Output: e^x in fixed point
-   */
-  function _exp(int256 x) internal pure returns (int256) {
-    int256 one = 1e18;
-
-    // Taylor series: e^x = 1 + x + x^2/2! + x^3/3! + ...
-    int256 result = one;
-    int256 term = one;
-
-    for (uint i = 1; i <= 20; i++) {
-      term = (term * x) / (int256(i) * one);
-      result += term;
-      if (term == 0) break;
-    }
-
-    return result;
+    return 18;
   }
 
   function _uint64ToString(uint64 value) internal pure returns (string memory) {
@@ -563,30 +694,55 @@ contract OSwaps is Ownable, ReentrancyGuard {
 
     return string(buffer);
   }
-
-  // ============ Emergency ============
-
-  function emergencyWithdraw(address token, uint256 amount) external onlyOwner {
-    require(IERC20(token).transfer(owner(), amount), 'Transfer failed');
-  }
 }
 
 /**
  * @title LiquidityToken
- * @dev ERC20 token representing liquidity pool shares
+ * @dev ERC-20 receipt for liquidity supplied to an OSwaps pool.
+ *
+ * Minted 1:1 against the raw amount deposited and burned 1:1 against the raw
+ * amount withdrawn, so it is a nominal claim on units supplied rather than a
+ * proportional share of the pool.
+ *
+ * Peer-to-peer transfers are blocked: every transfer must involve the pool.
+ * This mirrors the original contract, which restricted LIQ transfers to
+ * "to/from contract" so receipts could not be traded between accounts.
  */
 contract LiquidityToken is ERC20, Ownable {
+  uint8 private immutable _tokenDecimals;
+
   constructor(
     string memory name,
     string memory symbol,
-    address owner
-  ) ERC20(name, symbol) Ownable(owner) {}
+    uint8 tokenDecimals_,
+    address pool
+  ) ERC20(name, symbol) Ownable(pool) {
+    _tokenDecimals = tokenDecimals_;
+  }
+
+  function decimals() public view override returns (uint8) {
+    return _tokenDecimals;
+  }
 
   function mint(address to, uint256 amount) external onlyOwner {
     _mint(to, amount);
   }
 
+  /**
+   * @dev Burn without an allowance. The pool owns this token and burns receipts
+   * as part of `withdraw`; the original reached the same outcome by having the
+   * contract authorise the LIQ transfer itself.
+   */
   function burnFrom(address from, uint256 amount) external onlyOwner {
     _burn(from, amount);
+  }
+
+  function _update(address from, address to, uint256 value) internal override {
+    // Allow mint (from == 0) and burn (to == 0); block account-to-account moves.
+    if (from != address(0) && to != address(0)) {
+      address pool = owner();
+      require(from == pool || to == pool, 'LIQ: transfers must involve pool');
+    }
+    super._update(from, to, value);
   }
 }

--- a/packages/storage-evm/contracts/seedsexample/README.md
+++ b/packages/storage-evm/contracts/seedsexample/README.md
@@ -2,6 +2,19 @@
 
 This folder contains Solidity (EVM) implementations of the Seeds/Rainbows token ecosystem, originally written in C++ for EOSIO/Antelope blockchains.
 
+> **Reference code — not deployed.** None of these contracts have deployment addresses in
+> `contracts/addresses.txt`, deploy scripts, or tests, and they are excluded from `wagmi.config.ts`,
+> so they generate no bindings in `packages/core/src/generated.ts`.
+
+## Further documentation on OSwaps
+
+- **[`OSwaps.docs.md`](./OSwaps.docs.md)** — complete contract reference: full external surface,
+  role model, bootstrap sequence, pricing math with a bit-exact TypeScript port for off-chain
+  quoting, revert catalogue, and known defects. Written for implementing a UI against the contract.
+- **[`OSwaps.EOSIO-PARITY.md`](./OSwaps.EOSIO-PARITY.md)** — how faithfully the Solidity port
+  reproduces the original Antelope/EOSIO protocol, action by action, including where it diverges and
+  why.
+
 ## Contracts
 
 ### 1. OSwaps.sol
@@ -198,27 +211,30 @@ token.retire(amount, true);
 
 ## Testing
 
-Recommended test scenarios:
+**No tests exist for any contract in this folder.** The following are recommended scenarios still to
+be written, not a record of coverage. Note in particular that the accuracy of the Balancer formula
+has never been exercised on-chain — see [`OSwaps.EOSIO-PARITY.md`](./OSwaps.EOSIO-PARITY.md) §6 for
+measured error bounds.
 
 ### OSwaps
 
-- ✓ Create assets and add liquidity
-- ✓ Single-sided liquidity additions
-- ✓ Swaps with exact input/output
-- ✓ Weight adjustments
-- ✓ Freeze/unfreeze functionality
-- ✓ Mathematical accuracy of Balancer formula
+- Create assets and add liquidity
+- Single-sided liquidity additions
+- Swaps with exact input/output
+- Weight adjustments
+- Freeze/unfreeze functionality
+- Mathematical accuracy of Balancer formula
 
 ### RainbowToken
 
-- ✓ Token creation and approval
-- ✓ Backing operations (add/remove)
-- ✓ Issue and retire with backing
-- ✓ Credit limits (negative balances)
-- ✓ Positive limits
-- ✓ Membership restrictions
-- ✓ Demurrage calculations
-- ✓ Valuation tracking
+- Token creation and approval
+- Backing operations (add/remove)
+- Issue and retire with backing
+- Credit limits (negative balances)
+- Positive limits
+- Membership restrictions
+- Demurrage calculations
+- Valuation tracking
 
 ## Original Contracts
 

--- a/packages/storage-evm/contracts/seedsexample/README.md
+++ b/packages/storage-evm/contracts/seedsexample/README.md
@@ -3,14 +3,16 @@
 This folder contains Solidity (EVM) implementations of the Seeds/Rainbows token ecosystem, originally written in C++ for EOSIO/Antelope blockchains.
 
 > **Reference code — not deployed.** None of these contracts have deployment addresses in
-> `contracts/addresses.txt`, deploy scripts, or tests, and they are excluded from `wagmi.config.ts`,
-> so they generate no bindings in `packages/core/src/generated.ts`.
+> `contracts/addresses.txt`, and they are excluded from `wagmi.config.ts`, so they generate no
+> bindings in `packages/core/src/generated.ts`. `OSwaps.sol` has a deploy script
+> (`scripts/oswaps.deploy.ts`) and a test suite (`test/OSwaps.test.ts`); the Rainbow contracts have
+> neither. Nothing here has been audited.
 
 ## Further documentation on OSwaps
 
 - **[`OSwaps.docs.md`](./OSwaps.docs.md)** — complete contract reference: full external surface,
-  role model, bootstrap sequence, pricing math with a bit-exact TypeScript port for off-chain
-  quoting, revert catalogue, and known defects. Written for implementing a UI against the contract.
+  role model, bootstrap sequence, pricing math with measured accuracy bounds, revert catalogue, and
+  the constraints a UI has to handle. Written for implementing a UI against the contract.
 - **[`OSwaps.EOSIO-PARITY.md`](./OSwaps.EOSIO-PARITY.md)** — how faithfully the Solidity port
   reproduces the original Antelope/EOSIO protocol, action by action, including where it diverges and
   why.
@@ -34,10 +36,17 @@ A decentralized token swap protocol implementing a multi-token liquidity pool us
 
 - `createAsset()` - Register a token in the pool
 - `addLiquidity()` - Add liquidity and receive LIQ tokens
-- `withdraw()` - Withdraw liquidity by burning LIQ tokens
-- `swapExactIn()` - Swap with known input amount
-- `swapExactOut()` - Swap with known output amount
+- `withdraw()` - Withdraw liquidity by burning LIQ tokens (manager only)
+- `swapExactIn()` - Swap with known input amount, with a `minOutAmount` slippage floor
+- `swapExactOut()` - Swap with known output amount, with a `maxInAmount` cap
+- `quoteExactIn()` / `quoteExactOut()` - Price a swap without executing it
 - `queryPool()` - Get pool status for tokens
+- `getTokenIds()` / `getAsset()` - Enumerate and read registered assets
+- `setManager()` - Hand the manager role to a replacement (manager only)
+
+See [`OSwaps.docs.md`](./OSwaps.docs.md) for the full surface. Note the bootstrap sequence: a new
+asset needs `createAsset` → `unfreeze` → `addLiquidity` with a non-zero weight → `unfreeze` again
+before it can be swapped.
 
 ### 2. RainbowToken.sol
 
@@ -104,8 +113,10 @@ Factory contract for deploying new RainbowToken instances.
 
 - Removed chain ID validation (EVM is single-chain)
 - Simplified transaction validation (no "prep + transfer" pattern)
-- Direct token transfers using ERC20 standard
-- Natural logarithm approximation for gas efficiency
+- Direct token transfers using the ERC20 standard, via `SafeERC20`
+- Fixed-point `pow` in place of the original's `log()`/`exp()` on doubles
+- Slippage protection and reentrancy guards, which a public mempool makes necessary
+- Fee-on-transfer and rebasing tokens rejected rather than mispriced
 
 #### RainbowToken
 
@@ -117,21 +128,20 @@ Factory contract for deploying new RainbowToken instances.
 
 ### Mathematical Implementations
 
-Both contracts use approximations for mathematical operations:
-
-**Natural Logarithm (ln)**
-
-```solidity
-// Taylor series: ln(x) ≈ (x-1) - (x-1)²/2 + (x-1)³/3 - ...
-```
-
-**Exponential (e^x)**
+The Balancer invariant needs a fractional power, which the original computed as
+`exp(y * log(x))` using the C standard library on IEEE doubles. OSwaps evaluates the same expression
+with [PRBMath](https://github.com/PaulRBerg/prb-math)'s `UD60x18.pow` in 18-decimal fixed point:
 
 ```solidity
-// Taylor series: e^x = 1 + x + x²/2! + x³/3! + ...
+UD60x18 ratio  = ud(inBalAfter).div(ud(inBalBefore));
+UD60x18 factor = ratio.pow(ud(wIn).div(ud(wOut)));
 ```
 
-These provide reasonable accuracy for typical swap amounts while remaining gas-efficient.
+Each formula is rearranged so the base always exceeds one and the exponent is always positive, which
+keeps every intermediate value unsigned. Measured relative error is below 1e-10 across trade sizes
+from a millionth of the pool balance up to a hundred times it, and truncation is biased so leftover
+wei stay in the pool. See [`OSwaps.docs.md`](./OSwaps.docs.md) §6 for the measured bounds and the
+one domain limit that remains (extreme weight ratios cap the trade size).
 
 ## Usage Examples
 
@@ -148,15 +158,18 @@ uint64 token1Id = oswaps.createAsset(
 // 2. Approve tokens
 token1.approve(address(oswaps), amount);
 
-// 3. Add liquidity
+// 3. Add liquidity — the asset must be unfrozen first, and the initial
+//    weight must be non-zero, which freezes it again pending manager review
 oswaps.addLiquidity(token1Id, amount, initialWeight);
 
-// 4. Perform swap
+// 4. Quote, then swap with a slippage floor derived from the quote
+uint256 expected = oswaps.quoteExactIn(inputTokenId, outputTokenId, inputAmount);
 oswaps.swapExactIn(
     recipient,
     inputTokenId,
     outputTokenId,
-    inputAmount
+    inputAmount,
+    (expected * 995) / 1000 // 0.5% tolerance
 );
 ```
 
@@ -207,23 +220,29 @@ token.retire(amount, true);
 2. **Access Control**: Role-based access using modifiers
 3. **Integer Overflow**: Solidity 0.8+ has built-in overflow protection
 4. **Backing Escrow**: Escrow accounts must approve the token contract for redemption
-5. **Mathematical Precision**: Taylor series approximations have limited precision for extreme values
+5. **Mathematical Precision**: OSwaps delegates its fractional powers to PRBMath; residual error is
+   below 1e-10 relative and has no guaranteed sign, so per-swap invariant drift is bounded rather
+   than eliminated (measured below 1e-12 of pool value)
+6. **Single point of control**: every OSwaps operational power sits with one `manager` address, and
+   liquidity providers cannot exit without it. Deploy the manager as a multisig or space `Executor`,
+   never an EOA
+7. **Unaudited**: none of these contracts has had a third-party review
 
 ## Testing
 
-**No tests exist for any contract in this folder.** The following are recommended scenarios still to
-be written, not a record of coverage. Note in particular that the accuracy of the Balancer formula
-has never been exercised on-chain — see [`OSwaps.EOSIO-PARITY.md`](./OSwaps.EOSIO-PARITY.md) §6 for
-measured error bounds.
+`test/OSwaps.test.ts` covers OSwaps with 85 cases: the full external surface and access-control
+matrix, the bootstrap and retirement sequences, weight rescaling, LIQ receipt behaviour, reentrancy
+and misbehaving-token handling, and a pricing-math section that checks accuracy against a
+double-precision reference, invariant preservation, exact-in/exact-out duality, and the domain limit.
 
-### OSwaps
+Run it with:
 
-- Create assets and add liquidity
-- Single-sided liquidity additions
-- Swaps with exact input/output
-- Weight adjustments
-- Freeze/unfreeze functionality
-- Mathematical accuracy of Balancer formula
+```bash
+cd packages/storage-evm && npx hardhat test test/OSwaps.test.ts
+```
+
+**No tests exist for the Rainbow contracts.** The following are recommended scenarios still to be
+written, not a record of coverage.
 
 ### RainbowToken
 

--- a/packages/storage-evm/package.json
+++ b/packages/storage-evm/package.json
@@ -15,6 +15,7 @@
   "devDependencies": {
     "@hypha-platform/config-eslint": "workspace:*",
     "@hypha-platform/config-typescript": "workspace:*",
+    "@prb/math": "^4.1.2",
     "@wagmi/cli": "^2.2.0",
     "hardhat": "^2.22.17",
     "hardhat-contract-sizer": "^2.10.1"

--- a/packages/storage-evm/scripts/oswaps.deploy.ts
+++ b/packages/storage-evm/scripts/oswaps.deploy.ts
@@ -1,0 +1,56 @@
+import { ethers } from 'hardhat';
+
+/**
+ * Deploys the OSwaps pool and hands operational control to a manager.
+ *
+ * OSwaps is not upgradeable, so this is a plain deployment. The deployer becomes
+ * `owner`, whose only power is the one-time `init` call below; every operational
+ * action (freeze/unfreeze, withdraw, forgetAsset, manager rotation) belongs to
+ * the manager thereafter.
+ *
+ * Set OSWAPS_MANAGER to the address that should hold that role. It defaults to
+ * the deployer, which is fine for a local run but not for a real network.
+ *
+ * Usage:
+ *   OSWAPS_MANAGER=0x... pnpm --filter @hypha-platform/storage-evm run script \
+ *     scripts/oswaps.deploy.ts --network base-mainnet
+ */
+async function main(): Promise<void> {
+  const [deployer] = await ethers.getSigners();
+  const deployerAddress = await deployer.getAddress();
+  const manager = process.env.OSWAPS_MANAGER || deployerAddress;
+
+  if (!ethers.isAddress(manager)) {
+    throw new Error(`OSWAPS_MANAGER is not a valid address: ${manager}`);
+  }
+  if (manager === deployerAddress) {
+    console.warn(
+      'OSWAPS_MANAGER is unset — defaulting the manager to the deployer.',
+    );
+  }
+
+  console.log('Deploying OSwaps with deployer:', deployerAddress);
+
+  const OSwaps = await ethers.getContractFactory('OSwaps');
+  const oswaps = await OSwaps.deploy();
+  await oswaps.waitForDeployment();
+  const address = await oswaps.getAddress();
+  console.log('OSwaps deployed to:', address);
+
+  const tx = await oswaps.init(manager);
+  await tx.wait();
+  console.log('Manager set to:', manager);
+
+  console.log(
+    '\nNext: register each token with createAsset, then unfreeze it, then make ' +
+      'the first deposit with a non-zero weight, then unfreeze it again. ' +
+      'See OSwaps.docs.md for the bootstrap sequence.',
+  );
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error: Error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/packages/storage-evm/test/OSwaps.test.ts
+++ b/packages/storage-evm/test/OSwaps.test.ts
@@ -1,0 +1,1767 @@
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
+import { loadFixture } from '@nomicfoundation/hardhat-toolbox/network-helpers';
+import type { HardhatEthersSigner } from '@nomicfoundation/hardhat-ethers/signers';
+
+/*//////////////////////////////////////////////////////////////////////////
+                          REFERENCE MATH (ORACLE)
+//////////////////////////////////////////////////////////////////////////*/
+
+const SCALE = 10n ** 18n;
+const W = SCALE; // convenient unit weight
+
+/** a / b as a double, carrying ~18 fractional digits through BigInt first. */
+function ratio(a: bigint, b: bigint): number {
+  return Number((a * SCALE) / b) / 1e18;
+}
+
+/** Scale a positive double into 18-decimal fixed point. */
+function fp(x: number): bigint {
+  return BigInt(Math.round(x * 1e18));
+}
+
+/**
+ * Exact Balancer output, computed in double precision:
+ *   outAmount = outBal - outBal * (inBalAfter/inBal)^(-wIn/wOut)
+ */
+function refExactIn(
+  inBal: bigint,
+  inAmount: bigint,
+  outBal: bigint,
+  wIn: bigint,
+  wOut: bigint,
+): bigint {
+  const factor = Math.pow(ratio(inBal + inAmount, inBal), ratio(wIn, wOut));
+  const outBalAfter = (outBal * fp(1 / factor)) / SCALE;
+  return outBal - outBalAfter;
+}
+
+/**
+ * Exact Balancer input, computed in double precision:
+ *   inAmount = inBal * (outBal/outBalAfter)^(wOut/wIn) - inBal
+ */
+function refExactOut(
+  inBal: bigint,
+  outBal: bigint,
+  outAmount: bigint,
+  wIn: bigint,
+  wOut: bigint,
+): bigint {
+  const factor = Math.pow(ratio(outBal, outBal - outAmount), ratio(wOut, wIn));
+  const inBalAfter = (inBal * fp(factor)) / SCALE;
+  return inBalAfter - inBal;
+}
+
+/** Relative error between two amounts, as a plain fraction. */
+function relErr(actual: bigint, expected: bigint): number {
+  if (expected === 0n) return actual === 0n ? 0 : Infinity;
+  const diff = actual > expected ? actual - expected : expected - actual;
+  return Number((diff * SCALE) / expected) / 1e18;
+}
+
+/**
+ * ln(V) for a two-asset pool, with weights normalised so the value is
+ * comparable across trades. V = Ba^Wa * Bb^Wb is the quantity the invariant is
+ * meant to hold constant, so it must never fall.
+ */
+function lnInvariant(ba: bigint, wa: bigint, bb: bigint, wb: bigint): number {
+  const total = Number(wa + wb);
+  return (
+    (Number(wa) / total) * Math.log(Number(ba)) +
+    (Number(wb) / total) * Math.log(Number(bb))
+  );
+}
+
+/** Marginal (spot) price of `out` denominated in `in`. */
+function spotPrice(
+  inBal: bigint,
+  wIn: bigint,
+  outBal: bigint,
+  wOut: bigint,
+): number {
+  return ratio(inBal, wIn) / ratio(outBal, wOut);
+}
+
+/*//////////////////////////////////////////////////////////////////////////
+                                  FIXTURES
+//////////////////////////////////////////////////////////////////////////*/
+
+async function deployBare() {
+  const [owner, manager, lp, trader, recipient, outsider] =
+    await ethers.getSigners();
+  const OSwaps = await ethers.getContractFactory('OSwaps');
+  const oswaps = await OSwaps.deploy();
+  return { oswaps, owner, manager, lp, trader, recipient, outsider };
+}
+
+async function deployInitialised() {
+  const base = await deployBare();
+  await base.oswaps.connect(base.owner).init(base.manager.address);
+  return base;
+}
+
+async function newToken(name: string, symbol: string, decimals = 18) {
+  const MockERC20 = await ethers.getContractFactory('MockERC20');
+  return MockERC20.deploy(name, symbol, decimals);
+}
+
+/**
+ * Register an asset and bring it fully online.
+ *
+ * The bootstrap sequence is inherited from the original protocol and needs two
+ * unfreezes: a new asset is created inactive, and the first deposit must carry a
+ * non-zero weight, which freezes it again.
+ */
+async function bringAssetOnline(
+  oswaps: any,
+  manager: HardhatEthersSigner,
+  lp: HardhatEthersSigner,
+  token: any,
+  symbol: string,
+  amount: bigint,
+  weight: bigint,
+): Promise<bigint> {
+  await oswaps.connect(lp).createAsset(await token.getAddress(), symbol, '{}');
+  const id = (await oswaps.config()).lastTokenId;
+
+  await oswaps.connect(manager).unfreeze(id, symbol);
+
+  await token.mint(lp.address, amount);
+  await token.connect(lp).approve(await oswaps.getAddress(), amount);
+  await oswaps.connect(lp).addLiquidity(id, amount, weight);
+
+  await oswaps.connect(manager).unfreeze(id, symbol);
+  return id;
+}
+
+/** Two 18-decimal assets, 1000 units each, equal weights. */
+async function deployPool() {
+  const base = await deployInitialised();
+  const { oswaps, manager, lp } = base;
+
+  const tokenA = await newToken('Alpha', 'AAA', 18);
+  const tokenB = await newToken('Beta', 'BBB', 18);
+
+  const seed = ethers.parseEther('1000');
+  const idA = await bringAssetOnline(
+    oswaps,
+    manager,
+    lp,
+    tokenA,
+    'AAA',
+    seed,
+    W,
+  );
+  const idB = await bringAssetOnline(
+    oswaps,
+    manager,
+    lp,
+    tokenB,
+    'BBB',
+    seed,
+    W,
+  );
+
+  return { ...base, tokenA, tokenB, idA, idB, seed };
+}
+
+/** Fund a trader and approve the pool. */
+async function fund(
+  token: any,
+  oswaps: any,
+  who: HardhatEthersSigner,
+  amount: bigint,
+) {
+  await token.mint(who.address, amount);
+  await token.connect(who).approve(await oswaps.getAddress(), amount);
+}
+
+/*//////////////////////////////////////////////////////////////////////////
+                                    TESTS
+//////////////////////////////////////////////////////////////////////////*/
+
+describe('OSwaps', function () {
+  describe('Deployment and initialisation', function () {
+    it('Should set the deployer as owner and leave the manager unset', async function () {
+      const { oswaps, owner } = await loadFixture(deployBare);
+      expect(await oswaps.owner()).to.equal(owner.address);
+      expect((await oswaps.config()).manager).to.equal(ethers.ZeroAddress);
+      expect((await oswaps.config()).lastTokenId).to.equal(0);
+    });
+
+    it('Should record the real chain id, not a block hash', async function () {
+      const { oswaps } = await loadFixture(deployBare);
+      const { chainId } = await ethers.provider.getNetwork();
+      expect((await oswaps.config()).chainId).to.equal(
+        ethers.zeroPadValue(ethers.toBeHex(chainId), 32),
+      );
+    });
+
+    it('Should let only the owner initialise', async function () {
+      const { oswaps, manager, outsider } = await loadFixture(deployBare);
+      await expect(
+        oswaps.connect(outsider).init(manager.address),
+      ).to.be.revertedWithCustomError(oswaps, 'OwnableUnauthorizedAccount');
+    });
+
+    it('Should set the manager and emit ManagerUpdated', async function () {
+      const { oswaps, owner, manager } = await loadFixture(deployBare);
+      await expect(oswaps.connect(owner).init(manager.address))
+        .to.emit(oswaps, 'ManagerUpdated')
+        .withArgs(ethers.ZeroAddress, manager.address);
+      expect((await oswaps.config()).manager).to.equal(manager.address);
+    });
+
+    it('Should reject a zero manager and a second initialisation', async function () {
+      const { oswaps, owner, manager, outsider } = await loadFixture(
+        deployBare,
+      );
+      await expect(
+        oswaps.connect(owner).init(ethers.ZeroAddress),
+      ).to.be.revertedWith('Zero manager');
+
+      await oswaps.connect(owner).init(manager.address);
+      await expect(
+        oswaps.connect(owner).init(outsider.address),
+      ).to.be.revertedWith('Already initialized');
+    });
+
+    it('Should not expose any owner path that moves pool funds', async function () {
+      // The original protocol documents the owner as a cold key with no
+      // operational role. emergencyWithdraw contradicted that and was removed.
+      const { oswaps } = await loadFixture(deployBare);
+      expect(
+        oswaps.interface.fragments.some(
+          (f: any) => f.name === 'emergencyWithdraw',
+        ),
+      ).to.equal(false);
+    });
+  });
+
+  describe('Manager rotation', function () {
+    it('Should let the incumbent manager hand over', async function () {
+      const { oswaps, manager, outsider } = await loadFixture(
+        deployInitialised,
+      );
+      await expect(oswaps.connect(manager).setManager(outsider.address))
+        .to.emit(oswaps, 'ManagerUpdated')
+        .withArgs(manager.address, outsider.address);
+      expect((await oswaps.config()).manager).to.equal(outsider.address);
+    });
+
+    it('Should revoke the previous manager and empower the new one', async function () {
+      const { oswaps, manager, outsider } = await loadFixture(deployPool);
+      await oswaps.connect(manager).setManager(outsider.address);
+
+      await expect(oswaps.connect(manager).freeze(1, 'AAA')).to.be.revertedWith(
+        'Only manager',
+      );
+      await expect(oswaps.connect(outsider).freeze(1, 'AAA')).to.emit(
+        oswaps,
+        'AssetFrozen',
+      );
+    });
+
+    it('Should reject rotation by non-managers and to the zero address', async function () {
+      const { oswaps, owner, manager, outsider } = await loadFixture(
+        deployInitialised,
+      );
+      await expect(
+        oswaps.connect(outsider).setManager(outsider.address),
+      ).to.be.revertedWith('Only manager');
+      await expect(
+        oswaps.connect(owner).setManager(owner.address),
+      ).to.be.revertedWith('Only manager');
+      await expect(
+        oswaps.connect(manager).setManager(ethers.ZeroAddress),
+      ).to.be.revertedWith('Zero manager');
+    });
+  });
+
+  describe('Asset creation', function () {
+    it('Should register an asset inactive with zero weight', async function () {
+      const { oswaps, lp } = await loadFixture(deployInitialised);
+      const token = await newToken('Alpha', 'AAA');
+
+      await expect(
+        oswaps
+          .connect(lp)
+          .createAsset(await token.getAddress(), 'AAA', '{"a":1}'),
+      )
+        .to.emit(oswaps, 'AssetCreated')
+        .withArgs(1, await token.getAddress(), 'AAA');
+
+      const asset = await oswaps.getAsset(1);
+      expect(asset.tokenId).to.equal(1);
+      expect(asset.contractAddress).to.equal(await token.getAddress());
+      expect(asset.symbol).to.equal('AAA');
+      expect(asset.active).to.equal(false);
+      expect(asset.metadata).to.equal('{"a":1}');
+      expect(asset.weight).to.equal(0);
+    });
+
+    it('Should be permissionless and assign sequential ids', async function () {
+      const { oswaps, outsider } = await loadFixture(deployInitialised);
+      const t1 = await newToken('One', 'ONE');
+      const t2 = await newToken('Two', 'TWO');
+
+      await oswaps
+        .connect(outsider)
+        .createAsset(await t1.getAddress(), 'ONE', '');
+      await oswaps
+        .connect(outsider)
+        .createAsset(await t2.getAddress(), 'TWO', '');
+
+      expect((await oswaps.config()).lastTokenId).to.equal(2);
+      expect(await oswaps.getTokenIds()).to.deep.equal([1n, 2n]);
+      expect(await oswaps.getAssetCount()).to.equal(2);
+      expect(await oswaps.tokenIdByAddress(await t1.getAddress())).to.equal(1);
+    });
+
+    it('Should deploy a LIQ token named after the asset id', async function () {
+      const { oswaps, lp } = await loadFixture(deployInitialised);
+      const token = await newToken('Alpha', 'AAA');
+      await oswaps.connect(lp).createAsset(await token.getAddress(), 'AAA', '');
+
+      const liq = await ethers.getContractAt(
+        'LiquidityToken',
+        await oswaps.liquidityTokens(1),
+      );
+      expect(await liq.symbol()).to.equal('LIQ1');
+      expect(await liq.name()).to.equal('LIQ1');
+      expect(await liq.owner()).to.equal(await oswaps.getAddress());
+    });
+
+    it('Should match LIQ decimals to the underlying token', async function () {
+      const { oswaps, lp } = await loadFixture(deployInitialised);
+
+      for (const [i, decimals] of [0, 2, 6, 8, 18].entries()) {
+        const token = await newToken(`T${i}`, `T${i}`, decimals);
+        await oswaps
+          .connect(lp)
+          .createAsset(await token.getAddress(), `T${i}`, '');
+        const liq = await ethers.getContractAt(
+          'LiquidityToken',
+          await oswaps.liquidityTokens(i + 1),
+        );
+        expect(await liq.decimals()).to.equal(decimals);
+      }
+    });
+
+    it('Should fall back to 18 decimals for tokens without decimals()', async function () {
+      const { oswaps, lp } = await loadFixture(deployInitialised);
+      const Odd = await ethers.getContractFactory('MockNoDecimalsERC20');
+      const odd = await Odd.deploy();
+
+      await oswaps.connect(lp).createAsset(await odd.getAddress(), 'ODD', '');
+      const liq = await ethers.getContractAt(
+        'LiquidityToken',
+        await oswaps.liquidityTokens(1),
+      );
+      expect(await liq.decimals()).to.equal(18);
+    });
+
+    it('Should fall back to 18 decimals when decimals() misbehaves', async function () {
+      // A nonsensical value, undecodable return data, and an outright revert all
+      // have to degrade rather than block registration. Undecodable data in
+      // particular is not absorbable by try/catch, so this exercises the
+      // staticcall path.
+      const { oswaps, lp } = await loadFixture(deployInitialised);
+      const Bad = await ethers.getContractFactory('MockBadDecimalsERC20');
+
+      for (const mode of [0, 1, 2]) {
+        const bad = await Bad.deploy(mode);
+        await expect(
+          oswaps
+            .connect(lp)
+            .createAsset(await bad.getAddress(), `B${mode}`, ''),
+        ).to.emit(oswaps, 'AssetCreated');
+
+        const id = (await oswaps.config()).lastTokenId;
+        const liq = await ethers.getContractAt(
+          'LiquidityToken',
+          await oswaps.liquidityTokens(id),
+        );
+        expect(await liq.decimals(), `mode ${mode}`).to.equal(18);
+      }
+    });
+
+    it('Should reject the pool itself, the zero address and code-free addresses', async function () {
+      const { oswaps, lp } = await loadFixture(deployInitialised);
+      await expect(
+        oswaps.connect(lp).createAsset(await oswaps.getAddress(), 'X', ''),
+      ).to.be.revertedWith('Cannot be oswaps');
+      await expect(
+        oswaps.connect(lp).createAsset(ethers.ZeroAddress, 'X', ''),
+      ).to.be.revertedWith('Zero token address');
+
+      // Not a signer address: these tests run against a Base fork, where some
+      // well-known dev accounts carry an EIP-7702 delegation and so do have code.
+      const empty = ethers.Wallet.createRandom().address;
+      expect(await ethers.provider.getCode(empty)).to.equal('0x');
+      await expect(
+        oswaps.connect(lp).createAsset(empty, 'X', ''),
+      ).to.be.revertedWith('Token is not a contract');
+    });
+
+    it('Should reject registering the same token twice', async function () {
+      const { oswaps, lp } = await loadFixture(deployInitialised);
+      const token = await newToken('Alpha', 'AAA');
+      await oswaps.connect(lp).createAsset(await token.getAddress(), 'AAA', '');
+      await expect(
+        oswaps.connect(lp).createAsset(await token.getAddress(), 'AAA2', ''),
+      ).to.be.revertedWith('Token already registered');
+    });
+  });
+
+  describe('Freeze and unfreeze', function () {
+    it('Should toggle active and emit AssetFrozen', async function () {
+      const { oswaps, manager } = await loadFixture(deployPool);
+
+      await expect(oswaps.connect(manager).freeze(1, 'AAA'))
+        .to.emit(oswaps, 'AssetFrozen')
+        .withArgs(1, true);
+      expect((await oswaps.getAsset(1)).active).to.equal(false);
+
+      await expect(oswaps.connect(manager).unfreeze(1, 'AAA'))
+        .to.emit(oswaps, 'AssetFrozen')
+        .withArgs(1, false);
+      expect((await oswaps.getAsset(1)).active).to.equal(true);
+    });
+
+    it('Should require the symbol to match, as a typo guard', async function () {
+      const { oswaps, manager } = await loadFixture(deployPool);
+      await expect(oswaps.connect(manager).freeze(1, 'BBB')).to.be.revertedWith(
+        'Symbol mismatch',
+      );
+      await expect(
+        oswaps.connect(manager).unfreeze(1, 'aaa'),
+      ).to.be.revertedWith('Symbol mismatch');
+    });
+
+    it('Should reject non-managers and unknown ids', async function () {
+      const { oswaps, manager, outsider } = await loadFixture(deployPool);
+      await expect(
+        oswaps.connect(outsider).freeze(1, 'AAA'),
+      ).to.be.revertedWith('Only manager');
+      await expect(
+        oswaps.connect(manager).freeze(99, 'AAA'),
+      ).to.be.revertedWith('Token not found');
+    });
+  });
+
+  describe('forgetAsset', function () {
+    it('Should require an empty pool balance', async function () {
+      const { oswaps, manager } = await loadFixture(deployPool);
+      await expect(oswaps.connect(manager).forgetAsset(1)).to.be.revertedWith(
+        'Pool balance not zero',
+      );
+    });
+
+    it('Should remove all traces after the freeze-drain-forget sequence', async function () {
+      const { oswaps, manager, lp, tokenA, idA, seed } = await loadFixture(
+        deployPool,
+      );
+      const tokenAddr = await tokenA.getAddress();
+
+      // A live asset must keep a non-zero balance, so it cannot be emptied.
+      await expect(
+        oswaps.connect(manager).withdraw(lp.address, idA, seed, 0),
+      ).to.be.revertedWith('Insufficient balance');
+
+      // Freezing lifts that restriction, since the asset is no longer tradeable.
+      await oswaps.connect(manager).freeze(idA, 'AAA');
+      await oswaps.connect(manager).withdraw(lp.address, idA, seed, 0);
+      expect(await tokenA.balanceOf(await oswaps.getAddress())).to.equal(0);
+
+      await expect(oswaps.connect(manager).forgetAsset(idA))
+        .to.emit(oswaps, 'AssetForgotten')
+        .withArgs(idA, tokenAddr);
+
+      expect((await oswaps.getAsset(idA)).contractAddress).to.equal(
+        ethers.ZeroAddress,
+      );
+      expect(await oswaps.liquidityTokens(idA)).to.equal(ethers.ZeroAddress);
+      expect(await oswaps.tokenIdByAddress(tokenAddr)).to.equal(0);
+      expect(await oswaps.getTokenIds()).to.not.include(idA);
+    });
+
+    it('Should strand no funds, because any asset can be fully drained first', async function () {
+      const { oswaps, manager, lp, tokenA, idA, seed } = await loadFixture(
+        deployPool,
+      );
+      await oswaps.connect(manager).freeze(idA, 'AAA');
+      await oswaps.connect(manager).withdraw(lp.address, idA, seed, 0);
+
+      // Everything returned to the provider, so no owner rescue path is needed.
+      expect(await tokenA.balanceOf(lp.address)).to.equal(seed);
+      const liq = await ethers.getContractAt(
+        'LiquidityToken',
+        await oswaps.liquidityTokens(idA),
+      );
+      expect(await liq.totalSupply()).to.equal(0);
+    });
+
+    it('Should prune ids correctly when removing from the middle', async function () {
+      const { oswaps, manager, lp } = await loadFixture(deployInitialised);
+      const ids: bigint[] = [];
+      for (let i = 0; i < 4; i++) {
+        const t = await newToken(`T${i}`, `T${i}`);
+        await oswaps.connect(lp).createAsset(await t.getAddress(), `T${i}`, '');
+        ids.push((await oswaps.config()).lastTokenId);
+      }
+      expect(await oswaps.getTokenIds()).to.deep.equal(ids);
+
+      await oswaps.connect(manager).forgetAsset(ids[1]);
+      const remaining = await oswaps.getTokenIds();
+      expect(remaining).to.have.lengthOf(3);
+      expect(remaining).to.not.include(ids[1]);
+      for (const keep of [ids[0], ids[2], ids[3]]) {
+        expect(remaining).to.include(keep);
+      }
+
+      // Removing again still leaves a consistent set.
+      await oswaps.connect(manager).forgetAsset(ids[3]);
+      const after = await oswaps.getTokenIds();
+      expect(after).to.have.lengthOf(2);
+      expect(after).to.not.include(ids[3]);
+    });
+
+    it('Should not reuse a forgotten id', async function () {
+      const { oswaps, manager, lp } = await loadFixture(deployInitialised);
+      const t1 = await newToken('One', 'ONE');
+      await oswaps.connect(lp).createAsset(await t1.getAddress(), 'ONE', '');
+      await oswaps.connect(manager).forgetAsset(1);
+
+      const t2 = await newToken('Two', 'TWO');
+      await oswaps.connect(lp).createAsset(await t2.getAddress(), 'TWO', '');
+      expect((await oswaps.config()).lastTokenId).to.equal(2);
+    });
+
+    it('Should allow re-registering a token after it is forgotten', async function () {
+      const { oswaps, manager, lp } = await loadFixture(deployInitialised);
+      const token = await newToken('Alpha', 'AAA');
+      await oswaps.connect(lp).createAsset(await token.getAddress(), 'AAA', '');
+      await oswaps.connect(manager).forgetAsset(1);
+      await expect(
+        oswaps.connect(lp).createAsset(await token.getAddress(), 'AAA', ''),
+      ).to.emit(oswaps, 'AssetCreated');
+    });
+  });
+
+  describe('queryPool', function () {
+    it('Should report live balances and stored weights', async function () {
+      const { oswaps, idA, idB, seed } = await loadFixture(deployPool);
+      const statuses = await oswaps.queryPool([idA, idB]);
+      expect(statuses).to.have.lengthOf(2);
+      expect(statuses[0].tokenId).to.equal(idA);
+      expect(statuses[0].balance).to.equal(seed);
+      expect(statuses[0].weight).to.equal(W);
+    });
+
+    it('Should reflect donations sent directly to the pool', async function () {
+      const { oswaps, tokenA, idA, seed, outsider } = await loadFixture(
+        deployPool,
+      );
+      await tokenA.mint(outsider.address, ethers.parseEther('5'));
+      await tokenA
+        .connect(outsider)
+        .transfer(await oswaps.getAddress(), ethers.parseEther('5'));
+
+      const [status] = await oswaps.queryPool([idA]);
+      expect(status.balance).to.equal(seed + ethers.parseEther('5'));
+      // No LIQ was issued for the donation.
+      const liq = await ethers.getContractAt(
+        'LiquidityToken',
+        await oswaps.liquidityTokens(idA),
+      );
+      expect(await liq.balanceOf(outsider.address)).to.equal(0);
+    });
+
+    it('Should revert the whole batch if any id is unknown', async function () {
+      const { oswaps, idA } = await loadFixture(deployPool);
+      await expect(oswaps.queryPool([idA, 99])).to.be.revertedWith(
+        'Token not found',
+      );
+    });
+
+    it('Should return an empty array for an empty request', async function () {
+      const { oswaps } = await loadFixture(deployPool);
+      expect(await oswaps.queryPool([])).to.deep.equal([]);
+    });
+  });
+
+  describe('addLiquidity', function () {
+    it('Should reject a deposit into a frozen asset', async function () {
+      const { oswaps, lp } = await loadFixture(deployInitialised);
+      const token = await newToken('Alpha', 'AAA');
+      await oswaps.connect(lp).createAsset(await token.getAddress(), 'AAA', '');
+      await fund(token, oswaps, lp, ethers.parseEther('1'));
+
+      await expect(
+        oswaps.connect(lp).addLiquidity(1, ethers.parseEther('1'), W),
+      ).to.be.revertedWith('Token is frozen');
+    });
+
+    it('Should reject weight 0 on an empty pool instead of silently zeroing it', async function () {
+      // The original reverts with "zero weight requires existing balance"; an
+      // earlier port skipped the branch, leaving weight 0 and bricking swaps.
+      const { oswaps, manager, lp } = await loadFixture(deployInitialised);
+      const token = await newToken('Alpha', 'AAA');
+      await oswaps.connect(lp).createAsset(await token.getAddress(), 'AAA', '');
+      await oswaps.connect(manager).unfreeze(1, 'AAA');
+      await fund(token, oswaps, lp, ethers.parseEther('1'));
+
+      await expect(
+        oswaps.connect(lp).addLiquidity(1, ethers.parseEther('1'), 0),
+      ).to.be.revertedWith('Zero weight requires existing balance');
+      expect((await oswaps.getAsset(1)).weight).to.equal(0);
+    });
+
+    it('Should set the weight, freeze the asset and mint LIQ on the first deposit', async function () {
+      const { oswaps, manager, lp } = await loadFixture(deployInitialised);
+      const token = await newToken('Alpha', 'AAA');
+      await oswaps.connect(lp).createAsset(await token.getAddress(), 'AAA', '');
+      await oswaps.connect(manager).unfreeze(1, 'AAA');
+
+      const amount = ethers.parseEther('100');
+      await fund(token, oswaps, lp, amount);
+
+      await expect(oswaps.connect(lp).addLiquidity(1, amount, W))
+        .to.emit(oswaps, 'WeightUpdated')
+        .withArgs(1, 0, W, true)
+        .and.to.emit(oswaps, 'LiquidityAdded')
+        .withArgs(lp.address, 1, amount, amount);
+
+      const asset = await oswaps.getAsset(1);
+      expect(asset.weight).to.equal(W);
+      expect(asset.active).to.equal(false); // price changed => frozen
+
+      const liq = await ethers.getContractAt(
+        'LiquidityToken',
+        await oswaps.liquidityTokens(1),
+      );
+      expect(await liq.balanceOf(lp.address)).to.equal(amount);
+    });
+
+    it('Should scale the weight to hold the price when weight is 0', async function () {
+      const { oswaps, lp, tokenA, idA, seed } = await loadFixture(deployPool);
+      const before = await oswaps.getAsset(idA);
+      const priceBefore = ratio(seed, before.weight);
+
+      const add = ethers.parseEther('250');
+      await fund(tokenA, oswaps, lp, add);
+      await oswaps.connect(lp).addLiquidity(idA, add, 0);
+
+      const after = await oswaps.getAsset(idA);
+      // w_new = w_old * (bal + amount) / bal
+      expect(after.weight).to.equal((before.weight * (seed + add)) / seed);
+      expect(after.active).to.equal(true); // price held => stays tradeable
+      expect(ratio(seed + add, after.weight)).to.be.closeTo(priceBefore, 1e-9);
+    });
+
+    it('Should leave the marginal price unchanged after a price-holding deposit', async function () {
+      const { oswaps, lp, tokenA, idA, idB, seed } = await loadFixture(
+        deployPool,
+      );
+      const assetA = await oswaps.getAsset(idA);
+      const assetB = await oswaps.getAsset(idB);
+      const before = spotPrice(seed, assetA.weight, seed, assetB.weight);
+
+      const add = ethers.parseEther('500');
+      await fund(tokenA, oswaps, lp, add);
+      await oswaps.connect(lp).addLiquidity(idA, add, 0);
+
+      const a2 = await oswaps.getAsset(idA);
+      const after = spotPrice(seed + add, a2.weight, seed, assetB.weight);
+      expect(after).to.be.closeTo(before, 1e-9);
+    });
+
+    it('Should allow a weight-only reprice with amount 0, even while frozen', async function () {
+      const { oswaps, manager, lp, idA } = await loadFixture(deployPool);
+      await oswaps.connect(manager).freeze(idA, 'AAA');
+
+      const newWeight = W * 3n;
+      await expect(oswaps.connect(lp).addLiquidity(idA, 0, newWeight))
+        .to.emit(oswaps, 'WeightUpdated')
+        .withArgs(idA, W, newWeight, true);
+
+      expect((await oswaps.getAsset(idA)).weight).to.equal(newWeight);
+      // No deposit happened, so no LiquidityAdded event and no LIQ minted.
+      const liq = await ethers.getContractAt(
+        'LiquidityToken',
+        await oswaps.liquidityTokens(idA),
+      );
+      expect(await liq.totalSupply()).to.equal(ethers.parseEther('1000'));
+    });
+
+    it('Should reject fee-on-transfer tokens rather than misprice them', async function () {
+      const { oswaps, manager, lp } = await loadFixture(deployInitialised);
+      const Fee = await ethers.getContractFactory('MockFeeOnTransferERC20');
+      const fee = await Fee.deploy('Fee', 'FEE', 18, 100); // 1%
+
+      await oswaps.connect(lp).createAsset(await fee.getAddress(), 'FEE', '');
+      await oswaps.connect(manager).unfreeze(1, 'FEE');
+      await fee.mint(lp.address, ethers.parseEther('100'));
+      await fee
+        .connect(lp)
+        .approve(await oswaps.getAddress(), ethers.parseEther('100'));
+
+      await expect(
+        oswaps.connect(lp).addLiquidity(1, ethers.parseEther('100'), W),
+      ).to.be.revertedWith('Unexpected balance change');
+    });
+
+    it('Should reject an unknown asset', async function () {
+      const { oswaps, lp } = await loadFixture(deployPool);
+      await expect(
+        oswaps.connect(lp).addLiquidity(99, 1, W),
+      ).to.be.revertedWith('Token not found');
+    });
+
+    it('Should accumulate LIQ across multiple providers', async function () {
+      const { oswaps, lp, trader, tokenA, idA } = await loadFixture(deployPool);
+      const add = ethers.parseEther('100');
+      await fund(tokenA, oswaps, trader, add);
+      await oswaps.connect(trader).addLiquidity(idA, add, 0);
+
+      const liq = await ethers.getContractAt(
+        'LiquidityToken',
+        await oswaps.liquidityTokens(idA),
+      );
+      expect(await liq.balanceOf(lp.address)).to.equal(
+        ethers.parseEther('1000'),
+      );
+      expect(await liq.balanceOf(trader.address)).to.equal(add);
+    });
+  });
+
+  describe('withdraw', function () {
+    it('Should be manager-only, matching the original protocol', async function () {
+      const { oswaps, lp, idA } = await loadFixture(deployPool);
+      await expect(
+        oswaps.connect(lp).withdraw(lp.address, idA, ethers.parseEther('1'), 0),
+      ).to.be.revertedWith('Only manager');
+    });
+
+    it('Should pay out, burn LIQ, hold the price and emit', async function () {
+      const { oswaps, manager, lp, tokenA, idA, seed } = await loadFixture(
+        deployPool,
+      );
+      const amount = ethers.parseEther('200');
+      const before = await oswaps.getAsset(idA);
+
+      await expect(oswaps.connect(manager).withdraw(lp.address, idA, amount, 0))
+        .to.emit(oswaps, 'LiquidityWithdrawn')
+        .withArgs(lp.address, idA, amount, amount);
+
+      expect(await tokenA.balanceOf(lp.address)).to.equal(amount);
+      expect(await tokenA.balanceOf(await oswaps.getAddress())).to.equal(
+        seed - amount,
+      );
+
+      const after = await oswaps.getAsset(idA);
+      expect(after.weight).to.equal((before.weight * (seed - amount)) / seed);
+      expect(after.active).to.equal(true);
+
+      const liq = await ethers.getContractAt(
+        'LiquidityToken',
+        await oswaps.liquidityTokens(idA),
+      );
+      expect(await liq.balanceOf(lp.address)).to.equal(seed - amount);
+    });
+
+    it('Should freeze the asset when the weight is changed explicitly', async function () {
+      const { oswaps, manager, lp, idA } = await loadFixture(deployPool);
+      await oswaps
+        .connect(manager)
+        .withdraw(lp.address, idA, ethers.parseEther('100'), W * 2n);
+      const asset = await oswaps.getAsset(idA);
+      expect(asset.weight).to.equal(W * 2n);
+      expect(asset.active).to.equal(false);
+    });
+
+    it('Should never let a tradeable asset be emptied', async function () {
+      const { oswaps, manager, lp, idA, seed } = await loadFixture(deployPool);
+      await expect(
+        oswaps.connect(manager).withdraw(lp.address, idA, seed, 0),
+      ).to.be.revertedWith('Insufficient balance');
+      await expect(
+        oswaps.connect(manager).withdraw(lp.address, idA, seed + 1n, 0),
+      ).to.be.revertedWith('Insufficient balance');
+    });
+
+    it('Should still cap a frozen asset at its actual balance', async function () {
+      const { oswaps, manager, lp, idA, seed } = await loadFixture(deployPool);
+      await oswaps.connect(manager).freeze(idA, 'AAA');
+      await expect(
+        oswaps.connect(manager).withdraw(lp.address, idA, seed + 1n, 0),
+      ).to.be.revertedWith('Insufficient balance');
+    });
+
+    it('Should reject zero amounts and unknown assets', async function () {
+      const { oswaps, manager, lp } = await loadFixture(deployPool);
+      await expect(
+        oswaps.connect(manager).withdraw(lp.address, 1, 0, 0),
+      ).to.be.revertedWith('Zero amount');
+      await expect(
+        oswaps.connect(manager).withdraw(lp.address, 99, 1, 0),
+      ).to.be.revertedWith('Token not found');
+    });
+
+    it('Should fail when the named account does not hold enough LIQ', async function () {
+      const { oswaps, manager, outsider, idA } = await loadFixture(deployPool);
+      const liq = await ethers.getContractAt(
+        'LiquidityToken',
+        await oswaps.liquidityTokens(idA),
+      );
+      await expect(
+        oswaps
+          .connect(manager)
+          .withdraw(outsider.address, idA, ethers.parseEther('1'), 0),
+      ).to.be.revertedWithCustomError(liq, 'ERC20InsufficientBalance');
+    });
+  });
+
+  describe('Swap validation', function () {
+    it('Should reject swapping a token for itself', async function () {
+      const { oswaps, trader, idA } = await loadFixture(deployPool);
+      await expect(
+        oswaps
+          .connect(trader)
+          .swapExactIn(trader.address, idA, idA, ethers.parseEther('1'), 0),
+      ).to.be.revertedWith('Same token');
+    });
+
+    it('Should reject zero amounts and a zero recipient', async function () {
+      const { oswaps, trader, idA, idB } = await loadFixture(deployPool);
+      await expect(
+        oswaps.connect(trader).swapExactIn(trader.address, idA, idB, 0, 0),
+      ).to.be.revertedWith('Zero amount');
+      await expect(
+        oswaps.connect(trader).swapExactIn(ethers.ZeroAddress, idA, idB, 1, 0),
+      ).to.be.revertedWith('Zero recipient');
+    });
+
+    it('Should reject unknown assets on either side', async function () {
+      const { oswaps, trader, idA, idB } = await loadFixture(deployPool);
+      await expect(
+        oswaps.connect(trader).swapExactIn(trader.address, 99, idB, 1, 0),
+      ).to.be.revertedWith('Input token not found');
+      await expect(
+        oswaps.connect(trader).swapExactIn(trader.address, idA, 99, 1, 0),
+      ).to.be.revertedWith('Output token not found');
+    });
+
+    it('Should reject frozen assets on either side', async function () {
+      const { oswaps, manager, trader, idA, idB } = await loadFixture(
+        deployPool,
+      );
+      await oswaps.connect(manager).freeze(idA, 'AAA');
+      await expect(
+        oswaps.connect(trader).swapExactIn(trader.address, idA, idB, 1, 0),
+      ).to.be.revertedWith('Input token frozen');
+
+      await oswaps.connect(manager).unfreeze(idA, 'AAA');
+      await oswaps.connect(manager).freeze(idB, 'BBB');
+      await expect(
+        oswaps.connect(trader).swapExactIn(trader.address, idA, idB, 1, 0),
+      ).to.be.revertedWith('Output token frozen');
+    });
+
+    it('Should report an unset weight instead of panicking on divide-by-zero', async function () {
+      // Previously a zero weight caused a division-by-zero panic deep in the
+      // math; it is now a named precondition.
+      const { oswaps, manager, lp, trader, tokenA, idA } = await loadFixture(
+        deployPool,
+      );
+      const tokenC = await newToken('Gamma', 'CCC');
+      await oswaps
+        .connect(lp)
+        .createAsset(await tokenC.getAddress(), 'CCC', '');
+      const idC = (await oswaps.config()).lastTokenId;
+      await oswaps.connect(manager).unfreeze(idC, 'CCC');
+
+      await fund(tokenA, oswaps, trader, ethers.parseEther('1'));
+      await expect(
+        oswaps
+          .connect(trader)
+          .swapExactIn(trader.address, idA, idC, ethers.parseEther('1'), 0),
+      ).to.be.revertedWith('Output weight not set');
+    });
+
+    it('Should reject an output larger than the pool holds', async function () {
+      const { oswaps, trader, idA, idB, seed } = await loadFixture(deployPool);
+      await expect(
+        oswaps
+          .connect(trader)
+          .swapExactOut(trader.address, idA, idB, seed, ethers.MaxUint256),
+      ).to.be.revertedWith('Insufficient output balance');
+    });
+  });
+
+  describe('swapExactIn', function () {
+    it('Should move balances and emit TokenSwapped', async function () {
+      const { oswaps, trader, recipient, tokenA, tokenB, idA, idB, seed } =
+        await loadFixture(deployPool);
+      const inAmount = ethers.parseEther('100');
+      await fund(tokenA, oswaps, trader, inAmount);
+
+      const expected = await oswaps.quoteExactIn(idA, idB, inAmount);
+
+      await expect(
+        oswaps
+          .connect(trader)
+          .swapExactIn(recipient.address, idA, idB, inAmount, 0),
+      )
+        .to.emit(oswaps, 'TokenSwapped')
+        .withArgs(
+          trader.address,
+          recipient.address,
+          idA,
+          idB,
+          inAmount,
+          expected,
+        );
+
+      expect(await tokenB.balanceOf(recipient.address)).to.equal(expected);
+      expect(await tokenA.balanceOf(await oswaps.getAddress())).to.equal(
+        seed + inAmount,
+      );
+      expect(await tokenB.balanceOf(await oswaps.getAddress())).to.equal(
+        seed - expected,
+      );
+    });
+
+    it('Should enforce minOutAmount', async function () {
+      const { oswaps, trader, idA, idB, tokenA } = await loadFixture(
+        deployPool,
+      );
+      const inAmount = ethers.parseEther('100');
+      await fund(tokenA, oswaps, trader, inAmount * 2n);
+
+      const quote = await oswaps.quoteExactIn(idA, idB, inAmount);
+      await expect(
+        oswaps
+          .connect(trader)
+          .swapExactIn(trader.address, idA, idB, inAmount, quote + 1n),
+      ).to.be.revertedWith('Insufficient output amount');
+
+      await expect(
+        oswaps
+          .connect(trader)
+          .swapExactIn(trader.address, idA, idB, inAmount, quote),
+      ).to.not.be.reverted;
+    });
+
+    it('Should charge a worse rate as the trade grows', async function () {
+      const { oswaps, idA, idB, seed } = await loadFixture(deployPool);
+      let previousRate = Infinity;
+      for (const pct of [1n, 5n, 10n, 25n, 50n]) {
+        const inAmount = (seed * pct) / 100n;
+        const out = await oswaps.quoteExactIn(idA, idB, inAmount);
+        const rate = ratio(out, inAmount);
+        expect(rate).to.be.lessThan(previousRate);
+        previousRate = rate;
+      }
+    });
+
+    it('Should approach the spot price for vanishingly small trades', async function () {
+      const { oswaps, idA, idB, seed } = await loadFixture(deployPool);
+      // Qj = Qi * (Bj/Bi) * (Wi/Wj); equal balances and weights => 1:1
+      const tiny = seed / 1_000_000n;
+      const out = await oswaps.quoteExactIn(idA, idB, tiny);
+      expect(ratio(out, tiny)).to.be.closeTo(1, 1e-5);
+    });
+  });
+
+  describe('swapExactOut', function () {
+    it('Should pull exactly the computed input, with no refund needed', async function () {
+      const { oswaps, trader, recipient, tokenA, tokenB, idA, idB } =
+        await loadFixture(deployPool);
+      const outAmount = ethers.parseEther('100');
+      await fund(tokenA, oswaps, trader, ethers.parseEther('1000'));
+
+      const expectedIn = await oswaps.quoteExactOut(idA, idB, outAmount);
+      const balBefore = await tokenA.balanceOf(trader.address);
+
+      await oswaps
+        .connect(trader)
+        .swapExactOut(
+          recipient.address,
+          idA,
+          idB,
+          outAmount,
+          ethers.MaxUint256,
+        );
+
+      expect(balBefore - (await tokenA.balanceOf(trader.address))).to.equal(
+        expectedIn,
+      );
+      expect(await tokenB.balanceOf(recipient.address)).to.equal(outAmount);
+    });
+
+    it('Should enforce maxInAmount', async function () {
+      const { oswaps, trader, tokenA, idA, idB } = await loadFixture(
+        deployPool,
+      );
+      const outAmount = ethers.parseEther('100');
+      await fund(tokenA, oswaps, trader, ethers.parseEther('1000'));
+
+      const quote = await oswaps.quoteExactOut(idA, idB, outAmount);
+      await expect(
+        oswaps
+          .connect(trader)
+          .swapExactOut(trader.address, idA, idB, outAmount, quote - 1n),
+      ).to.be.revertedWith('Excessive input amount');
+
+      await expect(
+        oswaps
+          .connect(trader)
+          .swapExactOut(trader.address, idA, idB, outAmount, quote),
+      ).to.not.be.reverted;
+    });
+  });
+
+  describe('Quote views', function () {
+    it('Should match executed amounts exactly for exact-in', async function () {
+      const { oswaps, trader, tokenA, tokenB, idA, idB, seed } =
+        await loadFixture(deployPool);
+      for (const pct of [1n, 10n, 50n]) {
+        const inAmount = (seed * pct) / 1000n;
+        const quote = await oswaps.quoteExactIn(idA, idB, inAmount);
+        await fund(tokenA, oswaps, trader, inAmount);
+        const before = await tokenB.balanceOf(trader.address);
+        await oswaps
+          .connect(trader)
+          .swapExactIn(trader.address, idA, idB, inAmount, 0);
+        expect((await tokenB.balanceOf(trader.address)) - before).to.equal(
+          quote,
+        );
+      }
+    });
+
+    it('Should match executed amounts exactly for exact-out', async function () {
+      const { oswaps, trader, tokenA, idA, idB, seed } = await loadFixture(
+        deployPool,
+      );
+      for (const pct of [1n, 10n, 50n]) {
+        const outAmount = (seed * pct) / 1000n;
+        const quote = await oswaps.quoteExactOut(idA, idB, outAmount);
+        await fund(tokenA, oswaps, trader, quote);
+        const before = await tokenA.balanceOf(trader.address);
+        await oswaps
+          .connect(trader)
+          .swapExactOut(trader.address, idA, idB, outAmount, ethers.MaxUint256);
+        expect(before - (await tokenA.balanceOf(trader.address))).to.equal(
+          quote,
+        );
+      }
+    });
+
+    it('Should apply the same validation as the swaps themselves', async function () {
+      const { oswaps, manager, idA, idB } = await loadFixture(deployPool);
+      await expect(oswaps.quoteExactIn(idA, idA, 1)).to.be.revertedWith(
+        'Same token',
+      );
+      await expect(oswaps.quoteExactIn(idA, idB, 0)).to.be.revertedWith(
+        'Zero amount',
+      );
+      await oswaps.connect(manager).freeze(idB, 'BBB');
+      await expect(oswaps.quoteExactIn(idA, idB, 1)).to.be.revertedWith(
+        'Output token frozen',
+      );
+    });
+  });
+
+  describe('Pricing math', function () {
+    it('Should stay within 1e-10 relative error across trade sizes', async function () {
+      const { oswaps, idA, idB, seed } = await loadFixture(deployPool);
+      // Deliberately spans the range where the previous Taylor-series
+      // implementation degraded (60%+) and diverged (>=150%).
+      const fractions = [
+        1n,
+        10n,
+        100n,
+        1_000n,
+        5_000n,
+        10_000n,
+        25_000n,
+        50_000n,
+        60_000n,
+        75_000n,
+        90_000n,
+        100_000n,
+        150_000n,
+        300_000n,
+        1_000_000n,
+      ];
+      for (const num of fractions) {
+        const inAmount = (seed * num) / 100_000n;
+        const actual = await oswaps.quoteExactIn(idA, idB, inAmount);
+        const expected = refExactIn(seed, inAmount, seed, W, W);
+        expect(
+          relErr(actual, expected),
+          `exact-in at ${Number(num) / 1000}% of pool`,
+        ).to.be.lessThan(1e-10);
+      }
+    });
+
+    it('Should stay within 1e-10 relative error for exact-out across output sizes', async function () {
+      const { oswaps, idA, idB, seed } = await loadFixture(deployPool);
+      const fractions = [
+        1n,
+        10n,
+        100n,
+        1_000n,
+        10_000n,
+        25_000n,
+        40_000n,
+        50_000n,
+        60_000n,
+        75_000n,
+        90_000n,
+        99_000n,
+        99_900n,
+      ];
+      for (const num of fractions) {
+        const outAmount = (seed * num) / 100_000n;
+        const actual = await oswaps.quoteExactOut(idA, idB, outAmount);
+        const expected = refExactOut(seed, seed, outAmount, W, W);
+        expect(
+          relErr(actual, expected),
+          `exact-out at ${Number(num) / 1000}% of pool`,
+        ).to.be.lessThan(1e-10);
+      }
+    });
+
+    it('Should be accurate across a wide range of weight ratios', async function () {
+      const { oswaps, manager, lp } = await loadFixture(deployInitialised);
+      const seed = ethers.parseEther('1000');
+
+      for (const [i, wRatio] of [1n, 2n, 5n, 20n, 100n].entries()) {
+        const tokenX = await newToken(`X${i}`, `X${i}`);
+        const tokenY = await newToken(`Y${i}`, `Y${i}`);
+        const idX = await bringAssetOnline(
+          oswaps,
+          manager,
+          lp,
+          tokenX,
+          `X${i}`,
+          seed,
+          W * wRatio,
+        );
+        const idY = await bringAssetOnline(
+          oswaps,
+          manager,
+          lp,
+          tokenY,
+          `Y${i}`,
+          seed,
+          W,
+        );
+
+        for (const pct of [1n, 100n, 500n]) {
+          const inAmount = (seed * pct) / 1000n;
+          const actual = await oswaps.quoteExactIn(idX, idY, inAmount);
+          const expected = refExactIn(seed, inAmount, seed, W * wRatio, W);
+          expect(
+            relErr(actual, expected),
+            `wIn/wOut=${wRatio} at ${Number(pct) / 10}%`,
+          ).to.be.lessThan(1e-10);
+        }
+      }
+    });
+
+    it('Should handle trades far larger than the pool, which used to revert', async function () {
+      // The Taylor series for ln diverged past a ratio of 2, so any trade at or
+      // above ~150% of the input balance reverted. These all execute now.
+      const { oswaps, trader, tokenA, tokenB, idA, idB, seed } =
+        await loadFixture(deployPool);
+
+      for (const multiple of [1n, 2n, 5n, 10n, 100n]) {
+        const inAmount = seed * multiple;
+        const out = await oswaps.quoteExactIn(idA, idB, inAmount);
+        expect(out, `multiple ${multiple}`).to.be.greaterThan(0);
+        expect(
+          relErr(out, refExactIn(seed, inAmount, seed, W, W)),
+        ).to.be.lessThan(1e-10);
+      }
+
+      // And one of them actually settles on-chain.
+      const inAmount = seed * 10n;
+      await fund(tokenA, oswaps, trader, inAmount);
+      const quote = await oswaps.quoteExactIn(idA, idB, inAmount);
+      await oswaps
+        .connect(trader)
+        .swapExactIn(trader.address, idA, idB, inAmount, 0);
+      expect(await tokenB.balanceOf(trader.address)).to.equal(quote);
+      // A huge input buys almost the whole output side, but never all of it.
+      expect(quote).to.be.lessThan(seed);
+      expect(quote).to.be.greaterThan((seed * 90n) / 100n);
+    });
+
+    it('Should never reduce the invariant on exact-in swaps', async function () {
+      const { oswaps, trader, tokenA, tokenB, idA, idB, seed } =
+        await loadFixture(deployPool);
+
+      for (const pct of [1n, 10n, 50n, 90n, 150n]) {
+        const inAmount = (seed * pct) / 100n;
+        const balIn = await tokenA.balanceOf(await oswaps.getAddress());
+        const balOut = await tokenB.balanceOf(await oswaps.getAddress());
+        const wIn = (await oswaps.getAsset(idA)).weight;
+        const wOut = (await oswaps.getAsset(idB)).weight;
+
+        const before = lnInvariant(balIn, wIn, balOut, wOut);
+        await fund(tokenA, oswaps, trader, inAmount);
+        await oswaps
+          .connect(trader)
+          .swapExactIn(trader.address, idA, idB, inAmount, 0);
+
+        const after = lnInvariant(
+          await tokenA.balanceOf(await oswaps.getAddress()),
+          wIn,
+          await tokenB.balanceOf(await oswaps.getAddress()),
+          wOut,
+        );
+        expect(after, `exact-in ${pct}%`).to.be.greaterThan(before - 1e-12);
+      }
+    });
+
+    it('Should never reduce the invariant on exact-out swaps', async function () {
+      // This is the regression that mattered most: the Taylor-series version
+      // undercharged on exact-out, breaking the invariant by up to 16.8%.
+      const { oswaps, trader, tokenA, tokenB, idA, idB } = await loadFixture(
+        deployPool,
+      );
+
+      for (const pct of [1n, 10n, 50n, 75n, 90n]) {
+        const balIn = await tokenA.balanceOf(await oswaps.getAddress());
+        const balOut = await tokenB.balanceOf(await oswaps.getAddress());
+        const outAmount = (balOut * pct) / 100n;
+        const wIn = (await oswaps.getAsset(idA)).weight;
+        const wOut = (await oswaps.getAsset(idB)).weight;
+
+        const before = lnInvariant(balIn, wIn, balOut, wOut);
+        const needed = await oswaps.quoteExactOut(idA, idB, outAmount);
+        await fund(tokenA, oswaps, trader, needed);
+        await oswaps
+          .connect(trader)
+          .swapExactOut(trader.address, idA, idB, outAmount, ethers.MaxUint256);
+
+        const after = lnInvariant(
+          await tokenA.balanceOf(await oswaps.getAddress()),
+          wIn,
+          await tokenB.balanceOf(await oswaps.getAddress()),
+          wOut,
+        );
+        expect(after, `exact-out ${pct}%`).to.be.greaterThan(before - 1e-12);
+      }
+    });
+
+    it('Should bound the deviation from the exact price in either direction', async function () {
+      // The fixed-point `pow` is accurate but not exact, and the residual error
+      // has no guaranteed sign, so the property worth pinning down is a bound.
+      // The bound is loosest for dust-sized trades, where the ratio fed to `pow`
+      // sits closest to 1 and relative precision is worst.
+      const { oswaps, idA, idB, seed } = await loadFixture(deployPool);
+
+      let worst = 0;
+      for (const num of [
+        1n,
+        10n,
+        100n,
+        1_000n,
+        7_000n,
+        33_000n,
+        50_000n,
+        91_000n,
+        100_000n,
+        250_000n,
+        1_000_000n,
+      ]) {
+        const inAmount = (seed * num) / 100_000n;
+        worst = Math.max(
+          worst,
+          relErr(
+            await oswaps.quoteExactIn(idA, idB, inAmount),
+            refExactIn(seed, inAmount, seed, W, W),
+          ),
+        );
+
+        if (num < 100_000n) {
+          const outAmount = (seed * num) / 100_000n;
+          worst = Math.max(
+            worst,
+            relErr(
+              await oswaps.quoteExactOut(idA, idB, outAmount),
+              refExactOut(seed, seed, outAmount, W, W),
+            ),
+          );
+        }
+      }
+      expect(worst, 'worst relative deviation at equal weights').to.be.lessThan(
+        1e-10,
+      );
+    });
+
+    it('Should hold that bound even for dust trades at extreme weight ratios', async function () {
+      const { oswaps, manager, lp } = await loadFixture(deployInitialised);
+      const seed = ethers.parseEther('1000');
+      const tokenX = await newToken('X', 'X');
+      const tokenY = await newToken('Y', 'Y');
+      const idX = await bringAssetOnline(
+        oswaps,
+        manager,
+        lp,
+        tokenX,
+        'X',
+        seed,
+        W * 50n,
+      );
+      const idY = await bringAssetOnline(
+        oswaps,
+        manager,
+        lp,
+        tokenY,
+        'Y',
+        seed,
+        W,
+      );
+
+      let worst = 0;
+      for (const num of [1n, 10n, 1_000n, 50_000n, 99_000n]) {
+        const amount = (seed * num) / 100_000n;
+        worst = Math.max(
+          worst,
+          relErr(
+            await oswaps.quoteExactIn(idX, idY, amount),
+            refExactIn(seed, amount, seed, W * 50n, W),
+          ),
+          relErr(
+            await oswaps.quoteExactOut(idX, idY, amount),
+            refExactOut(seed, seed, amount, W * 50n, W),
+          ),
+        );
+      }
+      expect(worst, 'worst relative deviation at 50:1 weights').to.be.lessThan(
+        1e-9,
+      );
+    });
+
+    it('Should keep per-swap invariant drift far below any economically useful level', async function () {
+      // The residual error is unsigned, so the pool can in principle lose value.
+      // This pins the per-swap loss to a scale where extracting it would cost
+      // vastly more in gas than it yields.
+      const { oswaps, trader, tokenA, tokenB, idA, idB } = await loadFixture(
+        deployPool,
+      );
+      const pool = await oswaps.getAddress();
+      const wIn = (await oswaps.getAsset(idA)).weight;
+      const wOut = (await oswaps.getAsset(idB)).weight;
+
+      let worstDrop = 0;
+      for (const pct of [1n, 5n, 25n, 60n, 95n]) {
+        const balIn = await tokenA.balanceOf(pool);
+        const balOut = await tokenB.balanceOf(pool);
+        const before = lnInvariant(balIn, wIn, balOut, wOut);
+
+        const inAmount = (balIn * pct) / 100n;
+        await fund(tokenA, oswaps, trader, inAmount);
+        await oswaps
+          .connect(trader)
+          .swapExactIn(trader.address, idA, idB, inAmount, 0);
+
+        const after = lnInvariant(
+          await tokenA.balanceOf(pool),
+          wIn,
+          await tokenB.balanceOf(pool),
+          wOut,
+        );
+        worstDrop = Math.max(worstDrop, before - after);
+      }
+      // ln V drift translates roughly 1:1 into a fraction of pool value.
+      expect(worstDrop, 'worst ln(V) drop per swap').to.be.lessThan(1e-12);
+    });
+
+    it('Should reject only trades beyond the fixed-point exponent domain', async function () {
+      // pow requires log2(ratio) * (wIn/wOut) < 192, so an extreme weight ratio
+      // caps the trade size. At 50:1 that cap sits above 13x the pool balance,
+      // which is far outside any trade a real pool would see.
+      const { oswaps, manager, lp } = await loadFixture(deployInitialised);
+      const seed = ethers.parseEther('1000');
+      const tokenX = await newToken('X', 'X');
+      const tokenY = await newToken('Y', 'Y');
+      const idX = await bringAssetOnline(
+        oswaps,
+        manager,
+        lp,
+        tokenX,
+        'X',
+        seed,
+        W * 50n,
+      );
+      const idY = await bringAssetOnline(
+        oswaps,
+        manager,
+        lp,
+        tokenY,
+        'Y',
+        seed,
+        W,
+      );
+
+      expect(await oswaps.quoteExactIn(idX, idY, seed * 10n)).to.be.greaterThan(
+        0,
+      );
+      await expect(oswaps.quoteExactIn(idX, idY, seed * 20n)).to.be.reverted;
+    });
+
+    it('Should be self-consistent between the two directions', async function () {
+      const { oswaps, idA, idB, seed } = await loadFixture(deployPool);
+      for (const pct of [1n, 10n, 40n]) {
+        const inAmount = (seed * pct) / 100n;
+        const out = await oswaps.quoteExactIn(idA, idB, inAmount);
+        const backIn = await oswaps.quoteExactOut(idA, idB, out);
+        // Asking for exactly what the input buys should cost that input again.
+        expect(relErr(backIn, inAmount)).to.be.lessThan(1e-12);
+      }
+    });
+
+    it('Should price correctly for tokens with unequal decimals', async function () {
+      const { oswaps, manager, lp } = await loadFixture(deployInitialised);
+      const usdc = await newToken('USDC', 'USDC', 6);
+      const weth = await newToken('WETH', 'WETH', 18);
+
+      const usdcSeed = 2_000_000_000n; // 2,000 USDC
+      const wethSeed = ethers.parseEther('1'); // 1 WETH
+      const idU = await bringAssetOnline(
+        oswaps,
+        manager,
+        lp,
+        usdc,
+        'USDC',
+        usdcSeed,
+        W,
+      );
+      const idW = await bringAssetOnline(
+        oswaps,
+        manager,
+        lp,
+        weth,
+        'WETH',
+        wethSeed,
+        W,
+      );
+
+      const inAmount = 100_000_000n; // 100 USDC
+      const actual = await oswaps.quoteExactIn(idU, idW, inAmount);
+      const expected = refExactIn(usdcSeed, inAmount, wethSeed, W, W);
+      expect(relErr(actual, expected)).to.be.lessThan(1e-10);
+
+      // 100 USDC into a 2000/1 pool should buy just under 1/21 of an ETH.
+      expect(Number(ethers.formatEther(actual))).to.be.closeTo(0.0476, 0.001);
+    });
+
+    it('Should keep working after weights drift through deposits', async function () {
+      const { oswaps, lp, tokenA, idA, idB, seed } = await loadFixture(
+        deployPool,
+      );
+      const add = ethers.parseEther('333');
+      await fund(tokenA, oswaps, lp, add);
+      await oswaps.connect(lp).addLiquidity(idA, add, 0);
+
+      const wIn = (await oswaps.getAsset(idA)).weight;
+      const wOut = (await oswaps.getAsset(idB)).weight;
+      const inAmount = ethers.parseEther('50');
+      const actual = await oswaps.quoteExactIn(idA, idB, inAmount);
+      const expected = refExactIn(seed + add, inAmount, seed, wIn, wOut);
+      expect(relErr(actual, expected)).to.be.lessThan(1e-10);
+    });
+  });
+
+  describe('Multi-asset pools', function () {
+    it('Should route between any pair in a three-asset pool', async function () {
+      const { oswaps, manager, lp, trader, tokenA, tokenB, idA, idB, seed } =
+        await loadFixture(deployPool);
+      const tokenC = await newToken('Gamma', 'CCC');
+      const idC = await bringAssetOnline(
+        oswaps,
+        manager,
+        lp,
+        tokenC,
+        'CCC',
+        seed * 2n,
+        W * 2n,
+      );
+
+      const inAmount = ethers.parseEther('10');
+      for (const [from, to, token] of [
+        [idA, idB, tokenA],
+        [idB, idC, tokenB],
+        [idC, idA, tokenC],
+      ] as const) {
+        await fund(token, oswaps, trader, inAmount);
+        const quote = await oswaps.quoteExactIn(from, to, inAmount);
+        expect(quote).to.be.greaterThan(0);
+        await expect(
+          oswaps
+            .connect(trader)
+            .swapExactIn(trader.address, from, to, inAmount, quote),
+        ).to.not.be.reverted;
+      }
+    });
+
+    it('Should price a pair independently of unrelated assets', async function () {
+      const { oswaps, manager, lp, idA, idB, seed } = await loadFixture(
+        deployPool,
+      );
+      const quoteBefore = await oswaps.quoteExactIn(
+        idA,
+        idB,
+        ethers.parseEther('10'),
+      );
+
+      const tokenC = await newToken('Gamma', 'CCC');
+      await bringAssetOnline(oswaps, manager, lp, tokenC, 'CCC', seed, W * 7n);
+
+      expect(
+        await oswaps.quoteExactIn(idA, idB, ethers.parseEther('10')),
+      ).to.equal(quoteBefore);
+    });
+  });
+
+  describe('LIQ receipt token', function () {
+    it('Should block account-to-account transfers', async function () {
+      const { oswaps, lp, outsider, idA } = await loadFixture(deployPool);
+      const liq = await ethers.getContractAt(
+        'LiquidityToken',
+        await oswaps.liquidityTokens(idA),
+      );
+      await expect(
+        liq.connect(lp).transfer(outsider.address, 1),
+      ).to.be.revertedWith('LIQ: transfers must involve pool');
+
+      await liq.connect(lp).approve(outsider.address, 1);
+      await expect(
+        liq.connect(outsider).transferFrom(lp.address, outsider.address, 1),
+      ).to.be.revertedWith('LIQ: transfers must involve pool');
+    });
+
+    it('Should allow transfers that involve the pool', async function () {
+      const { oswaps, lp, idA } = await loadFixture(deployPool);
+      const liq = await ethers.getContractAt(
+        'LiquidityToken',
+        await oswaps.liquidityTokens(idA),
+      );
+      await expect(liq.connect(lp).transfer(await oswaps.getAddress(), 1)).to
+        .not.be.reverted;
+      expect(await liq.balanceOf(await oswaps.getAddress())).to.equal(1);
+    });
+
+    it('Should only let the pool mint and burn', async function () {
+      const { oswaps, lp, outsider, idA } = await loadFixture(deployPool);
+      const liq = await ethers.getContractAt(
+        'LiquidityToken',
+        await oswaps.liquidityTokens(idA),
+      );
+      await expect(
+        liq.connect(outsider).mint(outsider.address, 1),
+      ).to.be.revertedWithCustomError(liq, 'OwnableUnauthorizedAccount');
+      await expect(
+        liq.connect(outsider).burnFrom(lp.address, 1),
+      ).to.be.revertedWithCustomError(liq, 'OwnableUnauthorizedAccount');
+    });
+
+    it('Should track deposits and withdrawals 1:1 in raw units', async function () {
+      const { oswaps, manager, lp } = await loadFixture(deployInitialised);
+      const usdc = await newToken('USDC', 'USDC', 6);
+      const idU = await bringAssetOnline(
+        oswaps,
+        manager,
+        lp,
+        usdc,
+        'USDC',
+        1_000_000_000n,
+        W,
+      );
+      const liq = await ethers.getContractAt(
+        'LiquidityToken',
+        await oswaps.liquidityTokens(idU),
+      );
+
+      // 6 decimals on both sides, so 1000 USDC in reads as 1000 LIQ.
+      expect(await liq.decimals()).to.equal(6);
+      expect(await liq.balanceOf(lp.address)).to.equal(1_000_000_000n);
+      expect(ethers.formatUnits(await liq.balanceOf(lp.address), 6)).to.equal(
+        '1000.0',
+      );
+
+      await oswaps.connect(manager).withdraw(lp.address, idU, 400_000_000n, 0);
+      expect(await liq.balanceOf(lp.address)).to.equal(600_000_000n);
+    });
+  });
+
+  describe('Security properties', function () {
+    it('Should block reentrancy from a malicious output token', async function () {
+      const { oswaps, manager, lp, trader } = await loadFixture(
+        deployInitialised,
+      );
+      const seed = ethers.parseEther('1000');
+
+      const tokenA = await newToken('Alpha', 'AAA');
+      const Evil = await ethers.getContractFactory('MockReentrantERC20');
+      const evil = await Evil.deploy('Evil', 'EVL', 18);
+
+      const idA = await bringAssetOnline(
+        oswaps,
+        manager,
+        lp,
+        tokenA,
+        'AAA',
+        seed,
+        W,
+      );
+      const idE = await bringAssetOnline(
+        oswaps,
+        manager,
+        lp,
+        evil,
+        'EVL',
+        seed,
+        W,
+      );
+
+      const inAmount = ethers.parseEther('10');
+      await fund(tokenA, oswaps, trader, inAmount * 2n);
+
+      // While the pool pays out EVL, try to start another swap inside it.
+      const payload = oswaps.interface.encodeFunctionData('swapExactIn', [
+        trader.address,
+        idA,
+        idE,
+        inAmount,
+        0,
+      ]);
+      await evil.arm(await oswaps.getAddress(), payload);
+
+      await oswaps
+        .connect(trader)
+        .swapExactIn(trader.address, idA, idE, inAmount, 0);
+
+      expect(await evil.reentryAttempted()).to.equal(true);
+      expect(await evil.reentrySucceeded()).to.equal(false);
+    });
+
+    it('Should surface a failing output transfer rather than swallowing it', async function () {
+      const { oswaps, manager, lp, trader } = await loadFixture(
+        deployInitialised,
+      );
+      const seed = ethers.parseEther('1000');
+
+      const tokenA = await newToken('Alpha', 'AAA');
+      const Reverting = await ethers.getContractFactory('MockRevertingERC20');
+      const bad = await Reverting.deploy('Bad', 'BAD', 18);
+
+      const idA = await bringAssetOnline(
+        oswaps,
+        manager,
+        lp,
+        tokenA,
+        'AAA',
+        seed,
+        W,
+      );
+      const idB = await bringAssetOnline(
+        oswaps,
+        manager,
+        lp,
+        bad,
+        'BAD',
+        seed,
+        W,
+      );
+
+      await bad.setFailAllTransfers(true);
+      await fund(tokenA, oswaps, trader, ethers.parseEther('10'));
+      await expect(
+        oswaps
+          .connect(trader)
+          .swapExactIn(trader.address, idA, idB, ethers.parseEther('10'), 0),
+      ).to.be.revertedWith('MockRevertingERC20: transfers disabled');
+    });
+
+    it('Should require an allowance before pulling input tokens', async function () {
+      const { oswaps, trader, tokenA, idA, idB } = await loadFixture(
+        deployPool,
+      );
+      await tokenA.mint(trader.address, ethers.parseEther('10'));
+      await expect(
+        oswaps
+          .connect(trader)
+          .swapExactIn(trader.address, idA, idB, ethers.parseEther('10'), 0),
+      ).to.be.revertedWithCustomError(tokenA, 'ERC20InsufficientAllowance');
+    });
+
+    it('Should reject manager-gated calls from the owner', async function () {
+      const { oswaps, owner, lp, idA } = await loadFixture(deployPool);
+      await expect(oswaps.connect(owner).freeze(idA, 'AAA')).to.be.revertedWith(
+        'Only manager',
+      );
+      await expect(
+        oswaps.connect(owner).unfreeze(idA, 'AAA'),
+      ).to.be.revertedWith('Only manager');
+      await expect(oswaps.connect(owner).forgetAsset(idA)).to.be.revertedWith(
+        'Only manager',
+      );
+      await expect(
+        oswaps.connect(owner).withdraw(lp.address, idA, 1, 0),
+      ).to.be.revertedWith('Only manager');
+    });
+
+    it('Should leave the pool solvent after a long mixed sequence', async function () {
+      const { oswaps, manager, lp, trader, tokenA, tokenB, idA, idB } =
+        await loadFixture(deployPool);
+      const pool = await oswaps.getAddress();
+
+      for (let round = 0; round < 6; round++) {
+        const inAmount = ethers.parseEther(String(10 * (round + 1)));
+        await fund(tokenA, oswaps, trader, inAmount);
+        await oswaps
+          .connect(trader)
+          .swapExactIn(trader.address, idA, idB, inAmount, 0);
+
+        const outAmount = ethers.parseEther('5');
+        const needed = await oswaps.quoteExactOut(idB, idA, outAmount);
+        await fund(tokenB, oswaps, trader, needed);
+        await oswaps
+          .connect(trader)
+          .swapExactOut(trader.address, idB, idA, outAmount, ethers.MaxUint256);
+
+        const add = ethers.parseEther('20');
+        await fund(tokenA, oswaps, lp, add);
+        await oswaps.connect(lp).addLiquidity(idA, add, 0);
+
+        await oswaps
+          .connect(manager)
+          .withdraw(lp.address, idB, ethers.parseEther('1'), 0);
+      }
+
+      // Pool still holds both sides, weights are positive, and quotes work.
+      expect(await tokenA.balanceOf(pool)).to.be.greaterThan(0);
+      expect(await tokenB.balanceOf(pool)).to.be.greaterThan(0);
+      expect((await oswaps.getAsset(idA)).weight).to.be.greaterThan(0);
+      expect((await oswaps.getAsset(idB)).weight).to.be.greaterThan(0);
+      expect(
+        await oswaps.quoteExactIn(idA, idB, ethers.parseEther('1')),
+      ).to.be.greaterThan(0);
+
+      // LIQ supply still equals what the pool owes on each side.
+      const liqA = await ethers.getContractAt(
+        'LiquidityToken',
+        await oswaps.liquidityTokens(idA),
+      );
+      expect(await liqA.totalSupply()).to.be.greaterThan(0);
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1251,6 +1251,9 @@ importers:
       '@hypha-platform/config-typescript':
         specifier: workspace:*
         version: link:../../config/typescript
+      '@prb/math':
+        specifier: ^4.1.2
+        version: 4.1.2
       '@wagmi/cli':
         specifier: ^2.2.0
         version: 2.2.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
@@ -5916,6 +5919,9 @@ packages:
 
   '@popperjs/core@2.11.8':
     resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
+
+  '@prb/math@4.1.2':
+    resolution: {integrity: sha512-CBSg0SyOYfs4X+GD16klIYE39sqDs1skPmGP5SVKJPVfthmooAriaSkWC8NqBrkIi129XDnxm7f1cBXnu55FyQ==}
 
   '@privy-io/api-base@1.5.2':
     resolution: {integrity: sha512-0eJBoQNmCSsWSWhzEVSU8WqPm7bgeN6VaAmqeXvjk8Ni0jM8nyTYjmRAqiCSs3mRzsnlQVchkGR6lsMTHkHKbw==}
@@ -27166,6 +27172,8 @@ snapshots:
 
   '@popperjs/core@2.11.8': {}
 
+  '@prb/math@4.1.2': {}
+
   '@privy-io/api-base@1.5.2':
     dependencies:
       zod: 3.25.76
@@ -32122,7 +32130,7 @@ snapshots:
       pathe: 1.1.2
       picocolors: 1.1.1
       sirv: 2.0.4
-      vitest: 1.6.1(@types/node@24.2.1)(@vitest/ui@1.6.1)(jsdom@26.0.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(less@4.1.3)(lightningcss@1.30.1)(sass@1.86.3)(stylus@0.64.0)(terser@5.39.0)
+      vitest: 1.6.1(@types/node@22.15.33)(@vitest/ui@1.6.1)(jsdom@26.0.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(less@4.1.3)(lightningcss@1.30.1)(sass@1.86.3)(stylus@0.64.0)(terser@5.39.0)
 
   '@vitest/utils@1.6.1':
     dependencies:


### PR DESCRIPTION
## Summary

Answers a question from another developer — "how close is our contract to the oSwaps protocol Chuck designed?" — and then fixes what answering it turned up.

**Two documents** (`packages/storage-evm/contracts/seedsexample/`):

- `OSwaps.EOSIO-PARITY.md` — action-by-action comparison against the original Antelope `oswaps.cpp`/`.hpp`, for a human reader. What was reproduced, what was adapted for EVM and why, what diverges.
- `OSwaps.docs.md` — full contract reference for implementing a UI: external surface, role model, bootstrap sequence, pricing math with measured accuracy bounds, revert catalogue.

**The pricing math was wrong and is now fixed.** `_ln`/`_exp` were hand-written Taylor series. The `ln` series only converges for `0 < x < 2`, so trades at or above ~150% of the input balance reverted, and accuracy degraded well before that — up to 4.9% error on exact-in, and a 16.8% invariant break on exact-out. The exact-out direction erred *against* the pool, quietly moving liquidity-provider value to counterparties on large trades.

Both formulas now evaluate the fractional power with PRBMath's `UD60x18.pow`, rearranged so the base always exceeds one and the exponent stays positive. This substitutes the primitive, not the formula: the original used `exp(y*log(x))` on doubles because that is what libm offers.

|                                | Before                   | After                     |
| ------------------------------ | ------------------------ | ------------------------- |
| Relative error, equal weights  | up to 4.9%               | < 1e-11                   |
| Relative error, 100:1 weights  | reverts                  | < 1e-10                   |
| Max trade size                 | ~150% of input balance   | 100x the pool, and beyond |
| Invariant drift per swap       | up to −16.8%             | < 1e-12 of pool value     |

**Parity gaps closed.** Restores the zero-weight guard, manager rotation, LIQ precision and its no-peer-to-peer restriction — all present in the original, all lost in the port. Removes the owner's `emergencyWithdraw`, which contradicted the original's explicit cold-owner trust model, and completes `forgetAsset` behind a zero-balance gate so no balance can be stranded without it. Adds `SafeERC20`, a `minOutAmount` slippage floor, self-swap and duplicate-registration guards, fee-on-transfer rejection, an event on every state change, and `quoteExactIn`/`quoteExactOut`/`getTokenIds`/`getAsset` so a UI need not maintain a parallel copy of the math. Fixes `IOSwaps.assets`, which was ABI-incompatible with the real getter.

One change has no counterpart in the original and is called out in the parity doc: a **frozen** asset may now be drained completely (a live one still cannot). Without it, gating `forgetAsset` on a zero balance would make any funded asset impossible to retire, and the alternative was to keep an owner-level rescue hatch the original design deliberately withholds.

`OSwaps.sol` remains undeployed reference code, excluded from `wagmi.config.ts`, and unaudited.

## Test plan

- [x] `npx hardhat test test/OSwaps.test.ts` — 85 passing
- [x] Math accuracy checked against a double-precision reference across trade sizes from 1e-5x to 100x the pool balance and weight ratios up to 100:1
- [x] Invariant preservation asserted for both swap directions, plus a bound on per-swap drift
- [x] Exact-in/exact-out duality, quote views matching execution exactly, price-impact monotonicity, small-trade convergence to spot
- [x] Reentrancy guard driven by a malicious ERC-20 that re-enters mid-payout
- [x] Misbehaving tokens: fee-on-transfer, reverting transfers, missing and garbage `decimals()`
- [x] Full access-control matrix, including that the owner cannot call manager functions
- [x] Unequal decimals (USDC/WETH), three-asset pools, and a long mixed swap/deposit/withdraw sequence
- [x] `npx hardhat compile`, `npx hardhat check` (only a pre-existing `Executor.sol` line-length error), eslint, prettier
- [ ] Third-party audit before any deployment


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a full specification for the OSwaps example contract (lifecycle, permissions, events, pricing math, UI constraints, and limitations).
  * Added an EOSIO parity review covering preserved semantics and known divergences.
  * Clarified the reference contracts aren’t deployed and won’t produce generated bindings.
* **New Features**
  * Updated the OSwaps interface and contract with manager rotation, asset enumeration/query helpers, pool quote functions, and swap slippage protection (`minOutAmount`).
  * Added a deployment script that initializes OSwaps to the configured manager.
* **Tests**
  * Introduced an end-to-end OSwaps test suite; added documentation reflecting current coverage status.
* **Chores**
  * Added multiple ERC20 mocks to simulate edge cases (bad decimals, no decimals, fee-on-transfer, and reentrancy).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->