### PR TITLE
fix(assets): value HYPHA at its fixed $0.25 rate in wallet and treasury

### DIFF
--- a/apps/web/src/app/api/v1/people/[personSlug]/assets/route.ts
+++ b/apps/web/src/app/api/v1/people/[personSlug]/assets/route.ts
@@ -25,6 +25,8 @@ import {
   getEnergyCommunityToken,
   getEnergyCommunityTokensForSpace,
   getEnergyCommunityDisplayDecimals,
+  isHyphaToken,
+  HYPHA_PRICE_USD,
 } from '@hypha-platform/core/client';
 import { headers } from 'next/headers';
 import { hasEmojiOrLink, tryDecodeUriPart } from '@hypha-platform/ui-utils';
@@ -347,6 +349,10 @@ export async function GET(
             decimals,
           );
           let rate = isEnergyToken ? 1 : prices[token.address] || 0;
+          // HYPHA sells at a contract-fixed rate, so it overrides any feed price.
+          if (isHyphaToken(token.address)) {
+            rate = HYPHA_PRICE_USD;
+          }
           if (rate === 0) {
             rate = referencePriceByAddress[token.address.toLowerCase()] ?? 0;
           }

--- a/apps/web/src/app/api/v1/spaces/[spaceSlug]/assets/route.ts
+++ b/apps/web/src/app/api/v1/spaces/[spaceSlug]/assets/route.ts
@@ -22,6 +22,8 @@ import {
   getAllEnergyCommunityTokens,
   getEnergyCommunityToken,
   getEnergyCommunityDisplayDecimals,
+  isHyphaToken,
+  HYPHA_PRICE_USD,
 } from '@hypha-platform/core/client';
 import { db } from '@hypha-platform/storage-postgres';
 import { canConvertToBigInt, hasEmojiOrLink } from '@hypha-platform/ui-utils';
