### PR TITLE
fix: cross-context call awareness (#2424)

### DIFF
--- a/apps/web/src/app/api/v1/matrix/rooms/[roomId]/space/route.ts
+++ b/apps/web/src/app/api/v1/matrix/rooms/[roomId]/space/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { findSpaceHostFieldsByChatRoomId } from '@hypha-platform/core/server';
+import { db } from '@hypha-platform/storage-postgres';
+import { canConvertToBigInt } from '@hypha-platform/ui-utils';
+import { checkSpaceAccess } from '@web/utils/check-space-access';
+
+type Params = { roomId: string };
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<Params> },
+) {
+  const { roomId } = await params;
+  const trimmedRoomId = roomId?.trim();
+  if (!trimmedRoomId) {
+    return NextResponse.json({ error: 'roomId is required' }, { status: 400 });
+  }
+
+  try {
+    const space = await findSpaceHostFieldsByChatRoomId(
+      { roomId: trimmedRoomId },
+      { db },
+    );
+    if (!space) {
+      return NextResponse.json({ error: 'Space not found' }, { status: 404 });
+    }
+
+    if (space.web3SpaceId && canConvertToBigInt(space.web3SpaceId)) {
+      const access = await checkSpaceAccess(request, space.web3SpaceId);
+      if (!access.hasAccess) {
+        return (
+          access.response ??
+          NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+        );
+      }
+    }
+
+    return NextResponse.json({
+      spaceSlug: space.slug,
+      spaceTitle: space.title,
+      roomId: space.chatRoomId,
+    });
+  } catch (error) {
+    console.error('[matrix/rooms/space] lookup failed:', error);
+    return NextResponse.json(
+      { error: 'Failed to resolve space' },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/src/app/api/v1/matrix/rooms/[roomId]/space/route.ts
+++ b/apps/web/src/app/api/v1/matrix/rooms/[roomId]/space/route.ts
@@ -26,14 +26,15 @@ export async function GET(
       return NextResponse.json({ error: 'Space not found' }, { status: 404 });
     }
 
-    if (space.web3SpaceId && canConvertToBigInt(space.web3SpaceId)) {
-      const access = await checkSpaceAccess(request, space.web3SpaceId);
-      if (!access.hasAccess) {
-        return (
-          access.response ??
-          NextResponse.json({ error: 'Forbidden' }, { status: 403 })
-        );
-      }
+    if (!space.web3SpaceId || !canConvertToBigInt(space.web3SpaceId)) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+    const access = await checkSpaceAccess(request, space.web3SpaceId);
+    if (!access.hasAccess) {
+      return (
+        access.response ??
+        NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+      );
     }
 
     return NextResponse.json({

--- a/packages/core/src/matrix/client/hooks/index.ts
+++ b/packages/core/src/matrix/client/hooks/index.ts
@@ -3,6 +3,10 @@ export * from './use-user-privy-id-by-matrix-id';
 export * from './use-matrix-user-ids-by-privy-subs';
 export * from './use-matrix-user-ids-by-person-ids';
 export * from './use-space-group-call';
+export {
+  MATRIX_RTC_SESSION_EVENT,
+  type MatrixRtcSessionLike,
+} from './matrix-rtc-events';
 export { shouldMirrorCallFeedVideoForDisplay } from './call-local-video-orientation';
 export {
   getCallControlsPhase,

--- a/packages/core/src/matrix/client/hooks/use-space-group-call.ts
+++ b/packages/core/src/matrix/client/hooks/use-space-group-call.ts
@@ -2879,6 +2879,16 @@ export function useSpaceGroupCall(
         );
       }
       const p = readParticipantsFromRtcMemberships(session.memberships, myId);
+      logCallDebug('idle-room-participants:synced', {
+        roomId,
+        myId,
+        totalMemberships: session.memberships.length,
+        senders: session.memberships.map((m) => ({
+          sender: m.sender,
+          expired: m.isExpired(),
+        })),
+        idleParticipantCount: p.count,
+      });
       if (p.count === 0) {
         setIdleRoomParticipantCount(0);
         setIdleInCallUserIds([]);

--- a/packages/core/src/space/server/queries.ts
+++ b/packages/core/src/space/server/queries.ts
@@ -151,6 +151,28 @@ export const findSpaceHostFieldsBySlug = async (
   return row ?? null;
 };
 
+/** Reverse-lookup: which space owns this Matrix room (its general chat room). */
+export const findSpaceHostFieldsByChatRoomId = async (
+  { roomId }: { roomId: string },
+  { db }: DbConfig,
+) => {
+  const trimmed = roomId.trim();
+  if (!trimmed) return null;
+
+  const row = await db.query.spaces.findFirst({
+    columns: {
+      id: true,
+      slug: true,
+      title: true,
+      parentId: true,
+      web3SpaceId: true,
+      chatRoomId: true,
+    },
+    where: (spaces, { eq }) => eq(spaces.chatRoomId, trimmed),
+  });
+  return row ?? null;
+};
+
 export const findSpaceBySlug = async (
   { slug }: FindSpaceBySlugInput,
   { db }: DbConfig,

--- a/packages/epics/src/common/human-chat-panel/human-chat-panel-elsewhere-call-indicator.tsx
+++ b/packages/epics/src/common/human-chat-panel/human-chat-panel-elsewhere-call-indicator.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useState } from 'react';
+import { Phone } from 'lucide-react';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -11,8 +13,15 @@ import {
 } from '@hypha-platform/ui';
 import type { CallElsewhereEntry } from './use-call-membership-registry';
 
+/** Space logo, resolved the same way as the recent-spaces sidebar (`ai-left-panel.tsx`) — the
+ * caller batch-fetches space records and resolves this; `null`/`undefined` falls back to the
+ * first-letter avatar below. */
+export type CallElsewhereEntryWithAvatar = CallElsewhereEntry & {
+  avatarUrl?: string | null;
+};
+
 export type HumanChatPanelElsewhereCallIndicatorProps = {
-  entries: CallElsewhereEntry[];
+  entries: CallElsewhereEntryWithAvatar[];
   onSelect: (entry: CallElsewhereEntry) => void;
   label: string;
 };
@@ -21,15 +30,56 @@ function initialFor(title: string): string {
   return title.trim().slice(0, 1).toUpperCase() || '?';
 }
 
-const AVATAR_CLASS =
+/** Fixed square (not `min-w` + padding) so the circular image clip lines up exactly with
+ * the button's own edges — a non-square box left the `bg-accent` fallback color peeking
+ * out past the image's rounded corners once a real avatar loaded in. */
+const SINGLE_AVATAR_CLASS =
+  'relative flex h-6 w-6 items-center justify-center rounded-full text-[10px] font-medium text-accent-foreground ring-2 ring-background transition-colors';
+const AVATAR_FALLBACK_BG_CLASS = 'bg-accent hover:bg-accent/80';
+const COUNT_BADGE_CLASS =
   'relative flex h-6 min-w-6 items-center justify-center rounded-full bg-accent px-1 text-[10px] font-medium text-accent-foreground ring-2 ring-background transition-colors hover:bg-accent/80';
 
-/** Constant-pulse dot signaling "this is live right now," matching the sidebar trigger badge. */
-function LiveDot() {
+/**
+ * Clips just the image/letter to a circle — deliberately *not* on the outer button
+ * (`AVATAR_CLASS`), since `LiveCallBadge` below is a sibling positioned outside the
+ * button's own box; an `overflow-hidden` there would clip the badge (same bug fixed
+ * for the top-nav trigger in `panel-wrap-layout.tsx`).
+ */
+function EntryAvatarContent({
+  entry,
+}: {
+  entry: CallElsewhereEntryWithAvatar;
+}) {
+  if (entry.avatarUrl) {
+    return (
+      <span className="block h-full w-full overflow-hidden rounded-full">
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={entry.avatarUrl}
+          alt={entry.title}
+          className="block h-full w-full object-cover object-center"
+        />
+      </span>
+    );
+  }
+  return <>{initialFor(entry.title)}</>;
+}
+
+/**
+ * Constant-pulse call badge signaling "this is a live call right now" — a phone glyph
+ * (not just a generic dot) on the theme's `success` scale, matching the sidebar trigger
+ * badge and the app's other "active" indicators (e.g. `bank-account-card.tsx`).
+ */
+function LiveCallBadge() {
   return (
-    <span className="absolute -right-0.5 -top-0.5 flex h-2 w-2">
-      <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-500 opacity-75" />
-      <span className="relative inline-flex h-2 w-2 rounded-full bg-emerald-500" />
+    <span className="absolute -right-2 -top-2 flex h-5 w-5 items-center justify-center">
+      <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-success-9 opacity-60" />
+      {/* h-4.5/w-4.5 isn't a valid utility here — this theme's `--spacing-N` scale
+          (packages/ui-utils/src/global.css) only defines whole-number tokens past
+          Tailwind's built-in 3.5, so arbitrary values are used for the in-between size. */}
+      <span className="relative flex h-[18px] w-[18px] items-center justify-center rounded-full bg-success-9 ring-2 ring-background">
+        <Phone className="h-3 w-3 text-white" strokeWidth={2.5} />
+      </span>
     </span>
   );
 }
@@ -44,21 +94,36 @@ export function HumanChatPanelElsewhereCallIndicator({
   onSelect,
   label,
 }: HumanChatPanelElsewhereCallIndicatorProps) {
+  const [pendingRoomId, setPendingRoomId] = useState<string | null>(null);
+
   if (entries.length === 0) return null;
+
+  const handleSelect = (entry: CallElsewhereEntry) => {
+    setPendingRoomId(entry.roomId);
+    onSelect(entry);
+  };
 
   const [entry] = entries;
   if (entries.length === 1 && entry) {
+    const pending = pendingRoomId === entry.roomId;
     return (
       <Tooltip>
         <TooltipTrigger asChild>
           <button
             type="button"
-            onClick={() => onSelect(entry)}
-            className={AVATAR_CLASS}
+            onClick={() => handleSelect(entry)}
+            disabled={pending}
+            className={[
+              SINGLE_AVATAR_CLASS,
+              entry.avatarUrl ? '' : AVATAR_FALLBACK_BG_CLASS,
+              pending ? 'opacity-60' : '',
+            ]
+              .filter(Boolean)
+              .join(' ')}
             aria-label={label}
           >
-            {initialFor(entry.title)}
-            <LiveDot />
+            <EntryAvatarContent entry={entry} />
+            <LiveCallBadge />
           </button>
         </TooltipTrigger>
         <TooltipContent side="bottom">{entry.title}</TooltipContent>
@@ -69,15 +134,34 @@ export function HumanChatPanelElsewhereCallIndicator({
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <button type="button" className={AVATAR_CLASS} aria-label={label}>
+        <button type="button" className={COUNT_BADGE_CLASS} aria-label={label}>
           {entries.length}
-          <LiveDot />
+          <LiveCallBadge />
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
         {entries.map((entry) => (
-          <DropdownMenuItem key={entry.roomId} onSelect={() => onSelect(entry)}>
-            {entry.title}
+          <DropdownMenuItem
+            key={entry.roomId}
+            disabled={pendingRoomId === entry.roomId}
+            onSelect={() => handleSelect(entry)}
+          >
+            <span className="flex min-w-0 items-center gap-2">
+              <span
+                className={[
+                  'relative flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-[9px] font-medium text-accent-foreground',
+                  entry.avatarUrl ? '' : 'bg-accent',
+                ]
+                  .filter(Boolean)
+                  .join(' ')}
+              >
+                <EntryAvatarContent entry={entry} />
+              </span>
+              <span className="truncate">
+                {entry.title}
+                {pendingRoomId === entry.roomId ? '…' : ''}
+              </span>
+            </span>
           </DropdownMenuItem>
         ))}
       </DropdownMenuContent>

--- a/packages/epics/src/common/human-chat-panel/human-chat-panel-elsewhere-call-indicator.tsx
+++ b/packages/epics/src/common/human-chat-panel/human-chat-panel-elsewhere-call-indicator.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@hypha-platform/ui';
+import type { CallElsewhereEntry } from './use-call-membership-registry';
+
+export type HumanChatPanelElsewhereCallIndicatorProps = {
+  entries: CallElsewhereEntry[];
+  onSelect: (entry: CallElsewhereEntry) => void;
+  label: string;
+};
+
+function initialFor(title: string): string {
+  return title.trim().slice(0, 1).toUpperCase() || '?';
+}
+
+const AVATAR_CLASS =
+  'relative flex h-6 min-w-6 items-center justify-center rounded-full bg-accent px-1 text-[10px] font-medium text-accent-foreground ring-2 ring-background transition-colors hover:bg-accent/80';
+
+/** Constant-pulse dot signaling "this is live right now," matching the sidebar trigger badge. */
+function LiveDot() {
+  return (
+    <span className="absolute -right-0.5 -top-0.5 flex h-2 w-2">
+      <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-500 opacity-75" />
+      <span className="relative inline-flex h-2 w-2 rounded-full bg-emerald-500" />
+    </span>
+  );
+}
+
+/**
+ * Shows an avatar (single call elsewhere) or a stacked count with a menu (multiple),
+ * so the user can jump to whichever other active call they want without losing
+ * the one they're currently viewing. See #2424.
+ */
+export function HumanChatPanelElsewhereCallIndicator({
+  entries,
+  onSelect,
+  label,
+}: HumanChatPanelElsewhereCallIndicatorProps) {
+  if (entries.length === 0) return null;
+
+  const [entry] = entries;
+  if (entries.length === 1 && entry) {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            onClick={() => onSelect(entry)}
+            className={AVATAR_CLASS}
+            aria-label={label}
+          >
+            {initialFor(entry.title)}
+            <LiveDot />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">{entry.title}</TooltipContent>
+      </Tooltip>
+    );
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button type="button" className={AVATAR_CLASS} aria-label={label}>
+          {entries.length}
+          <LiveDot />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        {entries.map((entry) => (
+          <DropdownMenuItem key={entry.roomId} onSelect={() => onSelect(entry)}>
+            {entry.title}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/packages/epics/src/common/human-chat-panel/resolve-space-by-matrix-room.ts
+++ b/packages/epics/src/common/human-chat-panel/resolve-space-by-matrix-room.ts
@@ -1,0 +1,47 @@
+'use client';
+
+export type ResolvedSpaceTarget = {
+  spaceSlug: string;
+  spaceTitle: string;
+  roomId: string;
+};
+
+/** Resolve a Matrix room id (a space's general chat room) to its space. */
+export async function resolveSpaceByMatrixRoom(
+  roomId: string,
+  getAccessToken?: () => Promise<string | null | undefined>,
+): Promise<ResolvedSpaceTarget | null> {
+  const trimmed = roomId.trim();
+  if (!trimmed) return null;
+
+  const headers: HeadersInit = {};
+  try {
+    const token = getAccessToken ? await getAccessToken() : null;
+    if (token) {
+      headers.Authorization = `Bearer ${token}`;
+    }
+
+    const res = await fetch(
+      `/api/v1/matrix/rooms/${encodeURIComponent(trimmed)}/space`,
+      { headers },
+    );
+    if (!res.ok) return null;
+
+    const data = (await res.json()) as {
+      spaceSlug?: string;
+      spaceTitle?: string;
+      roomId?: string;
+    };
+    const spaceSlug = data.spaceSlug?.trim();
+    if (!spaceSlug) return null;
+
+    return {
+      spaceSlug,
+      spaceTitle: data.spaceTitle?.trim() || spaceSlug,
+      roomId: data.roomId?.trim() || trimmed,
+    };
+  } catch (error) {
+    console.warn('[resolveSpaceByMatrixRoom] lookup failed:', error);
+    return null;
+  }
+}

--- a/packages/epics/src/common/human-chat-panel/resolve-space-by-matrix-room.ts
+++ b/packages/epics/src/common/human-chat-panel/resolve-space-by-matrix-room.ts
@@ -23,7 +23,7 @@ export async function resolveSpaceByMatrixRoom(
 
     const res = await fetch(
       `/api/v1/matrix/rooms/${encodeURIComponent(trimmed)}/space`,
-      { headers },
+      { headers, signal: AbortSignal.timeout(8000) },
     );
     if (!res.ok) return null;
 

--- a/packages/epics/src/common/human-chat-panel/use-call-membership-registry.ts
+++ b/packages/epics/src/common/human-chat-panel/use-call-membership-registry.ts
@@ -1,0 +1,220 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type * as MatrixSdk from 'matrix-js-sdk';
+import { ClientEvent } from 'matrix-js-sdk';
+import {
+  useMatrix,
+  MATRIX_RTC_SESSION_EVENT,
+  type MatrixRtcSessionLike,
+} from '@hypha-platform/core/client';
+import { resolveSignalThreadByMatrixRoom } from './resolve-signal-thread-by-matrix-room';
+import { resolveSpaceByMatrixRoom } from './resolve-space-by-matrix-room';
+
+/**
+ * Not part of the public matrix-js-sdk types — same cast `use-space-group-call.ts` uses
+ * to reach the MatrixRTC extension attached to the client at `createClient()` time.
+ */
+type MatrixClientWithMatrixRtc = MatrixSdk.MatrixClient & {
+  matrixRTC: {
+    getRoomSession: (room: MatrixSdk.Room) => MatrixRtcSessionLike;
+  };
+};
+
+function getRoomRtcSession(
+  client: MatrixSdk.MatrixClient,
+  room: MatrixSdk.Room,
+): MatrixRtcSessionLike | null {
+  try {
+    return (client as MatrixClientWithMatrixRtc).matrixRTC.getRoomSession(room);
+  } catch {
+    return null;
+  }
+}
+
+function roomHasActiveCall(
+  client: MatrixSdk.MatrixClient,
+  room: MatrixSdk.Room,
+): boolean {
+  const session = getRoomRtcSession(client, room);
+  if (!session) return false;
+  return session.memberships.some((membership) => !membership.isExpired());
+}
+
+export type CallElsewhereEntry = {
+  roomId: string;
+  kind: 'space' | 'signal';
+  spaceSlug: string;
+  signalSlug?: string;
+  /** Space or signal title, for display (avatar tooltip / menu label). */
+  title: string;
+};
+
+export type UseCallMembershipRegistryParams = {
+  /** Exclude this room from the output — typically the user's own currently-bound call room. */
+  excludeRoomId?: string | null;
+  getAccessToken?: () => Promise<string | null | undefined>;
+};
+
+/**
+ * Tracks which rooms the user is joined to have an active MatrixRTC call, excluding
+ * whichever room they're already in. Reads state already flowing through the app's
+ * existing full-account Matrix `/sync` (see #2424 decisions.md #1, #11) — no new
+ * subscriptions or server queries for scoping; room-set scoping is just "rooms I'm
+ * joined to" (`client.getRooms()`), which the client already knows.
+ */
+export function useCallMembershipRegistry({
+  excludeRoomId,
+  getAccessToken,
+}: UseCallMembershipRegistryParams): CallElsewhereEntry[] {
+  const { client } = useMatrix();
+  const [activeRoomIds, setActiveRoomIds] = useState<string[]>([]);
+  const [entries, setEntries] = useState<CallElsewhereEntry[]>([]);
+  const identityCacheRef = useRef<Map<string, CallElsewhereEntry>>(new Map());
+  /**
+   * Callers pass an inline `getAccessToken` (a new function every render). Reading it via a
+   * ref — rather than depending on it directly — keeps `resolveIdentity` referentially stable,
+   * so the identity-resolution effect below doesn't re-run (and re-`setEntries` a brand-new
+   * array) on every render, which was causing a render loop ("Maximum update depth exceeded").
+   */
+  const getAccessTokenRef = useRef(getAccessToken);
+  getAccessTokenRef.current = getAccessToken;
+
+  useEffect(() => {
+    if (!client) {
+      setActiveRoomIds([]);
+      return;
+    }
+
+    const sessionListeners = new Map<string, MatrixRtcSessionLike>();
+
+    const recomputeActiveRoomIds = () => {
+      const joinedRooms = client
+        .getRooms()
+        .filter((room) => room.getMyMembership() === 'join');
+      const active = joinedRooms
+        .filter((room) => roomHasActiveCall(client, room))
+        .map((room) => room.roomId);
+      setActiveRoomIds((prev) => {
+        if (
+          prev.length === active.length &&
+          prev.every((id, index) => id === active[index])
+        ) {
+          return prev;
+        }
+        return active;
+      });
+    };
+
+    const attachSessionListeners = () => {
+      const joinedRooms = client
+        .getRooms()
+        .filter((room) => room.getMyMembership() === 'join');
+      for (const room of joinedRooms) {
+        if (sessionListeners.has(room.roomId)) continue;
+        const session = getRoomRtcSession(client, room);
+        if (!session) continue;
+        session.on(
+          MATRIX_RTC_SESSION_EVENT.MembershipsChanged,
+          recomputeActiveRoomIds,
+        );
+        sessionListeners.set(room.roomId, session);
+      }
+    };
+
+    attachSessionListeners();
+    recomputeActiveRoomIds();
+
+    /** New rooms can appear after initial sync (space joined, signal opened for the first time). */
+    const onRoom = () => {
+      attachSessionListeners();
+      recomputeActiveRoomIds();
+    };
+    client.on(ClientEvent.Room, onRoom);
+    client.on(ClientEvent.Sync, recomputeActiveRoomIds);
+
+    return () => {
+      client.removeListener(ClientEvent.Room, onRoom);
+      client.removeListener(ClientEvent.Sync, recomputeActiveRoomIds);
+      for (const session of sessionListeners.values()) {
+        session.off(
+          MATRIX_RTC_SESSION_EVENT.MembershipsChanged,
+          recomputeActiveRoomIds,
+        );
+      }
+    };
+  }, [client]);
+
+  const resolveIdentity = useCallback(
+    async (roomId: string): Promise<CallElsewhereEntry | null> => {
+      const cached = identityCacheRef.current.get(roomId);
+      if (cached) return cached;
+
+      const signal = await resolveSignalThreadByMatrixRoom(roomId, async () =>
+        getAccessTokenRef.current?.(),
+      );
+      if (signal) {
+        const entry: CallElsewhereEntry = {
+          roomId,
+          kind: 'signal',
+          spaceSlug: signal.spaceSlug,
+          signalSlug: signal.signalSlug,
+          title: signal.signalTitle,
+        };
+        identityCacheRef.current.set(roomId, entry);
+        return entry;
+      }
+
+      const space = await resolveSpaceByMatrixRoom(roomId, async () =>
+        getAccessTokenRef.current?.(),
+      );
+      if (space) {
+        const entry: CallElsewhereEntry = {
+          roomId,
+          kind: 'space',
+          spaceSlug: space.spaceSlug,
+          title: space.spaceTitle,
+        };
+        identityCacheRef.current.set(roomId, entry);
+        return entry;
+      }
+
+      return null;
+    },
+    [],
+  );
+
+  useEffect(() => {
+    const targetRoomIds = activeRoomIds.filter((id) => id !== excludeRoomId);
+    if (targetRoomIds.length === 0) {
+      setEntries([]);
+      return;
+    }
+
+    let cancelled = false;
+    void (async () => {
+      const resolved = await Promise.all(
+        targetRoomIds.map((roomId) => resolveIdentity(roomId)),
+      );
+      if (cancelled) return;
+      const next = resolved.filter(
+        (entry): entry is CallElsewhereEntry => entry !== null,
+      );
+      setEntries((prev) => {
+        if (
+          prev.length === next.length &&
+          prev.every((entry, index) => entry.roomId === next[index]?.roomId)
+        ) {
+          return prev;
+        }
+        return next;
+      });
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [activeRoomIds, excludeRoomId, resolveIdentity]);
+
+  return entries;
+}

--- a/packages/epics/src/common/human-chat-panel/use-call-membership-registry.ts
+++ b/packages/epics/src/common/human-chat-panel/use-call-membership-registry.ts
@@ -154,6 +154,38 @@ export function useCallMembershipRegistry({
   const getAccessTokenRef = useRef(getAccessToken);
   getAccessTokenRef.current = getAccessToken;
 
+  /**
+   * `useJwt`/equivalent callers often start with no token while auth is still loading.
+   * A room active at that point resolves without one, and `resolveIdentity` only skips its
+   * negative cache for such an entry on the *next* time it's asked to resolve that room —
+   * which otherwise only happens when the set of active-call rooms changes. If it doesn't
+   * (the same call stays active while the token loads), the room would never retry. Poll a
+   * few times for the token to appear and bump this to force one retry pass once it does.
+   */
+  const [tokenPollEpoch, setTokenPollEpoch] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    let attempt = 0;
+    const maxAttempts = 6;
+    const poll = async () => {
+      if (cancelled) return;
+      const token = (await getAccessTokenRef.current?.()) ?? null;
+      if (cancelled) return;
+      if (token) {
+        setTokenPollEpoch((epoch) => epoch + 1);
+        return;
+      }
+      attempt += 1;
+      if (attempt >= maxAttempts) return;
+      setTimeout(() => void poll(), 1500);
+    };
+    void poll();
+    return () => {
+      cancelled = true;
+    };
+  }, [client]);
+
   useEffect(() => {
     if (!client) {
       setActiveRoomIds([]);
@@ -381,7 +413,7 @@ export function useCallMembershipRegistry({
     return () => {
       cancelled = true;
     };
-  }, [activeRoomIds, excludeRoomIdsKey, resolveIdentity]);
+  }, [activeRoomIds, excludeRoomIdsKey, resolveIdentity, tokenPollEpoch]);
 
   return entries;
 }

--- a/packages/epics/src/common/human-chat-panel/use-call-membership-registry.ts
+++ b/packages/epics/src/common/human-chat-panel/use-call-membership-registry.ts
@@ -6,10 +6,17 @@ import { ClientEvent } from 'matrix-js-sdk';
 import {
   useMatrix,
   MATRIX_RTC_SESSION_EVENT,
+  isMatrixCallDebugEnabled,
   type MatrixRtcSessionLike,
 } from '@hypha-platform/core/client';
 import { resolveSignalThreadByMatrixRoom } from './resolve-signal-thread-by-matrix-room';
 import { resolveSpaceByMatrixRoom } from './resolve-space-by-matrix-room';
+
+/** Same convention as `use-space-group-call.ts`'s `logCallDebug` — gated by `hypha.callDebug`. */
+function logRegistryDebug(step: string, extra?: Record<string, unknown>) {
+  if (!isMatrixCallDebugEnabled()) return;
+  console.info('[hypha.call_membership_registry.debug] ' + step, extra);
+}
 
 /**
  * Not part of the public matrix-js-sdk types — same cast `use-space-group-call.ts` uses
@@ -32,16 +39,36 @@ function getRoomRtcSession(
   }
 }
 
-function roomHasActiveCall(
+/** Non-expired MatrixRTC memberships for a room — 0 means no active call. */
+function getRoomActiveCallParticipantCount(
   client: MatrixSdk.MatrixClient,
   room: MatrixSdk.Room,
-): boolean {
+): number {
   const session = getRoomRtcSession(client, room);
-  if (!session) return false;
-  return session.memberships.some((membership) => !membership.isExpired());
+  if (!session) {
+    logRegistryDebug('room-has-active-call:no-session', {
+      roomId: room.roomId,
+    });
+    return 0;
+  }
+  const active = session.memberships.filter(
+    (membership) => !membership.isExpired(),
+  );
+  logRegistryDebug('room-has-active-call:checked', {
+    roomId: room.roomId,
+    totalMemberships: session.memberships.length,
+    activeMemberships: active.length,
+    senders: session.memberships.map((m) => ({
+      sender: m.sender,
+      expired: m.isExpired(),
+    })),
+  });
+  return active.length;
 }
 
-export type CallElsewhereEntry = {
+/** Identity fields only — safe to cache indefinitely (immutable per room), unlike
+ * `participantCount` below which changes as people join/leave the call. */
+type CallIdentity = {
   roomId: string;
   kind: 'space' | 'signal';
   spaceSlug: string;
@@ -50,9 +77,20 @@ export type CallElsewhereEntry = {
   title: string;
 };
 
+export type CallElsewhereEntry = CallIdentity & {
+  /** Live count, refreshed whenever the active-room set is recomputed — not part of the
+   * cached identity, so a stale count is never served from `sharedIdentityCache`. */
+  participantCount: number;
+};
+
 export type UseCallMembershipRegistryParams = {
-  /** Exclude this room from the output — typically the user's own currently-bound call room. */
-  excludeRoomId?: string | null;
+  /**
+   * Exclude these rooms from the output. Callers combine whichever apply: the room
+   * currently being viewed, and/or the user's own actively-bound call room — these can
+   * differ (e.g. browsing space Z's chat while still on a call bound to space Y), and both
+   * need excluding so the badge never points at a room the user is already in a call in.
+   */
+  excludeRoomIds?: Array<string | null | undefined>;
   getAccessToken?: () => Promise<string | null | undefined>;
 };
 
@@ -63,14 +101,41 @@ export type UseCallMembershipRegistryParams = {
  * subscriptions or server queries for scoping; room-set scoping is just "rooms I'm
  * joined to" (`client.getRooms()`), which the client already knows.
  */
+/**
+ * Module-scope (not per-instance `useRef`) so every mount of this hook shares one cache —
+ * e.g. the always-mounted top-nav trigger and the right panel's own instance, which remounts
+ * whenever `PanelWrapLayout` switches JSX branches (space vs. non-space navigation changes
+ * which sidebar layout renders). Without sharing, a fresh mount re-resolves identities its
+ * sibling instance already has, showing up as a visible delay before the avatar appears.
+ * Lives for the page session only — reset on full reload, never persisted.
+ */
+const sharedIdentityCache = new Map<string, CallIdentity>();
+
 export function useCallMembershipRegistry({
-  excludeRoomId,
+  excludeRoomIds,
   getAccessToken,
 }: UseCallMembershipRegistryParams): CallElsewhereEntry[] {
   const { client } = useMatrix();
   const [activeRoomIds, setActiveRoomIds] = useState<string[]>([]);
   const [entries, setEntries] = useState<CallElsewhereEntry[]>([]);
-  const identityCacheRef = useRef<Map<string, CallElsewhereEntry>>(new Map());
+  const identityCacheRef =
+    useRef<Map<string, CallIdentity>>(sharedIdentityCache);
+  /** Not cached, unlike identity — refreshed on every recompute. Per-instance, since it's
+   * cheap to recompute and (unlike identity) must never go stale across mounts. */
+  const roomParticipantCountsRef = useRef<Map<string, number>>(new Map());
+  /**
+   * Callers pass a fresh array literal every render (e.g. `[roomId, activeRoomId]`) — read
+   * via a ref (same pattern as `getAccessTokenRef` below) so the identity-resolution effect
+   * depends on a stable derived string key instead of the array's identity.
+   */
+  const excludeRoomIdsRef = useRef<Array<string | null | undefined>>(
+    excludeRoomIds ?? [],
+  );
+  excludeRoomIdsRef.current = excludeRoomIds ?? [];
+  const excludeRoomIdsKey = (excludeRoomIds ?? [])
+    .filter((id): id is string => Boolean(id))
+    .sort()
+    .join(',');
   /**
    * Callers pass an inline `getAccessToken` (a new function every render). Reading it via a
    * ref — rather than depending on it directly — keeps `resolveIdentity` referentially stable,
@@ -86,15 +151,31 @@ export function useCallMembershipRegistry({
       return;
     }
 
-    const sessionListeners = new Map<string, MatrixRtcSessionLike>();
+    const sessionListeners = new Map<
+      string,
+      { session: MatrixRtcSessionLike; listener: () => void }
+    >();
 
-    const recomputeActiveRoomIds = () => {
+    const recomputeActiveRoomIds = (source = 'unknown') => {
       const joinedRooms = client
         .getRooms()
         .filter((room) => room.getMyMembership() === 'join');
-      const active = joinedRooms
-        .filter((room) => roomHasActiveCall(client, room))
-        .map((room) => room.roomId);
+      const nextCounts = new Map<string, number>();
+      const active: string[] = [];
+      for (const room of joinedRooms) {
+        const count = getRoomActiveCallParticipantCount(client, room);
+        if (count > 0) {
+          nextCounts.set(room.roomId, count);
+          active.push(room.roomId);
+        }
+      }
+      roomParticipantCountsRef.current = nextCounts;
+      logRegistryDebug('recompute-active-room-ids', {
+        source,
+        joinedRoomCount: joinedRooms.length,
+        joinedRoomIds: joinedRooms.map((room) => room.roomId),
+        activeRoomIds: active,
+      });
       setActiveRoomIds((prev) => {
         if (
           prev.length === active.length &&
@@ -111,42 +192,68 @@ export function useCallMembershipRegistry({
         .getRooms()
         .filter((room) => room.getMyMembership() === 'join');
       for (const room of joinedRooms) {
-        if (sessionListeners.has(room.roomId)) continue;
+        if (sessionListeners.has(room.roomId)) {
+          // Diagnostic: if the SDK hands back a *different* session object than the one
+          // we're subscribed to, our listener is attached to a now-orphaned instance and
+          // will never fire for this room again — would explain a call in one room never
+          // getting picked up while another room's calls work fine.
+          const current = getRoomRtcSession(client, room);
+          if (
+            current &&
+            current !== sessionListeners.get(room.roomId)?.session
+          ) {
+            logRegistryDebug('attach-session-listeners:stale-session-object', {
+              roomId: room.roomId,
+            });
+          }
+          continue;
+        }
         const session = getRoomRtcSession(client, room);
-        if (!session) continue;
+        if (!session) {
+          logRegistryDebug('attach-session-listeners:no-session', {
+            roomId: room.roomId,
+          });
+          continue;
+        }
+        const onMembershipsChanged = () =>
+          recomputeActiveRoomIds(`session-memberships-changed:${room.roomId}`);
         session.on(
           MATRIX_RTC_SESSION_EVENT.MembershipsChanged,
-          recomputeActiveRoomIds,
+          onMembershipsChanged,
         );
-        sessionListeners.set(room.roomId, session);
+        sessionListeners.set(room.roomId, {
+          session,
+          listener: onMembershipsChanged,
+        });
+        logRegistryDebug('attach-session-listeners:attached', {
+          roomId: room.roomId,
+        });
       }
     };
 
     attachSessionListeners();
-    recomputeActiveRoomIds();
+    recomputeActiveRoomIds('mount');
 
     /** New rooms can appear after initial sync (space joined, signal opened for the first time). */
     const onRoom = () => {
       attachSessionListeners();
-      recomputeActiveRoomIds();
+      recomputeActiveRoomIds('client-room-event');
     };
+    const onSync = () => recomputeActiveRoomIds('client-sync-event');
     client.on(ClientEvent.Room, onRoom);
-    client.on(ClientEvent.Sync, recomputeActiveRoomIds);
+    client.on(ClientEvent.Sync, onSync);
 
     return () => {
       client.removeListener(ClientEvent.Room, onRoom);
-      client.removeListener(ClientEvent.Sync, recomputeActiveRoomIds);
-      for (const session of sessionListeners.values()) {
-        session.off(
-          MATRIX_RTC_SESSION_EVENT.MembershipsChanged,
-          recomputeActiveRoomIds,
-        );
+      client.removeListener(ClientEvent.Sync, onSync);
+      for (const { session, listener } of sessionListeners.values()) {
+        session.off(MATRIX_RTC_SESSION_EVENT.MembershipsChanged, listener);
       }
     };
   }, [client]);
 
   const resolveIdentity = useCallback(
-    async (roomId: string): Promise<CallElsewhereEntry | null> => {
+    async (roomId: string): Promise<CallIdentity | null> => {
       const cached = identityCacheRef.current.get(roomId);
       if (cached) return cached;
 
@@ -154,38 +261,49 @@ export function useCallMembershipRegistry({
         getAccessTokenRef.current?.(),
       );
       if (signal) {
-        const entry: CallElsewhereEntry = {
+        const identity: CallIdentity = {
           roomId,
           kind: 'signal',
           spaceSlug: signal.spaceSlug,
           signalSlug: signal.signalSlug,
           title: signal.signalTitle,
         };
-        identityCacheRef.current.set(roomId, entry);
-        return entry;
+        identityCacheRef.current.set(roomId, identity);
+        return identity;
       }
 
       const space = await resolveSpaceByMatrixRoom(roomId, async () =>
         getAccessTokenRef.current?.(),
       );
       if (space) {
-        const entry: CallElsewhereEntry = {
+        const identity: CallIdentity = {
           roomId,
           kind: 'space',
           spaceSlug: space.spaceSlug,
           title: space.spaceTitle,
         };
-        identityCacheRef.current.set(roomId, entry);
-        return entry;
+        identityCacheRef.current.set(roomId, identity);
+        return identity;
       }
 
+      logRegistryDebug('resolve-identity:no-match', { roomId });
       return null;
     },
     [],
   );
 
   useEffect(() => {
-    const targetRoomIds = activeRoomIds.filter((id) => id !== excludeRoomId);
+    const excludeSet = new Set(
+      excludeRoomIdsRef.current.filter(
+        (id): id is string => typeof id === 'string' && id.length > 0,
+      ),
+    );
+    const targetRoomIds = activeRoomIds.filter((id) => !excludeSet.has(id));
+    logRegistryDebug('identity-resolution-effect', {
+      activeRoomIds,
+      excludeRoomIds: [...excludeSet],
+      targetRoomIds,
+    });
     if (targetRoomIds.length === 0) {
       setEntries([]);
       return;
@@ -197,13 +315,26 @@ export function useCallMembershipRegistry({
         targetRoomIds.map((roomId) => resolveIdentity(roomId)),
       );
       if (cancelled) return;
-      const next = resolved.filter(
-        (entry): entry is CallElsewhereEntry => entry !== null,
-      );
+      const next: CallElsewhereEntry[] = resolved
+        .filter((identity): identity is CallIdentity => identity !== null)
+        .map((identity) => ({
+          ...identity,
+          participantCount:
+            roomParticipantCountsRef.current.get(identity.roomId) ?? 0,
+        }));
+      logRegistryDebug('identity-resolution-effect:resolved', {
+        targetRoomIds,
+        resolvedCount: next.length,
+        entries: next,
+      });
       setEntries((prev) => {
         if (
           prev.length === next.length &&
-          prev.every((entry, index) => entry.roomId === next[index]?.roomId)
+          prev.every(
+            (entry, index) =>
+              entry.roomId === next[index]?.roomId &&
+              entry.participantCount === next[index]?.participantCount,
+          )
         ) {
           return prev;
         }
@@ -214,7 +345,7 @@ export function useCallMembershipRegistry({
     return () => {
       cancelled = true;
     };
-  }, [activeRoomIds, excludeRoomId, resolveIdentity]);
+  }, [activeRoomIds, excludeRoomIdsKey, resolveIdentity]);
 
   return entries;
 }

--- a/packages/epics/src/common/human-chat-panel/use-call-membership-registry.ts
+++ b/packages/epics/src/common/human-chat-panel/use-call-membership-registry.ts
@@ -92,6 +92,14 @@ export type UseCallMembershipRegistryParams = {
    */
   excludeRoomIds?: Array<string | null | undefined>;
   getAccessToken?: () => Promise<string | null | undefined>;
+  /**
+   * Whether `getAccessToken` currently has a token to give (e.g. `Boolean(jwt)` from
+   * `useJwt()`). A plain reactive primitive, unlike `getAccessToken` itself (a fresh
+   * function every render, read via ref to avoid retriggering effects) — passing this
+   * lets the identity-resolution effect below re-run the moment auth actually becomes
+   * available, instead of guessing with a polling timeout.
+   */
+  hasAccessToken?: boolean;
 };
 
 /**
@@ -123,6 +131,7 @@ const sharedUnresolvedRoomIds = new Map<string, { hadToken: boolean }>();
 export function useCallMembershipRegistry({
   excludeRoomIds,
   getAccessToken,
+  hasAccessToken,
 }: UseCallMembershipRegistryParams): CallElsewhereEntry[] {
   const { client } = useMatrix();
   const [activeRoomIds, setActiveRoomIds] = useState<string[]>([]);
@@ -153,38 +162,6 @@ export function useCallMembershipRegistry({
    */
   const getAccessTokenRef = useRef(getAccessToken);
   getAccessTokenRef.current = getAccessToken;
-
-  /**
-   * `useJwt`/equivalent callers often start with no token while auth is still loading.
-   * A room active at that point resolves without one, and `resolveIdentity` only skips its
-   * negative cache for such an entry on the *next* time it's asked to resolve that room —
-   * which otherwise only happens when the set of active-call rooms changes. If it doesn't
-   * (the same call stays active while the token loads), the room would never retry. Poll a
-   * few times for the token to appear and bump this to force one retry pass once it does.
-   */
-  const [tokenPollEpoch, setTokenPollEpoch] = useState(0);
-
-  useEffect(() => {
-    let cancelled = false;
-    let attempt = 0;
-    const maxAttempts = 6;
-    const poll = async () => {
-      if (cancelled) return;
-      const token = (await getAccessTokenRef.current?.()) ?? null;
-      if (cancelled) return;
-      if (token) {
-        setTokenPollEpoch((epoch) => epoch + 1);
-        return;
-      }
-      attempt += 1;
-      if (attempt >= maxAttempts) return;
-      setTimeout(() => void poll(), 1500);
-    };
-    void poll();
-    return () => {
-      cancelled = true;
-    };
-  }, [client]);
 
   useEffect(() => {
     if (!client) {
@@ -368,6 +345,7 @@ export function useCallMembershipRegistry({
     );
     const targetRoomIds = activeRoomIds.filter((id) => !excludeSet.has(id));
     logRegistryDebug('identity-resolution-effect', {
+      hasAccessToken: Boolean(hasAccessToken),
       activeRoomIds,
       excludeRoomIds: [...excludeSet],
       targetRoomIds,
@@ -413,7 +391,10 @@ export function useCallMembershipRegistry({
     return () => {
       cancelled = true;
     };
-  }, [activeRoomIds, excludeRoomIdsKey, resolveIdentity, tokenPollEpoch]);
+    // `hasAccessToken` is a plain reactive boolean (unlike `getAccessToken`, read via ref
+    // to stay referentially stable) — depending on it directly re-runs this effect the
+    // moment auth actually becomes available, instead of guessing with a polling timeout.
+  }, [activeRoomIds, excludeRoomIdsKey, resolveIdentity, hasAccessToken]);
 
   return entries;
 }

--- a/packages/epics/src/common/human-chat-panel/use-call-membership-registry.ts
+++ b/packages/epics/src/common/human-chat-panel/use-call-membership-registry.ts
@@ -160,6 +160,18 @@ export function useCallMembershipRegistry({
       return;
     }
 
+    /**
+     * `client` is a new `MatrixClient` instance on every login/logout/re-auth (see
+     * `matrix-provider.tsx`'s `setClient`) — it doesn't change on a same-session remount.
+     * `sharedIdentityCache`/`sharedUnresolvedRoomIds` are keyed by room id only, not by
+     * caller, so without this a resolved-while-authorized room identity could keep being
+     * served to a *different* account that later authenticates in the same browser tab,
+     * bypassing that account's own authorization check for it. Clearing on every client
+     * swap scopes both caches to the current session without needing a per-subject key.
+     */
+    sharedIdentityCache.clear();
+    sharedUnresolvedRoomIds.clear();
+
     const sessionListeners = new Map<
       string,
       { session: MatrixRtcSessionLike; listener: () => void }

--- a/packages/epics/src/common/human-chat-panel/use-call-membership-registry.ts
+++ b/packages/epics/src/common/human-chat-panel/use-call-membership-registry.ts
@@ -111,6 +111,15 @@ export type UseCallMembershipRegistryParams = {
  */
 const sharedIdentityCache = new Map<string, CallIdentity>();
 
+/**
+ * Rooms that resolved to neither a signal nor a space, so `resolveIdentity` isn't hammered
+ * with two requests on every sync event for a room that will never resolve (e.g. a call in a
+ * DM room). `hadToken` records whether the lookup ran with a bearer token: if it didn't (the
+ * caller's `getAccessToken` hadn't resolved yet), the entry doesn't block a retry once a token
+ * becomes available — only a token-backed non-match is treated as durable.
+ */
+const sharedUnresolvedRoomIds = new Map<string, { hadToken: boolean }>();
+
 export function useCallMembershipRegistry({
   excludeRoomIds,
   getAccessToken,
@@ -192,21 +201,25 @@ export function useCallMembershipRegistry({
         .getRooms()
         .filter((room) => room.getMyMembership() === 'join');
       for (const room of joinedRooms) {
-        if (sessionListeners.has(room.roomId)) {
-          // Diagnostic: if the SDK hands back a *different* session object than the one
-          // we're subscribed to, our listener is attached to a now-orphaned instance and
-          // will never fire for this room again — would explain a call in one room never
-          // getting picked up while another room's calls work fine.
+        const existing = sessionListeners.get(room.roomId);
+        if (existing) {
+          // If the SDK hands back a *different* session object than the one we're
+          // subscribed to, our listener is attached to a now-orphaned instance and will
+          // never fire for this room again. Detach it and re-subscribe below instead of
+          // just logging, so the room doesn't silently stop reporting call membership.
           const current = getRoomRtcSession(client, room);
-          if (
-            current &&
-            current !== sessionListeners.get(room.roomId)?.session
-          ) {
+          if (current && current !== existing.session) {
             logRegistryDebug('attach-session-listeners:stale-session-object', {
               roomId: room.roomId,
             });
+            existing.session.off(
+              MATRIX_RTC_SESSION_EVENT.MembershipsChanged,
+              existing.listener,
+            );
+            sessionListeners.delete(room.roomId);
+          } else {
+            continue;
           }
-          continue;
         }
         const session = getRoomRtcSession(client, room);
         if (!session) {
@@ -257,8 +270,15 @@ export function useCallMembershipRegistry({
       const cached = identityCacheRef.current.get(roomId);
       if (cached) return cached;
 
-      const signal = await resolveSignalThreadByMatrixRoom(roomId, async () =>
-        getAccessTokenRef.current?.(),
+      const token = (await getAccessTokenRef.current?.()) ?? null;
+      const unresolved = sharedUnresolvedRoomIds.get(roomId);
+      if (unresolved && (unresolved.hadToken || !token)) {
+        return null;
+      }
+
+      const signal = await resolveSignalThreadByMatrixRoom(
+        roomId,
+        async () => token,
       );
       if (signal) {
         const identity: CallIdentity = {
@@ -269,12 +289,11 @@ export function useCallMembershipRegistry({
           title: signal.signalTitle,
         };
         identityCacheRef.current.set(roomId, identity);
+        sharedUnresolvedRoomIds.delete(roomId);
         return identity;
       }
 
-      const space = await resolveSpaceByMatrixRoom(roomId, async () =>
-        getAccessTokenRef.current?.(),
-      );
+      const space = await resolveSpaceByMatrixRoom(roomId, async () => token);
       if (space) {
         const identity: CallIdentity = {
           roomId,
@@ -283,10 +302,15 @@ export function useCallMembershipRegistry({
           title: space.spaceTitle,
         };
         identityCacheRef.current.set(roomId, identity);
+        sharedUnresolvedRoomIds.delete(roomId);
         return identity;
       }
 
-      logRegistryDebug('resolve-identity:no-match', { roomId });
+      sharedUnresolvedRoomIds.set(roomId, { hadToken: Boolean(token) });
+      logRegistryDebug('resolve-identity:no-match', {
+        roomId,
+        hadToken: Boolean(token),
+      });
       return null;
     },
     [],

--- a/packages/epics/src/common/human-right-panel.tsx
+++ b/packages/epics/src/common/human-right-panel.tsx
@@ -1664,15 +1664,22 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
    * on the first click. Instead, record the intent and let an effect fire the join once
    * `callSessionRoomId` has actually cleared.
    */
-  const [pendingCallSwitchKind, setPendingCallSwitchKind] = useState<
-    'audio' | 'video' | null
-  >(null);
+  const [pendingCallSwitch, setPendingCallSwitch] = useState<{
+    kind: 'audio' | 'video';
+    roomId: string;
+  } | null>(null);
 
   const handleJoinCurrentRoomCallInstead = useCallback(
     (kind: 'audio' | 'video') => {
       if (callSessionRoomId && callSessionRoomId !== roomId) {
-        setPendingCallSwitchKind(kind);
-        void leaveSpaceCall();
+        const targetRoomId = roomId;
+        if (!targetRoomId) return;
+        setPendingCallSwitch({ kind, roomId: targetRoomId });
+        leaveSpaceCall().catch(() => {
+          setPendingCallSwitch((prev) =>
+            prev && prev.roomId === targetRoomId ? null : prev,
+          );
+        });
         return;
       }
       if (kind === 'audio') {
@@ -1691,17 +1698,23 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
   );
 
   useEffect(() => {
-    if (!pendingCallSwitchKind) return;
+    if (!pendingCallSwitch) return;
+    // User navigated away from the room they meant to join before the leave completed —
+    // abandon the switch instead of joining whatever room happens to be open now.
+    if (pendingCallSwitch.roomId !== roomId) {
+      setPendingCallSwitch(null);
+      return;
+    }
     if (callSessionRoomId && callSessionRoomId !== roomId) return;
-    const kind = pendingCallSwitchKind;
-    setPendingCallSwitchKind(null);
+    const { kind } = pendingCallSwitch;
+    setPendingCallSwitch(null);
     if (kind === 'audio') {
       handleCallAudio();
     } else {
       handleCallVideo();
     }
   }, [
-    pendingCallSwitchKind,
+    pendingCallSwitch,
     callSessionRoomId,
     roomId,
     handleCallAudio,
@@ -4502,7 +4515,7 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
             <HumanChatPanelCallJoinStrip
               deviceCount={currentRoomActiveCall.participantCount}
               disabled={!callUiEnabled}
-              busy={Boolean(pendingCallSwitchKind)}
+              busy={Boolean(pendingCallSwitch)}
               roomId={roomId}
               onJoinAudio={() => {
                 if (!canJoinSignalThreadCall && isSignalThread) {
@@ -5078,6 +5091,7 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
         )}
       </SidebarContent>
       {activeTab === 'chat' &&
+        Boolean(spaceSlug?.trim()) &&
         !showAuthPrompt &&
         !blockSpaceChatForActivityAccess && (
           <SidebarFooter className="relative z-20 bg-background-2 p-0">

--- a/packages/epics/src/common/human-right-panel.tsx
+++ b/packages/epics/src/common/human-right-panel.tsx
@@ -1362,6 +1362,7 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
   const otherActiveCallEntries = useCallMembershipRegistry({
     excludeRoomIds: [callSessionRoomId],
     getAccessToken: async () => authTokenRef.current,
+    hasAccessToken: Boolean(authToken),
   });
   const elsewhereCallEntries = useMemo(
     () => otherActiveCallEntries.filter((entry) => entry.roomId !== roomId),

--- a/packages/epics/src/common/human-right-panel.tsx
+++ b/packages/epics/src/common/human-right-panel.tsx
@@ -72,6 +72,7 @@ import {
   canInteractInSpace,
 } from '../spaces/utils/transparency-access';
 import { SpaceAccessDenied } from '../spaces/components/space-access-denied';
+import { Empty } from './empty';
 
 import {
   HumanChatPanelHeader,
@@ -122,6 +123,11 @@ import { useActiveCallInAnotherTab } from './human-chat-panel/use-active-call-in
 import { shouldShowCallScaleWarning } from './human-chat-panel/call-scale-warning';
 import { resolveSignalDeepLinkWithRetry } from './human-chat-panel/resolve-signal-deep-link';
 import { resolveSignalThreadByMatrixRoom } from './human-chat-panel/resolve-signal-thread-by-matrix-room';
+import {
+  useCallMembershipRegistry,
+  type CallElsewhereEntry,
+} from './human-chat-panel/use-call-membership-registry';
+import { HumanChatPanelElsewhereCallIndicator } from './human-chat-panel/human-chat-panel-elsewhere-call-indicator';
 import { getCoherenceBySlug } from '@hypha-platform/core/coherence/server/web3';
 import { upsertSignalDescriptionInRoom } from '../coherence/utils/signal-chat-description';
 import { matrixRoomShortLabel } from './human-chat-panel/matrix-chat-unread';
@@ -1342,6 +1348,27 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
   const spaceCallToolbarJoinHint =
     callUiEnabled &&
     (spaceCallShowJoinStrip || spaceCallRoomGroupDeviceCount > 0);
+  const elsewhereCallEntries = useCallMembershipRegistry({
+    excludeRoomId: roomId,
+    getAccessToken: async () => authTokenRef.current,
+  });
+
+  const handleSelectElsewhereCall = useCallback(
+    (entry: CallElsewhereEntry) => {
+      const lang = getLocaleFromPath(pathname);
+      const target =
+        entry.kind === 'signal' && entry.signalSlug
+          ? `/${lang}/dho/${entry.spaceSlug}?signal=${encodeURIComponent(
+              entry.signalSlug,
+            )}`
+          : `/${lang}/dho/${entry.spaceSlug}`;
+      router.push(target);
+      openHumanChatPanel();
+      setActiveTab('chat');
+    },
+    [pathname, router, openHumanChatPanel, setActiveTab],
+  );
+
   const showAuthedUi = !isAuthLoading && isAuthenticated;
   const showAuthPrompt = !isAuthLoading && !isAuthenticated;
   const showPanelInteractionPrompt =
@@ -4285,29 +4312,55 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
             mentionTabBadgeCount={bellMentionCount}
             mentionTabBadgeCapped={bellMentionCapped}
             tabRowEnd={
-              showSidebarCallChrome &&
-              !inSpaceCall &&
-              !spaceCallShowJoinStrip ? (
-                <HumanChatPanelCallToolbar
-                  callState={spaceCallState}
-                  callKind={spaceCallKind}
-                  disabled={!callUiEnabled}
-                  roomCallInProgressToJoin={spaceCallToolbarJoinHint}
-                  onAudio={() => {
-                    if (!canJoinSignalThreadCall && isSignalThread) {
-                      void requestSignalTeamAccess();
-                      return;
-                    }
-                    handleCallAudio();
-                  }}
-                  onVideo={() => {
-                    if (!canJoinSignalThreadCall && isSignalThread) {
-                      void requestSignalTeamAccess();
-                      return;
-                    }
-                    handleCallVideo();
-                  }}
-                />
+              (showSidebarCallChrome &&
+                !inSpaceCall &&
+                !spaceCallShowJoinStrip) ||
+              (showAuthedUi &&
+                Boolean(spaceSlug?.trim()) &&
+                elsewhereCallEntries.length > 0) ? (
+                <>
+                  {showSidebarCallChrome &&
+                  !inSpaceCall &&
+                  !spaceCallShowJoinStrip ? (
+                    <HumanChatPanelCallToolbar
+                      callState={spaceCallState}
+                      callKind={spaceCallKind}
+                      disabled={!callUiEnabled}
+                      roomCallInProgressToJoin={spaceCallToolbarJoinHint}
+                      onAudio={() => {
+                        if (!canJoinSignalThreadCall && isSignalThread) {
+                          void requestSignalTeamAccess();
+                          return;
+                        }
+                        handleCallAudio();
+                      }}
+                      onVideo={() => {
+                        if (!canJoinSignalThreadCall && isSignalThread) {
+                          void requestSignalTeamAccess();
+                          return;
+                        }
+                        handleCallVideo();
+                      }}
+                    />
+                  ) : null}
+                  {showAuthedUi &&
+                  Boolean(spaceSlug?.trim()) &&
+                  elsewhereCallEntries.length > 0 ? (
+                    <HumanChatPanelElsewhereCallIndicator
+                      entries={elsewhereCallEntries}
+                      onSelect={handleSelectElsewhereCall}
+                      label={
+                        elsewhereCallEntries.length === 1
+                          ? t('activeCallElsewhere', {
+                              title: elsewhereCallEntries[0]?.title ?? '',
+                            })
+                          : t('activeCallsElsewhereCount', {
+                              count: elsewhereCallEntries.length,
+                            })
+                      }
+                    />
+                  ) : null}
+                </>
               ) : null
             }
           />
@@ -4465,7 +4518,7 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
       >
         {isAuthLoading ? (
           <HumanChatPanelLoader />
-        ) : blockSpaceChatForActivityAccess ? (
+        ) : showAuthPrompt ? (
           <div className="flex flex-1 items-center justify-center px-6">
             <SpaceAccessDenied
               userState={userSpaceState}
@@ -4473,7 +4526,28 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
               spaceSlug={spaceSlug ?? undefined}
             />
           </div>
-        ) : showAuthPrompt ? (
+        ) : !spaceSlug?.trim() ? (
+          <div className="flex flex-1 flex-col items-center justify-center gap-4 px-6">
+            <Empty>
+              <p>{t('notInSpaceEmptyState')}</p>
+            </Empty>
+            {elsewhereCallEntries.length > 0 ? (
+              <HumanChatPanelElsewhereCallIndicator
+                entries={elsewhereCallEntries}
+                onSelect={handleSelectElsewhereCall}
+                label={
+                  elsewhereCallEntries.length === 1
+                    ? t('activeCallElsewhere', {
+                        title: elsewhereCallEntries[0]?.title ?? '',
+                      })
+                    : t('activeCallsElsewhereCount', {
+                        count: elsewhereCallEntries.length,
+                      })
+                }
+              />
+            ) : null}
+          </div>
+        ) : blockSpaceChatForActivityAccess ? (
           <div className="flex flex-1 items-center justify-center px-6">
             <SpaceAccessDenied
               userState={userSpaceState}

--- a/packages/epics/src/common/human-right-panel.tsx
+++ b/packages/epics/src/common/human-right-panel.tsx
@@ -11,6 +11,7 @@ import {
 import type { RoomMessageEventContent } from 'matrix-js-sdk/lib/@types/events';
 import { Check, Plus } from 'lucide-react';
 import { useTranslations } from 'next-intl';
+import { useTheme } from 'next-themes';
 import {
   useParams,
   usePathname,
@@ -38,6 +39,7 @@ import {
   useMe,
   useSpaceBySlug,
   useSpaceMutationsWeb2Rsc,
+  useSpacesBySlugs,
   Message,
   firstLineForReplyPreview,
   stripMatrixReplyFallback,
@@ -72,6 +74,7 @@ import {
   canInteractInSpace,
 } from '../spaces/utils/transparency-access';
 import { SpaceAccessDenied } from '../spaces/components/space-access-denied';
+import { resolveSpaceDisplayLogoUrl } from '../spaces/utils/resolve-space-display-logo-url';
 import { Empty } from './empty';
 
 import {
@@ -1348,10 +1351,62 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
   const spaceCallToolbarJoinHint =
     callUiEnabled &&
     (spaceCallShowJoinStrip || spaceCallRoomGroupDeviceCount > 0);
-  const elsewhereCallEntries = useCallMembershipRegistry({
-    excludeRoomId: roomId,
+  /**
+   * Only excludes the user's own actively-bound call room — the room currently being
+   * viewed is *not* excluded here (unlike the top-nav trigger / earlier version of this
+   * call), because this single result now drives two different views below: the "elsewhere"
+   * avatar list (which does exclude the viewed room) and the "there's a call in this room but
+   * I'm bound elsewhere" banner (which needs exactly the viewed room, when present). See
+   * #2424 QA notes, 2026-08-04.
+   */
+  const otherActiveCallEntries = useCallMembershipRegistry({
+    excludeRoomIds: [callSessionRoomId],
     getAccessToken: async () => authTokenRef.current,
   });
+  const elsewhereCallEntries = useMemo(
+    () => otherActiveCallEntries.filter((entry) => entry.roomId !== roomId),
+    [otherActiveCallEntries, roomId],
+  );
+  /** The room currently being viewed has its own active call, separate from whichever call
+   * (if any) the user is actively bound to elsewhere. */
+  const currentRoomActiveCall = useMemo(
+    () =>
+      otherActiveCallEntries.find((entry) => entry.roomId === roomId) ?? null,
+    [otherActiveCallEntries, roomId],
+  );
+
+  const { resolvedTheme } = useTheme();
+  const elsewhereCallSpaceSlugs = useMemo(
+    () =>
+      Array.from(
+        new Set(
+          elsewhereCallEntries
+            .map((entry) => entry.spaceSlug?.trim())
+            .filter((slug): slug is string => Boolean(slug)),
+        ),
+      ),
+    [elsewhereCallEntries],
+  );
+  const { spaces: elsewhereCallSpacesData } = useSpacesBySlugs(
+    elsewhereCallSpaceSlugs,
+    false,
+  );
+  /** Avatar images for the cross-context indicator — same source as the recent-spaces
+   * sidebar (`ai-left-panel.tsx`): batch-fetched space records, resolved logo URL with
+   * a first-letter fallback while the fetch is in flight or if no logo is set. */
+  const elsewhereCallEntriesWithAvatar = useMemo(
+    () =>
+      elsewhereCallEntries.map((entry) => ({
+        ...entry,
+        avatarUrl: resolveSpaceDisplayLogoUrl(
+          elsewhereCallSpacesData.find(
+            (space) => space.slug === entry.spaceSlug,
+          ),
+          resolvedTheme === 'dark' ? 'dark' : 'light',
+        ),
+      })),
+    [elsewhereCallEntries, elsewhereCallSpacesData, resolvedTheme],
+  );
 
   const handleSelectElsewhereCall = useCallback(
     (entry: CallElsewhereEntry) => {
@@ -1596,6 +1651,61 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
     startVideoForRoom,
     markPendingCallStartNotify,
     inSpaceCall,
+  ]);
+
+  /**
+   * "Join this room's call instead" — for the case where the room being viewed has its own
+   * active call but the user is already bound to a call in a *different* room.
+   * `startAudioForRoom`/`startVideoForRoom` silently no-op while pinned to another room
+   * (see `global-call-dock-context.tsx`), so the old call must actually end first. But
+   * `callSessionRoomId` only clears via a `useEffect` reacting to `call.callState === 'idle'`,
+   * not synchronously when `leave()`'s promise resolves — awaiting the promise and then
+   * immediately calling `handleCallAudio`/`handleCallVideo` would race that and likely fail
+   * on the first click. Instead, record the intent and let an effect fire the join once
+   * `callSessionRoomId` has actually cleared.
+   */
+  const [pendingCallSwitchKind, setPendingCallSwitchKind] = useState<
+    'audio' | 'video' | null
+  >(null);
+
+  const handleJoinCurrentRoomCallInstead = useCallback(
+    (kind: 'audio' | 'video') => {
+      if (callSessionRoomId && callSessionRoomId !== roomId) {
+        setPendingCallSwitchKind(kind);
+        void leaveSpaceCall();
+        return;
+      }
+      if (kind === 'audio') {
+        handleCallAudio();
+      } else {
+        handleCallVideo();
+      }
+    },
+    [
+      callSessionRoomId,
+      roomId,
+      leaveSpaceCall,
+      handleCallAudio,
+      handleCallVideo,
+    ],
+  );
+
+  useEffect(() => {
+    if (!pendingCallSwitchKind) return;
+    if (callSessionRoomId && callSessionRoomId !== roomId) return;
+    const kind = pendingCallSwitchKind;
+    setPendingCallSwitchKind(null);
+    if (kind === 'audio') {
+      handleCallAudio();
+    } else {
+      handleCallVideo();
+    }
+  }, [
+    pendingCallSwitchKind,
+    callSessionRoomId,
+    roomId,
+    handleCallAudio,
+    handleCallVideo,
   ]);
 
   const handleCallLeave = useCallback(() => {
@@ -4315,9 +4425,7 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
               (showSidebarCallChrome &&
                 !inSpaceCall &&
                 !spaceCallShowJoinStrip) ||
-              (showAuthedUi &&
-                Boolean(spaceSlug?.trim()) &&
-                elsewhereCallEntries.length > 0) ? (
+              (showAuthedUi && elsewhereCallEntries.length > 0) ? (
                 <>
                   {showSidebarCallChrome &&
                   !inSpaceCall &&
@@ -4343,11 +4451,9 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
                       }}
                     />
                   ) : null}
-                  {showAuthedUi &&
-                  Boolean(spaceSlug?.trim()) &&
-                  elsewhereCallEntries.length > 0 ? (
+                  {showAuthedUi && elsewhereCallEntries.length > 0 ? (
                     <HumanChatPanelElsewhereCallIndicator
-                      entries={elsewhereCallEntries}
+                      entries={elsewhereCallEntriesWithAvatar}
                       onSelect={handleSelectElsewhereCall}
                       label={
                         elsewhereCallEntries.length === 1
@@ -4387,6 +4493,33 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
               }}
             />
           )}
+          {/* Mutually exclusive with the banner above: that one needs `showSidebarCallChrome`
+              (bound call === this room), this one needs the opposite — a call here while
+              bound elsewhere. Joining leaves the other call first (#2424). */}
+          {currentRoomActiveCall &&
+          callSessionRoomId &&
+          callSessionRoomId !== roomId ? (
+            <HumanChatPanelCallJoinStrip
+              deviceCount={currentRoomActiveCall.participantCount}
+              disabled={!callUiEnabled}
+              busy={Boolean(pendingCallSwitchKind)}
+              roomId={roomId}
+              onJoinAudio={() => {
+                if (!canJoinSignalThreadCall && isSignalThread) {
+                  void requestSignalTeamAccess();
+                  return;
+                }
+                handleJoinCurrentRoomCallInstead('audio');
+              }}
+              onJoinVideo={() => {
+                if (!canJoinSignalThreadCall && isSignalThread) {
+                  void requestSignalTeamAccess();
+                  return;
+                }
+                handleJoinCurrentRoomCallInstead('video');
+              }}
+            />
+          ) : null}
           <HumanChatPanelCallJoinInvitation
             open={joinInviteOpen}
             deviceCount={spaceCallRoomGroupDeviceCount}
@@ -4531,21 +4664,6 @@ export function HumanRightPanel({ useMembers }: HumanRightPanelProps) {
             <Empty>
               <p>{t('notInSpaceEmptyState')}</p>
             </Empty>
-            {elsewhereCallEntries.length > 0 ? (
-              <HumanChatPanelElsewhereCallIndicator
-                entries={elsewhereCallEntries}
-                onSelect={handleSelectElsewhereCall}
-                label={
-                  elsewhereCallEntries.length === 1
-                    ? t('activeCallElsewhere', {
-                        title: elsewhereCallEntries[0]?.title ?? '',
-                      })
-                    : t('activeCallsElsewhereCount', {
-                        count: elsewhereCallEntries.length,
-                      })
-                }
-              />
-            ) : null}
           </div>
         ) : blockSpaceChatForActivityAccess ? (
           <div className="flex flex-1 items-center justify-center px-6">

--- a/packages/epics/src/common/panel-wrap-layout.tsx
+++ b/packages/epics/src/common/panel-wrap-layout.tsx
@@ -8,7 +8,13 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { Menu, MessageCircle, PanelLeftClose, Sparkles } from 'lucide-react';
+import {
+  Menu,
+  MessageCircle,
+  PanelLeftClose,
+  Phone,
+  Sparkles,
+} from 'lucide-react';
 import { usePathname } from 'next/navigation';
 import {
   SidebarProvider,
@@ -214,7 +220,7 @@ export function HumanSidebarTrigger() {
   const { activeRoomId } = useGlobalCallDock();
   const { jwt } = useJwt();
   const elsewhereCallEntries = useCallMembershipRegistry({
-    excludeRoomId: activeRoomId,
+    excludeRoomIds: [activeRoomId],
     getAccessToken: async () => jwt,
   });
   const hasCallElsewhere = elsewhereCallEntries.length > 0;
@@ -224,31 +230,40 @@ export function HumanSidebarTrigger() {
   if (open || (!isSpace && !hasCallElsewhere)) return null;
 
   return (
-    <button
-      type="button"
-      onClick={() => {
-        if (open) {
-          toggle();
-          return;
-        }
-        if (mutuallyExclusive && (leftOpen || overlayVisible)) {
-          closeAiPanel();
-        }
-        openHumanChatPanel();
-      }}
-      aria-expanded={open}
-      className={`relative ${APP_CHROME_ICON_TRIGGER}`}
-      title={t('openPanel')}
-      aria-label={t('openPanel')}
-    >
-      <MessageCircle className="craft-icon" />
+    // `APP_CHROME_ICON_TRIGGER` has `overflow-hidden`, which clips a badge positioned
+    // outside the icon's bounds — so the badge lives on this unclipped wrapper instead
+    // of inside the button.
+    <span className="relative inline-flex">
+      <button
+        type="button"
+        onClick={() => {
+          if (open) {
+            toggle();
+            return;
+          }
+          if (mutuallyExclusive && (leftOpen || overlayVisible)) {
+            closeAiPanel();
+          }
+          openHumanChatPanel();
+        }}
+        aria-expanded={open}
+        className={APP_CHROME_ICON_TRIGGER}
+        title={t('openPanel')}
+        aria-label={t('openPanel')}
+      >
+        <MessageCircle className="craft-icon" />
+      </button>
       {hasCallElsewhere ? (
-        <span className="absolute right-1 top-1 flex h-2 w-2">
-          <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-500 opacity-75" />
-          <span className="relative inline-flex h-2 w-2 rounded-full bg-emerald-500" />
+        <span className="pointer-events-none absolute -right-2 -top-2 flex h-5 w-5 items-center justify-center">
+          <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-success-9 opacity-60" />
+          {/* h-4.5/w-4.5 isn't valid here — see the matching comment in
+              human-chat-panel-elsewhere-call-indicator.tsx. */}
+          <span className="relative flex h-[18px] w-[18px] items-center justify-center rounded-full bg-success-9 ring-2 ring-background">
+            <Phone className="h-3 w-3 text-white" strokeWidth={2.5} />
+          </span>
         </span>
       ) : null}
-    </button>
+    </span>
   );
 }
 
@@ -338,8 +353,10 @@ export function PanelWrapLayout({
   const isSpace = useIsSpaceContext();
   const isOnboarding = pathname.includes('/onboarding');
   const effectiveLeft = isSpace ? left : undefined;
-  // Right human panel remains space-context only.
-  const effectiveRight = isSpace ? right : undefined;
+  // Right human panel is openable outside a space too (#2424) — the trigger only
+  // surfaces there when there's a call elsewhere to jump to, and `HumanRightPanel`
+  // itself renders a dedicated "not in a space" state instead of its space-only UI.
+  const effectiveRight = right;
   const [viewportWidth, setViewportWidth] = useState<number>(() => {
     if (typeof window === 'undefined') {
       return MOBILE_PANEL_BREAKPOINT_PX;

--- a/packages/epics/src/common/panel-wrap-layout.tsx
+++ b/packages/epics/src/common/panel-wrap-layout.tsx
@@ -222,6 +222,7 @@ export function HumanSidebarTrigger() {
   const elsewhereCallEntries = useCallMembershipRegistry({
     excludeRoomIds: [activeRoomId],
     getAccessToken: async () => jwt,
+    hasAccessToken: Boolean(jwt),
   });
   const hasCallElsewhere = elsewhereCallEntries.length > 0;
 

--- a/packages/epics/src/common/panel-wrap-layout.tsx
+++ b/packages/epics/src/common/panel-wrap-layout.tsx
@@ -18,6 +18,7 @@ import {
   useIsMobile,
 } from '@hypha-platform/ui';
 import { useTranslations } from 'next-intl';
+import { useJwt } from '@hypha-platform/core/client';
 import {
   AiPanelProvider,
   HumanChatPanelProvider,
@@ -25,6 +26,8 @@ import {
   useHumanChatPanel,
 } from './human-chat-panel-context';
 import { useIsSpaceContext } from './use-is-space-context';
+import { useGlobalCallDock } from './global-call-dock-context';
+import { useCallMembershipRegistry } from './human-chat-panel/use-call-membership-registry';
 import { PanelDualSidebarScrollBridge } from './panel-main-column-scroll-bridge';
 import { PanelScrollInset } from './panel-scroll-inset';
 import { APP_CHROME_ICON_TRIGGER } from './chrome-radius';
@@ -208,9 +211,17 @@ export function HumanSidebarTrigger() {
   const t = useTranslations('HumanChatPanel');
   const isSpace = useIsSpaceContext();
   const mutuallyExclusive = useMutuallyExclusivePanels();
+  const { activeRoomId } = useGlobalCallDock();
+  const { jwt } = useJwt();
+  const elsewhereCallEntries = useCallMembershipRegistry({
+    excludeRoomId: activeRoomId,
+    getAccessToken: async () => jwt,
+  });
+  const hasCallElsewhere = elsewhereCallEntries.length > 0;
 
   // Hide header trigger while the chat panel is open — the panel has its own chrome.
-  if (!isSpace || open) return null;
+  // Outside a space, still show it when there's a call elsewhere to notify about (#2424).
+  if (open || (!isSpace && !hasCallElsewhere)) return null;
 
   return (
     <button
@@ -226,11 +237,17 @@ export function HumanSidebarTrigger() {
         openHumanChatPanel();
       }}
       aria-expanded={open}
-      className={APP_CHROME_ICON_TRIGGER}
+      className={`relative ${APP_CHROME_ICON_TRIGGER}`}
       title={t('openPanel')}
       aria-label={t('openPanel')}
     >
       <MessageCircle className="craft-icon" />
+      {hasCallElsewhere ? (
+        <span className="absolute right-1 top-1 flex h-2 w-2">
+          <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-500 opacity-75" />
+          <span className="relative inline-flex h-2 w-2 rounded-full bg-emerald-500" />
+        </span>
+      ) : null}
     </button>
   );
 }

--- a/packages/epics/src/spaces/components/space-call-join-hero-banner.tsx
+++ b/packages/epics/src/spaces/components/space-call-join-hero-banner.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useAuthentication } from '@hypha-platform/authentication';
 import { useJwt, useMatrix } from '@hypha-platform/core/client';
 import { HumanChatPanelCallJoinStrip } from '../../common/human-chat-panel/human-chat-panel-call-join-strip';
+import { useCallMembershipRegistry } from '../../common/human-chat-panel/use-call-membership-registry';
 import { useGlobalCallDock } from '../../common/global-call-dock-context';
 import {
   UserSpaceState,
@@ -44,6 +45,7 @@ export function SpaceCallJoinHeroBanner({
     startVideoForRoom,
     pinnedCallSpaceSlug,
     activeRoomId,
+    leave: leaveSpaceCall,
   } = useGlobalCallDock();
 
   const canonicalRoomId = chatRoomId?.trim() || null;
@@ -92,6 +94,33 @@ export function SpaceCallJoinHeroBanner({
     roomGroupCallDeviceCount > 0 &&
     !inSpaceCall;
 
+  /**
+   * This space's own room has an active call, but the user is bound to a *different* one
+   * (`!roomMatches`) — `showBanner` above stays hidden for that case by design, so this is a
+   * separate signal reusing the same registry the cross-context badge/panel use (#2424).
+   * Only excludes the user's own bound room; nothing excludes `canonicalRoomId` itself, since
+   * that's exactly the room we're checking here.
+   */
+  const otherActiveCallEntries = useCallMembershipRegistry({
+    excludeRoomIds: [activeRoomId],
+    getAccessToken: async () => authToken,
+  });
+  const currentRoomActiveCallElsewhere = useMemo(
+    () =>
+      otherActiveCallEntries.find(
+        (entry) => entry.roomId === canonicalRoomId,
+      ) ?? null,
+    [otherActiveCallEntries, canonicalRoomId],
+  );
+  const showBoundElsewhereBanner =
+    !isAuthLoading &&
+    !isUserSpaceStateLoading &&
+    callUiEnabled &&
+    !inSpaceCall &&
+    Boolean(currentRoomActiveCallElsewhere) &&
+    Boolean(activeRoomId?.trim()) &&
+    activeRoomId?.trim() !== canonicalRoomId;
+
   const launchContext = useMemo(() => {
     const roomTitle = spaceTitle?.trim();
     return roomTitle ? { roomTitle } : undefined;
@@ -117,7 +146,76 @@ export function SpaceCallJoinHeroBanner({
     );
   }, [authToken, canonicalRoomId, launchContext, slug, startVideoForRoom]);
 
-  if (!showBanner || !isAuthenticated) {
+  /**
+   * Same sequencing as the right panel's `handleJoinCurrentRoomCallInstead`
+   * (`human-right-panel.tsx`) — `activeRoomId` only clears via a `useEffect` reacting to
+   * `callState === 'idle'`, not synchronously when `leave()`'s promise resolves, so awaiting
+   * the promise and immediately joining would race that. Record intent, let an effect fire
+   * the join once the room has actually cleared.
+   */
+  const [pendingCallSwitchKind, setPendingCallSwitchKind] = useState<
+    'audio' | 'video' | null
+  >(null);
+
+  const handleJoinInsteadOfBoundCall = useCallback(
+    (kind: 'audio' | 'video') => {
+      if (activeRoomId?.trim() && activeRoomId.trim() !== canonicalRoomId) {
+        setPendingCallSwitchKind(kind);
+        void leaveSpaceCall();
+        return;
+      }
+      if (kind === 'audio') {
+        handleJoinAudio();
+      } else {
+        handleJoinVideo();
+      }
+    },
+    [
+      activeRoomId,
+      canonicalRoomId,
+      leaveSpaceCall,
+      handleJoinAudio,
+      handleJoinVideo,
+    ],
+  );
+
+  useEffect(() => {
+    if (!pendingCallSwitchKind) return;
+    if (activeRoomId?.trim() && activeRoomId.trim() !== canonicalRoomId) return;
+    const kind = pendingCallSwitchKind;
+    setPendingCallSwitchKind(null);
+    if (kind === 'audio') {
+      handleJoinAudio();
+    } else {
+      handleJoinVideo();
+    }
+  }, [
+    pendingCallSwitchKind,
+    activeRoomId,
+    canonicalRoomId,
+    handleJoinAudio,
+    handleJoinVideo,
+  ]);
+
+  if (!isAuthenticated) {
+    return null;
+  }
+
+  if (showBoundElsewhereBanner && currentRoomActiveCallElsewhere) {
+    return (
+      <HumanChatPanelCallJoinStrip
+        variant="hero"
+        deviceCount={currentRoomActiveCallElsewhere.participantCount}
+        disabled={!callUiEnabled}
+        busy={Boolean(pendingCallSwitchKind)}
+        roomId={canonicalRoomId}
+        onJoinAudio={() => handleJoinInsteadOfBoundCall('audio')}
+        onJoinVideo={() => handleJoinInsteadOfBoundCall('video')}
+      />
+    );
+  }
+
+  if (!showBanner) {
     return null;
   }
 

--- a/packages/epics/src/spaces/components/space-call-join-hero-banner.tsx
+++ b/packages/epics/src/spaces/components/space-call-join-hero-banner.tsx
@@ -104,6 +104,7 @@ export function SpaceCallJoinHeroBanner({
   const otherActiveCallEntries = useCallMembershipRegistry({
     excludeRoomIds: [activeRoomId],
     getAccessToken: async () => authToken,
+    hasAccessToken: Boolean(authToken),
   });
   const currentRoomActiveCallElsewhere = useMemo(
     () =>

--- a/packages/epics/src/spaces/components/space-call-join-hero-banner.tsx
+++ b/packages/epics/src/spaces/components/space-call-join-hero-banner.tsx
@@ -116,7 +116,6 @@ export function SpaceCallJoinHeroBanner({
     !isAuthLoading &&
     !isUserSpaceStateLoading &&
     callUiEnabled &&
-    !inSpaceCall &&
     Boolean(currentRoomActiveCallElsewhere) &&
     Boolean(activeRoomId?.trim()) &&
     activeRoomId?.trim() !== canonicalRoomId;
@@ -153,15 +152,22 @@ export function SpaceCallJoinHeroBanner({
    * the promise and immediately joining would race that. Record intent, let an effect fire
    * the join once the room has actually cleared.
    */
-  const [pendingCallSwitchKind, setPendingCallSwitchKind] = useState<
-    'audio' | 'video' | null
-  >(null);
+  const [pendingCallSwitch, setPendingCallSwitch] = useState<{
+    kind: 'audio' | 'video';
+    roomId: string;
+  } | null>(null);
 
   const handleJoinInsteadOfBoundCall = useCallback(
     (kind: 'audio' | 'video') => {
       if (activeRoomId?.trim() && activeRoomId.trim() !== canonicalRoomId) {
-        setPendingCallSwitchKind(kind);
-        void leaveSpaceCall();
+        const targetRoomId = canonicalRoomId;
+        if (!targetRoomId) return;
+        setPendingCallSwitch({ kind, roomId: targetRoomId });
+        leaveSpaceCall().catch(() => {
+          setPendingCallSwitch((prev) =>
+            prev && prev.roomId === targetRoomId ? null : prev,
+          );
+        });
         return;
       }
       if (kind === 'audio') {
@@ -180,17 +186,23 @@ export function SpaceCallJoinHeroBanner({
   );
 
   useEffect(() => {
-    if (!pendingCallSwitchKind) return;
+    if (!pendingCallSwitch) return;
+    // This banner instance is bound to `canonicalRoomId`; if it no longer matches the
+    // room we meant to join (component reused for a different space), abandon the switch.
+    if (pendingCallSwitch.roomId !== canonicalRoomId) {
+      setPendingCallSwitch(null);
+      return;
+    }
     if (activeRoomId?.trim() && activeRoomId.trim() !== canonicalRoomId) return;
-    const kind = pendingCallSwitchKind;
-    setPendingCallSwitchKind(null);
+    const { kind } = pendingCallSwitch;
+    setPendingCallSwitch(null);
     if (kind === 'audio') {
       handleJoinAudio();
     } else {
       handleJoinVideo();
     }
   }, [
-    pendingCallSwitchKind,
+    pendingCallSwitch,
     activeRoomId,
     canonicalRoomId,
     handleJoinAudio,
@@ -207,7 +219,7 @@ export function SpaceCallJoinHeroBanner({
         variant="hero"
         deviceCount={currentRoomActiveCallElsewhere.participantCount}
         disabled={!callUiEnabled}
-        busy={Boolean(pendingCallSwitchKind)}
+        busy={Boolean(pendingCallSwitch)}
         roomId={canonicalRoomId}
         onJoinAudio={() => handleJoinInsteadOfBoundCall('audio')}
         onJoinVideo={() => handleJoinInsteadOfBoundCall('video')}

--- a/packages/i18n/src/messages/de.json
+++ b/packages/i18n/src/messages/de.json
@@ -2913,6 +2913,9 @@
   },
   "HumanChatPanel": {
     "title": "Chat",
+    "activeCallElsewhere": "Aktiver Anruf in {title}",
+    "activeCallsElsewhereCount": "{count} aktive Anrufe an anderer Stelle",
+    "notInSpaceEmptyState": "Du befindest dich gerade in keinem Space.",
     "welcome": "Willkommen im Chat! Starten Sie eine Unterhaltung mit anderen Mitgliedern dieses Spaces.",
     "placeholder": "Nachricht eingeben...",
     "placeholderChannel": "Nachricht #{channel}",

--- a/packages/i18n/src/messages/en.json
+++ b/packages/i18n/src/messages/en.json
@@ -2915,6 +2915,9 @@
   },
   "HumanChatPanel": {
     "title": "Chat",
+    "activeCallElsewhere": "Active call in {title}",
+    "activeCallsElsewhereCount": "{count} active calls elsewhere",
+    "notInSpaceEmptyState": "You're not in a space right now.",
     "welcome": "Welcome to the chat! Start a conversation with other members of this space.",
     "placeholder": "Type a message...",
     "placeholderChannel": "Message #{channel}",

--- a/packages/i18n/src/messages/es.json
+++ b/packages/i18n/src/messages/es.json
@@ -2349,6 +2349,9 @@
   },
   "HumanChatPanel": {
     "title": "Chat",
+    "activeCallElsewhere": "Llamada activa en {title}",
+    "activeCallsElsewhereCount": "{count} llamadas activas en otro lugar",
+    "notInSpaceEmptyState": "No estás en un espacio en este momento.",
     "welcome": "¡Bienvenido al chat! Inicia una conversación con otros miembros de este espacio.",
     "placeholder": "Escribe un mensaje...",
     "placeholderChannel": "Mensaje #{channel}",

--- a/packages/i18n/src/messages/fr.json
+++ b/packages/i18n/src/messages/fr.json
@@ -2349,6 +2349,9 @@
   },
   "HumanChatPanel": {
     "title": "Chat",
+    "activeCallElsewhere": "Appel actif dans {title}",
+    "activeCallsElsewhereCount": "{count} appels actifs ailleurs",
+    "notInSpaceEmptyState": "Vous n'êtes actuellement dans aucun espace.",
     "welcome": "Bienvenue dans le chat ! Démarrez une conversation avec les autres membres de cet espace.",
     "placeholder": "Tapez un message...",
     "placeholderChannel": "Message #{channel}",

--- a/packages/i18n/src/messages/mk.json
+++ b/packages/i18n/src/messages/mk.json
@@ -2895,6 +2895,9 @@
   },
   "HumanChatPanel": {
     "title": "Разговор",
+    "activeCallElsewhere": "Активен повик во {title}",
+    "activeCallsElsewhereCount": "{count} активни повици на друго место",
+    "notInSpaceEmptyState": "Во моментов не сте во простор.",
     "welcome": "Добредојде во разговорот! Започни разговор со другите членови на овој простор.",
     "placeholder": "Напиши порака...",
     "placeholderChannel": "Порака во #{channel}",

--- a/packages/i18n/src/messages/nl.json
+++ b/packages/i18n/src/messages/nl.json
@@ -2915,6 +2915,9 @@
   },
   "HumanChatPanel": {
     "title": "Chatten",
+    "activeCallElsewhere": "Actief gesprek in {title}",
+    "activeCallsElsewhereCount": "{count} actieve gesprekken elders",
+    "notInSpaceEmptyState": "Je bevindt je momenteel niet in een ruimte.",
     "welcome": "Welkom bij de chat! Begin een gesprek met andere leden van deze ruimte.",
     "placeholder": "Typ een bericht...",
     "placeholderChannel": "Bericht #{channel}",

--- a/packages/i18n/src/messages/no.json
+++ b/packages/i18n/src/messages/no.json
@@ -2914,6 +2914,9 @@
   },
   "HumanChatPanel": {
     "title": "Chat",
+    "activeCallElsewhere": "Aktiv samtale i {title}",
+    "activeCallsElsewhereCount": "{count} aktive samtaler andre steder",
+    "notInSpaceEmptyState": "Du er ikke i et rom akkurat nå.",
     "welcome": "Velkommen til chatten! Start en samtale med andre medlemmer av dette rommet.",
     "placeholder": "Skriv en melding...",
     "placeholderChannel": "Melding til #{channel}",

--- a/packages/i18n/src/messages/pt.json
+++ b/packages/i18n/src/messages/pt.json
@@ -2349,6 +2349,9 @@
   },
   "HumanChatPanel": {
     "title": "Chat",
+    "activeCallElsewhere": "Chamada ativa em {title}",
+    "activeCallsElsewhereCount": "{count} chamadas ativas em outros lugares",
+    "notInSpaceEmptyState": "Você não está em um espaço no momento.",
     "welcome": "Bem-vindo ao chat! Inicie uma conversa com outros membros deste espaço.",
     "placeholder": "Digite uma mensagem...",
     "placeholderChannel": "Mensagem #{channel}",


### PR DESCRIPTION
## Summary
Closes #2424 — notify a user of an active call while they're on a different context (a different space, or outside a space entirely), without over-notifying someone already on a call.

- **Top-nav badge**: pulsing indicator on the chat trigger when there's an active call elsewhere, visible even outside a space.
- **Right panel**: avatar (or stacked count + picker menu for 2+) in the chat tab row, with real space avatar images; clicking navigates to that call.
- **Cross-room join**: when the room being viewed has its own active call but the user is already bound to a call in a different room, a "Call in progress" banner (right panel + main hero banner) now offers to join — leaving the bound call first — instead of showing nothing.
- Registry hook (`useCallMembershipRegistry`) reads state already flowing through the existing full-account Matrix `/sync` — no new subscriptions or server-side polling.

Full design rationale and QA-driven fixes are tracked in `hypha-context` (ticket `2424-cross-context-call-awareness`: `spec.md`, `decisions.md` #1–#13, `implementation-plan.md`).

## Test plan
- [x] Typechecks clean (`packages/core`, `packages/epics`)
- [x] Manually verified live across two real accounts/rooms: badge appears/disappears correctly, avatar shows real space image, click-through navigates and opens the right call
- [x] Verified with 2+ concurrent calls (stacked count + picker menu)
- [x] Verified outside a space (top-nav badge + panel's "not in a space" fallback state)
- [x] Verified the cross-room join flow: viewing a space with its own call while bound to a call elsewhere now shows a join banner (both right panel and main hero banner) instead of nothing; joining correctly leaves the old call first
- [x] No server/infra changes beyond the existing read-only room→space lookup added earlier in this ticket; no new Matrix `/sync` filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added indicators for active calls in other spaces, including avatars, participant counts, and quick navigation.
  - Added support for leaving a current call before joining another room’s audio or video call.
  - Added sidebar access and notifications for calls happening elsewhere.
  - Added chat-room space lookup and improved non-space panel states and access handling.
- **Localization**
  - Added call and empty-state translations in English, German, Spanish, French, Macedonian, Dutch, Norwegian, and Portuguese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->