### PR TITLE
fix(ui): wrap proposal attachment label on mobile

### DIFF
--- a/packages/epics/src/agreements/components/create-agreement-base-fields.tsx
+++ b/packages/epics/src/agreements/components/create-agreement-base-fields.tsx
@@ -627,7 +627,7 @@ export function CreateAgreementBaseFields({
             />
           </section>
         ) : null}
-        <section className="rounded-lg border border-border/70 bg-muted/10 p-4 dark:bg-muted/10 lg:p-6">
+        <section className="min-w-0 max-w-full overflow-hidden rounded-lg border border-border/70 bg-muted/10 p-4 dark:bg-muted/10 lg:p-6">
           {mode === 'memory' ? (
             <FormField
               control={form.control}
@@ -643,7 +643,7 @@ export function CreateAgreementBaseFields({
                 ];
 
                 return (
-                  <FormItem className="mb-6">
+                  <FormItem className="mb-6 min-w-0 max-w-full">
                     <FormLabel className="mb-2 block gap-1 text-sm font-medium text-foreground">
                       {tCoherence('newMemoryUploadDocumentsTitle')}{' '}
                       <RequirementMark />
@@ -729,7 +729,7 @@ export function CreateAgreementBaseFields({
                 ];
 
                 return (
-                  <FormItem className="mt-6">
+                  <FormItem className="mt-6 min-w-0 max-w-full">
                     <FormControl>
                       <AddAttachment
                         label={attachmentLabel}

--- a/packages/ui/src/upload/add-attachment.tsx
+++ b/packages/ui/src/upload/add-attachment.tsx
@@ -125,16 +125,16 @@ export const AddAttachment: React.FC<AddAttachmentProps> = ({
   };
 
   return (
-    <div className="flex flex-col items-end w-full">
+    <div className="flex w-full min-w-0 max-w-full flex-col items-end">
       <Button
         variant="ghost"
         colorVariant="accent"
         type="button"
         onClick={handleClick}
-        className="w-full justify-start text-accent-11 hover:bg-accent-3 hover:text-neutral-12 [&_svg]:text-accent-11 hover:[&_svg]:text-neutral-12"
+        className="h-auto w-full min-w-0 max-w-full justify-start whitespace-normal text-left text-accent-11 hover:bg-accent-3 hover:text-neutral-12 [&_svg]:shrink-0 [&_svg]:text-accent-11 hover:[&_svg]:text-neutral-12"
       >
         <Link2Icon />
-        {label}
+        <span className="min-w-0 flex-1 break-words text-left">{label}</span>
         <input
           ref={inputRef}
           type="file"
@@ -148,17 +148,17 @@ export const AddAttachment: React.FC<AddAttachmentProps> = ({
         />
       </Button>
 
-      <div className="mt-4 space-y-2 w-full">
+      <div className="mt-4 w-full min-w-0 max-w-full space-y-2">
         {existingAttachments.map((file, idx) => (
           <div
             key={`existing-${idx}-${
               typeof file === 'string' ? file : file.url
             }`}
-            className="flex items-center justify-between text-sm p-2 rounded"
+            className="flex min-w-0 items-center justify-between rounded p-2 text-sm"
           >
-            <div className="flex items-center gap-2 overflow-hidden">
+            <div className="flex min-w-0 items-center gap-2 overflow-hidden">
               {renderFileIcon(file)}
-              <span className="text-neutral-11 truncate">
+              <span className="truncate text-neutral-11">
                 {getFileName(file)}
               </span>
             </div>
@@ -170,11 +170,11 @@ export const AddAttachment: React.FC<AddAttachmentProps> = ({
         {attachments.map((file, idx) => (
           <div
             key={`${file.name}-${file.size}-${idx}`}
-            className="flex items-center justify-between text-sm p-2 rounded"
+            className="flex min-w-0 items-center justify-between rounded p-2 text-sm"
           >
-            <div className="flex items-center gap-2 overflow-hidden">
+            <div className="flex min-w-0 items-center gap-2 overflow-hidden">
               {renderFileIcon(file)}
-              <span className="text-neutral-11 truncate">{file.name}</span>
+              <span className="truncate text-neutral-11">{file.name}</span>
             </div>
             <Button variant="ghost" onClick={() => handleRemove(idx)}>
               <X className="text-neutral-11" size={16} />
@@ -182,7 +182,7 @@ export const AddAttachment: React.FC<AddAttachmentProps> = ({
           </div>
         ))}
       </div>
-      <Separator />
+      <Separator className="max-w-full" />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- Allow the Create Proposal “Add Attachment…” helper text to wrap on narrow viewports instead of expanding the page width
- Constrain the proposal content section / attachment field with `min-w-0` / `max-w-full` so children cannot force horizontal scroll (and misplace Publish)

## Test plan
- [ ] On a phone-width viewport, open Create a Proposal
- [ ] Confirm `Add Attachment (JPEG, PNG, WebP, or PDF — max 16MB)` wraps within the white form card
- [ ] Confirm the page does not scroll horizontally
- [ ] Confirm Publish stays aligned within the form footer
- [ ] Desktop layout unchanged


Made with [Cursor](https://cursor.com)