### PR TITLE
fix(ai-panel): make My Spaces search tappable on mobile

### DIFF
--- a/packages/epics/src/common/ai-panel/ai-panel-header.tsx
+++ b/packages/epics/src/common/ai-panel/ai-panel-header.tsx
@@ -253,10 +253,23 @@ export function AiPanelHeader({
                 align="center"
                 sideOffset={4}
                 collisionPadding={8}
+                // Nested inside the mobile sidebar Sheet: keep modal=true so the
+                // menu opens above the sheet, but stop Radix menu focus/pointer
+                // handling from swallowing taps on the custom search field.
+                onOpenAutoFocus={(event) => {
+                  event.preventDefault();
+                  focusSpaceSearchInput();
+                }}
+                onCloseAutoFocus={(event) => {
+                  event.preventDefault();
+                }}
                 className="relative isolate z-[70] w-[min(16rem,calc(100vw-1.5rem))] overflow-hidden rounded-lg border border-border/60 bg-background-2 p-0 shadow-md data-[state=open]:animate-none data-[state=closed]:animate-none"
               >
                 <div className="flex max-h-[24.5rem] min-h-0 flex-col">
-                  <div className="shrink-0 border-b border-border/70 bg-background-3 px-2 pb-1.5 pt-1">
+                  <div
+                    className="relative z-[1] shrink-0 border-b border-border/70 bg-background-3 px-2 pb-1.5 pt-1"
+                    onPointerDown={(event) => event.stopPropagation()}
+                  >
                     <DropdownMenuLabel className="px-2 py-1.5 text-1 text-muted-foreground">
                       {tNavigation('mySpaces')}
                     </DropdownMenuLabel>
@@ -266,11 +279,20 @@ export function AiPanelHeader({
                         type="text"
                         value={spaceSearch}
                         onChange={(event) => setSpaceSearch(event.target.value)}
-                        onKeyDown={(event) => {
+                        onPointerDown={(event) => {
                           event.stopPropagation();
+                          spaceSearchInputRef.current?.focus({
+                            preventScroll: true,
+                          });
+                        }}
+                        onKeyDown={(event) => {
+                          // Keep typing out of DropdownMenu typeahead; Escape still closes.
+                          if (event.key !== 'Escape') {
+                            event.stopPropagation();
+                          }
                         }}
                         placeholder={tSpaces('search')}
-                        className="h-8 w-full rounded-lg border border-border/60 bg-background-2 px-2.5 text-xs text-foreground outline-none transition-colors placeholder:text-muted-foreground focus:border-border/85"
+                        className="pointer-events-auto relative z-[1] h-8 w-full rounded-lg border border-border/60 bg-background-2 px-2.5 text-xs text-foreground outline-none transition-colors placeholder:text-muted-foreground focus:border-border/85"
                         aria-label={tSpaces('search')}
                       />
                     </div>


### PR DESCRIPTION
## Summary
- Fixes the My Spaces space-switcher Search input not receiving taps on mobile (AI panel header dropdown).
- Stops Radix DropdownMenu pointer/focus handling from intercepting the custom search field while keeping `modal={true}` so the menu still opens above the mobile sidebar Sheet.

## Test plan
- [ ] On a phone (or Chrome mobile viewport), open a space and expand the left AI/nav panel
- [ ] Tap the space name chip (e.g. “ACAW Community”) to open My Spaces
- [ ] Tap the Search… field — keyboard should open and typing should filter the list
- [ ] Confirm space rows are still tappable and the menu still opens above the sheet
- [ ] Spot-check iPad/desktop: search still focuses and filters


Made with [Cursor](https://cursor.com)