### PR TITLE
fix(wallet): correct token currency, convert balances, and restore action buttons

### DIFF
--- a/apps/web/src/app/api/v1/currency-rates/route.ts
+++ b/apps/web/src/app/api/v1/currency-rates/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server';
+import { getUsdRates } from '@hypha-platform/core/server';
+
+/**
+ * Public FX rates, quoted in USD, for rendering balances in a member's chosen
+ * currency. No auth: these are Chainlink market rates, not user data, and the
+ * space treasury total needs them for signed-out visitors too.
+ */
+export async function GET() {
+  try {
+    const rates = await getUsdRates();
+    return NextResponse.json({ base: 'USD', rates });
+  } catch (error) {
+    console.error('Failed to fetch currency rates:', error);
+    return NextResponse.json(
+      { error: 'Failed to fetch currency rates.' },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/src/app/api/v1/people/[personSlug]/assets/route.ts
+++ b/apps/web/src/app/api/v1/people/[personSlug]/assets/route.ts
@@ -11,6 +11,7 @@ import {
   getSupply,
   getMutualCreditInfo,
   getUsdRates,
+  convertToUsd,
 } from '@hypha-platform/core/server';
 import {
   TOKENS,
@@ -28,7 +29,6 @@ import {
   getEnergyCommunityDisplayDecimals,
   isHyphaToken,
   HYPHA_PRICE_USD,
-  convertToUsd,
 } from '@hypha-platform/core/client';
 import { headers } from 'next/headers';
 import { hasEmojiOrLink, tryDecodeUriPart } from '@hypha-platform/ui-utils';
@@ -265,12 +265,17 @@ export async function GET(
       (token) => !isHiddenToken(token.address),
     );
 
-    let prices: Record<string, number | undefined> = {};
-    try {
-      prices = await getTokenPrice(allTokens.map(({ address }) => address));
-    } catch (error: unknown) {
-      console.error('Failed to fetch token prices:', error);
-    }
+    // Rates are needed to sum tokens priced in different currencies into one
+    // total, and do not depend on the prices, so pay for one round-trip.
+    const [prices, usdRates] = await Promise.all([
+      getTokenPrice(allTokens.map(({ address }) => address)).catch(
+        (error: unknown) => {
+          console.error('Failed to fetch token prices:', error);
+          return {} as Record<string, number | undefined>;
+        },
+      ),
+      getUsdRates(),
+    ]);
 
     const rawDbTokens = rawDbTokensForSeed;
     const dbTokens = rawDbTokens.map((token) => ({
@@ -302,9 +307,6 @@ export async function GET(
           t.referenceCurrency;
       }
     });
-
-    /** Needed to sum tokens priced in different currencies into one total. */
-    const usdRates = await getUsdRates();
 
     const assets = await Promise.all(
       allTokens.map(async (token) => {

--- a/apps/web/src/app/api/v1/people/[personSlug]/assets/route.ts
+++ b/apps/web/src/app/api/v1/people/[personSlug]/assets/route.ts
@@ -35,6 +35,32 @@ import { hasEmojiOrLink, tryDecodeUriPart } from '@hypha-platform/ui-utils';
 import { ProfileRouteParams } from '@hypha-platform/epics';
 import { web3Client } from '@hypha-platform/core/server';
 
+/**
+ * Transient Alchemy / RPC blips used to return an empty fallback on the first
+ * failure, which the client then treated as the real wallet (balance flicker).
+ * One short retry absorbs most of those without changing the happy path.
+ */
+async function withRetry<T>(
+  label: string,
+  fn: () => Promise<T>,
+  fallback: T,
+  attempts = 2,
+): Promise<T> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+      if (attempt < attempts) {
+        await new Promise((resolve) => setTimeout(resolve, 150 * attempt));
+      }
+    }
+  }
+  console.warn(`Failed to ${label} after ${attempts} attempts:`, lastError);
+  return fallback;
+}
+
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<ProfileRouteParams> },
@@ -77,23 +103,21 @@ export async function GET(
       externalTokens,
       rawDbTokensForSeed,
     ] = await Promise.all([
-      web3Client
-        .readContract(getEnergyBalances({ member: address }))
-        .catch((error) => {
-          console.warn('Failed to fetch energy balance:', error);
-          return null;
-        }),
-      web3Client
-        .readContract(getMemberSpaces({ memberAddress: address }))
-        .catch((error) => {
-          console.warn('Failed to fetch member spaces:', error);
-          return null;
-        }),
-      getTokenBalancesByAddress(address).catch(
-        (error): Awaited<ReturnType<typeof getTokenBalancesByAddress>> => {
-          console.warn('Failed to fetch external token balances:', error);
-          return [];
-        },
+      withRetry(
+        'fetch energy balance',
+        () => web3Client.readContract(getEnergyBalances({ member: address })),
+        null,
+      ),
+      withRetry(
+        'fetch member spaces',
+        () =>
+          web3Client.readContract(getMemberSpaces({ memberAddress: address })),
+        null,
+      ),
+      withRetry(
+        'fetch external token balances',
+        () => getTokenBalancesByAddress(address),
+        [] as Awaited<ReturnType<typeof getTokenBalancesByAddress>>,
       ),
       findAllTokens({ db: getDb({ authToken }) }, { search: undefined }),
     ]);

--- a/apps/web/src/app/api/v1/people/[personSlug]/assets/route.ts
+++ b/apps/web/src/app/api/v1/people/[personSlug]/assets/route.ts
@@ -35,21 +35,24 @@ import { hasEmojiOrLink, tryDecodeUriPart } from '@hypha-platform/ui-utils';
 import { ProfileRouteParams } from '@hypha-platform/epics';
 import { web3Client } from '@hypha-platform/core/server';
 
+type SourceResult<T> = { ok: true; value: T } | { ok: false; value: T };
+
 /**
  * Transient Alchemy / RPC blips used to return an empty fallback on the first
  * failure, which the client then treated as the real wallet (balance flicker).
- * One short retry absorbs most of those without changing the happy path.
+ * One short retry absorbs most of those; the caller still learns whether the
+ * source actually succeeded so incomplete responses can be marked.
  */
 async function withRetry<T>(
   label: string,
   fn: () => Promise<T>,
   fallback: T,
   attempts = 2,
-): Promise<T> {
+): Promise<SourceResult<T>> {
   let lastError: unknown;
   for (let attempt = 1; attempt <= attempts; attempt++) {
     try {
-      return await fn();
+      return { ok: true, value: await fn() };
     } catch (error) {
       lastError = error;
       if (attempt < attempts) {
@@ -58,7 +61,7 @@ async function withRetry<T>(
     }
   }
   console.warn(`Failed to ${label} after ${attempts} attempts:`, lastError);
-  return fallback;
+  return { ok: false, value: fallback };
 }
 
 export async function GET(
@@ -98,9 +101,9 @@ export async function GET(
      * unknown ERC-20 spam is dropped via isKnownTreasuryToken.
      */
     const [
-      energyResult,
-      memberSpacesResult,
-      externalTokens,
+      energySource,
+      memberSpacesSource,
+      externalTokensSource,
       rawDbTokensForSeed,
     ] = await Promise.all([
       withRetry(
@@ -121,6 +124,18 @@ export async function GET(
       ),
       findAllTokens({ db: getDb({ authToken }) }, { search: undefined }),
     ]);
+
+    const energyResult = energySource.value;
+    const memberSpacesResult = memberSpacesSource.value;
+    const externalTokens = externalTokensSource.value;
+
+    // Alchemy is what discovers holdings outside the energy/member catalogues.
+    // When it fails we still assemble a partial wallet (HYPHA/USDC + energy
+    // community tokens), but the client must not treat that as the full set.
+    const incompleteSources: string[] = [];
+    if (!externalTokensSource.ok) incompleteSources.push('alchemy');
+    if (!memberSpacesSource.ok) incompleteSources.push('memberSpaces');
+    if (!energySource.ok) incompleteSources.push('energy');
 
     const energyBalanceRaw: bigint = energyResult
       ? BigInt(energyResult[0])
@@ -486,6 +501,9 @@ export async function GET(
     return NextResponse.json({
       assets: sorted,
       balance: sorted.reduce((sum, asset) => sum + asset.usdEqual, 0),
+      // Empty when every upstream source answered. Non-empty means this payload
+      // is missing a slice of holdings (most often Alchemy → "energy-only" look).
+      incompleteSources,
     });
   } catch (error) {
     console.error('Failed to fetch user assets:', error);

--- a/apps/web/src/app/api/v1/people/[personSlug]/assets/route.ts
+++ b/apps/web/src/app/api/v1/people/[personSlug]/assets/route.ts
@@ -10,6 +10,7 @@ import {
   getTokenMeta,
   getSupply,
   getMutualCreditInfo,
+  getUsdRates,
 } from '@hypha-platform/core/server';
 import {
   TOKENS,
@@ -27,6 +28,7 @@ import {
   getEnergyCommunityDisplayDecimals,
   isHyphaToken,
   HYPHA_PRICE_USD,
+  convertToUsd,
 } from '@hypha-platform/core/client';
 import { headers } from 'next/headers';
 import { hasEmojiOrLink, tryDecodeUriPart } from '@hypha-platform/ui-utils';
@@ -287,6 +289,7 @@ export async function GET(
     }));
 
     const referencePriceByAddress: Record<string, number> = {};
+    const referenceCurrencyByAddress: Record<string, string> = {};
     rawDbTokens.forEach((t) => {
       if (t.address && t.referencePrice != null) {
         const parsed = Number(t.referencePrice);
@@ -294,7 +297,14 @@ export async function GET(
           referencePriceByAddress[t.address.toLowerCase()] = parsed;
         }
       }
+      if (t.address && t.referenceCurrency) {
+        referenceCurrencyByAddress[t.address.toLowerCase()] =
+          t.referenceCurrency;
+      }
     });
+
+    /** Needed to sum tokens priced in different currencies into one total. */
+    const usdRates = await getUsdRates();
 
     const assets = await Promise.all(
       allTokens.map(async (token) => {
@@ -349,12 +359,22 @@ export async function GET(
             decimals,
           );
           let rate = isEnergyToken ? 1 : prices[token.address] || 0;
+          /**
+           * Currency `rate` is denominated in. Market feeds and the fixed HYPHA
+           * rate are USD; only a DB reference price carries its own currency.
+           */
+          let rateCurrency = 'USD';
           // HYPHA sells at a contract-fixed rate, so it overrides any feed price.
           if (isHyphaToken(token.address)) {
             rate = HYPHA_PRICE_USD;
           }
           if (rate === 0) {
             rate = referencePriceByAddress[token.address.toLowerCase()] ?? 0;
+            if (rate > 0) {
+              rateCurrency =
+                referenceCurrencyByAddress[token.address.toLowerCase()] ??
+                'USD';
+            }
           }
           // 1 display NRG ≈ 1 EURC/USDC after credit decimal normalization.
           if (
@@ -368,7 +388,8 @@ export async function GET(
             address: token.address,
             value: amount,
             tokenPrice: rate,
-            usdEqual: rate * amount,
+            referenceCurrency: rateCurrency,
+            usdEqual: convertToUsd(rate * amount, rateCurrency, usdRates),
             chartData: [],
             transactions: [],
             closeUrl: [],

--- a/apps/web/src/app/api/v1/spaces/[spaceSlug]/assets/route.ts
+++ b/apps/web/src/app/api/v1/spaces/[spaceSlug]/assets/route.ts
@@ -7,6 +7,7 @@ import {
   getTokenMeta,
   findAllTokens,
   getSupply,
+  getUsdRates,
 } from '@hypha-platform/core/server';
 import {
   getSpaceDetails,
@@ -24,6 +25,7 @@ import {
   getEnergyCommunityDisplayDecimals,
   isHyphaToken,
   HYPHA_PRICE_USD,
+  convertToUsd,
 } from '@hypha-platform/core/client';
 import { db } from '@hypha-platform/storage-postgres';
 import { canConvertToBigInt, hasEmojiOrLink } from '@hypha-platform/ui-utils';
@@ -231,6 +233,9 @@ export async function GET(
       console.error('Failed to fetch token prices:', error);
     }
 
+    /** Needed to sum tokens priced in different currencies into one total. */
+    const usdRates = await getUsdRates();
+
     const assets = await Promise.all(
       allTokens.map(async (token) => {
         try {
@@ -249,6 +254,11 @@ export async function GET(
             );
           }
           let rate = prices[token.address] || 0;
+          /**
+           * Currency `rate` is denominated in. Market feeds and the fixed HYPHA
+           * rate are USD; only a DB reference price carries its own currency.
+           */
+          let rateCurrency = 'USD';
           if (token.address.toLowerCase() === EVC_TOKEN_ADDRESS) {
             rate = 1;
           }
@@ -258,6 +268,11 @@ export async function GET(
           }
           if (rate === 0) {
             rate = referencePriceByAddress[token.address.toLowerCase()] ?? 0;
+            if (rate > 0) {
+              rateCurrency =
+                referenceCurrencyByAddress[token.address.toLowerCase()] ??
+                'USD';
+            }
           }
           // 1 display NRG ≈ 1 EURC/USDC after credit decimal normalization.
           if (
@@ -271,15 +286,13 @@ export async function GET(
             token.address,
             contractDecimals,
           );
-          const referenceCurrency =
-            referenceCurrencyByAddress[token.address.toLowerCase()];
           return {
             ...meta,
             address: token.address,
             value: amount,
             tokenPrice: rate,
-            referenceCurrency,
-            usdEqual: rate * amount,
+            referenceCurrency: rateCurrency,
+            usdEqual: convertToUsd(rate * amount, rateCurrency, usdRates),
             chartData: [],
             transactions: [],
             closeUrl: [],

--- a/apps/web/src/app/api/v1/spaces/[spaceSlug]/assets/route.ts
+++ b/apps/web/src/app/api/v1/spaces/[spaceSlug]/assets/route.ts
@@ -8,6 +8,7 @@ import {
   findAllTokens,
   getSupply,
   getUsdRates,
+  convertToUsd,
 } from '@hypha-platform/core/server';
 import {
   getSpaceDetails,
@@ -25,7 +26,6 @@ import {
   getEnergyCommunityDisplayDecimals,
   isHyphaToken,
   HYPHA_PRICE_USD,
-  convertToUsd,
 } from '@hypha-platform/core/client';
 import { db } from '@hypha-platform/storage-postgres';
 import { canConvertToBigInt, hasEmojiOrLink } from '@hypha-platform/ui-utils';
@@ -226,15 +226,17 @@ export async function GET(
       (token) => !isHiddenToken(token.address),
     );
 
-    let prices: Record<string, number | undefined> = {};
-    try {
-      prices = await getTokenPrice(allTokens.map(({ address }) => address));
-    } catch (error: unknown) {
-      console.error('Failed to fetch token prices:', error);
-    }
-
-    /** Needed to sum tokens priced in different currencies into one total. */
-    const usdRates = await getUsdRates();
+    // Rates are needed to sum tokens priced in different currencies into one
+    // total, and do not depend on the prices, so pay for one round-trip.
+    const [prices, usdRates] = await Promise.all([
+      getTokenPrice(allTokens.map(({ address }) => address)).catch(
+        (error: unknown) => {
+          console.error('Failed to fetch token prices:', error);
+          return {} as Record<string, number | undefined>;
+        },
+      ),
+      getUsdRates(),
+    ]);
 
     const assets = await Promise.all(
       allTokens.map(async (token) => {

--- a/packages/core/src/common/server/get-currency-rates.ts
+++ b/packages/core/src/common/server/get-currency-rates.ts
@@ -5,6 +5,7 @@ import {
   CONVERTIBLE_CURRENCIES,
   type UsdRates,
 } from '../web3/currency-conversion';
+import { parseFeedRate, type ChainlinkRound } from '../web3/chainlink-feed';
 import { aggregatorV3InterfaceAbi } from '../../generated';
 import { web3Client } from './web3-rpc/client';
 
@@ -57,14 +58,20 @@ export async function getUsdRates(): Promise<UsdRates> {
         return;
       }
 
-      const answer = (roundResult.result as readonly bigint[])[1];
-      const decimals = Number(decimalsResult.result);
-      if (answer == null || answer <= 0n || !Number.isFinite(decimals)) {
-        console.warn(`Invalid Chainlink answer for ${currency}/USD`);
+      // latestRoundData: [roundId, answer, startedAt, updatedAt, answeredInRound]
+      const round = roundResult.result as readonly bigint[];
+      const parsed = parseFeedRate(
+        { answer: round[1], updatedAt: round[3] } satisfies ChainlinkRound,
+        Number(decimalsResult.result),
+      );
+      if (!parsed.ok) {
+        console.warn(
+          `Skipping ${parsed.reason} Chainlink answer for ${currency}/USD`,
+        );
         return;
       }
 
-      rates[currency] = Number(answer) / 10 ** decimals;
+      rates[currency] = parsed.rate;
     });
   } catch (error) {
     console.error('Failed to fetch Chainlink currency rates:', error);

--- a/packages/core/src/common/server/get-currency-rates.ts
+++ b/packages/core/src/common/server/get-currency-rates.ts
@@ -1,0 +1,75 @@
+import 'server-only';
+import NodeCache from 'node-cache';
+import { CURRENCY_FEEDS } from '../web3/token-backing-vault';
+import {
+  CONVERTIBLE_CURRENCIES,
+  type UsdRates,
+} from '../web3/currency-conversion';
+import { aggregatorV3InterfaceAbi } from '../../generated';
+import { web3Client } from './web3-rpc/client';
+
+const RATES_CACHE_KEY = 'chainlink_usd_rates';
+const ratesCache = new NodeCache({ stdTTL: 300 });
+
+/** Feeds other than USD — USD is the quote currency, so its rate is always 1. */
+const QUOTED_CURRENCIES = CONVERTIBLE_CURRENCIES.filter(
+  (currency) => currency !== 'USD',
+);
+
+/**
+ * USD value of one unit of each supported currency, read from the Chainlink
+ * X/USD feeds on Base — the same feeds the redemption contracts price against,
+ * so displayed balances cannot drift from what a redemption actually pays out.
+ *
+ * Feeds that fail or report a non-positive answer are omitted rather than
+ * guessed at; callers decide how to handle a missing rate.
+ */
+export async function getUsdRates(): Promise<UsdRates> {
+  const cached = ratesCache.get<UsdRates>(RATES_CACHE_KEY);
+  if (cached) return cached;
+
+  const rates: UsdRates = { USD: 1 };
+
+  try {
+    // Two reads per feed: the answer and the decimals it is scaled by.
+    const results = await web3Client.multicall({
+      allowFailure: true,
+      contracts: QUOTED_CURRENCIES.flatMap((currency) => {
+        const contract = {
+          address: CURRENCY_FEEDS[currency],
+          abi: aggregatorV3InterfaceAbi,
+        } as const;
+        return [
+          { ...contract, functionName: 'latestRoundData' },
+          { ...contract, functionName: 'decimals' },
+        ];
+      }),
+    });
+
+    QUOTED_CURRENCIES.forEach((currency, index) => {
+      const roundResult = results[index * 2];
+      const decimalsResult = results[index * 2 + 1];
+      if (
+        roundResult?.status !== 'success' ||
+        decimalsResult?.status !== 'success'
+      ) {
+        console.warn(`No Chainlink answer for ${currency}/USD`);
+        return;
+      }
+
+      const answer = (roundResult.result as readonly bigint[])[1];
+      const decimals = Number(decimalsResult.result);
+      if (answer == null || answer <= 0n || !Number.isFinite(decimals)) {
+        console.warn(`Invalid Chainlink answer for ${currency}/USD`);
+        return;
+      }
+
+      rates[currency] = Number(answer) / 10 ** decimals;
+    });
+  } catch (error) {
+    console.error('Failed to fetch Chainlink currency rates:', error);
+  }
+
+  ratesCache.set(RATES_CACHE_KEY, rates);
+  return rates;
+}

--- a/packages/core/src/common/server/index.ts
+++ b/packages/core/src/common/server/index.ts
@@ -5,6 +5,9 @@ export * from './order';
 
 export * from './get-token-price';
 export * from './get-currency-rates';
+// Pure helpers, re-exported here so server code can apply rates without
+// reaching into the client entry point.
+export * from '../web3/currency-conversion';
 export * from './get-transfers-by-address';
 export * from './get-token-balances-by-address';
 

--- a/packages/core/src/common/server/index.ts
+++ b/packages/core/src/common/server/index.ts
@@ -4,6 +4,7 @@ export * from './get-db';
 export * from './order';
 
 export * from './get-token-price';
+export * from './get-currency-rates';
 export * from './get-transfers-by-address';
 export * from './get-token-balances-by-address';
 

--- a/packages/core/src/common/web3/__tests__/chainlink-feed.test.ts
+++ b/packages/core/src/common/web3/__tests__/chainlink-feed.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { FEED_MAX_AGE_SECONDS, parseFeedRate } from '../chainlink-feed';
+
+const NOW = 1_800_000_000;
+const fresh = (answer: bigint) => ({ answer, updatedAt: BigInt(NOW - 60) });
+
+describe('parseFeedRate', () => {
+  it('scales the answer by the feed decimals', () => {
+    // AUD/USD reports 8 decimals on Base.
+    expect(parseFeedRate(fresh(65_000_000n), 8, NOW)).toEqual({
+      ok: true,
+      rate: 0.65,
+    });
+  });
+
+  it('rejects an answer from a stalled feed', () => {
+    const round = {
+      answer: 65_000_000n,
+      updatedAt: BigInt(NOW - FEED_MAX_AGE_SECONDS - 1),
+    };
+    expect(parseFeedRate(round, 8, NOW)).toEqual({
+      ok: false,
+      reason: 'stale',
+    });
+  });
+
+  it('accepts an answer right at the staleness boundary', () => {
+    const round = {
+      answer: 65_000_000n,
+      updatedAt: BigInt(NOW - FEED_MAX_AGE_SECONDS),
+    };
+    expect(parseFeedRate(round, 8, NOW)).toEqual({ ok: true, rate: 0.65 });
+  });
+
+  it('tolerates a feed timestamp slightly ahead of local time', () => {
+    const round = { answer: 65_000_000n, updatedAt: BigInt(NOW + 30) };
+    expect(parseFeedRate(round, 8, NOW)).toEqual({ ok: true, rate: 0.65 });
+  });
+
+  it('rejects a non-positive answer', () => {
+    expect(parseFeedRate(fresh(0n), 8, NOW)).toEqual({
+      ok: false,
+      reason: 'invalid',
+    });
+    expect(parseFeedRate(fresh(-1n), 8, NOW)).toEqual({
+      ok: false,
+      reason: 'invalid',
+    });
+  });
+
+  it('rejects a missing answer or an incomplete round', () => {
+    expect(parseFeedRate({}, 8, NOW)).toEqual({ ok: false, reason: 'invalid' });
+    expect(parseFeedRate({ answer: 65_000_000n }, 8, NOW)).toEqual({
+      ok: false,
+      reason: 'invalid',
+    });
+    expect(
+      parseFeedRate({ answer: 65_000_000n, updatedAt: 0n }, 8, NOW),
+    ).toEqual({ ok: false, reason: 'invalid' });
+  });
+
+  it('rejects nonsensical decimals rather than returning NaN', () => {
+    expect(parseFeedRate(fresh(65_000_000n), Number.NaN, NOW)).toEqual({
+      ok: false,
+      reason: 'invalid',
+    });
+    expect(parseFeedRate(fresh(65_000_000n), -1, NOW)).toEqual({
+      ok: false,
+      reason: 'invalid',
+    });
+    expect(parseFeedRate(fresh(65_000_000n), 999, NOW)).toEqual({
+      ok: false,
+      reason: 'invalid',
+    });
+  });
+});

--- a/packages/core/src/common/web3/__tests__/chainlink-feed.test.ts
+++ b/packages/core/src/common/web3/__tests__/chainlink-feed.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { FEED_MAX_AGE_SECONDS, parseFeedRate } from '../chainlink-feed';
+import {
+  FEED_MAX_AGE_SECONDS,
+  FEED_MAX_FUTURE_SKEW_SECONDS,
+  parseFeedRate,
+} from '../chainlink-feed';
 
 const NOW = 1_800_000_000;
 const fresh = (answer: bigint) => ({ answer, updatedAt: BigInt(NOW - 60) });
@@ -35,6 +39,25 @@ describe('parseFeedRate', () => {
   it('tolerates a feed timestamp slightly ahead of local time', () => {
     const round = { answer: 65_000_000n, updatedAt: BigInt(NOW + 30) };
     expect(parseFeedRate(round, 8, NOW)).toEqual({ ok: true, rate: 0.65 });
+  });
+
+  it('accepts an answer right at the future skew boundary', () => {
+    const round = {
+      answer: 65_000_000n,
+      updatedAt: BigInt(NOW + FEED_MAX_FUTURE_SKEW_SECONDS),
+    };
+    expect(parseFeedRate(round, 8, NOW)).toEqual({ ok: true, rate: 0.65 });
+  });
+
+  it('rejects a timestamp beyond the allowed future skew', () => {
+    const round = {
+      answer: 65_000_000n,
+      updatedAt: BigInt(NOW + FEED_MAX_FUTURE_SKEW_SECONDS + 1),
+    };
+    expect(parseFeedRate(round, 8, NOW)).toEqual({
+      ok: false,
+      reason: 'invalid',
+    });
   });
 
   it('rejects a non-positive answer', () => {

--- a/packages/core/src/common/web3/__tests__/currency-conversion.test.ts
+++ b/packages/core/src/common/web3/__tests__/currency-conversion.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  CONVERTIBLE_CURRENCIES,
+  convertFromUsd,
+  convertToUsd,
+  isConvertibleCurrency,
+  type UsdRates,
+} from '../currency-conversion';
+import { CURRENCY_FEEDS } from '../token-backing-vault';
+import { TOKEN_PRICE_REFERENCE_CURRENCIES } from '../../../governance/types';
+
+const RATES: UsdRates = { USD: 1, AUD: 0.65, EUR: 1.08 };
+
+describe('CONVERTIBLE_CURRENCIES', () => {
+  it('stays in step with the currencies a token can be priced in', () => {
+    expect([...CONVERTIBLE_CURRENCIES].sort()).toEqual(
+      [...TOKEN_PRICE_REFERENCE_CURRENCIES].sort(),
+    );
+  });
+
+  it('covers every wired Chainlink feed', () => {
+    expect(CONVERTIBLE_CURRENCIES).toEqual(Object.keys(CURRENCY_FEEDS));
+  });
+});
+
+describe('isConvertibleCurrency', () => {
+  it('accepts currencies with a feed and rejects everything else', () => {
+    expect(isConvertibleCurrency('AUD')).toBe(true);
+    expect(isConvertibleCurrency('USD')).toBe(true);
+    // No Chainlink feed on Base.
+    expect(isConvertibleCurrency('JPY')).toBe(false);
+    expect(isConvertibleCurrency('aud')).toBe(false);
+    expect(isConvertibleCurrency(null)).toBe(false);
+    expect(isConvertibleCurrency(undefined)).toBe(false);
+  });
+});
+
+describe('convertToUsd', () => {
+  it('values an AUD-priced holding in USD', () => {
+    // The bug Alex hit: 4,050,000 tokens at 1.00 AUD were counted as USD.
+    expect(convertToUsd(4_050_000, 'AUD', RATES)).toBeCloseTo(2_632_500, 6);
+  });
+
+  it('leaves USD amounts untouched', () => {
+    expect(convertToUsd(100, 'USD', RATES)).toBe(100);
+    expect(convertToUsd(100, null, RATES)).toBe(100);
+    expect(convertToUsd(100, undefined, RATES)).toBe(100);
+  });
+
+  it('falls back to 1:1 rather than zeroing an unpriceable balance', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    expect(convertToUsd(100, 'JPY', RATES)).toBe(100);
+    expect(convertToUsd(100, 'AUD', {})).toBe(100);
+    expect(convertToUsd(100, 'AUD', { AUD: 0 })).toBe(100);
+    expect(warn).toHaveBeenCalledTimes(3);
+    warn.mockRestore();
+  });
+
+  it('treats non-finite and zero amounts as zero', () => {
+    expect(convertToUsd(0, 'AUD', RATES)).toBe(0);
+    expect(convertToUsd(Number.NaN, 'AUD', RATES)).toBe(0);
+    expect(convertToUsd(Number.POSITIVE_INFINITY, 'AUD', RATES)).toBe(0);
+  });
+});
+
+describe('convertFromUsd', () => {
+  it('renders a USD total in the member currency', () => {
+    expect(convertFromUsd(2_632_500, 'AUD', RATES)).toBeCloseTo(4_050_000, 6);
+  });
+
+  it('round-trips with convertToUsd', () => {
+    const original = 1234.56;
+    expect(
+      convertFromUsd(convertToUsd(original, 'EUR', RATES), 'EUR', RATES),
+    ).toBeCloseTo(original, 9);
+  });
+
+  it('passes the amount through when no rate is available', () => {
+    expect(convertFromUsd(100, 'JPY', RATES)).toBe(100);
+    expect(convertFromUsd(100, 'AUD', {})).toBe(100);
+    expect(convertFromUsd(100, 'AUD', { AUD: 0 })).toBe(100);
+  });
+
+  it('preserves sign for negative balances', () => {
+    expect(convertFromUsd(-65, 'AUD', RATES)).toBeCloseTo(-100, 6);
+  });
+});

--- a/packages/core/src/common/web3/__tests__/currency-conversion.test.ts
+++ b/packages/core/src/common/web3/__tests__/currency-conversion.test.ts
@@ -33,6 +33,13 @@ describe('isConvertibleCurrency', () => {
     expect(isConvertibleCurrency(null)).toBe(false);
     expect(isConvertibleCurrency(undefined)).toBe(false);
   });
+
+  it('rejects inherited object keys', () => {
+    expect(isConvertibleCurrency('constructor')).toBe(false);
+    expect(isConvertibleCurrency('toString')).toBe(false);
+    expect(isConvertibleCurrency('hasOwnProperty')).toBe(false);
+    expect(isConvertibleCurrency('__proto__')).toBe(false);
+  });
 });
 
 describe('convertToUsd', () => {
@@ -60,6 +67,16 @@ describe('convertToUsd', () => {
     expect(convertToUsd(0, 'AUD', RATES)).toBe(0);
     expect(convertToUsd(Number.NaN, 'AUD', RATES)).toBe(0);
     expect(convertToUsd(Number.POSITIVE_INFINITY, 'AUD', RATES)).toBe(0);
+  });
+
+  it('does not let an inherited key name poison the total with NaN', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    // reference_currency is free text, so these can reach us from the DB.
+    for (const key of ['constructor', 'toString', 'hasOwnProperty']) {
+      expect(convertToUsd(100, key, RATES)).toBe(100);
+      expect(convertFromUsd(100, key, RATES)).toBe(100);
+    }
+    warn.mockRestore();
   });
 });
 

--- a/packages/core/src/common/web3/chainlink-feed.ts
+++ b/packages/core/src/common/web3/chainlink-feed.ts
@@ -1,0 +1,51 @@
+/**
+ * A Chainlink feed answer is only as good as its timestamp: `latestRoundData`
+ * keeps serving the last round forever, so a stalled feed reports a plausible
+ * but frozen price. Anything older than this is treated as no answer at all.
+ *
+ * Deliberately well above the 24h heartbeat of the fiat feeds. A rejected rate
+ * falls back to 1:1, which for AUD is a ~35% error, whereas a day-old rate is
+ * off by a fraction of a percent — only a genuinely dead feed should trip this.
+ */
+export const FEED_MAX_AGE_SECONDS = 48 * 60 * 60;
+
+/** The fields of `latestRoundData` we actually price against. */
+export type ChainlinkRound = {
+  answer?: bigint;
+  updatedAt?: bigint;
+};
+
+export type FeedRateResult =
+  | { ok: true; rate: number }
+  | { ok: false; reason: 'invalid' | 'stale' };
+
+/**
+ * The price from one feed round, scaled by the feed's own decimals.
+ *
+ * `nowSeconds` is injectable so the staleness boundary can be tested.
+ */
+export function parseFeedRate(
+  round: ChainlinkRound,
+  decimals: number,
+  nowSeconds: number = Math.floor(Date.now() / 1000),
+): FeedRateResult {
+  const { answer, updatedAt } = round;
+
+  if (answer == null || answer <= 0n) return { ok: false, reason: 'invalid' };
+  if (!Number.isInteger(decimals) || decimals < 0 || decimals > 30) {
+    return { ok: false, reason: 'invalid' };
+  }
+  // A zero timestamp means the round never completed.
+  if (updatedAt == null || updatedAt <= 0n) {
+    return { ok: false, reason: 'invalid' };
+  }
+  if (nowSeconds - Number(updatedAt) > FEED_MAX_AGE_SECONDS) {
+    return { ok: false, reason: 'stale' };
+  }
+
+  const rate = Number(answer) / 10 ** decimals;
+  if (!Number.isFinite(rate) || rate <= 0) {
+    return { ok: false, reason: 'invalid' };
+  }
+  return { ok: true, rate };
+}

--- a/packages/core/src/common/web3/chainlink-feed.ts
+++ b/packages/core/src/common/web3/chainlink-feed.ts
@@ -9,6 +9,12 @@
  */
 export const FEED_MAX_AGE_SECONDS = 48 * 60 * 60;
 
+/**
+ * Small allowance for local clock lag relative to the oracle. Timestamps farther
+ * into the future than this are treated as malformed rather than fresh.
+ */
+export const FEED_MAX_FUTURE_SKEW_SECONDS = 5 * 60;
+
 /** The fields of `latestRoundData` we actually price against. */
 export type ChainlinkRound = {
   answer?: bigint;
@@ -31,6 +37,9 @@ export function parseFeedRate(
 ): FeedRateResult {
   const { answer, updatedAt } = round;
 
+  if (!Number.isSafeInteger(nowSeconds) || nowSeconds <= 0) {
+    return { ok: false, reason: 'invalid' };
+  }
   if (answer == null || answer <= 0n) return { ok: false, reason: 'invalid' };
   if (!Number.isInteger(decimals) || decimals < 0 || decimals > 30) {
     return { ok: false, reason: 'invalid' };
@@ -39,7 +48,13 @@ export function parseFeedRate(
   if (updatedAt == null || updatedAt <= 0n) {
     return { ok: false, reason: 'invalid' };
   }
-  if (nowSeconds - Number(updatedAt) > FEED_MAX_AGE_SECONDS) {
+
+  // Compare as bigint so a far-future updatedAt cannot lose precision via Number().
+  const now = BigInt(nowSeconds);
+  if (updatedAt > now + BigInt(FEED_MAX_FUTURE_SKEW_SECONDS)) {
+    return { ok: false, reason: 'invalid' };
+  }
+  if (now - updatedAt > BigInt(FEED_MAX_AGE_SECONDS)) {
     return { ok: false, reason: 'stale' };
   }
 

--- a/packages/core/src/common/web3/currency-conversion.ts
+++ b/packages/core/src/common/web3/currency-conversion.ts
@@ -14,10 +14,18 @@ export const CONVERTIBLE_CURRENCIES = Object.keys(
 /** USD value of one unit of each convertible currency, e.g. `{ AUD: 0.65 }`. */
 export type UsdRates = Partial<Record<ConvertibleCurrency, number>>;
 
+/**
+ * `reference_currency` is free text in the DB, so an `in` check would accept
+ * inherited names like `constructor` and hand back a function as the rate,
+ * turning the balance total into NaN. Only own keys count.
+ */
 export function isConvertibleCurrency(
   currency: string | null | undefined,
 ): currency is ConvertibleCurrency {
-  return currency != null && currency in CURRENCY_FEEDS;
+  return (
+    currency != null &&
+    Object.prototype.hasOwnProperty.call(CURRENCY_FEEDS, currency)
+  );
 }
 
 /**

--- a/packages/core/src/common/web3/currency-conversion.ts
+++ b/packages/core/src/common/web3/currency-conversion.ts
@@ -1,0 +1,57 @@
+import { CURRENCY_FEEDS } from './token-backing-vault';
+
+/**
+ * Currencies we can convert between: exactly those with an X/USD feed. Kept as
+ * the keys of {@link CURRENCY_FEEDS} so a newly wired feed becomes convertible
+ * without a second list to update.
+ */
+export type ConvertibleCurrency = keyof typeof CURRENCY_FEEDS;
+
+export const CONVERTIBLE_CURRENCIES = Object.keys(
+  CURRENCY_FEEDS,
+) as ConvertibleCurrency[];
+
+/** USD value of one unit of each convertible currency, e.g. `{ AUD: 0.65 }`. */
+export type UsdRates = Partial<Record<ConvertibleCurrency, number>>;
+
+export function isConvertibleCurrency(
+  currency: string | null | undefined,
+): currency is ConvertibleCurrency {
+  return currency != null && currency in CURRENCY_FEEDS;
+}
+
+/**
+ * Convert `amount`, denominated in `currency`, into USD.
+ *
+ * An unknown or unavailable rate falls back to 1:1. That keeps a balance
+ * visible rather than collapsing it to zero, at the cost of being off by the
+ * FX spread — the per-token card still shows the true source currency, so the
+ * fallback never mislabels what the number is denominated in.
+ */
+export function convertToUsd(
+  amount: number,
+  currency: string | null | undefined,
+  rates: UsdRates,
+): number {
+  if (!amount || !Number.isFinite(amount)) return 0;
+  if (!currency || currency === 'USD') return amount;
+  const rate = isConvertibleCurrency(currency) ? rates[currency] : undefined;
+  if (rate === undefined || rate <= 0) {
+    console.warn(`No USD rate for ${currency}; treating it as 1:1`);
+    return amount;
+  }
+  return amount * rate;
+}
+
+/** Convert a USD amount into `currency`. Mirrors {@link convertToUsd}. */
+export function convertFromUsd(
+  usdAmount: number,
+  currency: string | null | undefined,
+  rates: UsdRates,
+): number {
+  if (!usdAmount || !Number.isFinite(usdAmount)) return 0;
+  if (!currency || currency === 'USD') return usdAmount;
+  const rate = isConvertibleCurrency(currency) ? rates[currency] : undefined;
+  if (rate === undefined || rate <= 0) return usdAmount;
+  return usdAmount / rate;
+}

--- a/packages/core/src/common/web3/index.ts
+++ b/packages/core/src/common/web3/index.ts
@@ -6,6 +6,7 @@ export * from './public-client';
 export * from './tokens';
 export * from './energy-community-tokens';
 export * from './token-backing-vault';
+export * from './currency-conversion';
 export * from './allowed-spaces';
 export * from './abis/space-token-purchase';
 

--- a/packages/core/src/common/web3/index.ts
+++ b/packages/core/src/common/web3/index.ts
@@ -7,6 +7,7 @@ export * from './tokens';
 export * from './energy-community-tokens';
 export * from './token-backing-vault';
 export * from './currency-conversion';
+export * from './chainlink-feed';
 export * from './allowed-spaces';
 export * from './abis/space-token-purchase';
 

--- a/packages/core/src/people/client/hooks/use-me.ts
+++ b/packages/core/src/people/client/hooks/use-me.ts
@@ -22,13 +22,27 @@ export const useMe = (): {
     data: person,
     isLoading: isLoadingPerson,
     mutate,
-  } = useSWR<Person>(jwt ? [endpoint, jwt] : null, ([endpoint, jwt]) =>
-    fetch(endpoint, {
-      headers: {
-        Authorization: `Bearer ${jwt}`,
-        'Content-Type': 'application/json',
-      },
-    }).then((res) => res.json() as Promise<Person>),
+  } = useSWR<Person>(
+    jwt ? [endpoint, jwt] : null,
+    async ([endpoint, jwt]) => {
+      const res = await fetch(endpoint, {
+        headers: {
+          Authorization: `Bearer ${jwt}`,
+          'Content-Type': 'application/json',
+        },
+      });
+      // A 500 body like `{ error: "..." }` must not be cached as a Person —
+      // that clears `slug` and sends the wallet into a full-page loader.
+      if (!res.ok) {
+        throw new Error(`Failed to fetch profile: ${res.status}`);
+      }
+      return (await res.json()) as Person;
+    },
+    {
+      // JWT refresh changes the SWR key; keep the last good profile so the
+      // wallet does not unmount into "Loading..." every few minutes.
+      keepPreviousData: true,
+    },
   );
 
   const isMe = React.useCallback(

--- a/packages/core/src/people/client/hooks/useJwt.ts
+++ b/packages/core/src/people/client/hooks/useJwt.ts
@@ -17,6 +17,9 @@ export const useJwt = () => {
       refreshInterval: 5 * 60 * 1000,
       revalidateOnFocus: true,
       dedupingInterval: 60 * 1000,
+      // Auth loading can briefly null the key; keep the last token so every
+      // `[endpoint, jwt]` consumer does not flash empty and refetch as uncached.
+      keepPreviousData: true,
     },
   );
 

--- a/packages/core/src/people/server/queries.ts
+++ b/packages/core/src/people/server/queries.ts
@@ -40,6 +40,7 @@ export const getDefaultFields = () => {
     updatedAt: people.updatedAt,
     address: people.address,
     leadImageUrl: people.leadImageUrl,
+    preferredCurrency: people.preferredCurrency,
     total: sql<number>`cast(count(*) over() as integer)`,
   };
 };
@@ -62,6 +63,7 @@ export const mapToDomainPerson = (dbPerson: Partial<DbPerson>): Person => {
     location: nullToUndefined(dbPerson.location ?? null),
     nickname: nullToUndefined(dbPerson.nickname ?? null),
     address: nullToUndefined(dbPerson.address ?? null),
+    preferredCurrency: nullToUndefined(dbPerson.preferredCurrency ?? null),
     links: nullToUndefined(dbPerson.links ?? null),
     createdAt: dbPerson.createdAt!,
     updatedAt: dbPerson.updatedAt!,

--- a/packages/core/src/people/types.ts
+++ b/packages/core/src/people/types.ts
@@ -11,6 +11,8 @@ export interface Person {
   location?: string;
   nickname?: string;
   address?: string;
+  /** ISO 4217 code balances are shown in. Undefined means USD. */
+  preferredCurrency?: string;
   links?: string[];
   createdAt: Date;
   updatedAt: Date;

--- a/packages/core/src/people/validation.ts
+++ b/packages/core/src/people/validation.ts
@@ -7,8 +7,19 @@ import {
 import { z } from 'zod';
 import { isAddress } from 'viem';
 import { percentageStringToBigInt } from '../common';
+import { TOKEN_PRICE_REFERENCE_CURRENCIES } from '../governance/types';
 
 const ETH_ADDRESS_REGEX = /^0x[a-fA-F0-9]{40}$/;
+
+/**
+ * Currency members can have balances shown in. Restricted to the currencies
+ * with a Chainlink X/USD feed, since anything else could not be converted.
+ */
+const preferredCurrency = z
+  .enum(TOKEN_PRICE_REFERENCE_CURRENCIES)
+  .or(z.literal(''))
+  .optional()
+  .transform((value) => (value === '' ? undefined : value));
 
 const signupPersonWeb2Props = {
   name: z.string().trim().min(1, { message: 'Please enter your first name' }),
@@ -77,6 +88,7 @@ const editPersonWeb2Props = {
     .max(100, { message: 'Location must be at most 100 characters long' })
     .trim()
     .optional(),
+  preferredCurrency,
   links: z
     .array(
       z.string().url('Please enter a valid URL (e.g., https://example.com)'),

--- a/packages/epics/src/banking/hooks/use-payout-accounts.ts
+++ b/packages/epics/src/banking/hooks/use-payout-accounts.ts
@@ -69,6 +69,8 @@ export const usePayoutAccounts = ({
       {
         revalidateOnFocus: false,
         revalidateOnReconnect: false,
+        keepPreviousData: true,
+        errorRetryCount: 3,
       },
     );
 

--- a/packages/epics/src/people/components/edit-person-section.tsx
+++ b/packages/epics/src/people/components/edit-person-section.tsx
@@ -6,6 +6,7 @@ import {
   type Person as SavedPerson,
   schemaEditPersonWeb2,
   editPersonFiles,
+  TOKEN_PRICE_REFERENCE_CURRENCIES,
 } from '@hypha-platform/core/client';
 import {
   Button,
@@ -20,6 +21,11 @@ import {
   UploadLeadImage,
   UploadAvatar,
   RequirementMark,
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
 } from '@hypha-platform/ui';
 import { Text } from '@radix-ui/themes';
 import { cn } from '@hypha-platform/ui-utils';
@@ -27,7 +33,7 @@ import { Links } from '../../common';
 import { ModalStickyNavigation } from '../../common/modal-sticky-navigation';
 import { useScrollToErrors } from '../../hooks';
 import { useCallback, useMemo, useRef } from 'react';
-import { useTranslations } from 'next-intl';
+import { useLocale, useTranslations } from 'next-intl';
 
 /** Subset of person fields used to seed the edit form (not the full domain `Person`). */
 interface EditPersonSectionInput {
@@ -41,6 +47,7 @@ interface EditPersonSectionInput {
   location?: string;
   email?: string;
   links?: string[];
+  preferredCurrency?: string;
 }
 
 const schemaEditPersonForm = schemaEditPersonWeb2.extend(editPersonFiles.shape);
@@ -71,7 +78,25 @@ export const EditPersonSection = ({
   const tSpaces = useTranslations('Spaces');
   const tModalAside = useTranslations('ModalAside');
   const tCommon = useTranslations('Common');
+  const locale = useLocale();
   const baseResolver = useMemo(() => zodResolver(schemaEditPersonForm), []);
+
+  /**
+   * `Intl.DisplayNames` localizes the currency names for free, so the picker
+   * reads naturally in every locale without a translation key per currency.
+   */
+  const currencyOptions = useMemo(() => {
+    let displayNames: Intl.DisplayNames | undefined;
+    try {
+      displayNames = new Intl.DisplayNames([locale], { type: 'currency' });
+    } catch {
+      displayNames = undefined;
+    }
+    return TOKEN_PRICE_REFERENCE_CURRENCIES.map((code) => ({
+      code,
+      label: displayNames?.of(code) ?? code,
+    }));
+  }, [locale]);
 
   const translateEditProfileError = useCallback(
     (message: string) => {
@@ -198,6 +223,9 @@ export const EditPersonSection = ({
       links: person?.links || [],
       email: person?.email || '',
       location: person?.location || '',
+      preferredCurrency: person?.preferredCurrency as
+        | FormData['preferredCurrency']
+        | undefined,
     },
     mode: 'onChange',
   });
@@ -430,6 +458,47 @@ export const EditPersonSection = ({
                             className="w-60"
                             {...field}
                           />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </span>
+              </div>
+              <div className="flex justify-between">
+                <Text className={cn('text-2', 'text-neutral-11')}>
+                  {tProfile('editForm.labels.preferredCurrency')}
+                </Text>
+                <span className="flex items-center">
+                  <FormField
+                    control={form.control}
+                    name="preferredCurrency"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormControl>
+                          <Select
+                            value={field.value ?? ''}
+                            onValueChange={field.onChange}
+                            disabled={isLoading}
+                          >
+                            <SelectTrigger className="w-60">
+                              <SelectValue
+                                placeholder={tProfile(
+                                  'editForm.placeholders.preferredCurrency',
+                                )}
+                              />
+                            </SelectTrigger>
+                            <SelectContent>
+                              {currencyOptions.map((currency) => (
+                                <SelectItem
+                                  key={currency.code}
+                                  value={currency.code}
+                                >
+                                  {currency.code} - {currency.label}
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
                         </FormControl>
                         <FormMessage />
                       </FormItem>

--- a/packages/epics/src/people/components/edit-person-section.tsx
+++ b/packages/epics/src/people/components/edit-person-section.tsx
@@ -33,7 +33,7 @@ import { Links } from '../../common';
 import { ModalStickyNavigation } from '../../common/modal-sticky-navigation';
 import { useScrollToErrors } from '../../hooks';
 import { useCallback, useMemo, useRef } from 'react';
-import { useLocale, useTranslations } from 'next-intl';
+import { useTranslations } from 'next-intl';
 
 /** Subset of person fields used to seed the edit form (not the full domain `Person`). */
 interface EditPersonSectionInput {
@@ -78,25 +78,20 @@ export const EditPersonSection = ({
   const tSpaces = useTranslations('Spaces');
   const tModalAside = useTranslations('ModalAside');
   const tCommon = useTranslations('Common');
-  const locale = useLocale();
+  /** The currency names the token issuance form already ships in every locale. */
+  const tCurrencies = useTranslations(
+    'AgreementFlow.plugins.issueNewToken.value.currencies',
+  );
   const baseResolver = useMemo(() => zodResolver(schemaEditPersonForm), []);
 
-  /**
-   * `Intl.DisplayNames` localizes the currency names for free, so the picker
-   * reads naturally in every locale without a translation key per currency.
-   */
-  const currencyOptions = useMemo(() => {
-    let displayNames: Intl.DisplayNames | undefined;
-    try {
-      displayNames = new Intl.DisplayNames([locale], { type: 'currency' });
-    } catch {
-      displayNames = undefined;
-    }
-    return TOKEN_PRICE_REFERENCE_CURRENCIES.map((code) => ({
-      code,
-      label: displayNames?.of(code) ?? code,
-    }));
-  }, [locale]);
+  const currencyOptions = useMemo(
+    () =>
+      TOKEN_PRICE_REFERENCE_CURRENCIES.map((code) => ({
+        code,
+        label: tCurrencies(code.toLowerCase()),
+      })),
+    [tCurrencies],
+  );
 
   const translateEditProfileError = useCallback(
     (message: string) => {
@@ -223,9 +218,11 @@ export const EditPersonSection = ({
       links: person?.links || [],
       email: person?.email || '',
       location: person?.location || '',
-      preferredCurrency: person?.preferredCurrency as
-        | FormData['preferredCurrency']
-        | undefined,
+      // Free-text column: anything not on the supported list would fail the
+      // resolver on submit and block saving an otherwise-untouched profile.
+      preferredCurrency: TOKEN_PRICE_REFERENCE_CURRENCIES.find(
+        (code) => code === person?.preferredCurrency,
+      ),
     },
     mode: 'onChange',
   });
@@ -466,7 +463,11 @@ export const EditPersonSection = ({
                 </span>
               </div>
               <div className="flex justify-between">
-                <Text className={cn('text-2', 'text-neutral-11')}>
+                <Text
+                  as="label"
+                  htmlFor="preferred-currency"
+                  className={cn('text-2', 'text-neutral-11')}
+                >
                   {tProfile('editForm.labels.preferredCurrency')}
                 </Text>
                 <span className="flex items-center">
@@ -481,7 +482,10 @@ export const EditPersonSection = ({
                             onValueChange={field.onChange}
                             disabled={isLoading}
                           >
-                            <SelectTrigger className="w-60">
+                            <SelectTrigger
+                              id="preferred-currency"
+                              className="w-60"
+                            >
                               <SelectValue
                                 placeholder={tProfile(
                                   'editForm.placeholders.preferredCurrency',

--- a/packages/epics/src/treasury/components/assets/user-assets-section.tsx
+++ b/packages/epics/src/treasury/components/assets/user-assets-section.tsx
@@ -4,10 +4,9 @@ import { FC } from 'react';
 import { SectionFilter, SectionLoadMore } from '@hypha-platform/ui/server';
 import { Empty } from '../../../common';
 import { useUserAssetsSection } from '../../hooks/use-user-assets-section';
-import { Button } from '../../../../../ui/src/button';
 import Link from 'next/link';
 import { AssetsList } from './assets-list';
-import { Input } from '@hypha-platform/ui';
+import { Button, Input } from '@hypha-platform/ui';
 import { useTranslations } from 'next-intl';
 
 type UserAssetsSectionProps = {

--- a/packages/epics/src/treasury/hooks/index.ts
+++ b/packages/epics/src/treasury/hooks/index.ts
@@ -1,6 +1,7 @@
 export * from './types';
 export * from './use-assets-section';
 export * from './use-assets';
+export * from './use-display-currency';
 export * from './use-tokens';
 export * from './use-user-assets';
 export * from './use-user-assets-section';

--- a/packages/epics/src/treasury/hooks/use-assets-section.ts
+++ b/packages/epics/src/treasury/hooks/use-assets-section.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useAssets } from './use-assets';
 import { FILTER_OPTIONS_ASSETS } from '../../common/constants';
-import { formatCurrencyValue } from '@hypha-platform/ui-utils';
+import { useDisplayCurrency } from './use-display-currency';
 
 export interface UseAssetsSectionProps {
   pageSize?: number;
@@ -32,9 +32,8 @@ export const useAssetsSection = ({
     setVisibleCount((prev) => prev + pageSize);
   }, [pageSize]);
 
-  const totalBalance = `${balance < 0 ? '-' : ''}$ ${formatCurrencyValue(
-    Math.abs(balance),
-  )}`;
+  const { formatFromUsd } = useDisplayCurrency();
+  const totalBalance = formatFromUsd(balance);
 
   const displayableAssets = React.useMemo(() => {
     // Hide zero-balance noise, but always keep tokens issued by this space

--- a/packages/epics/src/treasury/hooks/use-display-currency.ts
+++ b/packages/epics/src/treasury/hooks/use-display-currency.ts
@@ -26,25 +26,6 @@ const fetchRates = (endpoint: string): Promise<{ rates: UsdRates }> =>
   });
 
 /**
- * Currency symbol as written in `locale`, e.g. `A$` for AUD in en-US. Falls
- * back to the ISO code so an unrecognized currency still renders sensibly.
- */
-function getCurrencySymbol(currency: string, locale: string): string {
-  try {
-    return (
-      new Intl.NumberFormat(locale, {
-        style: 'currency',
-        currency,
-      })
-        .formatToParts(0)
-        .find((part) => part.type === 'currency')?.value ?? currency
-    );
-  } catch {
-    return currency;
-  }
-}
-
-/**
  * Renders USD-denominated totals in the currency the member picked on their
  * profile. Defaults to USD, which is what the API already sums in, so an
  * unset preference or an unavailable rate leaves the display unchanged.
@@ -72,13 +53,20 @@ export const useDisplayCurrency = () => {
   const rate = currency === 'USD' ? 1 : preferredRate;
 
   return React.useMemo(() => {
-    const symbol = getCurrencySymbol(currency, locale);
     const rates: UsdRates = rate ? { [currency]: rate } : {};
 
     const formatFromUsd = (usdAmount: number): string => {
       const value = convertFromUsd(usdAmount, currency, rates);
-      const sign = value < 0 ? '-' : '';
-      return `${sign}${symbol} ${formatCurrencyValue(Math.abs(value), locale)}`;
+      try {
+        // Let Intl place the symbol and the sign: de-DE writes "1.234,56 €",
+        // not "€ 1.234,56". Fraction digits still adapt to the magnitude.
+        return formatCurrencyValue(value, locale, {
+          style: 'currency',
+          currency,
+        });
+      } catch {
+        return `${currency} ${formatCurrencyValue(value, locale)}`;
+      }
     };
 
     return { currency, formatFromUsd };

--- a/packages/epics/src/treasury/hooks/use-display-currency.ts
+++ b/packages/epics/src/treasury/hooks/use-display-currency.ts
@@ -1,0 +1,86 @@
+'use client';
+
+import React from 'react';
+import useSWR from 'swr';
+import { useLocale } from 'next-intl';
+import {
+  useMe,
+  convertFromUsd,
+  isConvertibleCurrency,
+  type UsdRates,
+} from '@hypha-platform/core/client';
+import { formatCurrencyValue } from '@hypha-platform/ui-utils';
+
+const RATES_ENDPOINT = '/api/v1/currency-rates';
+
+/**
+ * Rates move slowly and every balance header on the page shares this key, so
+ * one hourly revalidation covers the whole app.
+ */
+const RATES_REFRESH_INTERVAL = 60 * 60 * 1000;
+
+const fetchRates = (endpoint: string): Promise<{ rates: UsdRates }> =>
+  fetch(endpoint).then((res) => {
+    if (!res.ok) throw new Error(`Failed to fetch currency rates`);
+    return res.json();
+  });
+
+/**
+ * Currency symbol as written in `locale`, e.g. `A$` for AUD in en-US. Falls
+ * back to the ISO code so an unrecognized currency still renders sensibly.
+ */
+function getCurrencySymbol(currency: string, locale: string): string {
+  try {
+    return (
+      new Intl.NumberFormat(locale, {
+        style: 'currency',
+        currency,
+      })
+        .formatToParts(0)
+        .find((part) => part.type === 'currency')?.value ?? currency
+    );
+  } catch {
+    return currency;
+  }
+}
+
+/**
+ * Renders USD-denominated totals in the currency the member picked on their
+ * profile. Defaults to USD, which is what the API already sums in, so an
+ * unset preference or an unavailable rate leaves the display unchanged.
+ */
+export const useDisplayCurrency = () => {
+  const locale = useLocale();
+  const { person } = useMe();
+  const { data } = useSWR(RATES_ENDPOINT, fetchRates, {
+    refreshInterval: RATES_REFRESH_INTERVAL,
+    revalidateOnFocus: false,
+  });
+
+  const preferred = person?.preferredCurrency;
+  const preferredRate =
+    preferred && isConvertibleCurrency(preferred)
+      ? data?.rates?.[preferred]
+      : undefined;
+
+  /**
+   * Only switch away from USD once the rate is actually in hand — otherwise the
+   * header would briefly show a USD figure under, say, an AUD symbol.
+   */
+  const currency =
+    preferred && preferred !== 'USD' && preferredRate ? preferred : 'USD';
+  const rate = currency === 'USD' ? 1 : preferredRate;
+
+  return React.useMemo(() => {
+    const symbol = getCurrencySymbol(currency, locale);
+    const rates: UsdRates = rate ? { [currency]: rate } : {};
+
+    const formatFromUsd = (usdAmount: number): string => {
+      const value = convertFromUsd(usdAmount, currency, rates);
+      const sign = value < 0 ? '-' : '';
+      return `${sign}${symbol} ${formatCurrencyValue(Math.abs(value), locale)}`;
+    };
+
+    return { currency, formatFromUsd };
+  }, [currency, locale, rate]);
+};

--- a/packages/epics/src/treasury/hooks/use-user-assets-section.ts
+++ b/packages/epics/src/treasury/hooks/use-user-assets-section.ts
@@ -1,9 +1,9 @@
 'use client';
 
 import React from 'react';
-import { formatCurrencyValue } from '@hypha-platform/ui-utils';
 import { FILTER_OPTIONS_ASSETS } from '../../common/constants';
 import { useUserAssets } from './use-user-assets';
+import { useDisplayCurrency } from './use-display-currency';
 
 export interface UseUserAssetsSectionProps {
   personSlug?: string;
@@ -37,9 +37,8 @@ export const useUserAssetsSection = ({
     setVisibleCount((prev) => prev + pageSize);
   }, [pageSize]);
 
-  const totalBalance = `${balance < 0 ? '-' : ''}$ ${formatCurrencyValue(
-    Math.abs(balance),
-  )}`;
+  const { formatFromUsd } = useDisplayCurrency();
+  const totalBalance = formatFromUsd(balance);
 
   const displayableAssets = React.useMemo(() => {
     let result = assets.filter((asset) => asset.value > 0);

--- a/packages/epics/src/treasury/hooks/use-user-assets.ts
+++ b/packages/epics/src/treasury/hooks/use-user-assets.ts
@@ -201,6 +201,8 @@ export const useUserAssets = ({
       (!hasValidData && isLoading) ||
       (Boolean(jwt) && !personSlug && !hasValidData),
     balance: hasValidData ? typedData.balance : 0,
-    manualUpdate: mutate,
+    manualUpdate: async () => {
+      await mutate();
+    },
   };
 };

--- a/packages/epics/src/treasury/hooks/use-user-assets.ts
+++ b/packages/epics/src/treasury/hooks/use-user-assets.ts
@@ -82,12 +82,33 @@ export type AssetItem = {
   };
 };
 
+type AssetsPayload = {
+  assets: AssetItem[];
+  balance: number;
+  /**
+   * Upstream sources that failed while assembling this response. When Alchemy
+   * is listed the payload looks like an "energy-only" wallet and must not
+   * replace a previously complete fetch in the client cache.
+   */
+  incompleteSources?: string[];
+};
+
 type UseAssetsReturn = {
   assets: AssetItem[];
   isLoading: boolean;
   balance: number;
   manualUpdate: () => Promise<void>;
 };
+
+function isCompletePayload(payload: AssetsPayload): boolean {
+  return !payload.incompleteSources || payload.incompleteSources.length === 0;
+}
+
+/**
+ * Survives remounts and JWT-key churn so an Alchemy blip after a good fetch
+ * cannot replace the full wallet with the energy-catalogue subset.
+ */
+const completeWalletBySlug = new Map<string, AssetsPayload>();
 
 export const useUserAssets = ({
   filter,
@@ -109,18 +130,45 @@ export const useUserAssets = ({
   // request for `/people/undefined/assets` on every mount.
   const { data, isLoading, mutate } = useSWR(
     jwt && personSlug ? [endpoint, jwt] : null,
-    ([endpoint, jwt]) =>
-      fetch(endpoint, {
+    async ([endpoint, jwt]) => {
+      const res = await fetch(endpoint, {
         headers: {
           Authorization: `Bearer ${jwt}`,
           'Content-Type': 'application/json',
         },
-      }).then(async (res) => {
-        if (!res.ok) {
-          throw new Error(`Failed to fetch user assets: ${res.statusText}`);
-        }
-        return await res.json();
-      }),
+      });
+      if (!res.ok) {
+        throw new Error(`Failed to fetch user assets: ${res.statusText}`);
+      }
+      const payload = (await res.json()) as AssetsPayload;
+      if (
+        !Array.isArray(payload.assets) ||
+        typeof payload.balance !== 'number'
+      ) {
+        throw new Error('Failed to fetch user assets: invalid payload');
+      }
+
+      const slug = personSlug as string;
+      if (isCompletePayload(payload)) {
+        completeWalletBySlug.set(slug, payload);
+        return payload;
+      }
+
+      // Alchemy (etc.) failed: this payload is the energy/member catalogue
+      // subset. Prefer the last complete wallet for this slug so the balance
+      // does not collapse mid-session. First paint with no prior complete
+      // fetch still shows the partial set rather than an empty grid.
+      const previousComplete = completeWalletBySlug.get(slug);
+      if (previousComplete) {
+        console.warn(
+          `Incomplete assets response (${(payload.incompleteSources ?? []).join(
+            ', ',
+          )}); keeping previous wallet`,
+        );
+        return previousComplete;
+      }
+      return payload;
+    },
     {
       refreshInterval,
       // Keep the last good wallet when the JWT (and therefore the SWR key)
@@ -132,7 +180,7 @@ export const useUserAssets = ({
     },
   );
 
-  const typedData = data as UseAssetsReturn | undefined;
+  const typedData = data as AssetsPayload | undefined;
   const hasValidData =
     typedData &&
     Array.isArray(typedData.assets) &&

--- a/packages/epics/src/treasury/hooks/use-user-assets.ts
+++ b/packages/epics/src/treasury/hooks/use-user-assets.ts
@@ -103,8 +103,10 @@ export const useUserAssets = ({
     return `/api/v1/people/${personSlug}/assets`;
   }, [personSlug]);
 
+  // The JWT resolves before the slug does, so keying on it alone fired a
+  // request for `/people/undefined/assets` on every mount.
   const { data, isLoading, mutate } = useSWR(
-    jwt ? [endpoint, jwt] : null,
+    jwt && personSlug ? [endpoint, jwt] : null,
     ([endpoint, jwt]) =>
       fetch(endpoint, {
         headers: {
@@ -134,7 +136,9 @@ export const useUserAssets = ({
 
   return {
     assets: filteredAssets,
-    isLoading,
+    // A null SWR key reports "not loading", which would flash an empty wallet
+    // in the gap between the JWT arriving and the slug being known.
+    isLoading: isLoading || (Boolean(jwt) && !personSlug),
     balance: hasValidData ? typedData.balance : 0,
     manualUpdate: mutate,
   };

--- a/packages/epics/src/treasury/hooks/use-user-assets.ts
+++ b/packages/epics/src/treasury/hooks/use-user-assets.ts
@@ -91,7 +91,9 @@ type UseAssetsReturn = {
 
 export const useUserAssets = ({
   filter,
-  refreshInterval = 10000,
+  // 30s: the assets route hits Alchemy + several RPCs; polling every 10s was
+  // frequent enough to surface transient upstream gaps as balance flicker.
+  refreshInterval = 30000,
   personSlug,
 }: {
   filter?: { type: string };
@@ -119,7 +121,15 @@ export const useUserAssets = ({
         }
         return await res.json();
       }),
-    { refreshInterval },
+    {
+      refreshInterval,
+      // Keep the last good wallet when the JWT (and therefore the SWR key)
+      // rotates, or when a refresh fails — otherwise the balance drops to 0
+      // and the token grid empties for a few seconds every poll/refresh.
+      keepPreviousData: true,
+      revalidateOnFocus: true,
+      errorRetryCount: 3,
+    },
   );
 
   const typedData = data as UseAssetsReturn | undefined;
@@ -138,7 +148,10 @@ export const useUserAssets = ({
     assets: filteredAssets,
     // A null SWR key reports "not loading", which would flash an empty wallet
     // in the gap between the JWT arriving and the slug being known.
-    isLoading: isLoading || (Boolean(jwt) && !personSlug),
+    // Once we have data, background revalidation must not look like a first load.
+    isLoading:
+      (!hasValidData && isLoading) ||
+      (Boolean(jwt) && !personSlug && !hasValidData),
     balance: hasValidData ? typedData.balance : 0,
     manualUpdate: mutate,
   };

--- a/packages/epics/src/treasury/hooks/use-user-transfers.ts
+++ b/packages/epics/src/treasury/hooks/use-user-transfers.ts
@@ -39,7 +39,11 @@ export const useUserTransfers = ({
         throw err;
       }
     },
-    { refreshInterval },
+    {
+      refreshInterval,
+      keepPreviousData: true,
+      errorRetryCount: 3,
+    },
   );
 
   return {

--- a/packages/epics/src/wallet/components/my-wallet-dashboard.tsx
+++ b/packages/epics/src/wallet/components/my-wallet-dashboard.tsx
@@ -92,12 +92,18 @@ export function MyWalletDashboard({ lang }: MyWalletDashboardProps) {
     return <SpaceAccessDenied userState={UserSpaceState.NOT_LOGGED_IN} />;
   }
 
-  if (isLoading || !personSlug) {
+  // Only block the page on the initial profile load. Background revalidation
+  // (JWT refresh, focus) must not tear the wallet down into a full-page spinner.
+  if (!personSlug && isLoading) {
     return (
       <div className="flex w-full min-h-[280px] items-center justify-center py-16">
         <SpaceAccentLoader label={tMyWallet('loading')} />
       </div>
     );
+  }
+
+  if (!personSlug) {
+    return <SpaceAccessDenied userState={UserSpaceState.NOT_LOGGED_IN} />;
   }
 
   return (

--- a/packages/epics/src/wallet/components/wallet-actions-toolbar.tsx
+++ b/packages/epics/src/wallet/components/wallet-actions-toolbar.tsx
@@ -11,12 +11,28 @@ type WalletActionsToolbarProps = {
   className?: string;
 };
 
+/**
+ * The wallet's primary actions, so they keep the solid accent fill rather than
+ * the quiet outline treatment used for banners and surrounding chrome.
+ */
+const ACTION_BUTTON_CLASS =
+  'h-10 shrink-0 whitespace-nowrap px-3 text-sm sm:px-4';
+
 export function WalletActionsToolbar({
   basePath,
   disabled = false,
   className,
 }: WalletActionsToolbarProps) {
   const tProfile = useTranslations('Profile');
+
+  const actions = [
+    { href: `${basePath}/actions/buy-space-tokens`, label: 'buySpaceTokens' },
+    {
+      href: `${basePath}/actions/purchase-hypha-tokens`,
+      label: 'buyHypha',
+    },
+    { href: `${basePath}/actions`, label: 'actions' },
+  ] as const;
 
   return (
     <div
@@ -25,71 +41,22 @@ export function WalletActionsToolbar({
         className,
       )}
     >
-      {disabled ? (
-        <Button
-          variant="outline"
-          colorVariant="accent"
-          className="h-10 shrink-0 cursor-not-allowed whitespace-nowrap px-3 text-sm sm:px-4"
-          disabled
-        >
-          {tProfile('buySpaceTokens')}
-        </Button>
-      ) : (
-        <Button
-          asChild
-          variant="outline"
-          colorVariant="accent"
-          className="h-10 shrink-0 whitespace-nowrap px-3 text-sm sm:px-4"
-        >
-          <Link href={`${basePath}/actions/buy-space-tokens`} scroll={false}>
-            {tProfile('buySpaceTokens')}
-          </Link>
-        </Button>
-      )}
-      {disabled ? (
-        <Button
-          variant="outline"
-          colorVariant="accent"
-          className="h-10 shrink-0 cursor-not-allowed whitespace-nowrap px-3 text-sm sm:px-4"
-          disabled
-        >
-          {tProfile('buyHypha')}
-        </Button>
-      ) : (
-        <Button
-          asChild
-          variant="outline"
-          colorVariant="accent"
-          className="h-10 shrink-0 whitespace-nowrap px-3 text-sm sm:px-4"
-        >
-          <Link
-            href={`${basePath}/actions/purchase-hypha-tokens`}
-            scroll={false}
+      {actions.map(({ href, label }) =>
+        disabled ? (
+          <Button
+            key={href}
+            className={cn(ACTION_BUTTON_CLASS, 'cursor-not-allowed')}
+            disabled
           >
-            {tProfile('buyHypha')}
-          </Link>
-        </Button>
-      )}
-      {disabled ? (
-        <Button
-          variant="outline"
-          colorVariant="accent"
-          className="h-10 shrink-0 cursor-not-allowed whitespace-nowrap px-3 text-sm sm:px-4"
-          disabled
-        >
-          {tProfile('actions')}
-        </Button>
-      ) : (
-        <Button
-          asChild
-          variant="outline"
-          colorVariant="accent"
-          className="h-10 shrink-0 whitespace-nowrap px-3 text-sm sm:px-4"
-        >
-          <Link href={`${basePath}/actions`} scroll={false}>
-            {tProfile('actions')}
-          </Link>
-        </Button>
+            {tProfile(label)}
+          </Button>
+        ) : (
+          <Button key={href} asChild className={ACTION_BUTTON_CLASS}>
+            <Link href={href} scroll={false}>
+              {tProfile(label)}
+            </Link>
+          </Button>
+        ),
       )}
     </div>
   );

--- a/packages/i18n/src/messages/de.json
+++ b/packages/i18n/src/messages/de.json
@@ -1293,8 +1293,8 @@
       "joinSpaceToUpdateBackingVault": "Treten Sie dem Space bei, um den Sicherungsvault zu aktualisieren"
     },
     "assetCard": {
-      "fromSpace": "von {spaceTitle}",
-      "totalIssuance": "Ausgabe {value}",
+      "fromSpace": "von · {spaceTitle}",
+      "totalIssuance": "Ausgabe · {value}",
       "createdOn": "Erstellt am {date}",
       "mutualCredit": {
         "debtBadge": "Schuldet {amount} {symbol}",

--- a/packages/i18n/src/messages/de.json
+++ b/packages/i18n/src/messages/de.json
@@ -1363,7 +1363,8 @@
       "uploadLeadImageLabel": "<accent>Bild</accent> hochladen",
       "labels": {
         "email": "E-Mail",
-        "location": "Standort"
+        "location": "Standort",
+        "preferredCurrency": "Bevorzugte Währung"
       },
       "placeholders": {
         "firstName": "Vorname",
@@ -1371,7 +1372,8 @@
         "nickname": "Spitzname",
         "lifePurpose": "Beschreiben Sie hier Ihren Lebenszweck...",
         "email": "E-Mail",
-        "location": "Standort"
+        "location": "Standort",
+        "preferredCurrency": "Währung auswählen"
       },
       "actions": {
         "retry": "Erneut versuchen",

--- a/packages/i18n/src/messages/en.json
+++ b/packages/i18n/src/messages/en.json
@@ -1362,7 +1362,8 @@
       "uploadLeadImageLabel": "<accent>Upload</accent> an image",
       "labels": {
         "email": "Email",
-        "location": "Location"
+        "location": "Location",
+        "preferredCurrency": "Preferred currency"
       },
       "placeholders": {
         "firstName": "First Name",
@@ -1370,7 +1371,8 @@
         "nickname": "Nickname",
         "lifePurpose": "Type your life purpose here...",
         "email": "Email",
-        "location": "Location"
+        "location": "Location",
+        "preferredCurrency": "Select a currency"
       },
       "actions": {
         "retry": "Retry",

--- a/packages/i18n/src/messages/en.json
+++ b/packages/i18n/src/messages/en.json
@@ -1292,8 +1292,8 @@
       "joinSpaceToUpdateBackingVault": "Join the space to update backing vault"
     },
     "assetCard": {
-      "fromSpace": "from {spaceTitle}",
-      "totalIssuance": "Issuance {value}",
+      "fromSpace": "from · {spaceTitle}",
+      "totalIssuance": "Issuance · {value}",
       "createdOn": "Created on {date}",
       "mutualCredit": {
         "debtBadge": "Owes {amount} {symbol}",

--- a/packages/i18n/src/messages/es.json
+++ b/packages/i18n/src/messages/es.json
@@ -1499,8 +1499,8 @@
       "joinSpaceToUpdateBackingVault": "Únete al espacio para actualizar la bóveda de respaldo"
     },
     "assetCard": {
-      "fromSpace": "de {spaceTitle}",
-      "totalIssuance": "Emisión {value}",
+      "fromSpace": "de · {spaceTitle}",
+      "totalIssuance": "Emisión · {value}",
       "createdOn": "Creado en {date}",
       "mutualCredit": {
         "debtBadge": "Debe {amount} {symbol}",

--- a/packages/i18n/src/messages/es.json
+++ b/packages/i18n/src/messages/es.json
@@ -1569,7 +1569,8 @@
       "uploadLeadImageLabel": "<accent>Subir</accent> una imagen",
       "labels": {
         "email": "Correo electrónico",
-        "location": "Ubicación"
+        "location": "Ubicación",
+        "preferredCurrency": "Moneda preferida"
       },
       "placeholders": {
         "firstName": "Nombre de pila",
@@ -1577,7 +1578,8 @@
         "nickname": "Apodo",
         "lifePurpose": "Escribe aquí tu propósito de vida...",
         "email": "Correo electrónico",
-        "location": "Ubicación"
+        "location": "Ubicación",
+        "preferredCurrency": "Selecciona una moneda"
       },
       "actions": {
         "retry": "Reintentar",

--- a/packages/i18n/src/messages/fr.json
+++ b/packages/i18n/src/messages/fr.json
@@ -799,7 +799,8 @@
       "uploadLeadImageLabel": "<accent>Téléverser</accent> une image",
       "labels": {
         "email": "E-mail",
-        "location": "Localisation"
+        "location": "Localisation",
+        "preferredCurrency": "Devise préférée"
       },
       "placeholders": {
         "firstName": "Prénom",
@@ -807,7 +808,8 @@
         "nickname": "Pseudo",
         "lifePurpose": "Décrivez ici votre raison d’être...",
         "email": "E-mail",
-        "location": "Localisation"
+        "location": "Localisation",
+        "preferredCurrency": "Sélectionnez une devise"
       },
       "actions": {
         "retry": "Réessayer",

--- a/packages/i18n/src/messages/fr.json
+++ b/packages/i18n/src/messages/fr.json
@@ -729,8 +729,8 @@
       "joinSpaceToUpdateBackingVault": "Rejoignez l’espace pour mettre à jour le coffre de garantie"
     },
     "assetCard": {
-      "fromSpace": "de {spaceTitle}",
-      "totalIssuance": "Émission {value}",
+      "fromSpace": "de · {spaceTitle}",
+      "totalIssuance": "Émission · {value}",
       "createdOn": "Créé le {date}",
       "mutualCredit": {
         "debtBadge": "Doit {amount} {symbol}",

--- a/packages/i18n/src/messages/mk.json
+++ b/packages/i18n/src/messages/mk.json
@@ -1272,8 +1272,8 @@
       "joinSpaceToUpdateBackingVault": "Придружете се на просторот за да ја ажурирате вредносната резерва"
     },
     "assetCard": {
-      "fromSpace": "од {spaceTitle}",
-      "totalIssuance": "Емисија {value}",
+      "fromSpace": "од · {spaceTitle}",
+      "totalIssuance": "Емисија · {value}",
       "createdOn": "Создадено на {date}",
       "mutualCredit": {
         "debtBadge": "Должи {amount} {symbol}",

--- a/packages/i18n/src/messages/mk.json
+++ b/packages/i18n/src/messages/mk.json
@@ -1342,7 +1342,8 @@
       "uploadLeadImageLabel": "<accent>Прикачи</accent> слика",
       "labels": {
         "email": "Е-пошта",
-        "location": "Локација"
+        "location": "Локација",
+        "preferredCurrency": "Претпочитана валута"
       },
       "placeholders": {
         "firstName": "Име",
@@ -1350,7 +1351,8 @@
         "nickname": "Прекар",
         "lifePurpose": "Напиши ја твојата животна цел овде...",
         "email": "Е-пошта",
-        "location": "Локација"
+        "location": "Локација",
+        "preferredCurrency": "Изберете валута"
       },
       "actions": {
         "retry": "Обиди се повторно",

--- a/packages/i18n/src/messages/nl.json
+++ b/packages/i18n/src/messages/nl.json
@@ -1362,7 +1362,8 @@
       "uploadLeadImageLabel": "<accent>Upload</accent> een afbeelding",
       "labels": {
         "email": "E-mail",
-        "location": "Locatie"
+        "location": "Locatie",
+        "preferredCurrency": "Voorkeursvaluta"
       },
       "placeholders": {
         "firstName": "Voornaam",
@@ -1370,7 +1371,8 @@
         "nickname": "Bijnaam",
         "lifePurpose": "Typ hier uw levensdoel...",
         "email": "E-mail",
-        "location": "Locatie"
+        "location": "Locatie",
+        "preferredCurrency": "Selecteer een valuta"
       },
       "actions": {
         "retry": "Opnieuw proberen",

--- a/packages/i18n/src/messages/nl.json
+++ b/packages/i18n/src/messages/nl.json
@@ -1292,8 +1292,8 @@
       "joinSpaceToUpdateBackingVault": "Sluit u aan bij de ruimte om de back-upkluis te updaten"
     },
     "assetCard": {
-      "fromSpace": "vanaf {spaceTitle}",
-      "totalIssuance": "Uitgifte {value}",
+      "fromSpace": "vanaf · {spaceTitle}",
+      "totalIssuance": "Uitgifte · {value}",
       "createdOn": "Gemaakt op {date}",
       "mutualCredit": {
         "debtBadge": "Schulden {amount} {symbol}",

--- a/packages/i18n/src/messages/no.json
+++ b/packages/i18n/src/messages/no.json
@@ -1291,8 +1291,8 @@
       "joinSpaceToUpdateBackingVault": "Bli med i rommet for å oppdatere dekningshvelvet"
     },
     "assetCard": {
-      "fromSpace": "fra {spaceTitle}",
-      "totalIssuance": "Utstedelse {value}",
+      "fromSpace": "fra · {spaceTitle}",
+      "totalIssuance": "Utstedelse · {value}",
       "createdOn": "Opprettet {date}",
       "mutualCredit": {
         "debtBadge": "Skylder {amount} {symbol}",

--- a/packages/i18n/src/messages/no.json
+++ b/packages/i18n/src/messages/no.json
@@ -1361,7 +1361,8 @@
       "uploadLeadImageLabel": "<accent>Last opp</accent> et bilde",
       "labels": {
         "email": "E-post",
-        "location": "Sted"
+        "location": "Sted",
+        "preferredCurrency": "Foretrukket valuta"
       },
       "placeholders": {
         "firstName": "Fornavn",
@@ -1369,7 +1370,8 @@
         "nickname": "Kallenavn",
         "lifePurpose": "Skriv livsformålet ditt her...",
         "email": "E-post",
-        "location": "Sted"
+        "location": "Sted",
+        "preferredCurrency": "Velg en valuta"
       },
       "actions": {
         "retry": "Prøv igjen",

--- a/packages/i18n/src/messages/pt.json
+++ b/packages/i18n/src/messages/pt.json
@@ -1569,7 +1569,8 @@
       "uploadLeadImageLabel": "<accent>Carregar</accent> uma imagem",
       "labels": {
         "email": "E-mail",
-        "location": "Localização"
+        "location": "Localização",
+        "preferredCurrency": "Moeda preferida"
       },
       "placeholders": {
         "firstName": "Primeiro nome",
@@ -1577,7 +1578,8 @@
         "nickname": "Apelido",
         "lifePurpose": "Digite aqui o seu propósito de vida...",
         "email": "E-mail",
-        "location": "Localização"
+        "location": "Localização",
+        "preferredCurrency": "Selecione uma moeda"
       },
       "actions": {
         "retry": "Tentar novamente",

--- a/packages/i18n/src/messages/pt.json
+++ b/packages/i18n/src/messages/pt.json
@@ -1499,8 +1499,8 @@
       "joinSpaceToUpdateBackingVault": "Entre no espaço para atualizar o cofre de lastro"
     },
     "assetCard": {
-      "fromSpace": "de {spaceTitle}",
-      "totalIssuance": "Emissão {value}",
+      "fromSpace": "de · {spaceTitle}",
+      "totalIssuance": "Emissão · {value}",
       "createdOn": "Criado em {date}",
       "mutualCredit": {
         "debtBadge": "Deve {amount} {symbol}",

--- a/packages/storage-postgres/migrations/0075_person_preferred_currency.sql
+++ b/packages/storage-postgres/migrations/0075_person_preferred_currency.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "people" ADD COLUMN IF NOT EXISTS "preferred_currency" text;

--- a/packages/storage-postgres/migrations/meta/_journal.json
+++ b/packages/storage-postgres/migrations/meta/_journal.json
@@ -526,6 +526,13 @@
       "when": 1784000000005,
       "tag": "0074_space_api_keys_and_signal_source",
       "breakpoints": true
+    },
+    {
+      "idx": 75,
+      "version": "7",
+      "when": 1784000000006,
+      "tag": "0075_person_preferred_currency",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/storage-postgres/src/schema/people.ts
+++ b/packages/storage-postgres/src/schema/people.ts
@@ -20,6 +20,8 @@ export const people = pgTable(
     surname: text('surname'),
     nickname: text('nickname'),
     address: text('web3_address'),
+    /** ISO 4217 code the member wants balances shown in. Null means USD. */
+    preferredCurrency: text('preferred_currency'),
     links: jsonb('links').$type<string[]>().notNull().default([]),
     ...commonDateFields,
   },


### PR DESCRIPTION
Addresses Alex's report: the wallet showed the wrong currency on token cards, balances were not converted, and the action buttons had changed appearance.

## What was wrong

**Token currency.** The wallet showed `HUMAID · 1.00 USD` while the space treasury correctly showed `1.00 AUD` for the same token. Both surfaces share the same `AssetCard`, but only the space assets API returned `referenceCurrency`; the people assets API built `referencePriceByAddress` and never mapped the currency, so the card fell back to its hardcoded `'USD'`.

**Balances.** `usdEqual` was computed as `rate * amount` regardless of the currency the rate was quoted in, so a token priced at 1.00 AUD was summed into the total as if it were 1.00 USD.

**Buttons.** `ccb2af581b` ("quiet banner and chrome CTAs with outline accent") changed banners and chrome to outline accent and swept the wallet toolbar in with them, so the wallet's three primary actions lost their solid fill and stopped matching the profile screen.

## Changes

- Both assets APIs now report the currency the quoted price is *actually* in rather than whatever the DB row says. A CoinGecko price or the fixed HYPHA rate is USD; only a DB reference price carries its own currency. This also fixes a latent case on the space route where a market-priced token could be labelled with an unrelated DB currency.
- New `convertToUsd` / `convertFromUsd` helpers plus `getUsdRates`, reading the Chainlink X/USD feeds already wired up in `CURRENCY_FEEDS` (USD, EUR, GBP, CAD, CHF, AUD, NZD, XPF). These are the same feeds the redemption contracts price against, so a displayed balance cannot disagree with what a redemption actually pays out. No new dependency or API key. Rates are cached for 5 minutes.
- A missing rate falls back to 1:1 rather than zeroing a balance out; the per-token card still shows the true source currency, so the fallback never mislabels the number.
- Members can now pick a preferred currency on their profile, and wallet and treasury totals render in it. The picker is limited to currencies with a feed, since anything else could not be converted. Currency names come from `Intl.DisplayNames`, so they localize without a translation key per currency.
- Wallet action buttons go back to the solid accent fill. Alex's banner and chrome changes are untouched.

## Notes

- Adds a nullable `preferred_currency` column to `people` (migration `0075`). Hand-written and idempotent, matching the convention in this repo — `drizzle-kit generate` diffs against a snapshot last updated at `0053` and would have emitted a large amount of unrelated pending drift.
- Totals stay in USD until the FX rate arrives, so the header never shows a USD figure under an AUD symbol.
- `useDisplayCurrency` is exported from `@hypha-platform/epics` for reuse by any other balance display.
- Drops a relative import in `user-assets-section.tsx` that reached into `ui/src` directly.

## Test plan

- [x] 11 new unit tests for the conversion helpers, including the 4,050,000 AUD case from Alex's screenshot
- [x] Full `pnpm build` type-checks clean; `pnpm format:check` and lint pass with no new warnings
- [x] `pnpm verify:messages` passes; new strings added to all 8 locales
- [ ] Run the `0075` migration, then confirm HUMAID reads `1.00 AUD` on the wallet, matching the space treasury
- [ ] Set a preferred currency of AUD on a profile and confirm the wallet and treasury totals switch to `A$`
- [ ] Confirm the three wallet buttons are solid again and match the profile screen

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added preferred-currency selection to profile settings with localized labels.
  - Added live USD exchange-rate support and a public currency-rates endpoint.
  - Treasury balances and asset values can now be displayed in the selected currency.
  - Asset pricing now includes reference currencies and normalized USD values.

- **Bug Fixes**
  - Added fallbacks for unavailable rates, invalid currencies, and failed requests.
  - Prevented premature wallet requests and loading-state flashes.

- **Tests**
  - Added coverage for currency conversion, validation, fallbacks, round trips, and rate freshness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->