### PR TITLE
fix(assets): value Hypha Energy EPARTS at its fixed 1 EUR participation rate

### DIFF
--- a/apps/web/src/app/api/v1/people/[personSlug]/assets/route.ts
+++ b/apps/web/src/app/api/v1/people/[personSlug]/assets/route.ts
@@ -27,6 +27,9 @@ import {
   getEnergyCommunityDisplayDecimals,
   isHyphaToken,
   HYPHA_PRICE_USD,
+  isEpartsToken,
+  EPARTS_PRICE_EUR,
+  EPARTS_REFERENCE_CURRENCY,
 } from '@hypha-platform/core/client';
 import { headers } from 'next/headers';
 import { hasEmojiOrLink, tryDecodeUriPart } from '@hypha-platform/ui-utils';
@@ -287,12 +290,17 @@ export async function GET(
     }));
 
     const referencePriceByAddress: Record<string, number> = {};
+    const referenceCurrencyByAddress: Record<string, string> = {};
     rawDbTokens.forEach((t) => {
       if (t.address && t.referencePrice != null) {
         const parsed = Number(t.referencePrice);
         if (Number.isFinite(parsed) && parsed >= 0) {
           referencePriceByAddress[t.address.toLowerCase()] = parsed;
         }
+      }
+      if (t.address && t.referenceCurrency) {
+        referenceCurrencyByAddress[t.address.toLowerCase()] =
+          t.referenceCurrency;
       }
     });
 