@@ -249,6 +251,10 @@ export async function GET(
           let rate = prices[token.address] || 0;
           if (token.address.toLowerCase() === EVC_TOKEN_ADDRESS) {
             rate = 1;
+          }
+          // HYPHA sells at a contract-fixed rate, so it overrides any feed price.
+          if (isHyphaToken(token.address)) {
+            rate = HYPHA_PRICE_USD;
           }
           if (rate === 0) {
             rate = referencePriceByAddress[token.address.toLowerCase()] ?? 0;

--- a/apps/web/src/app/api/v1/spaces/[spaceSlug]/vaults/route.ts
+++ b/apps/web/src/app/api/v1/spaces/[spaceSlug]/vaults/route.ts
@@ -12,6 +12,8 @@ import {
   getSpaceDecayingTokens,
   getSpaceOwnershipTokens,
   isHiddenToken,
+  isHyphaToken,
+  HYPHA_PRICE_USD,
 } from '@hypha-platform/core/client';
 import {
   tokenBackingVaultImplementationAbi,
@@ -336,6 +338,10 @@ export async function GET(
     const prices = await getTokenPrice(allAddresses);
 
     const resolveTokenPrice = (tokenAddress: `0x${string}`): number => {
+      // HYPHA sells at a contract-fixed rate, so it overrides any feed price.
+      if (isHyphaToken(tokenAddress)) {
+        return HYPHA_PRICE_USD;
+      }
       const marketPrice = prices[tokenAddress] ?? 0;
       if (marketPrice > 0) {
         return marketPrice;

--- a/packages/core/src/common/web3/__tests__/tokens.test.ts
+++ b/packages/core/src/common/web3/__tests__/tokens.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import { TOKENS, isCatalogueToken, isKnownTreasuryToken } from '../tokens';
+import {
+  TOKENS,
+  HYPHA_PRICE_USD,
+  HYPHA_TOKEN_ADDRESS,
+  isCatalogueToken,
+  isHyphaToken,
+  isKnownTreasuryToken,
+} from '../tokens';
 
 describe('isCatalogueToken', () => {
   it('returns true for hardcoded catalogue addresses', () => {
@@ -35,5 +42,33 @@ describe('isKnownTreasuryToken', () => {
 
   it('drops unknown spam addresses', () => {
     expect(isKnownTreasuryToken(spam, known)).toBe(false);
+  });
+});
+
+describe('HYPHA pricing', () => {
+  it('is fixed at $0.25 to match the HyphaToken contract rate', () => {
+    expect(HYPHA_PRICE_USD).toBe(0.25);
+  });
+
+  it('matches the HYPHA entry in the catalogue', () => {
+    const hypha = TOKENS.find((token) => token.symbol === 'HYPHA');
+    expect(hypha?.address).toBe(HYPHA_TOKEN_ADDRESS);
+  });
+});
+
+describe('isHyphaToken', () => {
+  it('matches the HYPHA address in any casing', () => {
+    expect(isHyphaToken(HYPHA_TOKEN_ADDRESS)).toBe(true);
+    expect(isHyphaToken(HYPHA_TOKEN_ADDRESS.toLowerCase())).toBe(true);
+    expect(isHyphaToken(HYPHA_TOKEN_ADDRESS.toUpperCase())).toBe(true);
+  });
+
+  it('returns false for other or empty addresses', () => {
+    expect(isHyphaToken('0x0000000000000000000000000000000000000001')).toBe(
+      false,
+    );
+    expect(isHyphaToken(null)).toBe(false);
+    expect(isHyphaToken(undefined)).toBe(false);
+    expect(isHyphaToken('')).toBe(false);
   });
 });

--- a/packages/core/src/common/web3/tokens.ts
+++ b/packages/core/src/common/web3/tokens.ts
@@ -15,6 +15,23 @@ export type Token = {
   transferable?: boolean;
 };
 
+/** HYPHA ERC-20 on Base. */
+export const HYPHA_TOKEN_ADDRESS =
+  '0x8b93862835C36e9689E9bb1Ab21De3982e266CD3' as const;
+
+/**
+ * HYPHA is sold at a fixed rate by `HyphaToken` (see `HYPHA_PRICE_USD` in
+ * `HyphaToken.sol`), so its USD value is not market-driven. Use this instead of
+ * a price feed — HYPHA is not listed on CoinGecko and would otherwise resolve to 0.
+ */
+export const HYPHA_PRICE_USD = 0.25;
+
+/** True when `address` is the HYPHA token. */
+export function isHyphaToken(address?: string | null): boolean {
+  if (!address) return false;
+  return address.toLowerCase() === HYPHA_TOKEN_ADDRESS.toLowerCase();
+}
+
 export const TOKENS: Token[] = [
   {
     symbol: 'USDC',
@@ -51,7 +68,7 @@ export const TOKENS: Token[] = [
   {
     symbol: 'HYPHA',
     icon: '/placeholder/hypha-token-icon.svg',
-    address: '0x8b93862835C36e9689E9bb1Ab21De3982e266CD3',
+    address: HYPHA_TOKEN_ADDRESS,
     name: 'Hypha',
     type: 'utility',
   },

--- a/packages/core/src/governance/client/hooks/useActivateSpacesOrchestrator.tsx
+++ b/packages/core/src/governance/client/hooks/useActivateSpacesOrchestrator.tsx
@@ -13,6 +13,7 @@ import {
   schemaActivateSpaces,
   schemaCreateAgreementFiles,
   schemaCreateAgreementWeb2,
+  HYPHA_PRICE_USD,
 } from '@hypha-platform/core/client';
 import { Config } from '@wagmi/core';
 
@@ -168,7 +169,6 @@ export const useActivateSpacesOrchestrator = ({
         if (config) {
           startTask('CREATE_WEB3_ACTIVATION');
           const HYPHA_PER_MONTH = 44;
-          const HYPHA_PRICE_USD = 0.25;
           const breakdown = arg.spaces.map(({ spaceId, months }) => ({
             spaceId,
             hypha: months * HYPHA_PER_MONTH,

--- a/packages/epics/src/agreements/plugins/buy-hypha-tokens/plugin.tsx
+++ b/packages/epics/src/agreements/plugins/buy-hypha-tokens/plugin.tsx
@@ -14,6 +14,7 @@ import { useFormContext, useWatch } from 'react-hook-form';
 import {
   TOKENS,
   useSpacesByWeb3Ids,
+  HYPHA_PRICE_USD,
   type Space,
 } from '@hypha-platform/core/client';
 import { Token } from '../components/common/token-payout-field-array';
@@ -25,7 +26,6 @@ type BuyHyphaTokensPluginProps = {
   spaces?: Space[];
 };
 
-const HYPHA_PRICE_USD = 0.25;
 const PAYMENT_TOKEN = TOKENS.find((t) => t.symbol === 'USDC');
 const RECIPIENT_SPACE_ADDRESS = '0x3dEf11d005F8C85c93e3374B28fcC69B25a650Af';
 

--- a/packages/epics/src/governance/components/proposal-activate-spaces-data.tsx
+++ b/packages/epics/src/governance/components/proposal-activate-spaces-data.tsx
@@ -4,6 +4,7 @@ import { formatCurrencyValue } from '@hypha-platform/ui-utils';
 import { useSpacesByWeb3IdsClient } from '../hooks';
 import { Image, Separator, Input } from '@hypha-platform/ui';
 import { useTranslations } from 'next-intl';
+import { HYPHA_PRICE_USD } from '@hypha-platform/core/client';
 
 interface ProposalActivateSpacesDataProps {
   spaceIds?: bigint[];
@@ -11,7 +12,6 @@ interface ProposalActivateSpacesDataProps {
   tokenSymbol?: string;
 }
 
-const HYPHA_PRICE_USD = 0.25;
 const HYPHA_PER_MONTH = 44;
 const USDC_PER_MONTH = 11;
 

--- a/packages/epics/src/people/components/people-purchase-hypha-tokens.tsx
+++ b/packages/epics/src/people/components/people-purchase-hypha-tokens.tsx
@@ -29,6 +29,7 @@ import {
   TOKENS,
   useInvestInHyphaMutation,
   useMe,
+  HYPHA_PRICE_USD,
 } from '@hypha-platform/core/client';
 import { TokenPayoutField } from '../../agreements/plugins/components/common/token-payout-field';
 import { formatCurrencyValue } from '@hypha-platform/ui-utils';
@@ -41,7 +42,6 @@ interface PeoplePurchaseHyphaTokensProps {
   closePanelUrl?: string;
 }
 
-const HYPHA_PRICE_USD = 0.25;
 const PAYMENT_TOKEN = TOKENS.find((t) => t.symbol === 'USDC');
 const RECIPIENT_SPACE_ADDRESS = '0x3dEf11d005F8C85c93e3374B28fcC69B25a650Af';
 

--- a/packages/epics/src/people/hooks/use-activate-hypha-spaces.ts
+++ b/packages/epics/src/people/hooks/use-activate-hypha-spaces.ts
@@ -1,9 +1,11 @@
 'use client';
 
 import { ActivateSpacesFormValues } from './validation';
-import { useActivateSpacesMutation } from '@hypha-platform/core/client';
+import {
+  useActivateSpacesMutation,
+  HYPHA_PRICE_USD,
+} from '@hypha-platform/core/client';
 
-const HYPHA_PRICE_USD = 0.25;
 const HYPHA_PER_MONTH = 44;
 
 export const useActivateSpaces = ({


### PR DESCRIPTION
## Summary

HYPHA was showing up with **no USD value** in My Wallet and in Space treasuries. Both asset endpoints price tokens via CoinGecko, falling back to the DB `tokens.reference_price`. HYPHA is listed on neither, so its rate resolved to `0` — the asset card hides the price line when the rate is 0, and the holding contributed nothing to the "Balance | $X" total.

HYPHA is sold at a contract-fixed rate (`HYPHA_PRICE_USD` in `HyphaToken.sol`, $0.25/HYPHA), so its value isn't market-driven and shouldn't come from a price feed. This adds that fixed rate as the authoritative price for HYPHA wherever assets are valued.

- New `HYPHA_PRICE_USD`, `HYPHA_TOKEN_ADDRESS`, and `isHyphaToken()` in `packages/core/src/common/web3/tokens.ts`.
- Applied in the three routes that value assets: user wallet (`/api/v1/people/[personSlug]/assets`), space treasury (`/api/v1/spaces/[spaceSlug]/assets`), and treasury vaults (`/api/v1/spaces/[spaceSlug]/vaults`). The override takes precedence over the feed, so a future speculative listing can't move the displayed rate away from the contract rate.
- The `0.25` literal was already duplicated in five places across the purchase and space-activation flows; those now import the shared constant, so there's one place to change if the contract rate ever moves.

No behaviour change for any other token — the CoinGecko → `reference_price` → hardcoded-$1 chain is untouched.

## Test plan

- [x] `pnpm --filter @hypha-platform/core exec vitest run src/common/web3/__tests__/tokens.test.ts` (9 passing, incl. new coverage for the constant and `isHyphaToken` casing)
- [x] `tsc --noEmit` clean on `packages/core`, `packages/epics`, `apps/web`
- [ ] On a preview deploy, open **My Wallet** as a HYPHA holder: the HYPHA card shows `0.25 USD` and the balance total increases by `holdings × 0.25`
- [ ] Open the **Treasury → Wallet** tab of a space in `ALLOWED_SPACES` (the only spaces that list HYPHA) and confirm the same
- [ ] Confirm the Buy HYPHA and Activate Spaces flows still quote $0.25/HYPHA (constant refactor, no math change)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - HYPHA tokens now use a fixed price of **$0.25 USD** across asset, vault, purchase, and space activation flows.
  - Added consistent HYPHA token recognition, including case-insensitive address matching.

- **Bug Fixes**
  - Prevented market or reference pricing from overriding the fixed HYPHA token price.
  - Unified HYPHA pricing across related user-facing calculations and displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->