### PR TITLE
fix(ui): iPad usability — sticky chrome, dialogs, touch Details

### DIFF
--- a/apps/web/src/app/[lang]/dho/[id]/_components/dho-sticky-space-chrome.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/dho-sticky-space-chrome.tsx
@@ -155,7 +155,7 @@ export function DhoStickySpaceChrome({
            */
           'pointer-events-none fixed left-[var(--panel-left-inset,var(--sidebar-left-width,0px))] z-[25] hidden md:block',
           'right-[var(--panel-right-inset,calc(var(--sidebar-right-width,0px)+var(--main-column-scrollbar-width,0px)))]',
-          'overflow-hidden border-x border-b border-border bg-background-2',
+          'border-x border-b border-border bg-background-2',
           'transition-[opacity,transform] duration-200 ease-out motion-reduce:transition-none',
           stuck
             ? 'pointer-events-auto translate-y-0 opacity-100'
@@ -184,9 +184,10 @@ export function DhoStickySpaceChrome({
               {title}
             </p>
           </div>
+          {/* Allow shrink + horizontal scroll so Settings/badges stay reachable on iPad when panels narrow the column */}
           <div
             ref={setStickyActionsEl}
-            className="flex shrink-0 flex-nowrap items-center gap-2"
+            className="flex min-w-0 shrink items-center gap-2 overflow-x-auto overscroll-x-contain touch-pan-x [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden"
           />
         </div>
       </div>

--- a/apps/web/src/app/[lang]/dho/[id]/_components/navigation-tabs.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/navigation-tabs.tsx
@@ -163,7 +163,9 @@ export function NavigationTabs({
         )}
       >
         <TabsList
-          className="flex h-10 min-w-max will-change-transform gap-0.5 md:min-w-0 md:w-full"
+          /* Keep content-sized strip so overflow-x on the parent can scroll at iPad widths
+             when side panels shrink the main column (viewport md ≠ usable column width). */
+          className="flex h-10 min-w-max will-change-transform gap-0.5"
           style={
             preferReducedMotion
               ? undefined

--- a/packages/epics/src/agreements/components/create-agreement-base-fields.tsx
+++ b/packages/epics/src/agreements/components/create-agreement-base-fields.tsx
@@ -432,12 +432,12 @@ export function CreateAgreementBaseFields({
           <h2 className="min-w-0 flex-1 truncate text-base font-semibold leading-tight tracking-tight text-foreground">
             {stickyHeaderTitle ?? resolvedLabel}
           </h2>
-          <div className="flex shrink-0 items-center justify-end gap-1">
+          <div className="flex min-w-0 shrink items-center justify-end gap-1 overflow-x-auto overscroll-x-contain touch-pan-x">
             {backUrl && (
               <ButtonBack
                 label={resolvedBackLabel}
                 backUrl={backUrl}
-                className="px-0 md:px-3 align-top"
+                className="shrink-0 px-0 md:px-3 align-top"
               />
             )}
             {form.formState.isDirty ? (
@@ -445,7 +445,7 @@ export function CreateAgreementBaseFields({
                 type="button"
                 variant="ghost"
                 colorVariant="neutral"
-                className="inline-flex items-center gap-1 px-0 text-neutral-10 md:px-3"
+                className="inline-flex shrink-0 items-center gap-1 px-0 text-neutral-10 md:px-3"
                 onClick={handleResetForm}
               >
                 <RotateCcw className="size-4 shrink-0" aria-hidden />
@@ -455,7 +455,7 @@ export function CreateAgreementBaseFields({
             <ButtonClose
               closeUrl={closeUrl}
               preferBack={mode === 'memory'}
-              className="px-0 md:px-3 align-top"
+              className="shrink-0 px-0 md:px-3 align-top"
             />
           </div>
         </div>

--- a/packages/epics/src/banking/components/banking-dialog-layout.tsx
+++ b/packages/epics/src/banking/components/banking-dialog-layout.tsx
@@ -5,7 +5,8 @@ import { cn } from '@hypha-platform/ui-utils';
 
 /** Apply on `DialogContent` — scroll the whole panel when content exceeds the viewport. */
 export const BANKING_DIALOG_CONTENT_CLASS = cn(
-  'block! max-h-[90vh]! overflow-y-scroll!',
+  /* Cap to remaining space under MenuTop so landscape iPad does not clip footers */
+  'block! max-h-[calc(100dvh-var(--menu-top-height,70px)-1rem)]! overflow-y-scroll!',
   'gap-0 p-0',
   'top-[max(0.5rem,calc(var(--menu-top-height,70px)+0.5rem))]! translate-y-0!',
 );

--- a/packages/epics/src/coherence/components/memory-filters.tsx
+++ b/packages/epics/src/coherence/components/memory-filters.tsx
@@ -71,23 +71,25 @@ export function MemoryFilters({
         onValueChange={(value) => onFilterChange(value as MemoryFilterValue)}
         className="w-full"
       >
-        <TabsList triggerVariant="switch" className="w-fit max-w-full">
-          {visibleTabItems.map((item) => (
-            <TabsTrigger
-              key={item.value}
-              variant="switch"
-              value={item.value}
-              className="justify-center"
-            >
-              <span className="inline-flex items-center gap-1">
-                <span>{item.label}</span>
-                <span className="text-xs text-muted-foreground">
-                  ({counts[item.value] ?? 0})
+        <div className="w-full max-w-full overflow-x-auto overscroll-x-contain touch-pan-x [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">
+          <TabsList triggerVariant="switch" className="w-max max-w-none">
+            {visibleTabItems.map((item) => (
+              <TabsTrigger
+                key={item.value}
+                variant="switch"
+                value={item.value}
+                className="justify-center"
+              >
+                <span className="inline-flex items-center gap-1">
+                  <span>{item.label}</span>
+                  <span className="text-xs text-muted-foreground">
+                    ({counts[item.value] ?? 0})
+                  </span>
                 </span>
-              </span>
-            </TabsTrigger>
-          ))}
-        </TabsList>
+              </TabsTrigger>
+            ))}
+          </TabsList>
+        </div>
       </Tabs>
 
       <div className="flex w-full flex-col gap-3 lg:flex-row lg:items-center">

--- a/packages/epics/src/common/select-action.tsx
+++ b/packages/epics/src/common/select-action.tsx
@@ -116,7 +116,8 @@ export const SelectAction = ({
               {group && (
                 <h3 className="text-3 font-medium text-neutral-11">{group}</h3>
               )}
-              <div className="grid w-full grid-cols-1 gap-3 md:grid-cols-2">
+              {/* Container query: viewport md on iPad ≠ overlay width when panels are open */}
+              <div className="@container/select-action grid w-full grid-cols-1 gap-3 @[36rem]:grid-cols-2">
                 {groupActions.map((action) => {
                   const isLink = !action.onAction && !!action.href;
 

--- a/packages/epics/src/spaces/components/compact-space-banner.tsx
+++ b/packages/epics/src/spaces/components/compact-space-banner.tsx
@@ -279,10 +279,14 @@ export function CompactSpaceBanner(props: CompactSpaceBannerProps) {
                       type="button"
                       className={cn(
                         'inline-flex w-fit items-center gap-1 text-1 font-medium text-white/70 hover:text-white/90',
-                        /* Fine pointer: chrome appears on hero hover; keep button for keyboard/a11y */
-                        'md:opacity-0 md:transition-opacity md:duration-150',
-                        'md:group-hover/hero:opacity-100 md:group-focus-within/hero:opacity-100',
-                        metaExpanded && 'md:opacity-100',
+                        /*
+                         * Hide until hover only on fine-pointer devices. iPad is md+ but
+                         * hover:none — keep the control visible so Details stays tappable.
+                         */
+                        '[@media(hover:hover)_and_(pointer:fine)]:opacity-0 [@media(hover:hover)_and_(pointer:fine)]:transition-opacity [@media(hover:hover)_and_(pointer:fine)]:duration-150',
+                        '[@media(hover:hover)_and_(pointer:fine)]:group-hover/hero:opacity-100 [@media(hover:hover)_and_(pointer:fine)]:group-focus-within/hero:opacity-100',
+                        metaExpanded &&
+                          '[@media(hover:hover)_and_(pointer:fine)]:opacity-100',
                       )}
                       aria-expanded={metaExpanded}
                       onClick={() => setMetaExpanded((v) => !v)}
@@ -302,11 +306,11 @@ export function CompactSpaceBanner(props: CompactSpaceBannerProps) {
                         metaExpanded
                           ? 'grid-rows-[1fr] opacity-100'
                           : 'grid-rows-[0fr] opacity-0',
-                        /* Desktop hover reveals without a click when collapsed */
+                        /* Fine-pointer hover reveals without a click when collapsed */
                         !metaExpanded &&
-                          'md:group-hover/hero:grid-rows-[1fr] md:group-hover/hero:opacity-100',
+                          '[@media(hover:hover)_and_(pointer:fine)]:group-hover/hero:grid-rows-[1fr] [@media(hover:hover)_and_(pointer:fine)]:group-hover/hero:opacity-100',
                         !metaExpanded &&
-                          'md:group-focus-within/hero:grid-rows-[1fr] md:group-focus-within/hero:opacity-100',
+                          '[@media(hover:hover)_and_(pointer:fine)]:group-focus-within/hero:grid-rows-[1fr] [@media(hover:hover)_and_(pointer:fine)]:group-focus-within/hero:opacity-100',
                       )}
                     >
                       <div className="min-h-0 overflow-hidden">

--- a/packages/epics/src/spaces/components/explore-spaces.tsx
+++ b/packages/epics/src/spaces/components/explore-spaces.tsx
@@ -369,8 +369,8 @@ export function ExploreSpaces({
   );
 
   const metricsSection = (
-    <div className="flex items-stretch justify-center gap-0">
-      <div className="flex min-w-[7rem] flex-col px-6 sm:min-w-[9rem] sm:px-10">
+    <div className="flex min-w-0 flex-wrap items-stretch justify-center gap-0">
+      <div className="flex min-w-0 flex-1 flex-col px-3 sm:min-w-[7rem] sm:flex-none sm:px-6 md:min-w-[9rem] md:px-10">
         <div className="flex justify-center text-7 font-medium">
           <CountValue
             value={selectedSpaces.length}
@@ -386,7 +386,7 @@ export function ExploreSpaces({
         orientation="vertical"
         className="h-auto self-stretch bg-neutral-6"
       />
-      <div className="flex min-w-[7rem] flex-col px-6 sm:min-w-[9rem] sm:px-10">
+      <div className="flex min-w-0 flex-1 flex-col px-3 sm:min-w-[7rem] sm:flex-none sm:px-6 md:min-w-[9rem] md:px-10">
         <div className="flex justify-center text-7 font-medium">
           <CountValue
             value={uniqueMemberAddresses.size}
@@ -402,7 +402,7 @@ export function ExploreSpaces({
         orientation="vertical"
         className="h-auto self-stretch bg-neutral-6"
       />
-      <div className="flex min-w-[7rem] flex-col px-6 sm:min-w-[9rem] sm:px-10">
+      <div className="flex min-w-0 flex-1 flex-col px-3 sm:min-w-[7rem] sm:flex-none sm:px-6 md:min-w-[9rem] md:px-10">
         <div className="flex justify-center text-7 font-medium">
           <CountValue
             value={agreementCount}

--- a/packages/ui/src/alert-dialog.tsx
+++ b/packages/ui/src/alert-dialog.tsx
@@ -68,6 +68,7 @@ const AlertDialogContent = React.forwardRef<
       ref={ref}
       className={cn(
         `fixed ${ALERT_DIALOG_Z} grid max-w-full translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg`,
+        'max-h-[min(90dvh,calc(100dvh-var(--menu-top-height,70px)-1rem))] overflow-y-auto',
         viewport === 'full'
           ? 'left-1/2 top-[50%] w-[min(32rem,calc(100vw-2rem))]'
           : 'left-[calc((var(--sidebar-left-width,0px)+100vw-var(--sidebar-right-width,0px))/2)] top-[50%] w-[min(32rem,calc(100vw-var(--sidebar-left-width,0px)-var(--sidebar-right-width,0px)-2rem))]',

--- a/packages/ui/src/dialog.tsx
+++ b/packages/ui/src/dialog.tsx
@@ -66,6 +66,8 @@ const DialogContent = React.forwardRef<
         ref={ref}
         className={cn(
           'fixed z-50 grid w-[min(32rem,calc(100vw-var(--sidebar-left-width,0px)-var(--sidebar-right-width,0px)-2rem))] max-w-full translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+          /* Keep close control reachable on short/landscape iPad viewports */
+          'max-h-[min(90dvh,calc(100dvh-var(--menu-top-height,70px)-1rem))] overflow-y-auto',
           'left-[calc((var(--sidebar-left-width,0px)+100vw-var(--sidebar-right-width,0px))/2)] top-[50%]',
           className,
         )}

--- a/packages/ui/src/organisms/section-filter.tsx
+++ b/packages/ui/src/organisms/section-filter.tsx
@@ -33,18 +33,18 @@ export const SectionFilter: FC<SectionFilterProps> = ({
   const hasLabel = label.trim().length > 0;
   const hasCount = count !== undefined && count !== null;
   return (
-    <div className="flex justify-between items-center w-full gap-4">
+    <div className="flex w-full min-w-0 flex-wrap items-center justify-between gap-3 sm:gap-4">
       {inlineLabel ? (
         <>
           {hasLabel ? (
-            <Text className="text-4 capitalize text-nowrap">
+            <Text className="min-w-0 shrink text-4 capitalize text-nowrap">
               {label} {hasCount ? <>| {count}</> : null}
             </Text>
           ) : null}
           {hasSearch ? (
             <Input
               type="search"
-              className="w-full"
+              className="w-full min-w-0 flex-1 basis-[12rem]"
               placeholder={searchPlaceholder}
               aria-label={searchPlaceholder}
               leftIcon={<SearchIcon className="text-accent-9" size="16px" />}
@@ -54,7 +54,12 @@ export const SectionFilter: FC<SectionFilterProps> = ({
             />
           ) : null}
           {children && (
-            <div className={cn('flex items-center text-nowrap', className)}>
+            <div
+              className={cn(
+                'flex min-w-0 max-w-full shrink-0 items-center gap-2 overflow-x-auto overscroll-x-contain touch-pan-x text-nowrap',
+                className,
+              )}
+            >
               {children}
             </div>
           )}


### PR DESCRIPTION
## Summary

iPad / tablet usability pass (~768–1024, including when side panels shrink the main column). **Usability only — no design language changes.**

### Are there issues on iPad?
**Yes.** Several tablet-width bugs made controls hard or impossible to use when the center column is narrowed. MenuTop compact hysteresis looked already guarded and was left alone.

### iPad issues found and fixed
1. **Sticky space chrome clipped actions** (`md+` only) — Settings / badges could be cut off with no way to reach them when panels are open. Actions row now allows shrink + horizontal scroll.
2. **Hero “Details” was hover-gated at `md+`** — iPad has no hover, so the control disappeared. Gated on `(hover: hover) and (pointer: fine)` instead of viewport `md`.
3. **Shared Dialog / AlertDialog lacked max-height** — tall dialogs could push the close control off-screen on landscape iPad. Added viewport-aware `max-h` + `overflow-y-auto`.
4. **Banking dialogs used `90vh` under MenuTop** — total height could exceed the viewport; footers clipped. Cap is now remaining space under `--menu-top-height`.
5. **Space section tabs crushed at `md+`** — `md:w-full` / `md:min-w-0` prevented horizontal scroll when the column (not the viewport) was narrow. Keep content-sized `min-w-max` so the existing overflow-x wrapper can scroll.
6. **Create / settings action chooser used viewport `md:grid-cols-2`** — cramped cards inside a narrowed overlay. Switched to a container query (`@[36rem]`).
7. **Create Proposal sticky toolbar** — Back / Reset / Close could collide on narrow overlays; actions now scroll horizontally.
8. **Memory filter pills** — full iPad tab set could clip; wrapped in a horizontal scroll viewport.
9. **Explore Spaces metrics + SectionFilter** — reduce clipping / overflow on narrow tablet columns.

### Intentionally left to sibling PRs
- **#2437** — shortcut tab scroll jump / parallax removal (`fix/mobile-shortcut-tab-jump`). This PR only adjusts tab strip sizing so iPad can scroll; merge carefully with #2437 (same file: `navigation-tabs.tsx`).
- **#2438** — Help Shape Hypha modal containment.
- **#2439** — proposal attachment label overflow.
- Filter / `ScrollableTabsList` adoption for Spaces / Treasury / Members / Documents — sibling WIP (`fix/mobile-filter-horizontal-scroll`); not duplicated here.

### iPad / tablet non-regression
- No forced phone-only stacking at `md` for layouts that should stay multi-column on iPad.
- Sticky chrome remains `md+` desktop/tablet chrome (not phone).
- MenuTop compact hysteresis unchanged (existing iPad WebKit guards retained).
- Desktop desktop widths should behave the same; changes are overflow/reachability constraints.

## Test plan
- [ ] iPad portrait (~810/834) and landscape (~1024): open a space with AI icon rail; scroll past banner — sticky chrome actions remain reachable
- [ ] Space hero: Details control visible/tappable without hover
- [ ] Open a tall dialog (banking / calendar / alert): close control stays on-screen; content scrolls
- [ ] Space section tabs with left panel open: tabs scroll horizontally instead of crushing
- [ ] Create Proposal / select-action chooser: cards stay usable in the overlay; sticky toolbar actions reachable
- [ ] Memory filters: all tabs reachable via horizontal scroll
- [ ] Spot-check desktop ≥1280: no layout regression
- [ ] Confirm no conflict intent with #2437 / #2438 / #2439 beyond noted `navigation-tabs.tsx` merge


Made with [Cursor](https://cursor.com)