@@ -353,6 +361,10 @@ export async function GET(
           if (isHyphaToken(token.address)) {
             rate = HYPHA_PRICE_USD;
           }
+          // EPARTS is a €1 participation, so its terms override any feed price.
+          if (isEpartsToken(token.address)) {
+            rate = EPARTS_PRICE_EUR;
+          }
           if (rate === 0) {
             rate = referencePriceByAddress[token.address.toLowerCase()] ?? 0;
           }
@@ -363,11 +375,15 @@ export async function GET(
           ) {
             rate = 1;
           }
+          const referenceCurrency = isEpartsToken(token.address)
+            ? EPARTS_REFERENCE_CURRENCY
+            : referenceCurrencyByAddress[token.address.toLowerCase()];
           return {
             ...meta,
             address: token.address,
             value: amount,
             tokenPrice: rate,
+            referenceCurrency,
             usdEqual: rate * amount,
             chartData: [],
             transactions: [],

--- a/apps/web/src/app/api/v1/spaces/[spaceSlug]/assets/route.ts
+++ b/apps/web/src/app/api/v1/spaces/[spaceSlug]/assets/route.ts
@@ -24,6 +24,9 @@ import {
   getEnergyCommunityDisplayDecimals,
   isHyphaToken,
   HYPHA_PRICE_USD,
+  isEpartsToken,
+  EPARTS_PRICE_EUR,
+  EPARTS_REFERENCE_CURRENCY,
 } from '@hypha-platform/core/client';
 import { db } from '@hypha-platform/storage-postgres';
 import { canConvertToBigInt, hasEmojiOrLink } from '@hypha-platform/ui-utils';
@@ -256,6 +259,10 @@ export async function GET(
           if (isHyphaToken(token.address)) {
             rate = HYPHA_PRICE_USD;
           }
+          // EPARTS is a €1 participation, so its terms override any feed price.
+          if (isEpartsToken(token.address)) {
+            rate = EPARTS_PRICE_EUR;
+          }
           if (rate === 0) {
             rate = referencePriceByAddress[token.address.toLowerCase()] ?? 0;
           }
@@ -271,8 +278,9 @@ export async function GET(
             token.address,
             contractDecimals,
           );
-          const referenceCurrency =
-            referenceCurrencyByAddress[token.address.toLowerCase()];
+          const referenceCurrency = isEpartsToken(token.address)
+            ? EPARTS_REFERENCE_CURRENCY
+            : referenceCurrencyByAddress[token.address.toLowerCase()];
           return {
             ...meta,
             address: token.address,

--- a/apps/web/src/app/api/v1/spaces/[spaceSlug]/vaults/route.ts
+++ b/apps/web/src/app/api/v1/spaces/[spaceSlug]/vaults/route.ts
@@ -14,6 +14,8 @@ import {
   isHiddenToken,
   isHyphaToken,
   HYPHA_PRICE_USD,
+  isEpartsToken,
+  EPARTS_PRICE_EUR,
 } from '@hypha-platform/core/client';
 import {
   tokenBackingVaultImplementationAbi,
@@ -341,6 +343,10 @@ export async function GET(
       // HYPHA sells at a contract-fixed rate, so it overrides any feed price.
       if (isHyphaToken(tokenAddress)) {
         return HYPHA_PRICE_USD;
+      }
+      // EPARTS is a €1 participation, so its terms override any feed price.
+      if (isEpartsToken(tokenAddress)) {
+        return EPARTS_PRICE_EUR;
       }
       const marketPrice = prices[tokenAddress] ?? 0;
       if (marketPrice > 0) {

--- a/packages/core/src/common/web3/__tests__/tokens.test.ts
+++ b/packages/core/src/common/web3/__tests__/tokens.test.ts
@@ -3,7 +3,11 @@ import {
   TOKENS,
   HYPHA_PRICE_USD,
   HYPHA_TOKEN_ADDRESS,
+  EPARTS_PRICE_EUR,
+  EPARTS_REFERENCE_CURRENCY,
+  EPARTS_TOKEN_ADDRESS,
   isCatalogueToken,
+  isEpartsToken,
   isHyphaToken,
   isKnownTreasuryToken,
 } from '../tokens';
@@ -70,5 +74,31 @@ describe('isHyphaToken', () => {
     expect(isHyphaToken(null)).toBe(false);
     expect(isHyphaToken(undefined)).toBe(false);
     expect(isHyphaToken('')).toBe(false);
+  });
+});
+
+describe('EPARTS pricing', () => {
+  it('values one participation at 1 EUR', () => {
+    expect(EPARTS_PRICE_EUR).toBe(1);
+    expect(EPARTS_REFERENCE_CURRENCY).toBe('EUR');
+  });
+
+  it('is not a catalogue token, so it needs the explicit override', () => {
+    expect(isCatalogueToken(EPARTS_TOKEN_ADDRESS)).toBe(false);
+  });
+});
+
+describe('isEpartsToken', () => {
+  it('matches the EPARTS address in any casing', () => {
+    expect(isEpartsToken(EPARTS_TOKEN_ADDRESS)).toBe(true);
+    expect(isEpartsToken(EPARTS_TOKEN_ADDRESS.toLowerCase())).toBe(true);
+    expect(isEpartsToken(EPARTS_TOKEN_ADDRESS.toUpperCase())).toBe(true);
+  });
+
+  it('returns false for other or empty addresses', () => {
+    expect(isEpartsToken(HYPHA_TOKEN_ADDRESS)).toBe(false);
+    expect(isEpartsToken(null)).toBe(false);
+    expect(isEpartsToken(undefined)).toBe(false);
+    expect(isEpartsToken('')).toBe(false);
   });
 });

--- a/packages/core/src/common/web3/tokens.ts
+++ b/packages/core/src/common/web3/tokens.ts
@@ -32,6 +32,26 @@ export function isHyphaToken(address?: string | null): boolean {
   return address.toLowerCase() === HYPHA_TOKEN_ADDRESS.toLowerCase();
 }
 
+/** Hypha Energy Participations (EPARTS) — ownership ERC-20 on Base. */
+export const EPARTS_TOKEN_ADDRESS =
+  '0x5d3394CAa6D09214aB86CF048e39dea058eC1921' as const;
+
+/**
+ * One EPARTS is a €1 participation in Hypha Energy's assets, so its value comes
+ * from the participation terms rather than a market. Use this instead of a price
+ * feed — EPARTS is not listed on CoinGecko and would otherwise resolve to 0.
+ */
+export const EPARTS_PRICE_EUR = 1;
+
+/** Currency label shown alongside {@link EPARTS_PRICE_EUR}. */
+export const EPARTS_REFERENCE_CURRENCY = 'EUR';
+
+/** True when `address` is the EPARTS token. */
+export function isEpartsToken(address?: string | null): boolean {
+  if (!address) return false;
+  return address.toLowerCase() === EPARTS_TOKEN_ADDRESS.toLowerCase();
+}
+
 export const TOKENS: Token[] = [
   {
     symbol: 'USDC',


### PR DESCRIPTION
## Summary

Hypha Energy Participations (**EPARTS**, `0x5d3394CAa6D09214aB86CF048e39dea058eC1921` on Base) had no price anywhere in the platform. It is not listed on CoinGecko and has no `referencePrice` row in the DB, so it resolved to `0`: asset cards rendered without a price line, and holdings were silently excluded from treasury / wallet portfolio totals.

One EPARTS is a €1 participation in Hypha Energy's assets, so its value comes from the participation terms rather than a market. This prices it from those terms, following the pattern already established for HYPHA in #2418 (`HYPHA_PRICE_USD`).

- Adds `EPARTS_TOKEN_ADDRESS`, `EPARTS_PRICE_EUR`, `EPARTS_REFERENCE_CURRENCY` and `isEpartsToken()` to `packages/core/src/common/web3/tokens.ts`.
- Applies the override in the three places that resolve token prices: the space treasury assets route, the profile wallet assets route, and the vaults (collateral) route.
- The card now reads **`1 EUR`** rather than falling back to the `USD` label, because the override also sets `referenceCurrency`.

## Notes for the reviewer

**The profile wallet route never returned `referenceCurrency`.** `use-user-assets.ts` and `AssetCard` both already accept it, and the space treasury route already builds a DB-backed map — the wallet route just didn't. So every EUR-referenced token in a user's wallet was labelled `USD` (the `AssetCard` fallback). This PR mirrors the existing map into that route, which fixes EPARTS and that pre-existing mislabel together.

**`usdEqual` treats €1 as $1.** Portfolio totals are summed in a single `usdEqual` field with no FX conversion, so EPARTS contributes 1.0 per token to the total. This matches how the codebase already handles the other euro-denominated energy assets — the NRG credit override is commented *"1 display NRG ≈ 1 EURC/USDC"* — and introducing real FX would be a separate change across all of them. Flagging it in case you'd rather hold this until an FX layer exists.

## Test plan

- [x] `pnpm --filter @hypha-platform/core exec vitest run src/common/web3/__tests__/tokens.test.ts` — 13 passing, including new coverage for the 1 EUR rate, case-insensitive address matching, and the fact that EPARTS is deliberately not a catalogue token.
- [x] Prettier + ESLint clean on all five changed files.
- [ ] Manual: open the Hypha Energy space treasury and confirm the EPARTS card shows `1 EUR` and its holdings are counted in the treasury total.
- [ ] Manual: open the profile wallet of an EPARTS holder and confirm the same, and that no other token's currency label regressed.
- [ ] Manual: confirm an EPARTS-collateralised backing vault reports a non-zero collateral value.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for EPARTS tokens across asset and vault views.
  * EPARTS tokens now display a fixed €1 price and EUR reference currency.
  * Asset details include the applicable reference currency for each token.
  * EPARTS pricing is applied consistently when market or stored pricing is unavailable.
* **Bug Fixes**
  * Improved EPARTS token recognition, including case-insensitive contract address matching.
  * Non-EPARTS and missing token addresses continue to be handled correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->