### PR TITLE
fix(calls): restore adaptiveStream for remote screenshare quality

### DIFF
--- a/packages/core/src/matrix/client/hooks/use-space-group-call.ts
+++ b/packages/core/src/matrix/client/hooks/use-space-group-call.ts
@@ -4,8 +4,12 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import * as MatrixSdk from 'matrix-js-sdk';
 import { ClientEvent, RoomEvent } from 'matrix-js-sdk';
 import type { RoomMessageEventContent } from 'matrix-js-sdk/lib/@types/events';
-import type { Room as LiveKitRoom } from 'livekit-client';
-import { LocalAudioTrack, Track } from 'livekit-client';
+import type {
+  Room as LiveKitRoom,
+  ScreenShareCaptureOptions,
+  TrackPublishOptions,
+} from 'livekit-client';
+import { LocalAudioTrack, ScreenSharePresets, Track } from 'livekit-client';
 import {
   MATRIX_RTC_SESSION_EVENT,
   type MatrixRtcSessionLike,
@@ -188,6 +192,22 @@ async function stopLiveKitLocalPublishing(lkRoom: LiveKitRoom): Promise<void> {
     }
   }
 }
+
+/**
+ * Screen content (text/UI) needs sharper encoding than motion video, and the standard
+ * `adaptiveStream`/`dynacast` mechanism only degrades layer selection correctly if a low
+ * fallback layer actually exists — see #2425 decision 31.
+ */
+const SCREEN_SHARE_CAPTURE_OPTIONS: ScreenShareCaptureOptions = {
+  contentHint: 'detail',
+};
+
+const SCREEN_SHARE_PUBLISH_OPTIONS: TrackPublishOptions = {
+  simulcast: true,
+  screenShareEncoding: ScreenSharePresets.h1080fps15.encoding,
+  screenShareSimulcastLayers: [ScreenSharePresets.h360fps15],
+  degradationPreference: 'maintain-resolution',
+};
 
 const CAPTURE_START_STALL_MS = 10_000;
 /** Minimum time capture must run before finalize produces a non-empty blob. */
@@ -1393,7 +1413,12 @@ export function useSpaceGroupCall(
         try {
           await withEnhancedScreenshareCapture(
             client,
-            () => lkRoom.localParticipant.setScreenShareEnabled(true),
+            () =>
+              lkRoom.localParticipant.setScreenShareEnabled(
+                true,
+                SCREEN_SHARE_CAPTURE_OPTIONS,
+                SCREEN_SHARE_PUBLISH_OPTIONS,
+              ),
             screenshareSurfaceModeRef.current,
           );
         } catch (e) {

--- a/packages/epics/src/common/human-chat-panel/call-livekit-feed-adapter.ts
+++ b/packages/epics/src/common/human-chat-panel/call-livekit-feed-adapter.ts
@@ -126,6 +126,15 @@ class LiveKitAdaptedCallFeed {
     return this.isLocalFeed;
   }
 
+  /**
+   * Underlying LiveKit `Track` for this feed's source, so callers can use LiveKit's own
+   * `track.attach()` instead of the manually-rebuilt `stream` — needed for remote screenshare
+   * tiles so `adaptiveStream` can see the rendered element size (#2425).
+   */
+  getLiveKitTrack(): Track | undefined {
+    return this.participant.getTrackPublication(this.trackSource)?.track;
+  }
+
   isVideoMuted(): boolean {
     if (this.trackSource === Track.Source.ScreenShare) {
       const pub = this.participant.getTrackPublication(
@@ -229,4 +238,13 @@ export function buildCallFeedsFromLiveKitRoom(room: Room | null): {
 /** LiveKit identity is the Matrix user id — no device suffix. */
 export function feedKeyForActive(feed: Pick<CallFeed, 'userId'>): string {
   return feed.userId?.trim() || '';
+}
+
+/**
+ * Every `CallFeed` handed to the call stage is actually a `LiveKitAdaptedCallFeed` (see
+ * `buildCallFeedsFromLiveKitRoom` — the only feed source). Narrow back to it so callers can
+ * reach the underlying LiveKit `Track` for `.attach()`.
+ */
+export function liveKitTrackFromCallFeed(feed: CallFeed): Track | undefined {
+  return (feed as unknown as LiveKitAdaptedCallFeed).getLiveKitTrack?.();
 }

--- a/packages/epics/src/common/human-chat-panel/human-chat-panel-call-stage.tsx
+++ b/packages/epics/src/common/human-chat-panel/human-chat-panel-call-stage.tsx
@@ -98,6 +98,7 @@ import { CallRaiseHandBadge } from './call-raise-hand-badge';
 import {
   buildCallFeedsFromLiveKitRoom,
   feedKeyForActive,
+  liveKitTrackFromCallFeed,
 } from './call-livekit-feed-adapter';
 import type { CallFloatingReaction } from './use-call-reactions';
 
@@ -2561,6 +2562,14 @@ const FeedContent = ({
   };
   const liveVideoTrack = resolveCallFeedLiveVideoTrack(feed, feedVideoOptions);
   const hasVideo = liveVideoTrack !== null;
+  /**
+   * Remote screenshare tiles bind via LiveKit's own `track.attach()` instead of the
+   * manually-rebuilt `MediaStream`, so `adaptiveStream` can see the rendered tile size and pick
+   * simulcast layers accordingly (#2425). Camera tiles and local screenshare preview are
+   * unaffected — they keep the existing `srcObject` path.
+   */
+  const remoteShareLiveKitTrack =
+    isShare && !feed.isLocal() ? liveKitTrackFromCallFeed(feed) : undefined;
   const isAudioOnlyTile = !isShare && !hasVideo;
   const {
     text: resolvedName,
@@ -2617,8 +2626,12 @@ const FeedContent = ({
     const el = ref.current;
     if (!el || !liveVideoTrack) return;
 
-    const videoStream = createCallFeedVideoStream(liveVideoTrack);
-    el.srcObject = videoStream;
+    if (remoteShareLiveKitTrack) {
+      remoteShareLiveKitTrack.attach(el);
+    } else {
+      const videoStream = createCallFeedVideoStream(liveVideoTrack);
+      el.srcObject = videoStream;
+    }
     el.disablePictureInPicture = true;
 
     const markReady = () => {
@@ -2685,9 +2698,13 @@ const FeedContent = ({
       window.clearInterval(retryTimer);
       window.clearTimeout(giveUpTimer);
       resizeObserver?.disconnect();
-      el.srcObject = null;
+      if (remoteShareLiveKitTrack) {
+        remoteShareLiveKitTrack.detach(el);
+      } else {
+        el.srcObject = null;
+      }
     };
-  }, [liveVideoTrack?.id, streamBindVersion]);
+  }, [liveVideoTrack?.id, streamBindVersion, remoteShareLiveKitTrack]);
 
   const showVideoElement = hasVideo && !warmingVideoTrack;
   /** Avatar until video paints — avoids black tiles while remote/local tracks warm up. */
@@ -2781,7 +2798,11 @@ const FeedContent = ({
       rerenderOnFeed();
       const el = ref.current;
       if (el && liveVideoTrack) {
-        el.srcObject = createCallFeedVideoStream(liveVideoTrack);
+        if (remoteShareLiveKitTrack) {
+          remoteShareLiveKitTrack.attach(el);
+        } else {
+          el.srcObject = createCallFeedVideoStream(liveVideoTrack);
+        }
         void el.play().catch(() => undefined);
       }
       const audioEl = audioRef.current;
@@ -2794,7 +2815,7 @@ const FeedContent = ({
     return () => {
       document.removeEventListener('visibilitychange', onVisibility);
     };
-  }, [liveVideoTrack?.id, mountRemoteAudio, stream]);
+  }, [liveVideoTrack?.id, mountRemoteAudio, stream, remoteShareLiveKitTrack]);
 
   /** Analyse mic/remote line whenever the tile has a live audio track (not just Matrix `isSpeaking`, which lags and hid real levels). */
   const hasLiveAudioTrack =


### PR DESCRIPTION
## Summary
- Remote screenshare tiles never used LiveKit's own `track.attach()` — `LiveKitAdaptedCallFeed` manually rebuilt a `MediaStream` from `pub.track.mediaStreamTrack` instead, so `adaptiveStream` had no visibility into the rendered tile size and never adjusted simulcast layers as viewers zoomed/resized.
- **Publish side** (`use-space-group-call.ts`): `setScreenShareEnabled(true)` now passes explicit `TrackPublishOptions` — `contentHint: 'detail'`, 2-layer simulcast (~1080p15 high / ~360p15 low via `ScreenSharePresets`), `degradationPreference: 'maintain-resolution'`.
- **Render side**: `LiveKitAdaptedCallFeed` exposes the underlying LiveKit `Track`; the call-stage tile video-binding effect (mount + visibility-change re-bind) now calls `track.attach()`/`detach()` for **remote screenshare tiles only**, so `adaptiveStream` actually runs. Camera tiles and the local screenshare preview are untouched.

Root cause confirmed via #2361's own migration docs — `LiveKitAdaptedCallFeed` was a migration-continuity shim, not a deliberate quality decision. See decisions #29–32 in the ticket doc for the full record.

Fixes #2425. Out of scope (flagged to #2427): manual quality pickers, PiP full-size parity, in-app zoom/pan tool.

## Test plan
- [x] `call-feed-tile-video.test.ts`, `call-feed-tile-audio.test.ts`, `call-regression-manual-gates.test.ts` — 86/86 passing, before and after
- [x] `tsc --noEmit` clean on both edited packages (`core`, `epics`)
- [x] Live verification on this preview build: shared-screen tile's `<video>` element measured directly (`videoWidth`/`videoHeight`) on the viewer's tab — `640x340` (low layer) at small tile size, stepping up to `1920x1020` (high layer) a few seconds after enlarging the tile, with the visible sharpness change lining up with the transition. Confirms `adaptiveStream` is reacting to the rendered tile size end-to-end.
- [ ] Confirm camera tiles and local screenshare preview are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)