### PR TITLE
docs(intelligent-org): add stakeholder journeys and memory architecture

### DIFF
--- a/docs/architecture/organizational-intelligence.md
+++ b/docs/architecture/organizational-intelligence.md
@@ -392,6 +392,32 @@ So one vote on "this domain, this owner, this envelope, this review date" retire
 votes. Mandates are the compression mechanism for governance in the same way that L3 artifacts are
 the compression mechanism for memory.
 
+### Where new mandates come from
+
+Mandates should be created from observed need, not asserted need. The mechanism is work routing.
+
+When the system detects that something needs doing, it matches the work to a person using stated
+skills and mandates (L3), plus demonstrated history and current load (L2). Most of the time it finds
+someone. The interesting case is when it does not.
+
+**Unmatched work is a measurement, not a failure.** Left alone, unrouteable work silently lands on
+whoever is most responsive, which hides the shortage and burns out the conscientious. Instead it
+should stay open, labelled with the capability it needs, and **aggregate**. Three unfilled tasks in
+one domain over a month is not three problems; it is one role that does not exist yet.
+
+That aggregate is the evidence base for a Tier 3 proposal to create a mandate — a domain, an owner,
+an envelope, a review date. It is the answer to "how do we know we need to hire?" and it means the
+proposal arrives with a demonstrated pattern attached rather than someone's conviction.
+
+Two constraints on the matcher itself:
+
+- **Propose, do not allocate.** In a voluntary organization work cannot be assigned, only made
+  visible to the person most likely to take it. Suggested owner, reasoning shown, claimable by
+  anyone.
+- **Reserve a minority of routing for stretch matches.** Matching purely on demonstrated history
+  ossifies roles and quietly creates single points of failure. Capabilities held by exactly one
+  person are a risk the system is well placed to notice and surface.
+
 ### What this means for the AI
 
 Routing is a more valuable capability than drafting. For every candidate decision the AI should

--- a/docs/architecture/organizational-intelligence.md
+++ b/docs/architecture/organizational-intelligence.md
@@ -1,0 +1,452 @@
+---
+title: 'Organizational Intelligence — Memory Architecture'
+date: 2026-08-20
+status: draft
+tags: [architecture, ai, memory, intelligent-org]
+---
+
+# Organizational Intelligence — Memory Architecture
+
+**Target-state architecture**, written for the whole team. It answers five questions:
+
+1. How is organizational memory maintained?
+2. How does the AI retrieve from it?
+3. How big can memory get — can we give the AI _absolutely everything_ about the organization?
+4. How does the AI work out what is relevant?
+5. How do we make the AI actually intelligent?
+
+Companion to [User Journeys](../product/user-journeys.md), which describes what this is for.
+
+Numbers here are grounded in two documents that currently live on other branches: the measured AI
+cost model (`docs/hypha-ai-cost/`, branch `docs/hypha-ai-cost-per-space`) and the frozen Space
+Intelligence spec (`docs/plans/space-intelligence.md`, branch `feat/org-memory` /
+[PR #2461](https://github.com/hypha-dao/hypha-web/pull/2461)).
+
+---
+
+## 0. The core idea
+
+An organization is intelligent to the degree it can reliably run one loop:
+
+```mermaid
+flowchart LR
+  Perceive --> Interpret --> Remember --> Recommend --> Act --> Observe --> Revise
+  Revise --> Remember
+```
+
+Most AI products build only **Recommend**, wired directly to a model, and call it intelligence. It
+isn't — it's autocomplete with company data. The intelligence lives in the loop being _closed_: the
+organization observes what happened after it acted, and revises what it believes.
+
+This has one strategic consequence worth stating plainly:
+
+> **The model is a commodity. The memory and the loop are the asset.**
+
+Our own cost analysis shows a ~24× price spread between models of broadly comparable quality, and
+the frontier moves every few months. Anything we build that depends on a specific model is
+temporary. What no competitor can replicate is a curated, versioned, human-approved record of what
+_this_ organization believes, plus the history of what it tried and what happened. That is what we
+are building. The model is a rented interpreter for it.
+
+---
+
+## 1. Four layers of memory
+
+Almost every failed AI-memory project fails by conflating these. They have different sizes,
+different writers, different lifespans, and — critically — different rules about whether they are
+ever allowed near the AI's context.
+
+|        | Layer           | What it holds                                                                                     | Rough size                        | Written by                              | Reaches the AI         |
+| ------ | --------------- | ------------------------------------------------------------------------------------------------- | --------------------------------- | --------------------------------------- | ---------------------- |
+| **L1** | Substrate       | chat messages, call recordings, uploaded files, raw blockchain events                             | millions of tokens, grows forever | machines, automatically                 | **never directly**     |
+| **L2** | Activity ledger | typed timestamped facts: _proposal 12 executed_, _treasury −8%_, _member joined_, _signal closed_ | large, grows forever              | the system, automatically               | **only as aggregates** |
+| **L3** | Semantic memory | what the organization believes: purpose, stakeholders, risks, charter, standing assessments       | **small — tens of documents**     | humans, and AI proposals humans approve | **always**             |
+| **L4** | Decision memory | recommendation → action → outcome chains; what we tried, what happened, what we now think instead | medium                            | the system, on state change             | **selectively**        |
+
+Where we stand today: L1 exists. L3 is built and awaiting merge (the Space Intelligence Markdown
+artifacts). L2 exists as an unused table. **L4 does not exist.** L2 and L4 are both ordinary
+database tables — inexpensive to build, and they are what make the loop closeable.
+
+The single most important design rule follows from this table:
+
+> **L3 holds interpretation. It never holds readings.**
+
+Treasury balances, vote counts, and membership numbers change constantly and are always fetched
+live at question time. If a number gets written into a memory document, the AI will confidently
+recite a stale figure forever. Artifacts say _"we are over-exposed to a single funding source"_;
+they never say _"we hold 43,000 USDC"_.
+
+---
+
+## 2. How memory is maintained
+
+Memory quality is a governance process, not a storage problem. The lifecycle:
+
+**Capture.** Raw material accumulates in L1 continuously. Nothing is curated at this stage.
+
+**Propose.** Something — the AI, a connected app, or a person — proposes that the organization
+should _know_ something. The AI's default is always to propose, never to publish. This is the
+critical guardrail: memory an AI can silently rewrite launders hallucination into institutional
+truth, which is strictly worse than having no memory at all.
+
+**Approve.** A member reviews the proposed change against the current version and accepts, edits,
+or rejects it. This moment is where human judgment enters the corpus, which makes it the most
+valuable data we collect — we should record the _edits_ approvers make, not just the yes/no.
+
+**Version.** The approved change is written as a new immutable version, content-addressed, with a
+pointer to what it supersedes. Old versions stay readable forever. This is what lets the
+organization ask "what did we believe in March, and who changed it, and why?"
+
+**Consolidate.** On a regular rhythm, the AI proposes compressions: these four overlapping insights
+are one insight; this assessment is contradicted by that decision. Humans approve. This is the
+mechanism that keeps the corpus small, and it should be a scheduled organizational ritual rather
+than a background job nobody sees.
+
+**Retire.** Beliefs that no longer hold are marked superseded or contested with a recorded reason.
+Nothing is deleted.
+
+Two properties every artifact carries:
+
+- **Provenance** — which app or person produced it, when, and from what.
+- **A falsification condition** — what would make this wrong? The energy-pack templates already
+  ask "how will we know this identity still fits". Generalize that. A belief with no stated way of
+  being wrong can never be revised, and will quietly rot.
+
+### The invariant that matters most
+
+> **L3 must stay small enough that a person could read all of it in an afternoon.**
+
+This is not an efficiency target, it is what makes the memory trustworthy. A corpus nobody can
+audit is a corpus nobody should rely on. If a space accumulates two hundred "insights", the
+organization has no insight — it has a landfill. Growth in L3 is a symptom to investigate, not
+progress to celebrate.
+
+---
+
+## 3. How the AI retrieves — the context budget
+
+We do not "search a big pile." We **spend a fixed budget** on every turn, filled in a defined
+order. The ordering is the design.
+
+The key move — and the answer to most of the difficulty — is this:
+
+> **Always send the _map_ of memory. Send the _contents_ only on demand.**
+
+The whole index of an organization's memory (every artifact's title, type, status, last-updated
+date, and a one-line summary) costs around **1,500 tokens**. The full text of all those artifacts
+costs around **60,000**. So for roughly 2% of the cost, the AI can always know _everything it
+knows about_ — and then ask precisely for the two or three documents it actually needs.
+
+This is why we do not need a vector database to get good behaviour. The model is choosing from a
+short labelled menu, which is something models are extremely reliable at, rather than guessing
+search keywords and hoping.
+
+A typical turn, budgeted:
+
+| Slice                                                          | Tokens       | Always present? |
+| -------------------------------------------------------------- | ------------ | --------------- |
+| System prompt (trimmed from today's 5.6k)                      | 3,000        | yes             |
+| Identity card — who this org is, its purpose, its phase        | 300          | yes             |
+| Memory index — one line per artifact                           | 1,500        | yes             |
+| Current state — members, treasury, open proposals, top signals | 700          | yes             |
+| What changed since this person last looked                     | 1,000        | yes             |
+| Selected artifact bodies (2–4, chosen from the index)          | 6,000        | on demand       |
+| Conversation history (bounded, not the full transcript)        | 3,000        | trimmed         |
+| **Total**                                                      | **≈ 15,500** |                 |
+
+For comparison, a multi-tool advisory task today consumes about **28,000** input tokens. So the
+proposed design is both **better grounded and roughly half the cost** of current behaviour — because
+the index replaces bulk loading, and history is bounded instead of re-sent whole.
+
+The first four slices are stable between turns, which makes them ideal for prompt caching (cached
+reads run 60–80% cheaper on most hosts).
+
+---
+
+## 4. How big can memory be? Can we provide _everything_?
+
+This is the question that most needs a real answer, so here is the arithmetic.
+
+**The curated memory of an entire organization is small.** A realistic artifact is one to two pages
+— call it 2,000 tokens. A mature organization with a fully populated ontology has perhaps 30 of
+them. That is **~60,000 tokens for everything the organization believes about itself.** Every
+current frontier model has a context window several times larger than that. So yes: technically,
+we could put the organization's entire belief system into every single request.
+
+**The raw substrate is not small, and never will be.** Working from the measured cost model — around
+120 discussion-summary runs and 6 call transcripts per month for a typical space — a single active
+organization generates on the order of **one to three million tokens of chat and transcript per
+year**, growing every year. That is twenty to fifty times the curated corpus in year one alone, and
+the ratio worsens indefinitely.
+
+So the honest formulation of what we can offer:
+
+> **We can give the AI everything the organization _believes_. We can let it query everything the
+> organization has _done_. We will never send it everything the organization has _said_.**
+
+L3 goes in whole (or as an index plus selections). L2 is queried and arrives as aggregates and
+trends. L1 is reachable only by explicit drill-down into a specific transcript or file.
+
+### Why we should not send everything even when we can
+
+There are two arguments, and the weaker one is about money.
+
+**Cost** — at 15,500 tokens per turn a typical space is affordable on any tier; at 60,000+ per turn,
+premium models get expensive fast. But this argument erodes every year as prices fall, so we should
+not build the architecture around it.
+
+**Attention** — this is the durable argument. A model's ability to use a fact _degrades_ as that
+fact is buried in more undifferentiated context. The same document that produces a sharp answer in
+a 4,000-token context produces a vague one inside 60,000 tokens of everything-else. Filling the
+window is not the same as informing the model.
+
+Which yields the principle:
+
+> **Curation is an accuracy requirement, not a cost optimization.**
+
+We keep memory small because it makes the AI _better_, and it happens to also make it cheaper. If
+inference were free tomorrow, this architecture would not change.
+
+---
+
+## 5. How the AI works out what is relevant
+
+Relevance is decided in a fixed order, cheapest and most reliable signals first. A memorable
+shorthand: **pinned, changed, nearby, named, fresh, similar.**
+
+1. **Pinned** — identity, purpose, and charter are always in context. Not a ranking decision.
+2. **Changed** — the activity ledger says what actually moved since this person last looked,
+   weighted by magnitude and by whether it touches an open decision. This is deterministic, and it
+   is where most genuinely useful advice comes from. _Trend beats snapshot._
+3. **Nearby** — artifacts linked to whatever the person is currently looking at: this signal, this
+   proposal, this member. The artifact-to-signal graph already gives us this.
+4. **Named** — the model selects from the always-present index by label. Reliable because the menu
+   is short and well described.
+5. **Fresh** — prefer current over contested; never load superseded versions unless the question is
+   explicitly historical.
+6. **Similar** — semantic search by embedding. **Deliberately last, and not needed yet.** It becomes
+   worthwhile only when the index itself outgrows the budget (order of a hundred-plus artifacts),
+   and even then it should run over artifact _summaries_, not raw text chunks.
+
+Building steps 1–5 first is not a compromise on the way to "real" retrieval. Steps 1–5 are more
+accurate, fully explainable, and free. Step 6 is an optimization for scale we do not have.
+
+---
+
+## 6. How we make the AI intelligent
+
+Four ingredients, and the model is not one of them.
+
+**Grounding — it knows this organization.** Everything it says is anchored in the curated corpus and
+cites what it drew on. An uncited recommendation is an opinion, and the organization already has
+plenty of those.
+
+**Salience — it knows what changed.** Detection comes from thresholds on the activity ledger, not
+from a model. This is the difference between advice and a horoscope. It is worth being explicit
+about how the work divides:
+
+| Job                                  | Do it with                        | Because                                                             |
+| ------------------------------------ | --------------------------------- | ------------------------------------------------------------------- |
+| Detect that something changed        | deterministic rules on the ledger | must be reproducible, auditable, and cheap enough to run constantly |
+| Decide whether it matters            | rules plus organizational context | needs to be inspectable when it gets it wrong                       |
+| Explain what it means and what to do | the language model                | requires judgment and phrasing, which is what models are for        |
+
+Today's system does both jobs with arithmetic, which is why its output reads like a fortune cookie.
+The mistake to avoid next is the mirror image — using a model as the trigger, which is
+non-deterministic, unauditable, and expensive to run continuously.
+
+**Judgment — it knows how this organization decides.** Decision memory means the AI can say "you
+faced this in March, chose that, and here is how it turned out." No general-purpose model has
+access to that, and it is the thing that makes advice feel like it came from a colleague rather
+than a consultant.
+
+**Feedback — it knows whether it was right.** Every proactive recommendation records whether a human
+acted on it. That number is simultaneously our product KPI and the loop's error signal. Below
+roughly a third acceptance, the channel is noise and should be switched off rather than tuned —
+because a low-quality proactive channel is not a neutral placeholder. It spends the attention
+budget you need for the real thing.
+
+And the delivery contract, which is where intelligence becomes visible or fails:
+
+> Every proactive recommendation must name **an owner**, state **one specific next action**, and
+> **cite the evidence** it rests on. If it cannot do all three, it is not sent.
+
+---
+
+## 7. Anti-patterns we are choosing against
+
+Each of these is a plausible, popular design that we are consciously rejecting.
+
+- **Vector-database-first memory.** Opaque, unauditable, unmaintainable by the organization itself.
+  We use readable Markdown that a member can correct. Embeddings are an optimization we add later,
+  if ever.
+- **Letting the AI write memory directly.** Turns model error into institutional belief with no
+  audit trail. Propose-then-approve, always.
+- **A model as the proactive trigger.** Non-deterministic, unexplainable, and costly to run
+  continuously. Rules trigger; models explain.
+- **Unbounded accumulation.** "Store everything, retrieve later" produces a corpus nobody trusts
+  and a retrieval problem that gets harder forever.
+- **Numbers inside memory documents.** Guarantees confident stale answers. Volatile state is always
+  fetched live.
+- **Notification per event.** Destroys the attention budget. Digest, then earn the interrupt.
+- **Escalating by default.** Sending anything uncertain to a vote feels safe and is not. It
+  manufactures approval fatigue, which then degrades the votes that actually matter. Route to the
+  lightest channel that fits — see §8.
+- **Measuring activity.** Artifacts created and messages sent are vanity metrics that actively
+  reward the wrong behaviour. Measure acceptance and outcomes.
+
+---
+
+## 8. Decision rights — what becomes a proposal
+
+An intelligent organization is not one that decides more things together. It is one that knows
+which things need deciding together. If every recommendation can become a proposal, approval
+fatigue sets in, participation collapses, and the votes that genuinely matter get rubber-stamped
+alongside the ones that don't. **Protecting the vote channel is a core architectural concern**, not
+a governance nicety, because the AI will be generating candidate decisions faster than any previous
+system did.
+
+### The wrong test
+
+"Anything involving money is a proposal" is the intuitive rule, and it fails in both directions.
+
+It **under-protects**: the most consequential decisions in a Hypha space are not spends, they are
+rule changes. Altering the voting method, the entry or exit method, or who counts as a member
+reshapes every future decision — which is why the platform already treats those as proposals
+(`change-voting-method`, entry/exit methods, space-to-space membership) alongside the monetary ones
+(`issue-new-token`, `mint-tokens-to-space-treasury`, `token-burning`).
+
+It also **fails to reduce load**: "does money move?" catches every reimbursement, contractor
+invoice, and tool subscription. The overwhelm remains.
+
+### The test
+
+A decision requires a vote only on **yes to both**:
+
+1. **Does it commit shared resources or change shared rules?** Shared means the treasury, the rules
+   of the game, who is a member, or anything binding the organization externally. If no, it is
+   operational and should never reach a vote.
+2. **Is it hard to reverse, or large relative to our capacity?** If no, it belongs to a named owner
+   inside a mandate, with a record.
+
+The first question is a claim about rights — people should have a say over decisions whose
+consequences land on them and who are not otherwise in the room. The second is what keeps that
+principle from consuming the organization.
+
+### The tiers
+
+| Tier | Mechanism                                                              | For                                                         |
+| ---- | ---------------------------------------------------------------------- | ----------------------------------------------------------- |
+| 0    | Just do it, logged to the ledger                                       | Work inside an existing mandate                             |
+| 1    | One named owner approves                                               | Small, reversible, inside a budget envelope                 |
+| 2    | **Visible for N days; proceeds unless someone objects, with a reason** | Most of what gets over-escalated to votes today             |
+| 3    | Vote                                                                   | Shared resources beyond a mandate; rule changes; membership |
+| 4    | Supermajority                                                          | How decisions get made; purpose; exit rights                |
+
+**Tier 2 is the one we do not have, and its absence is the actual cause of the overload.** Most
+organizations offer only two channels — do it quietly, or put it to a vote — and since only the
+second confers legitimacy, everything ambiguous drifts upward. A visible objection window that
+closes in silence gives collective legitimacy without collective effort, and absorbs the majority of
+borderline cases.
+
+### Constituencies, not just thresholds
+
+The tiers above vary _how much_ agreement a decision needs. A second axis varies _whose_ agreement it
+needs, and it is easy to miss because most governance tooling assumes one electorate.
+
+- Operational decisions need the people accountable for the work.
+- Rule changes need the members.
+- **Reserved matters** — changing the purpose, diluting holders, disposing of major assets — need
+  investor or funder consent, which is a different set of people from the members.
+- Decisions that land on the people the organization serves need **beneficiary consultation**, even
+  when those people hold no vote at all.
+
+So a decision class is a pair: a threshold _and_ a constituency. A space today can configure
+`quorum` and `unity`, which addresses the threshold and nothing else — every vote implicitly has the
+same electorate. Supporting the edge stakeholders in
+[User Journeys](../product/user-journeys.md#stakeholders) properly means decision classes can name
+who must consent, not only how many.
+
+The useful discipline: **being heard and having authority are separate grants, and most edge
+stakeholders should get the first without the second.** An investor who can file an observation into
+normal triage is well served. An investor who can direct operations has quietly become management.
+
+### Mandates, not transactions
+
+The highest-leverage move is to change what a vote is _about_.
+
+> **The tier is a property of the decision's relationship to existing mandates, not a property of
+> the request.**
+
+Take "we want feature X, we need developer Y, budget Z". Its tier depends entirely on something
+outside the request:
+
+- A product domain already holds a quarterly envelope and a named owner → **Tier 0/1**. An owner
+  spending their mandate is not a governance event; it is them doing their job.
+- It exceeds the envelope, creates an ongoing obligation rather than a one-off, or is the first hire
+  in a domain nobody owns → **Tier 3**.
+- It needs a domain that does not exist yet → vote on **the mandate**, once. The next thirty
+  decisions inside it are then Tier 0/1.
+
+So one vote on "this domain, this owner, this envelope, this review date" retires dozens of future
+votes. Mandates are the compression mechanism for governance in the same way that L3 artifacts are
+the compression mechanism for memory.
+
+### What this means for the AI
+
+Routing is a more valuable capability than drafting. For every candidate decision the AI should
+propose the **lowest** tier satisfying both questions, name the mandate it believes covers it, and
+treat escalation as the exception it must argue for. A human can always override the routing
+upward; the AI's bias must run downward.
+
+This also yields a governance health metric worth tracking: **what share of votes pass
+near-unanimously with no substantive discussion?** Those were not decisions, they were Tier 2 items
+taxing everyone's attention. A high consensus rate is a symptom of mis-tiered governance, not of a
+healthy organization.
+
+### What the platform would need
+
+Three gaps between this model and what exists today:
+
+- **Per-decision-class thresholds.** `quorum` and `unity` are configurable 0–100, but per _space_,
+  not per decision class. Tiering needs a space to say "spending: 20% quorum; rule changes: 80%".
+- **An objection-window mechanism.** Tier 2 has no implementation today.
+- **A mandate / budget-envelope primitive.** There is nothing for spending to be checked against, so
+  no decision can currently be classified as "inside an existing mandate".
+
+---
+
+## 9. Open questions
+
+Worth resolving before or during build, but not blocking the shape above.
+
+1. **Consolidation cadence and trigger** — calendar rhythm, corpus-size threshold, or steward
+   discretion?
+2. **Per-artifact size limit.** The current cap is 256 KiB, which is roughly 64,000 tokens — a
+   single artifact could consume an entire context budget. For documents intended to be
+   always-loadable, something closer to 4,000–8,000 tokens seems right. What is the enforcement?
+3. **Digest cadence** and whether it is per-person or per-organization.
+4. **Where decision outcomes come from** — inferred from on-chain and ledger state, or explicitly
+   recorded by a human at close-out? Inference scales; explicit recording is accurate.
+5. **Cross-organization memory** — what may be relayed to a parent or sibling space by default, and
+   what requires consent?
+6. **Model routing.** Our cost analysis suggests a premium tier for interactive work and a cheap
+   tier for background jobs lands a typical space at $1–3/month. Which model per tier, and who
+   decides?
+7. **Objection windows.** How long, who may object, and does one reasoned objection escalate to a
+   vote or block outright?
+8. **Mandates as a primitive.** Do mandates and budget envelopes become first-class objects, or are
+   they expressed as memory artifacts that the AI reads and reasons over? The first is enforceable;
+   the second is far cheaper to build.
+9. **Who sets the tier when the AI and a member disagree?** A member can escalate upward, but should
+   anyone be able to route a decision _downward_ out of the vote channel?
+
+---
+
+## Related
+
+- [User Journeys — The Intelligent Organization](../product/user-journeys.md) — what this serves
+- Space Intelligence & Documentation spec — the L3 substrate as specified and built; arrives with
+  [PR #2461](https://github.com/hypha-dao/hypha-web/pull/2461) at `docs/plans/space-intelligence.md`
+- [Documents and media overview](./documents-and-media-overview.md) — where L1 raw media lives
+- [Space Memory panel](../plans/space-memory-panel.md) — current aggregation surface

--- a/docs/architecture/organizational-intelligence.md
+++ b/docs/architecture/organizational-intelligence.md
@@ -396,9 +396,10 @@ The useful discipline: **being heard and having authority are separate grants, a
 stakeholders should get the first without the second.** An investor who can file an observation into
 normal triage is well served. An investor who can direct operations has quietly become management.
 
-**Shaper is itself a grant**, named by the founder at creation. A steward or a contributor can hold
-it; founding the organization does not keep it forever. It is the body that decides strategy, who
-holds a pot of money and how big it is, and organizational memory. They do not sign every payment.
+**Shaper is itself a grant.** The founder names the first set. After that, only Shapers decide who
+is a Shaper. A steward or a contributor can hold it if they are added; founding the organization
+does not keep it forever. Shapers decide strategy, pots, and all organizational memory. They do
+not sign every payment.
 A pot may name cosigners who must release funds; default is none.
 The product list of every decision and who takes it lives in
 [User Journeys — What has to be decided, and by whom](../product/user-journeys.md#what-has-to-be-decided-and-by-whom).
@@ -419,8 +420,7 @@ The same classes, mapped onto this section's tiers:
 | A payment no existing pot covers                                                   | Shapers                                     | 3                  |
 | Issue, mint, or burn tokens; space-to-space membership                             | Shapers                                     | 3                  |
 | Admit or remove a member                                                           | Whatever entry/exit method the founder set  | follows the method |
-| Memory update that changes strategy or purpose                                     | Shapers                                     | 1                  |
-| Memory update in a domain                                                          | Steward of that domain                      | 1                  |
+| Memory update (strategy, purpose, or domain)                                       | Shapers                                     | 1                  |
 | Memory hygiene (unsupported assertion, contradiction)                              | Shapers                                     | 0 / 1              |
 | Purpose change, dilution, major-asset disposal                                     | Shapers **and** investor consent            | 4 + reserved       |
 | Decision that lands on the people the org serves                                   | Shapers decide; beneficiaries consulted     | 3 + heard          |

--- a/docs/architecture/organizational-intelligence.md
+++ b/docs/architecture/organizational-intelligence.md
@@ -444,14 +444,12 @@ So one vote on "this domain, this owner, this envelope, this review date" retire
 votes. Mandates are the compression mechanism for governance in the same way that L3 artifacts are
 the compression mechanism for memory.
 
-**Mandates nest, or the mechanism only works while the org is small.** A steward may carve a
-sub-mandate from their remaining pot — same four fields — without a Shaper vote. Org Shapers see a
-handful of top-level pots; they cannot usefully review fifty. Two or three levels cover a
-10,000-member org without a second funding system. A parent close freezes children. The parent
-steward stays accountable for the whole. The Shaper set does not grow with membership; if it does,
-every mandate is a town meeting again.
+**Same object at 10 members and at 10,000.** With ten people, Shapers fill two or three pots and
+stewards spend. With ten thousand, Shapers still fill a handful of pots; a steward carves
+sub-mandates from their remaining pot (same four fields, no Shaper vote). Parent close freezes
+children. The Shaper set does not grow with membership.
 
-See [Will this still work at 10,000 members?](../product/user-journeys.md#will-this-still-work-at-10000-members).
+See [How it looks with 10 members, and with 10,000](../product/user-journeys.md#how-it-looks-with-10-members-and-with-10000).
 
 ### Where new mandates come from
 

--- a/docs/architecture/organizational-intelligence.md
+++ b/docs/architecture/organizational-intelligence.md
@@ -396,29 +396,30 @@ The useful discipline: **being heard and having authority are separate grants, a
 stakeholders should get the first without the second.** An investor who can file an observation into
 normal triage is well served. An investor who can direct operations has quietly become management.
 
-**Voting power is itself a grant**, configured by the founder at creation — all members, a named
-subset, token holders, or another rule. It is not a property of the contributor role. The product
-list of every decision and who takes it lives in
+**Shaper is itself a grant**, named by the founder at creation. A steward or a contributor can hold
+it; founding the organization does not keep it forever. It is the body that decides strategy,
+funding beyond a mandate, and organizational memory. The product list of every decision and who
+takes it lives in
 [User Journeys — What has to be decided, and by whom](../product/user-journeys.md#what-has-to-be-decided-and-by-whom).
 The same classes, mapped onto this section's tiers:
 
-| Decision class                                                                       | Who decides                                   | Tier               |
-| ------------------------------------------------------------------------------------ | --------------------------------------------- | ------------------ |
-| High-level strategy (purpose, direction, which domains the org needs)                | Founder, at creation and after                | 1                  |
-| Constitution at creation (electorate, entry/exit, first mandates, trust-ladder rung) | Founder, AI proposes                          | —                  |
-| Add, remove, or replace a steward; create or resize a mandate                        | Voting power                                  | 3                  |
-| Change electorate, voting method, purpose, or entry/exit                             | Voting power                                  | 4                  |
-| Green-light a ticket (approve / reject / hold)                                       | Matching steward, before work starts          | 1                  |
-| Spend or commit inside an existing envelope                                          | Steward of that mandate                       | 1                  |
-| New allocation, spend beyond every envelope                                          | Voting power                                  | 3                  |
-| Issue, mint, or burn tokens; space-to-space membership                               | Voting power                                  | 3                  |
-| Admit or remove a member                                                             | Whatever entry/exit method the founder set    | follows the method |
-| Memory update that changes strategy or purpose                                       | Founder                                       | 1                  |
-| Memory update in a domain                                                            | Steward of that domain                        | 1                  |
-| Memory hygiene (unsupported assertion, contradiction)                                | Founder                                       | 0 / 1              |
-| Purpose change, dilution, major-asset disposal                                       | Voting power **and** investor consent         | 4 + reserved       |
-| Decision that lands on the people the org serves                                     | Voting power decides; beneficiaries consulted | 3 + heard          |
-| Claim, decline, or act on approved work; declare capacity                            | The individual                                | —                  |
+| Decision class                                                                     | Who decides                                | Tier               |
+| ---------------------------------------------------------------------------------- | ------------------------------------------ | ------------------ |
+| Constitution at creation (first Shapers, entry/exit, first mandates, trust-ladder) | Founder, AI proposes                       | —                  |
+| High-level strategy (purpose, direction, which domains the org needs)              | Shapers                                    | 1 / 3              |
+| Add, remove, or replace a steward; create or resize a mandate                      | Shapers                                    | 3                  |
+| Change who is a Shaper, voting method, purpose, or entry/exit                      | Shapers                                    | 4                  |
+| Green-light a ticket (approve / reject / hold)                                     | Matching steward, before work starts       | 1                  |
+| Spend or commit inside an existing envelope                                        | Steward of that mandate                    | 1                  |
+| New allocation, spend beyond every envelope                                        | Shapers                                    | 3                  |
+| Issue, mint, or burn tokens; space-to-space membership                             | Shapers                                    | 3                  |
+| Admit or remove a member                                                           | Whatever entry/exit method the founder set | follows the method |
+| Memory update that changes strategy or purpose                                     | Shapers                                    | 1                  |
+| Memory update in a domain                                                          | Steward of that domain                     | 1                  |
+| Memory hygiene (unsupported assertion, contradiction)                              | Shapers                                    | 0 / 1              |
+| Purpose change, dilution, major-asset disposal                                     | Shapers **and** investor consent           | 4 + reserved       |
+| Decision that lands on the people the org serves                                   | Shapers decide; beneficiaries consulted    | 3 + heard          |
+| Claim, decline, or act on approved work; declare capacity                          | The individual                             | —                  |
 
 ### Mandates, not transactions
 

--- a/docs/architecture/organizational-intelligence.md
+++ b/docs/architecture/organizational-intelligence.md
@@ -360,13 +360,13 @@ principle from consuming the organization.
 
 ### The tiers
 
-| Tier | Mechanism                                                              | For                                                         |
-| ---- | ---------------------------------------------------------------------- | ----------------------------------------------------------- |
-| 0    | Just do it, logged to the ledger                                       | Work inside an existing mandate                             |
-| 1    | One named owner approves                                               | Small, reversible, inside a budget envelope                 |
-| 2    | **Visible for N days; proceeds unless someone objects, with a reason** | Most of what gets over-escalated to votes today             |
-| 3    | Vote                                                                   | A payment no pot covers; rule changes; membership           |
-| 4    | Supermajority                                                          | How decisions get made; purpose; exit rights                |
+| Tier | Mechanism                                                              | For                                               |
+| ---- | ---------------------------------------------------------------------- | ------------------------------------------------- |
+| 0    | Just do it, logged to the ledger                                       | Work inside an existing mandate                   |
+| 1    | One named owner approves                                               | Small, reversible, inside a budget envelope       |
+| 2    | **Visible for N days; proceeds unless someone objects, with a reason** | Most of what gets over-escalated to votes today   |
+| 3    | Vote                                                                   | A payment no pot covers; rule changes; membership |
+| 4    | Supermajority                                                          | How decisions get made; purpose; exit rights      |
 
 **Tier 2 is the one we do not have, and its absence is the actual cause of the overload.** Most
 organizations offer only two channels — do it quietly, or put it to a vote — and since only the
@@ -444,6 +444,11 @@ votes. Mandates are the compression mechanism for governance in the same way tha
 the compression mechanism for memory.
 
 ### Where new mandates come from
+
+A mandate is created as **one Shaper decision**, usually on an AI draft: this domain, this steward,
+this pot (which may be zero), this review date. Strategy that is not a job — purpose, who is a
+Shaper, entry rules — stays memory and is not turned into a mandate. If a belief change implies a
+new job, that job is on the same item, not a second vote.
 
 Mandates should be created from observed need, not asserted need. The mechanism is work routing.
 

--- a/docs/architecture/organizational-intelligence.md
+++ b/docs/architecture/organizational-intelligence.md
@@ -76,6 +76,31 @@ live at question time. If a number gets written into a memory document, the AI w
 recite a stale figure forever. Artifacts say _"we are over-exposed to a single funding source"_;
 they never say _"we hold 43,000 USDC"_.
 
+A second rule carries equal weight, and it governs where memory draws its authority from:
+
+> **Deliberative artifacts record what the organization believes about itself. Behavioural evidence
+> records what it did. Where the two disagree, the disagreement is the finding.**
+
+Nearly all of L3 is deliberative — charters, stated risks, standing assessments, proposal text. That
+material is indispensable for interpretation, and it is also the organization's self-image. People
+posture in governance forums, and a proposal records intent rather than outcome. An intelligence
+built mainly from it becomes a very sophisticated model of how a space would like to be seen.
+
+The corrective is behavioural, and in this domain it is unusually good. Treasury movements,
+contributor payments actually made, funds deployed against funds promised, votes cast rather than
+opinions voiced — money is the least dishonest signal an organization emits, and in a DAO it is
+public and cryptographically verifiable rather than merely observed. That is L2, which is why L2
+sitting unused is a foundational gap rather than deferred plumbing.
+
+Two consequences for how the system should behave:
+
+- **Anchor interpretation to evidence.** An L3 claim that no ledger fact supports is an opinion.
+  Assertions that go long enough without behavioural corroboration should be surfaced for review,
+  not quietly retained as fact.
+- **Treat the gap as the product.** The distance between what a space committed to and what its
+  ledger shows it did is the most valuable thing this system can show a member — and it is invisible
+  to everyone today precisely because nobody holds both halves at once.
+
 ---
 
 ## 2. How memory is maintained

--- a/docs/architecture/organizational-intelligence.md
+++ b/docs/architecture/organizational-intelligence.md
@@ -399,29 +399,32 @@ normal triage is well served. An investor who can direct operations has quietly 
 **Shaper is itself a grant**, named by the founder at creation. A steward or a contributor can hold
 it; founding the organization does not keep it forever. It is the body that decides strategy, who
 holds a pot of money and how big it is, and organizational memory. They do not sign every payment.
+A pot may name cosigners who must release funds; default is none.
 The product list of every decision and who takes it lives in
 [User Journeys — What has to be decided, and by whom](../product/user-journeys.md#what-has-to-be-decided-and-by-whom).
 The same classes, mapped onto this section's tiers:
 
-| Decision class                                                                     | Who decides                                | Tier               |
-| ---------------------------------------------------------------------------------- | ------------------------------------------ | ------------------ |
-| Constitution at creation (first Shapers, entry/exit, first mandates, trust-ladder) | Founder, AI proposes                       | —                  |
-| High-level strategy (purpose, direction, which domains the org needs)              | Shapers                                    | 1 / 3              |
-| Add, remove, or replace a steward; create or resize a mandate                      | Shapers                                    | 3                  |
-| Change who is a Shaper, voting method, purpose, or entry/exit                      | Shapers                                    | 4                  |
-| Green-light a ticket (approve / reject / hold)                                     | Matching steward, before work starts       | 1                  |
-| Spend or commit inside an existing envelope                                        | Steward of that mandate                    | 1                  |
-| Fill, refill, enlarge, shrink, or close a top-level pot                            | Shapers                                    | 3                  |
-| Carve a sub-mandate from a remaining pot                                           | Steward of the parent pot                  | 1                  |
-| A payment no existing pot covers                                                   | Shapers                                    | 3                  |
-| Issue, mint, or burn tokens; space-to-space membership                             | Shapers                                    | 3                  |
-| Admit or remove a member                                                           | Whatever entry/exit method the founder set | follows the method |
-| Memory update that changes strategy or purpose                                     | Shapers                                    | 1                  |
-| Memory update in a domain                                                          | Steward of that domain                     | 1                  |
-| Memory hygiene (unsupported assertion, contradiction)                              | Shapers                                    | 0 / 1              |
-| Purpose change, dilution, major-asset disposal                                     | Shapers **and** investor consent           | 4 + reserved       |
-| Decision that lands on the people the org serves                                   | Shapers decide; beneficiaries consulted    | 3 + heard          |
-| Claim, decline, or act on approved work; declare capacity                          | The individual                             | —                  |
+| Decision class                                                                     | Who decides                                 | Tier               |
+| ---------------------------------------------------------------------------------- | ------------------------------------------- | ------------------ |
+| Constitution at creation (first Shapers, entry/exit, first mandates, trust-ladder) | Founder, AI proposes                        | —                  |
+| High-level strategy (purpose, direction, which domains the org needs)              | Shapers                                     | 1 / 3              |
+| Add, remove, or replace a steward; create or resize a mandate                      | Shapers                                     | 3                  |
+| Change who is a Shaper, voting method, purpose, or entry/exit                      | Shapers                                     | 4                  |
+| Green-light a ticket (approve / reject / hold)                                     | Matching steward, before work starts        | 1                  |
+| Spend or commit inside an existing envelope                                        | Steward of that mandate                     | 1                  |
+| Fill, refill, enlarge, shrink, or close a top-level pot                            | Shapers                                     | 3                  |
+| Set, change, or clear cosigners on a pot                                           | Shapers, or the parent steward on a sub-pot | 1 / 3              |
+| Release a payment from a pot that names cosigners                                  | Those cosigners                             | 1                  |
+| Carve a sub-mandate from a remaining pot                                           | Steward of the parent pot                   | 1                  |
+| A payment no existing pot covers                                                   | Shapers                                     | 3                  |
+| Issue, mint, or burn tokens; space-to-space membership                             | Shapers                                     | 3                  |
+| Admit or remove a member                                                           | Whatever entry/exit method the founder set  | follows the method |
+| Memory update that changes strategy or purpose                                     | Shapers                                     | 1                  |
+| Memory update in a domain                                                          | Steward of that domain                      | 1                  |
+| Memory hygiene (unsupported assertion, contradiction)                              | Shapers                                     | 0 / 1              |
+| Purpose change, dilution, major-asset disposal                                     | Shapers **and** investor consent            | 4 + reserved       |
+| Decision that lands on the people the org serves                                   | Shapers decide; beneficiaries consulted     | 3 + heard          |
+| Claim, decline, or act on approved work; declare capacity                          | The individual                              | —                  |
 
 ### Mandates, not transactions
 
@@ -446,7 +449,8 @@ the compression mechanism for memory.
 
 **Same object at 10 members and at 10,000.** With ten people, Shapers fill two or three pots and
 stewards spend. With ten thousand, Shapers still fill a handful of pots; a steward carves
-sub-mandates from their remaining pot (same four fields, no Shaper vote). Parent close freezes
+sub-mandates from their remaining pot (same fields, no Shaper vote; they may add a cosigner on
+what they carve). Parent close freezes
 children. The Shaper set does not grow with membership.
 
 See [How it looks with 10 members, and with 10,000](../product/user-journeys.md#how-it-looks-with-10-members-and-with-10000).
@@ -454,7 +458,8 @@ See [How it looks with 10 members, and with 10,000](../product/user-journeys.md#
 ### Where new mandates come from
 
 A mandate is created as **one Shaper decision**, usually on an AI draft: this domain, this steward,
-this pot (which may be zero), this review date. Strategy that is not a job — purpose, who is a
+this pot (which may be zero), this review date, and optionally who must cosign. Strategy that is
+not a job — purpose, who is a
 Shaper, entry rules — stays memory and is not turned into a mandate. If a belief change implies a
 new job, that job is on the same item, not a second vote.
 

--- a/docs/architecture/organizational-intelligence.md
+++ b/docs/architecture/organizational-intelligence.md
@@ -397,8 +397,8 @@ the compression mechanism for memory.
 Mandates should be created from observed need, not asserted need. The mechanism is work routing.
 
 When the system detects that something needs doing, it matches the work to a person using stated
-skills and mandates (L3), plus demonstrated history and current load (L2). Most of the time it finds
-someone. The interesting case is when it does not.
+skills and mandates (L3) plus demonstrated history (L2), then checks the match against that person's
+**declared** capacity. Most of the time it finds someone. The interesting case is when it does not.
 
 **Unmatched work is a measurement, not a failure.** Left alone, unrouteable work silently lands on
 whoever is most responsive, which hides the shortage and burns out the conscientious. Instead it
@@ -409,7 +409,7 @@ That aggregate is the evidence base for a Tier 3 proposal to create a mandate �
 an envelope, a review date. It is the answer to "how do we know we need to hire?" and it means the
 proposal arrives with a demonstrated pattern attached rather than someone's conviction.
 
-Two constraints on the matcher itself:
+Three constraints on the matcher itself:
 
 - **Propose, do not allocate.** In a voluntary organization work cannot be assigned, only made
   visible to the person most likely to take it. Suggested owner, reasoning shown, claimable by
@@ -417,6 +417,12 @@ Two constraints on the matcher itself:
 - **Reserve a minority of routing for stretch matches.** Matching purely on demonstrated history
   ossifies roles and quietly creates single points of failure. Capabilities held by exactly one
   person are a risk the system is well placed to notice and surface.
+- **Capacity is declared, not inferred.** Do not build a load model. Most of what constrains a
+  contributor is off-platform and therefore unmeasurable here, and the tempting proxy — open item
+  count — penalises whoever takes on slow work. Store a coarse, revisable, self-set limit; use it to
+  gate flow rather than to score fit; and let observation surface a discrepancy to the person
+  without ever overriding them. "Everyone who fits is at their self-set limit" is then a first-class
+  capacity signal, and a much more honest one than an inferred number.
 
 ### What this means for the AI
 

--- a/docs/architecture/organizational-intelligence.md
+++ b/docs/architecture/organizational-intelligence.md
@@ -411,7 +411,8 @@ The same classes, mapped onto this section's tiers:
 | Change who is a Shaper, voting method, purpose, or entry/exit                      | Shapers                                    | 4                  |
 | Green-light a ticket (approve / reject / hold)                                     | Matching steward, before work starts       | 1                  |
 | Spend or commit inside an existing envelope                                        | Steward of that mandate                    | 1                  |
-| Fill, refill, enlarge, shrink, or close a pot                                      | Shapers                                    | 3                  |
+| Fill, refill, enlarge, shrink, or close a top-level pot                            | Shapers                                    | 3                  |
+| Carve a sub-mandate from a remaining pot                                           | Steward of the parent pot                  | 1                  |
 | A payment no existing pot covers                                                   | Shapers                                    | 3                  |
 | Issue, mint, or burn tokens; space-to-space membership                             | Shapers                                    | 3                  |
 | Admit or remove a member                                                           | Whatever entry/exit method the founder set | follows the method |
@@ -442,6 +443,15 @@ outside the request:
 So one vote on "this domain, this owner, this envelope, this review date" retires dozens of future
 votes. Mandates are the compression mechanism for governance in the same way that L3 artifacts are
 the compression mechanism for memory.
+
+**Mandates nest, or the mechanism only works while the org is small.** A steward may carve a
+sub-mandate from their remaining pot — same four fields — without a Shaper vote. Org Shapers see a
+handful of top-level pots; they cannot usefully review fifty. Two or three levels cover a
+10,000-member org without a second funding system. A parent close freezes children. The parent
+steward stays accountable for the whole. The Shaper set does not grow with membership; if it does,
+every mandate is a town meeting again.
+
+See [Will this still work at 10,000 members?](../product/user-journeys.md#will-this-still-work-at-10000-members).
 
 ### Where new mandates come from
 

--- a/docs/architecture/organizational-intelligence.md
+++ b/docs/architecture/organizational-intelligence.md
@@ -405,26 +405,26 @@ The product list of every decision and who takes it lives in
 [User Journeys — What has to be decided, and by whom](../product/user-journeys.md#what-has-to-be-decided-and-by-whom).
 The same classes, mapped onto this section's tiers:
 
-| Decision class                                                                     | Who decides                                 | Tier               |
-| ---------------------------------------------------------------------------------- | ------------------------------------------- | ------------------ |
-| Constitution at creation (first Shapers, entry/exit, first mandates, trust-ladder) | Founder, AI proposes                        | —                  |
-| High-level strategy (purpose, direction, which domains the org needs)              | Shapers                                     | 1 / 3              |
-| Add, remove, or replace a steward; create or resize a mandate                      | Shapers                                     | 3                  |
-| Change who is a Shaper, voting method, purpose, or entry/exit                      | Shapers                                     | 4                  |
-| Green-light a ticket (approve / reject / hold)                                     | Matching steward, before work starts        | 1                  |
-| Spend or commit inside an existing envelope                                        | Steward of that mandate                     | 1                  |
-| Fill, refill, enlarge, shrink, or close a top-level pot                            | Shapers                                     | 3                  |
-| Set, change, or clear cosigners on a pot                                           | Shapers, or the parent steward on a sub-pot | 1 / 3              |
-| Release a payment from a pot that names cosigners                                  | Those cosigners                             | 1                  |
-| Carve a sub-mandate from a remaining pot                                           | Steward of the parent pot                   | 1                  |
-| A payment no existing pot covers                                                   | Shapers                                     | 3                  |
-| Issue, mint, or burn tokens; space-to-space membership                             | Shapers                                     | 3                  |
-| Admit or remove a member                                                           | Whatever entry/exit method the founder set  | follows the method |
-| Memory update (strategy, purpose, or domain)                                       | Shapers                                     | 1                  |
-| Memory hygiene (unsupported assertion, contradiction)                              | Shapers                                     | 0 / 1              |
-| Purpose change, dilution, major-asset disposal                                     | Shapers **and** investor consent            | 4 + reserved       |
-| Decision that lands on the people the org serves                                   | Shapers decide; beneficiaries consulted     | 3 + heard          |
-| Claim, decline, or act on approved work; declare capacity                          | The individual                              | —                  |
+| Decision class                                                        | Who decides                                 | Tier               |
+| --------------------------------------------------------------------- | ------------------------------------------- | ------------------ |
+| Constitution at creation (first Shapers, entry/exit, first mandates)  | Founder, AI proposes                        | —                  |
+| High-level strategy (purpose, direction, which domains the org needs) | Shapers                                     | 1 / 3              |
+| Add, remove, or replace a steward; create or resize a mandate         | Shapers                                     | 3                  |
+| Change who is a Shaper, voting method, purpose, or entry/exit         | Shapers                                     | 4                  |
+| Green-light a ticket (approve / reject / hold)                        | Matching steward, before work starts        | 1                  |
+| Spend or commit inside an existing envelope                           | Steward of that mandate                     | 1                  |
+| Fill, refill, enlarge, shrink, or close a top-level pot               | Shapers                                     | 3                  |
+| Set, change, or clear cosigners on a pot                              | Shapers, or the parent steward on a sub-pot | 1 / 3              |
+| Release a payment from a pot that names cosigners                     | Those cosigners                             | 1                  |
+| Carve a sub-mandate from a remaining pot                              | Steward of the parent pot                   | 1                  |
+| A payment no existing pot covers                                      | Shapers                                     | 3                  |
+| Issue, mint, or burn tokens; space-to-space membership                | Shapers                                     | 3                  |
+| Admit or remove a member                                              | Whatever entry/exit method the founder set  | follows the method |
+| Memory update (strategy, purpose, or domain)                          | Shapers                                     | 1                  |
+| Memory hygiene (unsupported assertion, contradiction)                 | Shapers                                     | 0 / 1              |
+| Purpose change, dilution, major-asset disposal                        | Shapers **and** investor consent            | 4 + reserved       |
+| Decision that lands on the people the org serves                      | Shapers decide; beneficiaries consulted     | 3 + heard          |
+| Claim, decline, or act on approved work; declare capacity             | The individual                              | —                  |
 
 ### Mandates, not transactions
 

--- a/docs/architecture/organizational-intelligence.md
+++ b/docs/architecture/organizational-intelligence.md
@@ -469,14 +469,12 @@ When the system detects that something needs doing, it matches the work to a per
 skills and mandates (L3) plus demonstrated history (L2), then checks the match against that person's
 **declared** capacity. Most of the time it finds someone. The interesting case is when it does not.
 
-**Unmatched work is a measurement, not a failure.** Left alone, unrouteable work silently lands on
-whoever is most responsive, which hides the shortage and burns out the conscientious. Instead it
-should stay open, labelled with the capability it needs, and **aggregate**. Three unfilled tasks in
-one domain over a month is not three problems; it is one role that does not exist yet.
-
-That aggregate is the evidence base for a Tier 3 proposal to create a mandate — a domain, an owner,
-an envelope, a review date. It is the answer to "how do we know we need to hire?" and it means the
-proposal arrives with a demonstrated pattern attached rather than someone's conviction.
+**A ticket with no steward is a measurement, not a failure — and it is enough.** Left alone,
+unrouteable work silently lands on whoever is most responsive, which hides the shortage and burns
+out the conscientious. The AI must draft a mandate for the Shapers on that first ticket: this
+domain, a steward if it can name one, this pot, this review date. Further tickets in the same gap
+attach to the same open proposal; they do not open a second vote, and they do not wait to
+accumulate before the first one is filed.
 
 Three constraints on the matcher itself:
 

--- a/docs/architecture/organizational-intelligence.md
+++ b/docs/architecture/organizational-intelligence.md
@@ -365,7 +365,7 @@ principle from consuming the organization.
 | 0    | Just do it, logged to the ledger                                       | Work inside an existing mandate                             |
 | 1    | One named owner approves                                               | Small, reversible, inside a budget envelope                 |
 | 2    | **Visible for N days; proceeds unless someone objects, with a reason** | Most of what gets over-escalated to votes today             |
-| 3    | Vote                                                                   | Shared resources beyond a mandate; rule changes; membership |
+| 3    | Vote                                                                   | A payment no pot covers; rule changes; membership           |
 | 4    | Supermajority                                                          | How decisions get made; purpose; exit rights                |
 
 **Tier 2 is the one we do not have, and its absence is the actual cause of the overload.** Most
@@ -397,9 +397,9 @@ stakeholders should get the first without the second.** An investor who can file
 normal triage is well served. An investor who can direct operations has quietly become management.
 
 **Shaper is itself a grant**, named by the founder at creation. A steward or a contributor can hold
-it; founding the organization does not keep it forever. It is the body that decides strategy,
-funding beyond a mandate, and organizational memory. The product list of every decision and who
-takes it lives in
+it; founding the organization does not keep it forever. It is the body that decides strategy, who
+holds a pot of money and how big it is, and organizational memory. They do not sign every payment.
+The product list of every decision and who takes it lives in
 [User Journeys — What has to be decided, and by whom](../product/user-journeys.md#what-has-to-be-decided-and-by-whom).
 The same classes, mapped onto this section's tiers:
 
@@ -411,7 +411,8 @@ The same classes, mapped onto this section's tiers:
 | Change who is a Shaper, voting method, purpose, or entry/exit                      | Shapers                                    | 4                  |
 | Green-light a ticket (approve / reject / hold)                                     | Matching steward, before work starts       | 1                  |
 | Spend or commit inside an existing envelope                                        | Steward of that mandate                    | 1                  |
-| New allocation, spend beyond every envelope                                        | Shapers                                    | 3                  |
+| Fill, refill, enlarge, shrink, or close a pot                                      | Shapers                                    | 3                  |
+| A payment no existing pot covers                                                   | Shapers                                    | 3                  |
 | Issue, mint, or burn tokens; space-to-space membership                             | Shapers                                    | 3                  |
 | Admit or remove a member                                                           | Whatever entry/exit method the founder set | follows the method |
 | Memory update that changes strategy or purpose                                     | Shapers                                    | 1                  |

--- a/docs/architecture/organizational-intelligence.md
+++ b/docs/architecture/organizational-intelligence.md
@@ -396,6 +396,30 @@ The useful discipline: **being heard and having authority are separate grants, a
 stakeholders should get the first without the second.** An investor who can file an observation into
 normal triage is well served. An investor who can direct operations has quietly become management.
 
+**Voting power is itself a grant**, configured by the founder at creation — all members, a named
+subset, token holders, or another rule. It is not a property of the contributor role. The product
+list of every decision and who takes it lives in
+[User Journeys — What has to be decided, and by whom](../product/user-journeys.md#what-has-to-be-decided-and-by-whom).
+The same classes, mapped onto this section's tiers:
+
+| Decision class                                                                       | Who decides                                   | Tier               |
+| ------------------------------------------------------------------------------------ | --------------------------------------------- | ------------------ |
+| High-level strategy (purpose, direction, which domains the org needs)                | Founder, at creation and after                | 1                  |
+| Constitution at creation (electorate, entry/exit, first mandates, trust-ladder rung) | Founder, AI proposes                          | —                  |
+| Add, remove, or replace a steward; create or resize a mandate                        | Voting power                                  | 3                  |
+| Change electorate, voting method, purpose, or entry/exit                             | Voting power                                  | 4                  |
+| Green-light a ticket (approve / reject / hold)                                       | Matching steward, before work starts          | 1                  |
+| Spend or commit inside an existing envelope                                          | Steward of that mandate                       | 1                  |
+| New allocation, spend beyond every envelope                                          | Voting power                                  | 3                  |
+| Issue, mint, or burn tokens; space-to-space membership                               | Voting power                                  | 3                  |
+| Admit or remove a member                                                             | Whatever entry/exit method the founder set    | follows the method |
+| Memory update that changes strategy or purpose                                       | Founder                                       | 1                  |
+| Memory update in a domain                                                            | Steward of that domain                        | 1                  |
+| Memory hygiene (unsupported assertion, contradiction)                                | Founder                                       | 0 / 1              |
+| Purpose change, dilution, major-asset disposal                                       | Voting power **and** investor consent         | 4 + reserved       |
+| Decision that lands on the people the org serves                                     | Voting power decides; beneficiaries consulted | 3 + heard          |
+| Claim, decline, or act on approved work; declare capacity                            | The individual                                | —                  |
+
 ### Mandates, not transactions
 
 The highest-leverage move is to change what a vote is _about_.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Documentation Hub"
+title: 'Documentation Hub'
 date: 2026-03-29
 status: final
 tags: [index, documentation]
@@ -15,29 +15,30 @@ Central index for all project documentation.
 
 The product intent and the memory architecture that serves it. Read these two together.
 
-| Document | Description | Status |
-|---|---|---|
-| [User Journeys](./product/user-journeys.md) | Target-state journeys per stakeholder: how we intend people to use Hypha once the intelligent organization works | draft |
-| [Organizational Intelligence — Memory Architecture](./architecture/organizational-intelligence.md) | How memory is maintained and retrieved, how large it can get, how the AI determines relevance, and which decisions need a vote | draft |
+| Document                                                                                           | Description                                                                                   | Status |
+| -------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- | ------ |
+| [User Journeys](./product/user-journeys.md)                                                        | Target-state journeys: roles, decisions, funding — how we intend people to use Hypha          | draft  |
+| [User Journeys — UI and flows](./product/user-journeys-ux.md)                                      | Screen-by-screen flows: join, become steward or contributor, and the three homes              | draft  |
+| [Organizational Intelligence — Memory Architecture](./architecture/organizational-intelligence.md) | How memory is maintained and retrieved, how large it can get, how the AI determines relevance | draft  |
 
 ## Plans
 
 Active implementation plans and feature roadmaps.
 
-| Document | Description | Status |
-|---|---|---|
-| [Coherence Research](./plans/coherence-research.md) | Reference implementation analysis for the coherence screen feature | final |
-| [Coherence Incremental Plan](./plans/coherence-incremental-plan.md) | Step-by-step implementation plan (storage → core → epics → routes → nav) | final |
-| [Coherence Chat Panel Research](./plans/coherence-chat-panel-research.md) | Architecture research for integrating coherence chat into the Human Right Panel | final |
-| [Coherence Chat Panel Plan](./plans/coherence-chat-panel-plan.md) | Step-by-step plan to open coherence chats in the right panel sidebar (6 steps) | draft |
+| Document                                                                  | Description                                                                     | Status |
+| ------------------------------------------------------------------------- | ------------------------------------------------------------------------------- | ------ |
+| [Coherence Research](./plans/coherence-research.md)                       | Reference implementation analysis for the coherence screen feature              | final  |
+| [Coherence Incremental Plan](./plans/coherence-incremental-plan.md)       | Step-by-step implementation plan (storage → core → epics → routes → nav)        | final  |
+| [Coherence Chat Panel Research](./plans/coherence-chat-panel-research.md) | Architecture research for integrating coherence chat into the Human Right Panel | final  |
+| [Coherence Chat Panel Plan](./plans/coherence-chat-panel-plan.md)         | Step-by-step plan to open coherence chats in the right panel sidebar (6 steps)  | draft  |
 
 ## Requirements
 
 Feature requirements and specifications are in [docs/requirements/](./requirements/).
 
-| Document | Description |
-|----------|-------------|
-| [MCP `get_documents_by_space_slug`](./requirements/mcp-get-documents-by-space-slug-tech-spec.md) | MCP read tool for space documents (DB + access parity); **§8** org memory roadmap (upload URLs today; Matrix via catalogue) |
-| [Chat AI `get_documents_by_space_slug`](./requirements/chat-ai-get-documents-by-space-slug-integration.md) | Hypha AI / chat-server integration; prompt + fetch guidance for **attachments** / org memory alignment |
-| [Documents and media overview](./architecture/documents-and-media-overview.md) | **§4** org memory + **§4.7** MCP / Chat AI |
-| [Space Memory panel](./plans/space-memory-panel.md) | Coherence UI plan; **§9** MCP / Chat |
+| Document                                                                                                   | Description                                                                                                                 |
+| ---------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| [MCP `get_documents_by_space_slug`](./requirements/mcp-get-documents-by-space-slug-tech-spec.md)           | MCP read tool for space documents (DB + access parity); **§8** org memory roadmap (upload URLs today; Matrix via catalogue) |
+| [Chat AI `get_documents_by_space_slug`](./requirements/chat-ai-get-documents-by-space-slug-integration.md) | Hypha AI / chat-server integration; prompt + fetch guidance for **attachments** / org memory alignment                      |
+| [Documents and media overview](./architecture/documents-and-media-overview.md)                             | **§4** org memory + **§4.7** MCP / Chat AI                                                                                  |
+| [Space Memory panel](./plans/space-memory-panel.md)                                                        | Coherence UI plan; **§9** MCP / Chat                                                                                        |

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,15 @@ Central index for all project documentation.
 
 ---
 
+## Start here — Intelligent Organization
+
+The product intent and the memory architecture that serves it. Read these two together.
+
+| Document | Description | Status |
+|---|---|---|
+| [User Journeys](./product/user-journeys.md) | Target-state journeys per stakeholder: how we intend people to use Hypha once the intelligent organization works | draft |
+| [Organizational Intelligence — Memory Architecture](./architecture/organizational-intelligence.md) | How memory is maintained and retrieved, how large it can get, how the AI determines relevance, and which decisions need a vote | draft |
+
 ## Plans
 
 Active implementation plans and feature roadmaps.

--- a/docs/product/user-journeys-ux.md
+++ b/docs/product/user-journeys-ux.md
@@ -1,0 +1,339 @@
+---
+title: 'User Journeys — UI and flows'
+date: 2026-08-22
+status: draft
+tags: [product, journeys, ux, intelligent-org]
+---
+
+# User Journeys — UI and flows
+
+How the intelligent organization **looks and moves** on screen. Companion to the
+[product brief](./user-journeys.md) (roles, decisions, funding) and the
+[architecture](../architecture/organizational-intelligence.md).
+
+This file is the one to use when designing or building a flow. Each journey is a path through
+screens, not a principle.
+
+---
+
+## How someone gets a hat
+
+Hats are granted. Joining the org does not make you a contributor or a steward.
+
+```
+Outsider
+   │  open entry, or request + accept
+   ▼
+Member          — inside the space; no work queue yet
+   │
+   ├─ Shapers offer a mandate ──────────────► Steward
+   │                                            │
+   └─ A steward invites them to do work ──────► Contributor
+```
+
+- **Member** — they got in. They can read what members may read, and they can be offered a hat.
+- **Contributor** — a steward invited them to do work in that steward's domain. They now have
+  **What needs me?**
+- **Steward** — Shapers offered them a mandate (job, pot, review date) and they accepted. They now
+  have **What is waiting on me?**
+- **Shaper** — named at founding, or added later by existing Shapers. They have **What needs a
+  Shaper?**
+
+One person can hold several hats. Each hat is a **separate home**. Switching hats switches the
+first screen, it does not dump every queue into one list.
+
+---
+
+## The three homes
+
+After the person is in, almost every later flow lands on one of these. Design them first.
+
+| Home                       | Who sees it  | First line                                           | Primary actions                               |
+| -------------------------- | ------------ | ---------------------------------------------------- | --------------------------------------------- |
+| **What needs me?**         | Contributors | One ticket, or "Nothing needs you"                   | Claim / decline / act                         |
+| **What is waiting on me?** | Stewards     | Tickets to green-light, pot remaining                | Approve / reject / hold / change person / pay |
+| **What needs a Shaper?**   | Shapers      | Mandates, memory, pots — or "Nothing needs a Shaper" | Approve / amend / reject                      |
+
+A member with no hat yet sees **Your space** — purpose, who is here, open work they could be
+invited onto — not an empty contributor queue. The invite is how they get a queue.
+
+---
+
+## 1. Founder creates the organization
+
+**Who:** someone with a purpose and no space yet.
+**Starts:** "Create a space" from the signed-in home.
+
+1. **Conversation, not a form.** Full-width chat. The AI asks the [founding questions](./user-journeys.md#journey-1--the-founder-starts-an-organization)
+   in their language. One question at a time. They can skip.
+2. **Side panel fills as they talk.** Purpose, who it is for, boundaries, 90-day objectives, first
+   Shapers, first mandates — each as a card that appears when that answer exists. Empty cards stay
+   empty. No invented legal steward.
+3. **Review screen.** Every card with a confirm control. They edit in place. Naming themselves a
+   Shaper is a checkbox, off unless they turn it on.
+4. **Entry method.** Two clear choices: _Anyone can join_ or _People request, Shapers accept_.
+   Not a dropdown of ten governance modes.
+5. **Create.** They land in the new space on **What needs a Shaper?** if they took that hat, else
+   on **Your space**.
+
+**If they quit mid-conversation:** draft space, resume the same thread.
+
+---
+
+## 2. Someone joins — entry is open
+
+**Who:** a prospect who has decided this space is real.
+**Starts:** public space page.
+
+1. **Public brief.** What this org is for, what it has actually done, what is still open, what
+   is unresolved. Generated from memory. A list of **open work nobody holds** — the same list as
+   unmatched tickets — with "this needs someone who can X".
+2. **Join.** One button. No application essay.
+3. **You're in.** They land on **Your space**. They are a **member**. They do not yet have
+   **What needs me?** A short line: "A steward can invite you to work. You can say yes or no."
+4. If they tapped a specific open ticket on the public page, that ticket is pinned on **Your
+   space** as "you said you were interested" — a hint for the steward, not an assignment.
+
+---
+
+## 3. Someone asks to join — entry is request-only
+
+**Who:** a prospect; Shapers on the other side.
+**Starts:** same public brief, button reads **Request to join**.
+
+1. Prospect writes a short note (optional) and can point at one open ticket. Submit.
+2. They see **Request sent** and can leave. No fake "member" view.
+3. Each Shaper's **What needs a Shaper?** gets a card: this person, their note, the ticket they
+   pointed at, "Accept" / "Decline" / "Ask a question".
+4. **Accept.** They become a member. They get **Your space**. If they pointed at a ticket, the
+   matching steward sees "this new member is interested in X" on that ticket — still not a
+   contributor until invited.
+5. **Decline.** Prospect sees a short reason if the Shaper wrote one. No further access.
+
+One Shaper accept is enough unless the space was founded with a harder rule. Do not send join
+requests to every member.
+
+---
+
+## 4. A member becomes a steward
+
+**Who:** Shapers offer; a member (or contributor) accepts.
+**Starts:** Shapers decide a mandate is needed — founding review, or an unplaced ticket the AI
+already drafted.
+
+1. **Shaper sees a mandate card.** Domain, proposed person, pot, review date, optional cosigners.
+   Person is a typeahead of members. AI may have pre-filled a name. They can change it, change the
+   pot, add a cosigner, or pick _open — no one yet_.
+2. **Offer.** The named person gets a distinct screen, not a buried notification: **You are being
+   asked to hold [domain].** The mandate in plain language, the pot, the review date, who the
+   Shapers are, what they would be saying yes to (green-light work, spend this pot, not write
+   memory).
+3. **Accept.** They become a steward. Next open of the app is **What is waiting on me?** Any
+   tickets already waiting in that domain are there, each with a recommended contributor.
+4. **Decline.** They write a short why if they want. The mandate card returns to Shapers with that
+   note. The job stays open. They remain a member (or contributor). Nothing is taken from them.
+
+Shapers do not "assign" a steward. They offer. The person has to take the hat.
+
+---
+
+## 5. A member becomes a contributor
+
+**Who:** a steward invites; a member accepts.
+**Starts:** steward is looking at a ticket, or at **People in this domain**.
+
+**From a ticket**
+
+1. Steward has a ticket with a recommended person. If that person is already a contributor in
+   this domain, confirming the ticket is enough — it goes to **What needs me?**
+2. If the recommended person is only a **member**, the steward sees **Invite to contribute**
+   instead of a silent assign. One extra step: "Ask [name] to take work in [domain]." Optional
+   note.
+3. The member gets **[Steward] is asking you to contribute on [domain].** First ticket shown
+   underneath, already drafted. **Accept** / **Not now**.
+4. **Accept.** They become a contributor. The ticket is the first item on **What needs me?**
+5. **Not now.** Ticket returns to the steward with the name cleared. They pick someone else or
+   leave it open.
+
+**From the people list**
+
+Steward opens **People** → a member → **Invite to contribute**. No ticket required. The member
+accepts and then has an empty **What needs me?** until a ticket is green-lit to them.
+
+A contributor is per domain, not a global badge. Being invited by the community steward does not
+put treasury tickets on their queue.
+
+---
+
+## 6. Contributor — do the next thing
+
+**Who:** a contributor.
+**Starts:** they open the space (or a push if something urgent and theirs).
+
+1. **What needs me?**
+   - Empty: "Nothing needs you." In-progress work, if any, listed below.
+   - One card on top: title, why them (one line), next action, steward who approved it.
+2. They tap the card. **Ticket screen:** the draft, the evidence, **Claim** / **Decline** /
+   **Start**.
+3. **Decline** asks _not my thing_ or _no room right now_, then they can change their capacity
+   (a small number: "up to N things at once").
+4. **Start** opens the draft in place. They edit. **Done** marks it finished. Steward sees it
+   completed on the ticket; they do not re-approve unless that mandate said so.
+5. **Why is this?** on the ticket opens a short answer with citations into memory and the
+   mandate — not a chat dump.
+
+If they are also a steward, a switch at the top takes them to **What is waiting on me?** It does
+not mix the two lists.
+
+---
+
+## 7. Steward — green-light and spend
+
+**Who:** a steward.
+**Starts:** they open the space.
+
+1. **What is waiting on me?** Two strips:
+   - **Tickets** — count waiting, first card visible.
+   - **Pot** — remaining / total, next review date, cosign pending if any.
+2. They open a ticket. Recommended contributor, why, draft. Actions: **Approve** / **Reject** /
+   **Hold** / **Change person**. Hold requires a date or a condition.
+3. **Approve** sends it to that contributor's **What needs me?** (or starts the invite in
+   [flow 5](#5-a-member-becomes-a-contributor) if they are only a member).
+4. **Change person** is a member/contributor picker in this domain. Same invite rule.
+5. **Pot.** List of payments. **New payment** — amount, to whom, for which ticket (optional).
+   If this pot has cosigners, the payment sits as **Waiting for release** until they sign. The
+   steward is not blocked from preparing the next one.
+6. **Carve a pot** (if they have room): same four fields, smaller. The child appears under their
+   pot. Org Shapers do not get a card.
+
+A ticket with no steward for any domain does **not** appear here.
+
+---
+
+## 8. Shaper — decide the next structural thing
+
+**Who:** a Shaper.
+**Starts:** they open the space.
+
+1. **What needs a Shaper?** If empty: "Nothing needs a Shaper." They can still open pots, memory,
+   and people from a quieter secondary nav.
+2. Cards, one kind per row:
+   - **Mandate to offer** (unplaced ticket, or a Shaper-started draft)
+   - **Join request** (only if entry is gated)
+   - **Memory to confirm or retire**
+   - **Cosign waiting** (only if they are named on that pot)
+   - **Shaper change** (rare)
+3. They open a mandate card, edit fields, **Offer** (flow 4) or **Reject** (ticket stays open,
+   labelled, not assigned to them).
+4. They open a memory card. Diff of the proposed belief. **Write** / **Edit** / **Dismiss**.
+   Dismiss is recorded.
+5. They open **Pots** from secondary nav to refill or add a cosigner — not because a payment
+   needs them, because they chose to look.
+
+They never see contributor tickets on this home.
+
+---
+
+## 9. No steward for a ticket
+
+**Who:** AI, then Shapers, then the person who is offered the mandate.
+
+1. A need is detected. No mandate covers it. **No steward queue.**
+2. AI files one mandate card on **What needs a Shaper?** Ticket is attached underneath.
+3. A second ticket in the same gap attaches to the **same** card.
+4. Shapers offer the mandate ([flow 4](#4-a-member-becomes-a-steward)).
+5. On accept, those attached tickets move to the new steward's **What is waiting on me?**, each
+   still carrying a recommended contributor.
+
+---
+
+## 10. Pay from a pot, with and without a cosigner
+
+**Without cosigner**
+
+Steward: pot → new payment → confirm. Ledger updates. Shapers do not get a card. Anyone can open
+the payment from the public ledger if they go looking.
+
+**With cosigner**
+
+1. Steward creates the payment. Status: **Waiting for release**.
+2. Named cosigners get a card on **What needs a Shaper?** (or a dedicated **To release** if they
+   are not Shapers — a trusted body can be a cosigner without that hat).
+3. **Release** or **Refuse**. Refuse returns the payment to the steward with a reason.
+4. On release, money moves.
+
+---
+
+## 11. Investor or funder looks in
+
+**Who:** someone with capital at risk, no operational hat.
+**Starts:** a link the space gave them, or their list of spaces.
+
+1. **Overview** — not a member home. Four blocks: what we said, what we did, the pots, what
+   changed since they last opened. Bad news first if there is any.
+2. They can **set a watch** on a line ("runway under six months", "this pot hits 80%"). That is
+   the only interrupt they should get.
+3. **Ask** files an observation onto the Shaper or steward queue as a question, never as a
+   ticket they assigned.
+4. Reserved matter (purpose, dilution, major asset): they see **Your consent is needed** with
+   the same draft the Shapers see. **Consent** / **Object**.
+
+They cannot open **What needs me?** or green-light a ticket.
+
+---
+
+## 12. Beneficiary reports an outcome
+
+**Who:** someone the org exists to serve, not a member.
+**Starts:** a short public link, no account required if the space allows it.
+
+1. One screen: "Did [this] help?" Yes / partly / no, plus optional note.
+2. That report attaches to the mandate and to decision memory. Shapers see a memory card if the
+   report contradicts a belief. Steward sees it on the review-date view of their pot.
+3. Next time that beneficiary opens the link, they see **what changed from what you said** if
+   anything did. If nothing did, the space should not ask again yet.
+
+---
+
+## 13. Someone puts a hat down
+
+**Contributor** leaves a domain: from **What needs me?** → **Stop contributing here**. Open
+tickets they hold go back to the steward. They stay a member.
+
+**Steward** resigns: from **What is waiting on me?** → **Put this mandate down**. Waiting tickets
+freeze and the mandate card returns to Shapers as "needs a steward". The pot freezes. They do not
+pick their successor.
+
+**Shaper** is removed only by other Shapers ([flow 8](#8-shaper--decide-the-next-structural-thing)).
+They cannot remove the last Shaper.
+
+---
+
+## 14. One person, three hats
+
+Sam is a Shaper, the community steward, and a contributor on product.
+
+- Open the space → last hat they used, with a **switch** (Contributor / Steward / Shaper).
+- **Contributor:** product tickets only.
+- **Steward:** community green-lights and the community pot.
+- **Shaper:** mandates, memory, top-level pots.
+
+A community ticket they should green-light never appears on their contributor home. A Shaper
+mandate never appears on their steward home. The switch is how we keep "Nothing needs you" honest.
+
+---
+
+## What not to build
+
+- One inbox that mixes join requests, tickets, payments, and memory diffs.
+- Auto-assigning a member as contributor because the AI named them.
+- Auto-assigning a steward. Offer, then accept.
+- A contributor queue for people who have only joined.
+- Shapers in the ticket approve button.
+
+---
+
+## Related
+
+- [User Journeys — The Intelligent Organization](./user-journeys.md) — roles, decisions, funding
+- [Organizational Intelligence — Architecture](../architecture/organizational-intelligence.md)

--- a/docs/product/user-journeys-ux.md
+++ b/docs/product/user-journeys-ux.md
@@ -78,6 +78,9 @@ invited onto — not an empty contributor queue. The invite is how they get a qu
 
 **If they quit mid-conversation:** draft space, resume the same thread.
 
+A full run of this conversation, the cards she approves, and what Sam and Lea then see is
+[Example A](#example-a--river-commons-from-a-conversation-to-a-ticket).
+
 ---
 
 ## 2. Someone joins — entry is open
@@ -320,6 +323,177 @@ Sam is a Shaper, the community steward, and a contributor on product.
 
 A community ticket they should green-light never appears on their contributor home. A Shaper
 mandate never appears on their steward home. The switch is how we keep "Nothing needs you" honest.
+
+---
+
+## Worked examples
+
+Two runs of the same space. The first is founding through the first piece of work. The second is
+six weeks later, when something has no steward.
+
+---
+
+### Example A — River Commons, from a conversation to a ticket
+
+Maya is starting a neighborhood food hub. She taps **Create a space**.
+
+#### What she says (the input)
+
+The AI asks; she answers in her words. This is the whole of the founding interview that matters:
+
+| The AI asks                                                | Maya says                                                                                           |
+| ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| What is this for?                                          | A place our street can buy food from people we know, not a supermarket.                             |
+| Who is it for?                                             | Neighbours, and the three growers we already buy from.                                              |
+| What will you not do?                                      | We will not run a restaurant. We will not take money that says we have to carry brands.             |
+| What would "working" look like in six months?              | Open two days a week, five growers selling, enough in the pot to pay the hall without a whip-round. |
+| Who is already doing work?                                 | Sam already runs the Saturday stall. I do the money and the hall booking.                           |
+| Who do you trust to decide if you disappeared for a month? | Sam. And me.                                                                                        |
+| Who would you not hand the treasury to yet?                | Sam is great with people. I still want a second pair of eyes on the money.                          |
+| What has to happen in the next 90 days?                    | Keep Saturday going. Find a hall we can use in the week. Write down how we pay growers.             |
+| What is already blocked?                                   | Weekday hall — I have no one for that.                                                              |
+| If you could spend tomorrow, on what?                      | Hall deposit. A simple fridge. Paying Sam something so Saturday is not a gift.                      |
+| Is there a treasury? Who can move it?                      | About 4,200 from a small grant. My account, for now.                                                |
+| Any pot that needs a second signature?                     | The money one, yes.                                                                                 |
+| How does someone join? Who puts money in?                  | Anyone on the street can join. The grant is one-off; neighbours can put in later. They don't vote.  |
+
+She skips nothing important. She does not mention "legal" or "comms".
+
+#### What the review screen shows (she approves or rejects)
+
+**Memory — she writes all four**
+
+- Purpose: a street food hub from people we know, not a supermarket.
+- For: neighbours and the three growers.
+- Will not: restaurant; brand money.
+- Working, six months: two days a week, five growers, hall paid without a whip-round.
+
+**Objectives, 90 days — she writes two, rejects one**
+
+| AI drafted                                       | Maya                                                |
+| ------------------------------------------------ | --------------------------------------------------- |
+| Saturday stall stays open every week             | **Write**                                           |
+| Weekday hall agreed and first mid-week day tried | **Write**                                           |
+| A written rule for how growers are paid          | **Write**                                           |
+| A comms steward and a newsletter                 | **Dismiss** — she never said this. Card disappears. |
+
+**Shapers — she edits**
+
+| AI drafted | Maya                                     |
+| ---------- | ---------------------------------------- |
+| Maya, Sam  | She leaves both. Checks "I am a Shaper". |
+
+**Mandates — she offers two, leaves one open, refuses one**
+
+| AI drafted                                                          | Maya                                       |
+| ------------------------------------------------------------------- | ------------------------------------------ |
+| **Stall** — Sam — pot 1,200 — review 1 June — no cosigner           | **Offer to Sam**                           |
+| **Money and hall** — Maya — pot 3,000 — review 1 June — Sam cosigns | **Offer to myself** — she keeps the cosign |
+| **Weekday hall** — open, no steward — pot 0 — review 1 June         | **Keep open** — no name to offer           |
+| **Legal / contracts** — open — pot 400                              | **Reject** — not a 90-day job. Card gone.  |
+
+**Door:** _Anyone can join._
+
+She taps **Create**.
+
+#### What Sam sees (becoming steward, then the queue)
+
+Sam is not in the space yet. He gets **You are being asked to hold Stall** — pot 1,200, review
+1 June, Shapers Maya and Sam, "you green-light stall work and spend this pot; you do not write
+what the hub believes."
+
+He taps **Accept**. Next open is **What is waiting on me?**
+
+Two tickets the AI already made from the 90-day jobs, sitting under Stall:
+
+1. **Pay Sam for four Saturdays** — recommended: Maya (she holds money). Draft: a payment of 400
+   from the Stall pot, four lines of dates. Why Maya: she moves money today.
+2. **Write the Saturday setup so someone else could run it** — recommended: Sam. Draft: a one-page
+   setup (open, cash box, grower list). Why Sam: he already runs it.
+
+Sam opens ticket 1. He **changes person** off Maya — he does not want her paying herself through
+his pot — and picks _open_ for now. He **Holds** ticket 1 until "Maya has a second signatory on
+the grant account."
+
+He opens ticket 2. Recommended is him. He is the steward, not a contributor on Stall yet. He
+**Approves** and **Invites himself to contribute** (same person, two hats). He accepts the invite
+on the next screen.
+
+#### What is passed to a contributor
+
+Lea joins from the public page (open entry). She is a **member**. **Your space** shows the open
+weekday-hall job and "you can be invited to work."
+
+A week later Sam has a new ticket: **Find two neighbours who can cover a Saturday.** Recommended:
+Lea (she joined, she said she can host). She is only a member, so Sam sees **Invite to contribute**
+not Approve-and-send.
+
+Lea gets **Sam is asking you to contribute on Stall.** The ticket is underneath, draft already
+written: a short message she can send on the street chat, three names as placeholders.
+
+She taps **Accept**. **What needs me?** now has one card:
+
+> Find two neighbours who can cover a Saturday.
+> Why you: you just joined and said you can host.
+> Next: send this message, fill in two names.
+> Approved by Sam.
+
+She taps **Start**, edits the message, marks **Done**. Sam sees the ticket completed. Maya, as
+Shaper, sees nothing — this was inside the Stall pot.
+
+Maya still has **What needs a Shaper?** with one card: **Weekday hall — open, no steward.** No
+tickets have been dumped on her.
+
+---
+
+### Example B — six weeks later, something has no owner
+
+Saturday is running. The weekday hall is still open. A grower asks, in chat, "who signs the hall
+licence?"
+
+The AI creates a ticket: **Sign the weekday hall licence.** No mandate covers "licences." It does
+**not** put this on Sam's stall queue and it does **not** put it on Maya's money queue.
+
+#### What Shapers see
+
+Maya opens **What needs a Shaper?** One new card:
+
+> **Mandate needed: Hall licence / weekday hall**
+> Attached ticket: Sign the weekday hall licence.
+> Draft: domain Weekday hall · steward _open_ · pot 800 (hall deposit, from leftover grant) ·
+> review 1 August · cosigner Maya (she asked for a second pair of eyes on money).
+> Suggested steward: none of the members have done this. Lea said she can host — stretch.
+
+Maya **amends**: steward Lea, pot 600 not 800, keeps herself as cosigner. **Offer to Lea.**
+
+Lea gets **You are being asked to hold Weekday hall.** She **Declines** — "I can host a Saturday,
+I cannot sign a licence." The card returns to Maya with that note. The ticket stays attached.
+
+Maya offers the same mandate, no steward, **Keep open.** The public brief now shows "Weekday hall
+needs someone who can sign a simple licence." A new neighbour, Rafi, requests to join and points
+at that line. Maya accepts the join (she is a Shaper). He is a member.
+
+She offers the mandate to Rafi. He **Accepts.**
+
+#### What the new steward sees
+
+Rafi's **What is waiting on me?**
+
+- Pot: 600 / 600, review 1 August, cosigner Maya.
+- Ticket: **Sign the weekday hall licence** — recommended: Rafi. Draft: the licence, the hall
+  address, the date, a payment of 400 for the deposit.
+
+He **Approves** (himself as contributor — invite + accept in one). He prepares the payment. Status:
+**Waiting for release.**
+
+#### What Maya sees as cosigner, and what a contributor would see
+
+Maya's **What needs a Shaper?** now has **To release: 400 hall deposit, Weekday hall, Rafi.** She
+**Releases.** Money moves.
+
+If Rafi had picked a different member to collect keys, that member would have been invited as a
+**Weekday hall contributor** and seen one card on **What needs me?** — collect keys, draft
+already written. Sam would not see it. Stall contributors would not see it.
 
 ---
 

--- a/docs/product/user-journeys-ux.md
+++ b/docs/product/user-journeys-ux.md
@@ -328,8 +328,8 @@ mandate never appears on their steward home. The switch is how we keep "Nothing 
 
 ## Worked examples
 
-Two runs of the same space. The first is founding through the first piece of work. The second is
-six weeks later, when something has no steward.
+Three runs. A and B are River Commons, start to finish. C is a different space, written only as
+**who is who** and **who sees what** at each moment.
 
 ---
 
@@ -494,6 +494,120 @@ Maya's **What needs a Shaper?** now has **To release: 400 hall deposit, Weekday 
 If Rafi had picked a different member to collect keys, that member would have been invited as a
 **Weekday hall contributor** and seen one card on **What needs me?** — collect keys, draft
 already written. Sam would not see it. Stall contributors would not see it.
+
+---
+
+### Example C — North Workshop, who is who and who sees what
+
+A bike-repair workshop. Five people. Read the cast first; then each moment is only a table of
+screens.
+
+#### Who is who
+
+| Person  | Hats they hold                                         | Home they open first       | They do not see                          |
+| ------- | ------------------------------------------------------ | -------------------------- | ---------------------------------------- |
+| **Ana** | Founder, **Shaper** (not a steward, not a contributor) | **What needs a Shaper?**   | Tickets. Contributor queues.             |
+| **Ben** | **Steward** of Workshop floor                          | **What is waiting on me?** | Shaper mandate cards. Other domains.     |
+| **Cat** | **Contributor** on Workshop floor                      | **What needs me?**         | Green-light buttons. Pots. Memory diffs. |
+| **Dan** | **Member** only                                        | **Your space**             | Any work queue.                          |
+| **Eli** | **Investor** — put in 2,000, no hat                    | **Overview**               | Join as a member, tickets, green-lights. |
+
+One mandate exists: **Workshop floor** — Ben — pot 1,500 — review 1 May — no cosigner.
+
+Ana was offered Workshop floor at founding and **declined** ("I shape, I don't run the floor").
+Ben accepted. Cat was invited by Ben after she joined. Dan joined yesterday. Eli has a link, not
+a membership.
+
+#### Moment 1 — Tuesday morning, nothing new
+
+| Person | Their screen says                                                                                             |
+| ------ | ------------------------------------------------------------------------------------------------------------- |
+| Ana    | **What needs a Shaper?** — "Nothing needs a Shaper." Secondary nav: pots (Workshop floor 1,100 left), memory. |
+| Ben    | **What is waiting on me?** — 0 tickets. Pot 1,100 / 1,500.                                                    |
+| Cat    | **What needs me?** — "Nothing needs you." One in-progress: "Label the loaner tools" (started Monday).         |
+| Dan    | **Your space** — purpose, people, one line: "A steward can invite you to work." No queue.                     |
+| Eli    | **Overview** — said / done / pots / changed. Watch: none yet.                                                 |
+
+#### Moment 2 — a broken stand is reported
+
+Someone writes in chat that the repair stand is unsafe. The AI creates a ticket: **Replace the
+repair stand.** Recommended contributor: Cat. Steward: Ben.
+
+| Person | Their screen now                                                                                                          |
+| ------ | ------------------------------------------------------------------------------------------------------------------------- |
+| Ana    | **Unchanged.** This ticket has a steward. She gets no card.                                                               |
+| Ben    | **What is waiting on me?** — 1 ticket: Replace the repair stand · recommended Cat · draft: buy stand, 180, from this pot. |
+| Cat    | **Unchanged.** The ticket has not been green-lit. She must not see it yet.                                                |
+| Dan    | **Unchanged.**                                                                                                            |
+| Eli    | **Unchanged.** The payment has not happened.                                                                              |
+
+Ben opens the ticket. He **Approves** Cat (already a contributor — no extra invite).
+
+| Person | Their screen after Ben approves                                                                                                                                |
+| ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Ana    | Still nothing.                                                                                                                                                 |
+| Ben    | Ticket left the waiting list. Pot still 1,100 (not paid yet).                                                                                                  |
+| Cat    | **What needs me?** — one card on top: Replace the repair stand. Why you: you did the tool labels. Next: order this stand (link in the draft). Approved by Ben. |
+| Dan    | Still **Your space**. He is not in this domain.                                                                                                                |
+| Eli    | Still no payment to show.                                                                                                                                      |
+
+Cat taps **Start**, orders, marks **Done**. Ben pays 180 from the pot. No cosigner, so it just
+moves.
+
+| Person | Their screen after it's done                                                                     |
+| ------ | ------------------------------------------------------------------------------------------------ |
+| Ana    | Still "Nothing needs a Shaper." She can open the ledger if she wants. She is not asked to sign.  |
+| Ben    | Pot 920 / 1,500. Ticket completed.                                                               |
+| Cat    | **What needs me?** — "Nothing needs you."                                                        |
+| Dan    | **Your space.** Still no queue.                                                                  |
+| Eli    | **Overview** — pot Workshop floor now 920. He can set a watch. He cannot approve the next stand. |
+
+#### Moment 3 — Dan is interested; Ben invites him
+
+Dan taps **I'm interested** on an open line on **Your space**: "evening shift needs a second pair
+of hands." He is still only a member.
+
+| Person | Their screen                                                                                             |
+| ------ | -------------------------------------------------------------------------------------------------------- |
+| Ana    | Nothing. Interest is not a Shaper decision.                                                              |
+| Ben    | On that ticket: "Dan (member) said they are interested." Button: **Invite to contribute** — not Approve. |
+| Cat    | Nothing. This is not her ticket.                                                                         |
+| Dan    | **Your space** — "You said you were interested in evening shift." Waiting.                               |
+| Eli    | Nothing.                                                                                                 |
+
+Ben taps **Invite to contribute**. Dan gets **Ben is asking you to contribute on Workshop floor**,
+with the evening-shift ticket underneath.
+
+Dan **Accepts**.
+
+| Person | Their screen                                                                                              |
+| ------ | --------------------------------------------------------------------------------------------------------- |
+| Dan    | **What needs me?** — first time this home exists for him. One card: evening shift, draft already written. |
+| Ben    | Ticket left waiting; Dan is now a contributor _on Workshop floor only_.                                   |
+| Cat    | Still "Nothing needs you." Dan's ticket is not on her list.                                               |
+| Ana    | Still nothing. She did not make Dan a contributor.                                                        |
+| Eli    | Nothing.                                                                                                  |
+
+#### Moment 4 — a thing with no steward
+
+A neighbour asks to borrow the workshop for a kids' Saturday. No mandate covers "lend the space."
+
+| Person | Their screen                                                                                                                          |
+| ------ | ------------------------------------------------------------------------------------------------------------------------------------- |
+| Ana    | **What needs a Shaper?** — one card: **Mandate needed: Lending the space.** Attached ticket: kids' Saturday. Suggested steward: open. |
+| Ben    | **Unchanged.** This is not Workshop floor (repairing bikes). It is not dumped on him.                                                 |
+| Cat    | **Unchanged.**                                                                                                                        |
+| Dan    | **Unchanged.**                                                                                                                        |
+| Eli    | **Unchanged.**                                                                                                                        |
+
+Ana offers the mandate to Ben. Ben **Declines** ("that's not the floor"). Card returns to Ana.
+She leaves it **open**. The public brief now shows "Lending the space — needs someone." Dan does
+not become that steward unless she **Offers** and he **Accepts**.
+
+---
+
+That is the whole point of the three homes: Ana never sees Cat's ticket. Cat never sees Ana's
+mandate card. Dan has no queue until Ben invites him. Eli never gets a green-light button.
 
 ---
 

--- a/docs/product/user-journeys.md
+++ b/docs/product/user-journeys.md
@@ -10,7 +10,8 @@ tags: [product, journeys, intelligent-org, ai]
 **This document describes the target state**: how we intend people to use Hypha once the
 intelligent organization works, not how the product behaves today. It is the product brief that
 the [Organizational Intelligence architecture](../architecture/organizational-intelligence.md)
-exists to serve. Written for the whole team — no code required.
+exists to serve. Written for the whole team — no code required. For screens and click-paths see
+[User Journeys — UI and flows](./user-journeys-ux.md).
 
 ---
 
@@ -768,6 +769,8 @@ generates governance rather than one that resolves it.
 
 ## Related
 
+- [User Journeys — UI and flows](./user-journeys-ux.md) — how someone joins, becomes a steward or
+  contributor, and what each hat opens
 - [Organizational Intelligence — Architecture](../architecture/organizational-intelligence.md) —
   how memory is maintained, retrieved, and bounded to serve these journeys
 - Space Intelligence & Documentation spec — the memory substrate; arrives with

--- a/docs/product/user-journeys.md
+++ b/docs/product/user-journeys.md
@@ -196,7 +196,8 @@ So the queue is always current; the digest is a **catch-up for people who haven'
 delivery mechanism; and the interrupt is reserved for things that will go wrong if they wait.
 
 1. **The moment a need is detected, the AI routes it.** It identifies who fits, based on stated
-   skills, demonstrated history, current load, and whose mandate the work falls under.
+   skills, demonstrated history, and whose mandate the work falls under — then checks that against
+   what that person has said they can take on.
 2. **It proposes rather than assigns.** The work appears in the suggested person's queue with the
    reasoning visible, and stays claimable by anyone else. In a voluntary organization you cannot
    allocate work — you can only put it in front of the person most likely to pick it up, and make it
@@ -221,9 +222,34 @@ The matcher needs a deliberate minority of stretch routing — to people who pla
 this, not only those who already have — and should treat single-person capabilities as a risk worth
 surfacing to the steward.
 
+**On capacity: the person decides, the system only holds up a mirror.** How much someone can take
+on is theirs to declare, not ours to infer. Most of what determines it — a day job, a sick child,
+the other three things they committed to elsewhere — is invisible to the platform, so any load we
+compute from platform activity is inferred from a sliver of the truth. Worse, the obvious proxy
+(count of open items) punishes exactly the people doing slow, hard work.
+
+So capacity is **declared**, coarse, and revisable: a band or a number of concurrent commitments,
+not hours, because nobody knows their hours and asking invites timesheet thinking. Two consequences
+worth being deliberate about:
+
+- **Capacity gates flow; it does not decide fit.** Match on who is right for the work, then let
+  declared capacity govern how much reaches them. Otherwise an available mediocre fit beats a
+  stretched excellent one. If the best-fit person is full, the work waits, moves to the next
+  candidate, or stays open — it is never force-fed.
+- **Observation informs, it never overrides.** The system may say "this would be your fifth open
+  item and you said three"; it may never refuse on someone's behalf. Self-declaration is not a
+  burnout fix on its own — conscientious people over-commit, and the org must not treat "they said
+  yes" as absolution.
+
+This also sharpens Journey 3's escalation rather than weakening it. "Everyone who fits is at the
+limit they set for themselves" is a far cleaner capacity signal than any inferred-load heuristic,
+because a person stated it. Relatedly, declining should distinguish _not my thing_ from _no room
+right now_: the first is evidence about fit, the second about capacity, and they should not be
+learned from interchangeably.
+
 **What memory does:** memory supplies the interpretation ("this matters because of the commitment we
-made in March") and the profiles and mandates that make matching possible; the activity ledger
-supplies both the detection ("this changed") and the honest picture of who is already loaded.
+made in March") and the profiles, mandates, and declared capacity that make matching possible; the
+activity ledger supplies the detection ("this changed").
 **Why it feels intelligent:** work reaches people instead of waiting to be discovered, and the
 organization admits when it is short-handed instead of overloading its most conscientious member.
 **How we know it works:** three numbers. Acceptance rate — below roughly a third and the channel is

--- a/docs/product/user-journeys.md
+++ b/docs/product/user-journeys.md
@@ -185,7 +185,8 @@ a Shaper, and entry rules stay strategy. They never need a steward or a pot.
 
 When the job _is_ the decision, Shapers decide it **once**, as one object:
 
-> this domain, this steward, this pot (which may be zero), this review date
+> this domain, this steward, this pot (which may be zero), this review date, and optionally who
+> must cosign to release funds
 
 The AI drafts that object. Shapers approve, amend, or reject it. Attaching funds is a field on the
 same proposal, not a follow-up. A job with no money is still a mandate — someone owns the work. A
@@ -219,8 +220,9 @@ the job it creates. One queue, one decision.
 #### D. Funding
 
 A **mandate** is a job with a pot attached: this domain, this steward, this much money, until this
-review date. **Funding a mandate** is the Shapers filling that pot. It is one decision. After it,
-the steward spends without asking again.
+review date, and **optionally who must cosign to release funds**. **Funding a mandate** is the
+Shapers filling that pot. It is one decision. After it, the default is that the steward spends
+without asking again.
 
 That is the whole point. The alternatives fail the aim — minimum bureaucracy, full transparency,
 trust — in opposite directions:
@@ -236,20 +238,31 @@ trust — in opposite directions:
 
 So the pot is not extra process. It is the _minimum_ process that lets Shapers stop looking. Trust
 is granted up to a number, for a job, until a date. Every payment is still on the ledger — full
-transparency — and a Shaper can set a standing watch ("tell me if this pot is 80% gone"). They do
-not sign the payment.
+transparency — and a Shaper can set a standing watch ("tell me if this pot is 80% gone").
+
+**Cosigners are how concern becomes a check on one pot, not a rule for every pot.** Default is
+none. If Shapers are uneasy — a new steward, a large pot, a sensitive domain — they name who must
+also sign before funds leave that pot. That can be one or more of themselves, the parent steward,
+or another trusted body. The steward still initiates the payment; it does not move until the
+named people release it.
+
+This stays a field on the mandate, set when the pot is created or changed, and removable at review
+when the concern has passed. It is not a standing Shaper queue. If every pot has the org Shapers
+as cosigners, we have rebuilt "approve every movement" under another name. Use it where trust is
+not yet full. Leave it off where it is.
 
 What Shapers decide, and only this:
 
 - Fill, refill, enlarge, shrink, or close a pot (create or change a mandate).
+- Set, change, or clear the cosigners on a pot.
 - A payment that **no pot covers** — there is no steward for this, or this one spend would overflow
   the pot. That is the only sense in which they "fund beyond a mandate."
 - Dispose of major assets or dilute holders, with investor consent where that is reserved.
 
-What they do not decide: the contractor invoice, the tool subscription, the contributor payment
-that already sits inside a live pot. That is the steward doing their job. If Shapers disagree with
-how a pot is being used, they resize or close it at the review date — or sooner, as a structure
-decision — they do not start countersigning.
+What they do not decide by default: the contractor invoice, the tool subscription, the contributor
+payment that already sits inside a live pot with no cosigners. That is the steward doing their job.
+If Shapers disagree with how a pot is being used, they resize it, close it, or add a cosigner —
+they do not start countersigning pots they never marked.
 
 #### How it looks with 10 members, and with 10,000
 
@@ -265,10 +278,10 @@ Example: the treasury is 20,000.
 - Community — Sam — 8,000 — review in June
 - Product — Lea — 12,000 — review in June
 
-Sam pays a facilitator from the community pot. Nobody else signs. Lea pays a designer from the
-product pot. The Shapers see two numbers: how much each pot has left. When unmatched tickets pile
-up in "legal" and nobody owns that, the AI drafts a third mandate. Until then there is no third
-pot, and no chart for its own sake.
+Sam pays a facilitator from the community pot. Nobody else signs — neither pot has a cosigner.
+Lea pays a designer from the product pot. The Shapers see two numbers: how much each pot has left.
+When unmatched tickets pile up in "legal" and nobody owns that, the AI drafts a third mandate.
+Until then there is no third pot, and no chart for its own sake.
 
 If the org is even smaller — one person wearing every hat — there is a single mandate, pot equals
 the treasury, review in a few months.
@@ -280,20 +293,21 @@ object, one level down.
 
 Example: the treasury is 2,000,000. Org Shapers fill five pots, not fifty.
 
-- Product — Lea — 800,000 — review in June
-- Community — Sam — 400,000
-- Operations — Miro — 300,000
+- Product — Lea — 800,000 — review in June — two Shapers cosign (the pot is large, Lea is new)
+- Community — Sam — 400,000 — no cosigner
+- Operations — Miro — 300,000 — no cosigner
 - …two more
 
-Lea does not ask the org Shapers every time product needs a narrower job. She carves from her
-remaining 800,000:
+Lea still does not ask the org Shapers every time product needs a narrower job. She carves from
+her remaining 800,000:
 
 - Mobile — Rafi — 200,000 — review in April
 - Protocol — Noa — 350,000
 
-Rafi pays engineers from the mobile pot. Lea sees burn on mobile and protocol. Org Shapers see
-burn on product. Nobody above Rafi signs his payments. If Lea closes product, mobile and protocol
-freeze.
+Rafi pays engineers from the mobile pot. Lea may put herself as cosigner on that sub-pot; the org
+Shapers do not. She sees burn on mobile and protocol. Org Shapers see burn on product, and they
+still release Lea's own product-level payments until they drop the cosign at review. If Lea
+closes product, mobile and protocol freeze.
 
 Two or three levels of that is enough. Eight pots, each split eight ways, each split eight ways
 again, is already room for hundreds of teams. The org Shapers never look at hundreds of pots.
@@ -307,8 +321,9 @@ What each person opens:
 | Contributor home    | the next approved ticket             | the next approved ticket                                       |
 | Anyone, if they ask | every payment                        | every payment — the ledger is complete. The home screen is not |
 
-The thing that must not happen at either size: the Shaper set grows with membership, or people
-start asking Shapers to sign payments a pot already covers.
+The thing that must not happen at either size: the Shaper set grows with membership, or every pot
+quietly gets the org Shapers as cosigners. Cosign is a mark on a pot you are concerned about, not
+the way money always moves.
 
 #### E. Membership — follows the entry method the founder set
 

--- a/docs/product/user-journeys.md
+++ b/docs/product/user-journeys.md
@@ -178,26 +178,62 @@ new members stop asking questions that are already answered in memory.
 
 ---
 
-## Journey 3 — A contributor's week (the core loop)
+## Journey 3 — Work finds the right person (the core loop)
 
 **Who:** an active member with limited attention and a real job.
-**Wants:** to not miss the thing that needed them.
+**Wants:** to be handed the thing that genuinely needs them, when it arises — not to discover it
+next Friday.
 
-1. **Once per period, they receive a digest** — not a notification per event. It says what changed
-   in the organization, what it means, and what needs them specifically.
-2. Each item names _them_, states one concrete next action, and shows the evidence it is based on.
-   Anything that can't do all three doesn't get sent.
-3. They act, defer, or dismiss. Dismissing is a first-class action and it is recorded.
-4. When they act, the AI has already drafted the artifact — the proposal text, the summary, the
+Three things happen at three different speeds here, and conflating them is a design error:
+
+|                                                   | Cadence                         | Why                                                |
+| ------------------------------------------------- | ------------------------------- | -------------------------------------------------- |
+| **Detection** — something needs doing             | continuous                      | delay here is pure loss                            |
+| **Routing** — it reaches the right person's queue | continuous                      | work should never sit unrouted waiting for a cycle |
+| **Interruption** — a push, email, or ping         | rate-limited, urgency overrides | the only genuinely scarce resource is attention    |
+
+So the queue is always current; the digest is a **catch-up for people who haven't looked**, not the
+delivery mechanism; and the interrupt is reserved for things that will go wrong if they wait.
+
+1. **The moment a need is detected, the AI routes it.** It identifies who fits, based on stated
+   skills, demonstrated history, current load, and whose mandate the work falls under.
+2. **It proposes rather than assigns.** The work appears in the suggested person's queue with the
+   reasoning visible, and stays claimable by anyone else. In a voluntary organization you cannot
+   allocate work — you can only put it in front of the person most likely to pick it up, and make it
+   easy to say yes.
+3. Each item names a person, states one concrete next action, and shows the evidence behind it.
+   Anything that can't do all three isn't routed to a human at all.
+4. **When nobody fits, that is information, not a failure.** The AI says so explicitly rather than
+   quietly dropping the work on whoever answers fastest — the most common and most corrosive default
+   in every organization. The item stays open, visible, and labelled with the capability it needs.
+5. **Unmatched work escalates as a capacity signal** to whoever holds that domain, or to the
+   founders if nobody does. Repeated misses aggregate: three unfilled tasks in the same area over a
+   month is not three problems, it is one role that needs filling.
+6. The person acts, defers, declines, or the work stays open. Declining is a first-class action and
+   is recorded — it is how the matcher learns.
+7. When they act, the AI has already drafted the artifact — the proposal text, the summary, the
    update — so acting is editing.
-5. What they dismissed shapes what they are shown next time.
 
-**What memory does:** memory supplies the interpretation ("this matters because of the commitment
-we made in March"); the activity ledger supplies the detection ("this changed").
-**Why it feels intelligent:** it respects attention. The measure of this journey is not how much
-the AI says, but how rarely it is wrong to speak.
-**How we know it works:** the acceptance rate. If fewer than roughly a third of items are acted on,
-the channel is noise and should be turned off rather than tuned.
+**On matching without ossifying roles.** Matching purely on demonstrated history is the obvious
+approach and it slowly calcifies the organization: whoever did the treasury work keeps getting the
+treasury work, nobody else ever learns it, and the org acquires a bus-factor problem it cannot see.
+The matcher needs a deliberate minority of stretch routing — to people who plausibly _could_ do
+this, not only those who already have — and should treat single-person capabilities as a risk worth
+surfacing to the steward.
+
+**What memory does:** memory supplies the interpretation ("this matters because of the commitment we
+made in March") and the profiles and mandates that make matching possible; the activity ledger
+supplies both the detection ("this changed") and the honest picture of who is already loaded.
+**Why it feels intelligent:** work reaches people instead of waiting to be discovered, and the
+organization admits when it is short-handed instead of overloading its most conscientious member.
+**How we know it works:** three numbers. Acceptance rate — below roughly a third and the channel is
+noise. Time from detection to a claimed owner. And the share of work that finds someone without
+escalation, which is the honest read on whether the org has the people it needs.
+
+> Unmatched work accumulating in a domain is the evidence base for a new mandate — which is a Tier 3
+> decision, because it creates an ongoing obligation. This is where "we need a developer and a
+> budget" should come from: an observed pattern of unmet need, not an assertion. See
+> [decision rights](../architecture/organizational-intelligence.md#8-decision-rights--what-becomes-a-proposal).
 
 ---
 
@@ -351,8 +387,8 @@ and without central control.
 2. When their app produces something the organization should _know_ — an assessment, a risk, a
    recommendation — it promotes that as a memory artifact.
 3. Hypha never learns their schema. The shared layer is meaning, not tables.
-4. Their insight now appears in every member's digest and in every AI answer, attributed to their
-   app.
+4. Their insight can now route work, appear in any member's queue, and inform every AI answer —
+   attributed to their app.
 
 **What memory does:** memory is the integration surface. This is what makes the platform
 extensible without becoming a data warehouse.

--- a/docs/product/user-journeys.md
+++ b/docs/product/user-journeys.md
@@ -251,43 +251,64 @@ that already sits inside a live pot. That is the steward doing their job. If Sha
 how a pot is being used, they resize or close it at the review date — or sooner, as a structure
 decision — they do not start countersigning.
 
-#### Will this still work at 10,000 members?
+#### How it looks with 10 members, and with 10,000
 
-A **member** is not a Shaper. Ten thousand people doing the work does not mean ten thousand people
-filling pots. Contributors scale; the Shaper set must not. If it grows with membership, every
-mandate becomes a town meeting and the design is dead. The founder names a small first set; adding
-a Shaper stays hard (Tier 4) on purpose.
+Same rules. Different depth. A member is not a Shaper — ten thousand people working does not mean
+ten thousand people filling pots.
 
-At **small scale** — five people, one of them founder, Shaper, and steward — the system has to
-collapse to one object without ceremony: one mandate, pot equals the treasury, review date in a
-few months. The second mandate appears when unmatched work says a second job exists, not because
-the software wants a chart.
+**With 10 members**
 
-At **large scale** a flat list of pots dies. A Shaper body can hold in its head about as many
-top-level mandates as a decent manager can hold reports — call it five to eight. Fifty pots, and
-they are either rubber-stamping reviews or they become the invoice queue we already rejected.
-Transparency dies the same way: a complete ledger that dumps ten thousand payments on a home
-screen is not transparency, it is noise.
+One layer. Three or four Shapers (often the same people as the stewards). Two or three mandates.
 
-So mandates **nest**. Same object, one more rule: a steward may carve a sub-mandate from their own
-pot — this narrower job, this person, this much (not more than remains), this review date — without
-asking the org Shapers. They are Shaper _of that pot_, not of the organization. The org Shapers
-still see five to eight top-level jobs. Two or three levels of nesting covers thousands of people
-(eight times eight times eight is already five hundred work cells). Close or freeze a parent and
-the children freeze with it. The parent steward stays accountable for the whole, including what
-they delegated.
+Example: the treasury is 20,000.
 
-That is one mechanism at both sizes, not a small-org mode and a large-org mode. The pot _is_ the
-coordination layer that hierarchy used to be. What used to travel through status meetings travels
-as burn rate, unmatched work, and review dates.
+- Community — Sam — 8,000 — review in June
+- Product — Lea — 12,000 — review in June
 
-What still requires discipline, and will not be saved by software:
+Sam pays a facilitator from the community pot. Nobody else signs. Lea pays a designer from the
+product pot. The Shapers see two numbers: how much each pot has left. When unmatched tickets pile
+up in "legal" and nobody owns that, the AI drafts a third mandate. Until then there is no third
+pot, and no chart for its own sake.
 
-- Keep the Shaper set small. A 10,000-member org with two hundred Shapers has rebuilt a parliament.
-- Do not let "payment no pot covers" become the overflow drain. If that queue is busy, the tree is
-  wrong — carve a pot, don't countersign.
-- A small Shaper set at that scale is an oligarchy unless the ledger is public, review dates are
-  real, and changing who is a Shaper is possible. Those are the checks. They are not optional.
+If the org is even smaller — one person wearing every hat — there is a single mandate, pot equals
+the treasury, review in a few months.
+
+**With 10,000 members**
+
+Still a handful of Shapers. Still a handful of pots _those Shapers see_. The rest is the same
+object, one level down.
+
+Example: the treasury is 2,000,000. Org Shapers fill five pots, not fifty.
+
+- Product — Lea — 800,000 — review in June
+- Community — Sam — 400,000
+- Operations — Miro — 300,000
+- …two more
+
+Lea does not ask the org Shapers every time product needs a narrower job. She carves from her
+remaining 800,000:
+
+- Mobile — Rafi — 200,000 — review in April
+- Protocol — Noa — 350,000
+
+Rafi pays engineers from the mobile pot. Lea sees burn on mobile and protocol. Org Shapers see
+burn on product. Nobody above Rafi signs his payments. If Lea closes product, mobile and protocol
+freeze.
+
+Two or three levels of that is enough. Eight pots, each split eight ways, each split eight ways
+again, is already room for hundreds of teams. The org Shapers never look at hundreds of pots.
+
+What each person opens:
+
+|                     | 10 members                           | 10,000 members                                                 |
+| ------------------- | ------------------------------------ | -------------------------------------------------------------- |
+| Shaper home         | two pots, a bit of leftover treasury | five top-level pots                                            |
+| Steward home        | their one pot and its tickets        | their pot, any pots they carved, their tickets                 |
+| Contributor home    | the next approved ticket             | the next approved ticket                                       |
+| Anyone, if they ask | every payment                        | every payment — the ledger is complete. The home screen is not |
+
+The thing that must not happen at either size: the Shaper set grows with membership, or people
+start asking Shapers to sign payments a pot already covers.
 
 #### E. Membership — follows the entry method the founder set
 

--- a/docs/product/user-journeys.md
+++ b/docs/product/user-journeys.md
@@ -20,7 +20,9 @@ exists to serve. Written for the whole team — no code required.
 > next — because the organization remembers, and the AI keeps that memory active.
 
 Everything below is a way of delivering that sentence to a specific kind of person on a specific
-kind of day.
+kind of day. Both halves of it — _what matters_ and _what to do next_ — resolve differently for a
+contributor, a steward, and an investor; see
+[what each stakeholder opens the app for](#what-each-stakeholder-opens-the-app-for).
 
 ---
 
@@ -124,6 +126,94 @@ They stake attention.
 | Verifier        | their own assurance   | specified claims plus on-chain proof          | none                                     | 6       |
 
 Journeys 1–5 sit inside the organization, 6–7 at the committed edge, 8–9 outside it.
+
+### What each stakeholder opens the app for
+
+The promise at the top of this document — _knows what matters and what to do next_ — means something
+different for each of them. Below is that sentence made specific: the one question each arrives
+with, what answers it, and what they can actually do about it.
+
+Four rules govern all ten:
+
+1. **One question, answered before anything is asked of them.** The landing state is the answer, not
+   a dashboard of everything with the answer somewhere inside it.
+2. **The next action must sit inside their authority.** Showing someone a problem they have no lever
+   for is not transparency, it is anxiety. For Rings 2 and 3, acting means asking, watching,
+   reporting, or disputing — never directing.
+3. **"Nothing needs you" must be sayable.** A surface that can never come up empty will manufacture
+   urgency to fill itself, and then everything on it is noise.
+4. **Outside Ring 1, bad news goes first.** A curated view that only carries good news is discounted
+   to zero within two cycles, and after that the honest reports cannot be heard either.
+
+#### Ring 1 — inside
+
+**Founder — _"Am I still the bottleneck?"_**
+Decisions still routing through them that a mandate could absorb, and people whose track record now
+justifies holding one. The next action is a handoff: create the mandate, name the steward. This is
+the one surface designed to make its own user redundant — the founder role dissolves by being used,
+and progress is measured by how much stops arriving here.
+
+**Contributor — _"What needs me?"_**
+A queue with one item at the top, not a dashboard: work routed to them, plus changes to work they
+already own. They claim, decline, or act on an artifact the AI has already drafted. Declining
+distinguishes _not my thing_ from _no room right now_. When nothing needs them it says so plainly —
+the willingness to show an empty queue is what makes a full one credible.
+
+**Steward — _"What is waiting on me, and is my domain drifting?"_**
+Every item inside their mandate awaiting a call, plus envelope burn measured against the review
+date. They approve, reject, or hold — and **a hold must carry a resumption trigger**, a date or a
+condition, because a hold without one is a silent no that nobody has to own. Repeated rejections of
+similar items are evidence that the routing or the mandate boundary is wrong, not that the steward
+is being difficult.
+
+**Coordinator — _"Is what we believe still true?"_**
+The hygiene queue: assertions no ledger fact supports, contradictions between artifacts, onboarding
+that has stalled. They confirm, retire, or escalate a specific claim. This is the human end of the
+[behavioural-evidence rule](../architecture/organizational-intelligence.md#1-four-layers-of-memory)
+— someone has to adjudicate when the record and the reality diverge.
+
+#### Ring 2 — the committed edge
+
+**Investor or funder — _"Is my capital doing what it was meant to, and should I add, hold, or
+exit?"_**
+Commitments made against commitments kept, burn against plan, and the arguments the organization has
+not yet settled. The actions are the honest ones available to someone without operational authority:
+ask a question that memory answers with evidence, file an observation, **set a standing watch**
+("tell me if runway falls below six months"), or move their position. The watch matters most — it
+converts a periodic-report reader into someone subscribed to the facts they actually care about.
+Credibility here is asymmetric: what earns it is the organization surfacing a problem before the
+investor finds it themselves. Sometimes the honest answer to "should I invest" is _not yet_, and a
+system willing to say that is the only kind worth reading.
+
+**Beneficiary — _"Is this actually helping, and can I say what I need?"_**
+Outcomes in language they recognize, not governance activity — they do not care that proposal 12
+executed. They report whether something helped, or file a need. Those reports are the organization's
+ground truth and feed decision memory. Asking beneficiaries for input and never showing them a
+change that came from it is extractive, so the loop has to close visibly.
+
+**Partner organization — _"Are our joint commitments on track, and what do they need from us?"_**
+Only the shared surface: commitments between the two organizations, never the partner's internals.
+They confirm, dispute, or flag a dependency at risk, then take it to their own members. The failure
+worth designing against is the joint commitment each side assumes the other owns, so unclaimed
+shared commitments surface to both.
+
+#### Ring 3 — outside
+
+**Prospective member — _"Is this real, and is there something here for me?"_**
+The public brief, evidence the organization is actually doing things, and — the important part —
+open work nobody has picked up that matches what they say they can do. Journey 3's unmatched queue
+_is_ the recruitment surface: the capacity gap and the joining funnel are one list read from two
+directions. They express interest against a specific piece of work, so joining arrives with a first
+task attached instead of a generic welcome.
+
+**Builder or integrator — _"Is what my tool contributes being used?"_**
+The acceptance rate of artifacts their app has published: read, acted on, or ignored. They publish,
+and they see what became of it. Integrators leave when their output disappears into a void.
+
+**Verifier or auditor — _"Is this one claim true?"_**
+One claim, its evidence chain, and the on-chain proof. They verify or dispute, and a dispute becomes
+a signal the organization has to answer. They should need no account and no relationship to do it —
+verification that depends on trusting the platform is not verification.
 
 ---
 

--- a/docs/product/user-journeys.md
+++ b/docs/product/user-journeys.md
@@ -74,8 +74,8 @@ fits, never toward the vote. See [Journey 5](#journey-5--the-organization-decide
 Two things to hold before reading the list.
 
 **These are roles, not people.** In a five-person organization, one person is plausibly founder,
-steward _and_ beneficiary at once. The taxonomy answers "what does this person need right now", not
-"what is their job title". Someone can move between rings, and most people do.
+shaper, steward _and_ beneficiary at once. The taxonomy answers "what does this person need right
+now", not "what is their job title". Someone can move between rings, and most people do.
 
 **What someone stakes should determine their authority over memory.** This is the organizing
 principle. A person who stakes their time and judgment gets to change what the organization
@@ -85,17 +85,19 @@ mapping wrong in either direction is how organizations either capture themselves
 
 ### Ring 1 — Inside: members who hold decision rights
 
-They stake time and judgment. They read memory freely and can propose changes to it. **Voting power
-is a grant, not a property of being inside.** The founder decides who holds it when the organization
-is created; a contributor or steward may or may not have it.
+They stake time and judgment. They read memory freely and can propose changes to it.
 
-- **Founder** — holds high-level strategy: purpose, direction, which domains exist, and whether
-  what the organization believes is still true. Strategy becomes more specific work that passes to
-  stewards. There is no separate coordinator role.
+- **Founder** — the person who initially sets up the organization. A one-time role. They name the
+  first Shapers, the first steward mandates, and the entry and exit methods, then they are a member
+  like anyone else — usually also a Shaper, but "founder" is not an ongoing decision right.
+- **Shaper** — a grant, not an exclusive role. Shapers decide high-level strategy, funding beyond
+  a mandate, and organizational memory. A steward or a contributor can also be a Shaper; being one
+  is what used to get called voting power. Strategy becomes more specific work that passes to
+  stewards.
 - **Steward** — accountable for a domain; holds a mandate and a budget envelope; approves the
   implementations that strategy has become.
-- **Contributor** — does the work the steward has approved. The majority. Votes only if granted
-  voting power.
+- **Contributor** — does the work the steward has approved. The majority. A Shaper only if granted
+  that hat.
 
 ### Ring 2 — The committed edge: a formal stake, no operational vote
 
@@ -116,17 +118,18 @@ They stake attention.
 
 ### The mapping
 
-| Stakeholder     | Stakes                | Memory access                                 | Decision rights                                                 | Journey |
-| --------------- | --------------------- | --------------------------------------------- | --------------------------------------------------------------- | ------- |
-| Founder         | purpose, reputation   | writes and keeps the strategic corpus         | high-level strategy; memory hygiene; proposes new steward needs | 1, 4    |
-| Steward         | domain accountability | approves changes in their domain              | approves implementations and spends inside their mandate        | 3       |
-| Contributor     | time, judgment        | reads all; proposes changes                   | does the work; votes only if granted voting power               | 2, 3    |
-| Investor/funder | capital               | curated view, including unsettled arguments   | consent on reserved matters only                                | 6       |
-| Beneficiary     | dependency on outcome | published subset; contributes outcome reports | none; consulted when decisions land on them                     | 7       |
-| Partner org     | joint commitments     | artifacts relayed to them                     | decides for itself                                              | 8       |
-| Prospective     | attention             | the public brief                              | none                                                            | 2       |
-| Builder         | effort, reputation    | writes via app identity; proposes only        | none                                                            | 9       |
-| Verifier        | their own assurance   | specified claims plus on-chain proof          | none                                                            | 6       |
+| Stakeholder     | Stakes                  | Memory access                                 | Decision rights                                                      | Journey |
+| --------------- | ----------------------- | --------------------------------------------- | -------------------------------------------------------------------- | ------- |
+| Founder         | purpose, reputation     | writes the seed corpus                        | sets the organization up once; then only as Shaper and/or other hats | 1       |
+| Shaper          | judgment over the whole | reads all; approves strategic memory          | strategy, funding beyond a mandate, memory, the steward set          | 4, 5    |
+| Steward         | domain accountability   | approves changes in their domain              | approves implementations and spends inside their mandate             | 3       |
+| Contributor     | time, judgment          | reads all; proposes changes                   | does the work; shapes only if also a Shaper                          | 2, 3    |
+| Investor/funder | capital                 | curated view, including unsettled arguments   | consent on reserved matters only                                     | 6       |
+| Beneficiary     | dependency on outcome   | published subset; contributes outcome reports | none; consulted when decisions land on them                          | 7       |
+| Partner org     | joint commitments       | artifacts relayed to them                     | decides for itself                                                   | 8       |
+| Prospective     | attention               | the public brief                              | none                                                                 | 2       |
+| Builder         | effort, reputation      | writes via app identity; proposes only        | none                                                                 | 9       |
+| Verifier        | their own assurance     | specified claims plus on-chain proof          | none                                                                 | 6       |
 
 Journeys 1–5 sit inside the organization, 6–7 at the committed edge, 8–9 outside it. The catalog
 below is what "decision rights" actually means.
@@ -137,41 +140,40 @@ The tiers in the [architecture](../architecture/organizational-intelligence.md#8
 say how much agreement a decision needs. This section says **which decisions exist** and **which
 person or body takes each one**. Four sentences hold the whole catalog:
 
-1. **The founder decides high-level strategy** — at creation and after: purpose, direction, who
-   has voting power, which domains the organization needs, and whether its beliefs still hold. The
-   AI proposes; the founder confirms.
-2. **Strategy becomes more specific work that passes to stewards.** Voting power is the body that
-   can change the constitution or the steward set — add, remove, replace, or resize a mandate —
-   usually on a proposal the founder raises from an observed strategic gap.
-3. **Stewards approve implementations.** An AI ticket is a recommendation. It does not become work
-   until the matching steward approves, rejects, or holds it.
+1. **The founder sets the organization up once:** purpose, who the first Shapers are, how votes
+   work, entry and exit, and the first steward mandates. The AI proposes; the founder confirms.
+2. **Shapers decide high-level strategy, funding beyond a mandate, and organizational memory.**
+   They are the body that can change the constitution or the steward set. A steward or contributor
+   can hold this grant; the founder usually does after setup, but not because they founded it.
+3. **Stewards approve implementations.** Strategy becomes more specific work that passes to them.
+   An AI ticket is a recommendation. It does not become work until the matching steward approves,
+   rejects, or holds it.
 4. **Contributors do the approved work.** Money inside a mandate is the steward's; money beyond
-   any mandate is a vote.
+   any mandate is a Shaper decision.
 
 #### A. Founding — founder confirms, AI proposes
 
 - Purpose, boundaries, and success signals (the seed memory).
-- **Who holds voting power** — all members, a named subset, token holders, or another rule the
-  founder chooses. This is a grant, not a role.
+- **Who the first Shapers are** — a named set of people, which may include the founder, some
+  stewards, some contributors, or all of them. This is a grant, not an exclusive role.
 - Voting method, quorum, and unity.
 - Entry and exit method.
 - The first steward mandates: domain, named person, envelope, review date.
 - The starting [trust-ladder](#the-trust-ladder) rung for the AI.
 
-The founder role does not dissolve. After creation they keep the strategic layer: direction,
-whether beliefs still hold, and which new domains the work is asking for. They do not approve
-tickets or do the work — that is the cascade below.
+After this, "founder" is a historical fact, not a queue. Ongoing strategy, funding, and memory sit
+with the Shapers.
 
-#### B. Structure — voting power
+#### B. Structure — Shapers
 
 Tier 3, or Tier 4 when the decision changes how decisions get made.
 
-- Add a steward or create a mandate. Evidence is unmatched work accumulating in a domain, or anyone
-  with voting power proposing. The AI may draft the proposal; the electorate decides.
-- Remove or replace a steward. A steward can resign without a vote; filling the seat is a vote. A
-  steward cannot fire themselves out of accountability.
+- Add a steward or create a mandate. Evidence is unmatched work accumulating in a domain, or any
+  Shaper proposing. The AI may draft the proposal; the Shapers decide.
+- Remove or replace a steward. A steward can resign without a vote; filling the seat is a Shaper
+  decision. A steward cannot fire themselves out of accountability.
 - Renew, expand, or shrink an envelope.
-- Change the electorate, the voting method, the purpose, or entry and exit.
+- Change who is a Shaper, the voting method, the purpose, or entry and exit.
 - Issue, mint, or burn tokens; space-to-space membership; activating a space.
 
 #### C. Work tickets — matching steward, before anyone starts
@@ -182,7 +184,7 @@ Tier 3, or Tier 4 when the decision changes how decisions get made.
   using the mandate, not a new decision class, and it is how they avoid becoming a per-ticket
   bottleneck.
 - **No matching steward:** the ticket stays open, labelled with the capability it needs, and
-  becomes evidence for a "we need this steward" vote. It is not silently dumped on the founder as
+  becomes evidence for a "we need this steward" vote. It is not silently dumped on a Shaper as
   permanent work.
 - The contributor then claims, declines, or acts. That is a personal decision, not an organizational
   one.
@@ -191,12 +193,11 @@ Tier 3, or Tier 4 when the decision changes how decisions get made.
 
 - Spend or commit **inside** an existing envelope → the steward of that mandate (Tier 1).
 - A new allocation, a spend **beyond** every envelope, or an ongoing obligation nobody owns →
-  voting power (Tier 3).
-- Dispose of major assets or dilute holders → voting power **and** investor consent (reserved
-  matter).
+  Shapers (Tier 3).
+- Dispose of major assets or dilute holders → Shapers **and** investor consent (reserved matter).
 
-This is what "funding is a vote" means without sending every in-mandate reimbursement to the
-electorate — the failure the architecture already named.
+This is what "funding is a Shaper decision" means without sending every in-mandate reimbursement
+to them — the failure the architecture already named.
 
 #### E. Membership — follows the entry method the founder set
 
@@ -207,16 +208,16 @@ follows that method. Changing the method is a vote. This catalog does not invent
 #### F. Memory
 
 - An AI-proposed belief update that changes strategy, purpose, or a cross-cutting assumption → the
-  founder.
+  Shapers.
 - An AI-proposed belief update inside a domain → the steward of that domain.
 - An assertion with no ledger support, a contradiction between artifacts, or stalled onboarding →
-  the founder confirms, retires, or escalates. This is strategy maintenance, not a separate role.
+  the Shapers confirm, retire, or escalate.
 
 #### G. Reserved matters and the edge — heard is not authority
 
-- Purpose change, dilution, major-asset disposal → voting power **plus** investor consent.
-- Decisions that land on the people the organization serves → voting power decides; beneficiaries
-  are consulted.
+- Purpose change, dilution, major-asset disposal → Shapers **plus** investor consent.
+- Decisions that land on the people the organization serves → Shapers decide; beneficiaries are
+  consulted.
 - Partner commitments → each organization decides for itself.
 - An investor adding, holding, or exiting; a beneficiary reporting an outcome; a prospect
   expressing interest — individual actions, listed here so they are not mistaken for organizational
@@ -228,7 +229,7 @@ The promise at the top of this document — _knows what matters and what to do n
 different for each of them. Below is that sentence made specific: the one question each arrives
 with, what answers it, and what they can actually do about it.
 
-Four rules govern all nine:
+Four rules govern all ten:
 
 1. **One question, answered before anything is asked of them.** The landing state is the answer, not
    a dashboard of everything with the answer somewhere inside it.
@@ -242,11 +243,18 @@ Four rules govern all nine:
 
 #### Ring 1 — inside
 
-**Founder — _"Is the strategy still right, and is it becoming work?"_**
-Direction, purpose, and the beliefs those rest on — plus work that still has no steward, which is
-a strategic gap rather than a ticket they should do themselves. They confirm, revise, or retire a
-claim, and they pass more specific work to the matching steward. Adding a steward is a vote they
-typically raise, not a mandate they create alone. This is the human end of the
+**Founder — _"Is the organization standing?"_**
+Only while they are setting it up: the seed memory, the first Shapers, the first steward mandates.
+Once those are confirmed, this surface closes. Anything later that looks like strategy is a Shaper
+question — even if the same person is looking at it.
+
+**Shaper — _"Is the strategy still right, and is it becoming work?"_**
+Direction, purpose, funding beyond any mandate, and the beliefs those rest on — plus work that
+still has no steward, which is a strategic gap rather than a ticket they should do themselves. They
+confirm, revise, or retire a claim, and they pass more specific work to the matching steward.
+Adding a steward is a Shaper decision, not a mandate one person creates alone. A steward or
+contributor who is also a Shaper sees this surface as well as their other one. This is the human
+end of the
 [behavioural-evidence rule](../architecture/organizational-intelligence.md#1-four-layers-of-memory).
 
 **Steward — _"What implementations are waiting on me, and is my domain drifting?"_**
@@ -319,8 +327,9 @@ theory first.
    it will not do, and how they will know it's working. It draws on patterns from comparable
    organizations in the network to ask sharper questions.
 3. It proposes a structure the founder edits rather than invents: the space, sensible entry and
-   decision methods, **who holds voting power**, and **a first set of steward mandates** — domain,
-   named person, envelope, review date. The founder confirms each, or changes it.
+   decision methods, **who the first Shapers are**, and **a first set of steward mandates** —
+   domain, named person, envelope, review date. The founder confirms each, or changes it. They
+   usually name themselves as a Shaper; that is a choice, not automatic.
 4. **The conversation becomes the organization's first memory.** The purpose, the boundaries, and
    the success signals are written as the founding artifacts — not buried in a chat log.
 5. The founder is shown what was recorded and asked to confirm it. This is the first approval.
@@ -451,11 +460,12 @@ escalation, which is the honest read on whether the org has the people it needs.
 
 ---
 
-## Journey 4 — The founder keeps the strategy alive
+## Journey 4 — The shapers keep the strategy alive
 
-**Who:** whoever holds high-level strategy — usually the founder, sometimes more than one.
-**Wants:** the organization to keep pointing at the thing it exists to do, without becoming the
-person who does every next task.
+**Who:** whoever holds the Shaper grant — often including the founder, and often including people
+who are also stewards or contributors.
+**Wants:** the organization to keep pointing at the thing it exists to do, without any one of them
+becoming the person who does every next task.
 
 1. They see where **stated strategy and actual behaviour have diverged** — we said this was the
    priority, and here is where the attention and money actually went.
@@ -463,24 +473,24 @@ person who does every next task.
    (two parts of the org are acting on incompatible assumptions).
 3. They decide the high-level correction — a revised purpose, a new domain, a retired belief —
    and **pass the more specific work to the matching steward**. They do not approve the
-   implementations; the steward does.
-4. They review memory changes that touch strategy, and approve, edit, or reject them. Domain-level
-   memory stays with the steward.
+   implementations; the steward does, even when that steward is also a Shaper.
+4. They review memory changes that touch strategy or funding, and approve, edit, or reject them.
+   Domain-level memory stays with the steward.
 5. Unmatched work that has no steward is a strategic signal: this capability does not exist yet.
-   They raise it to the electorate rather than absorbing the tickets themselves.
+   They decide whether to create the mandate rather than absorbing the tickets themselves.
 
 **What memory does:** this journey is memory _maintenance_ at the strategic layer — the gardening
 that keeps the corpus small, current, and trusted.
 **Why it feels intelligent:** the organization can be wrong out loud, and strategy turns into work
-without the founder becoming the work.
+without the Shapers becoming the work.
 **How we know it works:** the memory corpus stays small enough for a person to read in an
-afternoon, and the founder's queue is strategy and gaps — not a dump of every open ticket.
+afternoon, and the Shaper queue is strategy, funding, and gaps — not a dump of every open ticket.
 
 ---
 
 ## Journey 5 — The organization decides, and then learns
 
-**Who:** whoever holds voting power, at a governance moment.
+**Who:** the Shapers, at a governance moment.
 **Wants:** to decide well, without being asked to approve everything.
 
 The failure mode this journey has to avoid is approval fatigue. If every good idea becomes
@@ -494,17 +504,16 @@ begins with routing, not drafting.
    for the test and the tiers.
 2. **Most things stop here** — done inside an existing mandate and logged, or waved through by the
    one person who holds that envelope, or opened for a short objection window that closes in silence.
-3. **What remains goes to a vote of the configured electorate** — not "the members" by default.
-   The founder named who holds voting power; that body decides commitments of shared resources
-   beyond an existing mandate, changes to the rules, changes to who counts as a member, and changes
-   to the steward set. The AI drafts it grounded in memory, and states what it is assuming and what
-   would make the proposal wrong.
-4. Voters can see what the organization decided before on similar questions, and what happened as
+3. **What remains goes to the Shapers** — not "the members" by default. The founder named the
+   first of them; they decide commitments of shared resources beyond an existing mandate, changes
+   to the rules, changes to who counts as a member, and changes to the steward set. The AI drafts
+   it grounded in memory, and states what it is assuming and what would make the proposal wrong.
+4. Shapers can see what the organization decided before on similar questions, and what happened as
    a result.
 5. The decision is made by people, on-chain where it matters.
 6. **The outcome is recorded against the decision** — did it do what we expected?
 7. Later, when reality disagrees with the prediction, the AI proposes updating the belief that
-   produced it. The founder approves if it is strategic; the matching steward approves if it is
+   produced it. The Shapers approve if it is strategic; the matching steward approves if it is
    inside a domain.
 
 **What memory does:** step 1 depends on memory knowing the organization's mandates; step 6 is what

--- a/docs/product/user-journeys.md
+++ b/docs/product/user-journeys.md
@@ -168,13 +168,40 @@ with the Shapers.
 
 Tier 3, or Tier 4 when the decision changes how decisions get made.
 
-- Add a steward or create a mandate. Evidence is unmatched work accumulating in a domain, or any
-  Shaper proposing. The AI may draft the proposal; the Shapers decide.
+- Create, change, or close a mandate — one decision, see below.
 - Remove or replace a steward. A steward can resign without a vote; filling the seat is a Shaper
   decision. A steward cannot fire themselves out of accountability.
-- Renew, expand, or shrink an envelope.
 - Change who is a Shaper, the voting method, the purpose, or entry and exit.
 - Issue, mint, or burn tokens; space-to-space membership; activating a space.
+
+#### How a mandate is created
+
+A mandate is not a strategic essay with money taped on, and strategy is not a second vote that later
+becomes a mandate. Those two designs both add a step.
+
+**Strategy is what we believe. A mandate is a job.** "We exist to regenerate this watershed" is
+memory. "Alex holds community, up to 5,000, until September" is a mandate. Purpose changes, who is
+a Shaper, and entry rules stay strategy. They never need a steward or a pot.
+
+When the job _is_ the decision, Shapers decide it **once**, as one object:
+
+> this domain, this steward, this pot (which may be zero), this review date
+
+The AI drafts that object. Shapers approve, amend, or reject it. Attaching funds is a field on the
+same proposal, not a follow-up. A job with no money is still a mandate — someone owns the work. A
+pot with no job is not a mandate; that is the slush fund we already rejected.
+
+Where the draft comes from, in order of honesty:
+
+1. **Unmatched work** — tickets that had no steward, aggregated. This is the default after
+   founding. Three unfilled tasks in one area is one job that does not exist yet.
+2. **Founding** — the AI proposes the first set; the founder confirms.
+3. **A Shaper proposes** — allowed, and weaker. An assertion without a pattern of unmet need
+   should have to argue harder than a pile of open tickets.
+
+There is not a separate "strategy vote" that later spawns a mandate. If a belief change implies a
+new job, the AI puts the mandate on the same item: here is what we would now believe, and here is
+the job it creates. One queue, one decision.
 
 #### C. Work tickets — matching steward, before anyone starts
 
@@ -497,13 +524,15 @@ becoming the person who does every next task.
    priority, and here is where the attention and money actually went.
 2. They see which beliefs have gone **stale** (nobody has revisited this in a year) or **contested**
    (two parts of the org are acting on incompatible assumptions).
-3. They decide the high-level correction — a revised purpose, a new domain, a retired belief —
-   and **pass the more specific work to the matching steward**. They do not approve the
-   implementations; the steward does, even when that steward is also a Shaper.
-4. They review memory changes that touch strategy or funding, and approve, edit, or reject them.
-   Domain-level memory stays with the steward.
-5. Unmatched work that has no steward is a strategic signal: this capability does not exist yet.
-   They decide whether to create the mandate rather than absorbing the tickets themselves.
+3. They decide the high-level correction. If it is only a belief, they update memory. If it
+   implies a new job, the AI has already drafted the mandate onto the same item — domain, steward,
+   pot, review date — so they are not asked twice. They then **pass the more specific work to the
+   matching steward**. They do not approve the implementations; the steward does, even when that
+   steward is also a Shaper.
+4. They review memory changes that touch strategy, and approve, edit, or reject them. Domain-level
+   memory stays with the steward.
+5. Unmatched work that has no steward is the usual evidence for a new mandate. They decide that
+   one object rather than absorbing the tickets themselves.
 
 **What memory does:** this journey is memory _maintenance_ at the strategic layer — the gardening
 that keeps the corpus small, current, and trusted.

--- a/docs/product/user-journeys.md
+++ b/docs/product/user-journeys.md
@@ -1,0 +1,409 @@
+---
+title: 'User Journeys — The Intelligent Organization'
+date: 2026-08-20
+status: draft
+tags: [product, journeys, intelligent-org, ai]
+---
+
+# User Journeys — The Intelligent Organization
+
+**This document describes the target state**: how we intend people to use Hypha once the
+intelligent organization works, not how the product behaves today. It is the product brief that
+the [Organizational Intelligence architecture](../architecture/organizational-intelligence.md)
+exists to serve. Written for the whole team — no code required.
+
+---
+
+## The promise, in one sentence
+
+> Anyone in a Hypha organization opens the app and immediately knows what matters and what to do
+> next — because the organization remembers, and the AI keeps that memory active.
+
+Everything below is a way of delivering that sentence to a specific kind of person on a specific
+kind of day.
+
+---
+
+## Three rules that make a journey feel intelligent
+
+These are the tests we apply to every screen and every interaction. If a journey breaks one of
+them, it isn't an intelligent-organization journey — it's just software with a chat box.
+
+1. **Nobody starts from a blank page.** Whatever you are about to write — a proposal, a summary, a
+   plan, an onboarding note — the organization's memory has already drafted a first version, and
+   your job is to correct it rather than produce it.
+2. **Nobody has to ask what changed.** The organization tells you, unprompted, in a form short
+   enough to read in thirty seconds. You should never have to go hunting to find out you were
+   needed.
+3. **Nothing the organization learns is lost.** Every decision, and every recommendation you
+   accepted or rejected, leaves a trace that shapes what the AI says next month. The org gets
+   sharper with use.
+
+---
+
+## The trust ladder
+
+The AI does not arrive with full autonomy. It climbs. Each rung must be earned by demonstrated
+accuracy at the rung below, and we should be able to say out loud which rung we are on for any
+given space.
+
+| Rung         | The AI...                                         | Human role         |
+| ------------ | ------------------------------------------------- | ------------------ |
+| 1. Observe   | records and organizes what happened               | reads              |
+| 2. Brief     | explains what changed and what it means           | reads, corrects    |
+| 3. Recommend | names an owner and a next action, with evidence   | accepts or rejects |
+| 4. Draft     | writes the proposal, memo, or memory update       | edits and approves |
+| 5. Propose   | files it into the real workflow, pending approval | approves           |
+| — Decide     | **never**                                         | always human       |
+
+The last row is a product commitment, not a technical limitation. Money, membership, and
+governance outcomes are decided by people. This is what makes the memory trustworthy enough to be
+worth having.
+
+One nuance about rung 5. Filing something into the workflow includes choosing _which_ workflow —
+whether this needs one owner's nod, a quiet objection window, or a full vote. Routing well is more
+valuable than drafting well, and the AI's bias must always run toward the lightest channel that
+fits, never toward the vote. See [Journey 5](#journey-5--the-organization-decides-and-then-learns).
+
+---
+
+## Stakeholders
+
+Two things to hold before reading the list.
+
+**These are roles, not people.** In a five-person organization, one person is plausibly founder,
+steward, coordinator _and_ beneficiary at once. The taxonomy answers "what does this person need
+right now", not "what is their job title". Someone can move between rings, and most people do.
+
+**What someone stakes should determine their authority over memory.** This is the organizing
+principle. A person who stakes their time and judgment gets to change what the organization
+believes. A person who stakes capital gets to see honestly and to be heard — but not to direct. A
+person who stakes nothing yet gets to read what the organization chooses to publish. Getting this
+mapping wrong in either direction is how organizations either capture themselves or lose trust.
+
+### Ring 1 — Inside: members who hold decision rights
+
+They stake time and judgment. They read memory freely, propose changes to it, and vote.
+
+- **Founder / initiator** — defines purpose and initial structure. A deliberately temporary role
+  that should dissolve into the others.
+- **Contributor** — does the work and holds a vote. The majority.
+- **Steward** — accountable for a domain; holds a mandate and a budget envelope; approves at Tier 1.
+- **Coordinator** — keeps rhythms, onboarding, and memory hygiene running. Custodian of the corpus.
+
+### Ring 2 — The committed edge: a formal stake, no operational vote
+
+They stake capital, dependency, or reputation. They see a curated view and can file observations.
+They do not direct operations.
+
+- **Investor / funder** — capital at risk.
+- **Beneficiary** — the people the organization exists to serve.
+- **Partner organization** — a peer or parent space with its own membership.
+
+### Ring 3 — Outside: no formal stake yet
+
+They stake attention.
+
+- **Prospective member** — evaluating whether to join.
+- **Builder / integrator** — extending the platform with their own tool.
+- **Verifier / auditor** — checking one specific claim.
+
+### The mapping
+
+| Stakeholder     | Stakes                | Memory access                                 | Decision rights                          | Journey |
+| --------------- | --------------------- | --------------------------------------------- | ---------------------------------------- | ------- |
+| Founder         | purpose, reputation   | writes the seed corpus                        | all tiers                                | 1       |
+| Contributor     | time, judgment        | reads all; proposes changes                   | votes at Tier 3                          | 2, 3    |
+| Steward         | domain accountability | approves changes in their domain              | approves Tier 1 inside their mandate     | 4       |
+| Coordinator     | the org's coherence   | curates and consolidates                      | routes and schedules; no extra authority | 4, 5    |
+| Investor/funder | capital               | curated view, including unsettled arguments   | consent on reserved matters only         | 6       |
+| Beneficiary     | dependency on outcome | published subset; contributes outcome reports | none; files observations                 | 7       |
+| Partner org     | joint commitments     | artifacts relayed to them                     | decides for itself                       | 8       |
+| Prospective     | attention             | the public brief                              | none                                     | 2       |
+| Builder         | effort, reputation    | writes via app identity; proposes only        | none                                     | 9       |
+| Verifier        | their own assurance   | specified claims plus on-chain proof          | none                                     | 6       |
+
+Journeys 1–5 sit inside the organization, 6–7 at the committed edge, 8–9 outside it.
+
+---
+
+## Journey 1 — The founder starts an organization
+
+**Who:** someone with a purpose and no structure yet.
+**Wants:** to go from an idea to a real organization others can join, without learning governance
+theory first.
+
+1. They describe what they're trying to do, in their own words, in conversation.
+2. The AI interviews them — not a form. It asks what the organization is for, who it serves, what
+   it will not do, and how they will know it's working. It draws on patterns from comparable
+   organizations in the network to ask sharper questions.
+3. It proposes a structure: the space, sensible entry and decision methods, a first set of roles.
+   The founder edits rather than invents.
+4. **The conversation becomes the organization's first memory.** The purpose, the boundaries, and
+   the success signals are written as the founding artifacts — not buried in a chat log.
+5. The founder is shown what was recorded and asked to confirm it. This is the first approval.
+
+**What memory does:** this journey _creates_ the seed corpus. Nothing else works well without it.
+**Why it feels intelligent:** the founder never sees an empty form, and the organization can
+already answer "what are we for?" on day one.
+**How we know it works:** the founding artifacts are still being cited and revised six months
+later, instead of abandoned.
+
+---
+
+## Journey 2 — Joining: from prospect to contributor
+
+**Who:** a prospective member evaluating an organization, and then the same person once inside.
+**Wants:** first, to judge whether this is worth joining. Then, to become useful quickly without
+reading a year of chat.
+
+1. **Before joining**, they read the organization's public brief — what it is for, how it decides,
+   what it has actually done. Generated from memory, so it is current rather than a stale landing
+   page, and honest about what is unresolved. Deciding _not_ to join on good information is a
+   successful outcome of this step.
+2. On arrival they get a briefing generated from the organization's memory: what this org believes
+   it is for, what it has decided, what is currently open, and what is contested.
+3. They can ask follow-ups in plain language — "why did we choose this voting method?" — and get an
+   answer that cites the actual decision, with its date and reasoning.
+4. The AI proposes where this person plausibly fits, based on the stated skills and the
+   organization's open needs.
+5. Their first contribution is scoped for them: one specific, small, real thing.
+
+**What memory does:** this is the clearest proof that memory has value. Onboarding a human — and
+persuading a prospect — is mostly reading organizational memory aloud.
+**Why it feels intelligent:** the org explains itself, including its unresolved arguments, rather
+than handing over a document dump.
+**How we know it works:** time from joining to first meaningful contribution drops sharply, and
+new members stop asking questions that are already answered in memory.
+
+---
+
+## Journey 3 — A contributor's week (the core loop)
+
+**Who:** an active member with limited attention and a real job.
+**Wants:** to not miss the thing that needed them.
+
+1. **Once per period, they receive a digest** — not a notification per event. It says what changed
+   in the organization, what it means, and what needs them specifically.
+2. Each item names _them_, states one concrete next action, and shows the evidence it is based on.
+   Anything that can't do all three doesn't get sent.
+3. They act, defer, or dismiss. Dismissing is a first-class action and it is recorded.
+4. When they act, the AI has already drafted the artifact — the proposal text, the summary, the
+   update — so acting is editing.
+5. What they dismissed shapes what they are shown next time.
+
+**What memory does:** memory supplies the interpretation ("this matters because of the commitment
+we made in March"); the activity ledger supplies the detection ("this changed").
+**Why it feels intelligent:** it respects attention. The measure of this journey is not how much
+the AI says, but how rarely it is wrong to speak.
+**How we know it works:** the acceptance rate. If fewer than roughly a third of items are acted on,
+the channel is noise and should be turned off rather than tuned.
+
+---
+
+## Journey 4 — The steward keeps the organization coherent
+
+**Who:** whoever holds responsibility for the organization staying true to itself.
+**Wants:** to notice drift before it becomes a crisis.
+
+1. They see where **stated intent and actual behaviour have diverged** — we said this was the
+   priority, and here is where the attention and money actually went.
+2. They see which beliefs have gone **stale** (nobody has revisited this in a year) or **contested**
+   (two parts of the org are acting on incompatible assumptions).
+3. They review memory changes proposed by the AI and by connected apps, and approve, edit, or
+   reject them. This is the main way memory quality is maintained.
+4. They can retire beliefs that no longer hold, with the reason recorded.
+
+**What memory does:** this journey is memory _maintenance_ — the gardening that keeps the corpus
+small, current, and trusted.
+**Why it feels intelligent:** the organization can be wrong out loud. Surfacing contradiction is
+more valuable than projecting false consensus.
+**How we know it works:** the memory corpus stays small enough for a person to read in an
+afternoon, and its age profile stays healthy.
+
+---
+
+## Journey 5 — The organization decides, and then learns
+
+**Who:** the membership, at a governance moment.
+**Wants:** to decide well, without being asked to approve everything.
+
+The failure mode this journey has to avoid is approval fatigue. If every good idea becomes
+something everyone must vote on, participation collapses and the votes that matter get rubber-
+stamped alongside the ones that don't. **Most decisions must never reach a vote.** So the journey
+begins with routing, not drafting.
+
+1. **The decision is routed to a tier.** The AI proposes the lowest tier that fits, names the
+   mandate it believes already covers this, and has to argue for escalation rather than default to
+   it. See [decision rights](../architecture/organizational-intelligence.md#8-decision-rights--what-becomes-a-proposal)
+   for the test and the tiers.
+2. **Most things stop here** — done inside an existing mandate and logged, or waved through by the
+   one person who holds that envelope, or opened for a short objection window that closes in silence.
+3. **What remains goes to a vote**: commitments of shared resources beyond an existing mandate,
+   changes to the rules, and changes to who counts as a member. The AI drafts it grounded in memory,
+   and states what it is assuming and what would make the proposal wrong.
+4. Members can see what the organization decided before on similar questions, and what happened as
+   a result.
+5. The decision is made by people, on-chain where it matters.
+6. **The outcome is recorded against the decision** — did it do what we expected?
+7. Later, when reality disagrees with the prediction, the AI proposes updating the belief that
+   produced it. A steward approves.
+
+**What memory does:** step 1 depends on memory knowing the organization's mandates; step 6 is what
+turns a record into learning. Without step 6 the organization has a filing cabinet, not
+intelligence.
+**Why it feels intelligent:** the organization protects its own attention. Being asked to vote
+means something, because it happens rarely and only about things that are genuinely shared.
+**How we know it works:** two numbers. The share of votes that pass near-unanimously with no real
+discussion should be _low_ — a high rate means we are taxing everyone with decisions that belonged
+at a lower tier. And the same argument should stop recurring, with beliefs carrying a visible
+history of revision.
+
+---
+
+## Journey 6 — The investor or funder
+
+**Who:** someone with capital at risk and no operational role. A token holder, an impact investor, a
+grant funder, a philanthropic backer.
+**Wants:** to know whether the organization is doing what it said it would, without anyone having to
+prepare a report.
+
+1. They open a **standing overview**, not a quarterly deck. It answers: what did this organization
+   say it would do, what has it done, where is the money, what changed since I last looked, and what
+   is at risk.
+2. The overview is a **view over the same memory and ledger the members use**. It is not a separate
+   narrative maintained for outsiders.
+3. Claims that matter are **verifiable rather than asserted**. Treasury movements, votes, and
+   membership changes settle on-chain, so the investor can check instead of trusting. The AI's job is
+   to explain that record in plain language and keep the underlying proof one step away. This is also
+   the whole of the verifier's journey.
+4. **They can respond.** An observation, concern, or question becomes a signal in the organization's
+   normal triage — visible, owned, and answerable. It does not become an instruction.
+5. On **reserved matters** — changing the purpose, diluting holders, disposing of major assets —
+   their consent is required. That is a distinct decision class with a distinct constituency, not a
+   normal member vote.
+6. If they flag a risk that turns out to be real, or decline to fund again, that becomes part of
+   decision memory too.
+
+**What memory does:** it removes reporting as a separate activity. Because the report is a view, it
+costs almost nothing to produce and cannot quietly drift from what members see.
+**Why it feels intelligent:** the investor gets a current and honest picture, including the arguments
+the organization has not settled. Counter-intuitively that builds more confidence than a polished
+one, because it is checkable.
+**How we know it works:** reporting effort per funder trends toward zero, and investor-raised signals
+get resolved rather than parked.
+
+> **Design constraint: one organization, one memory, different views.** The moment an investor-facing
+> narrative is maintained separately from what members see, we have built an investor-relations tool
+> and destroyed the thing that made it trustworthy. Curation may legitimately differ — privacy,
+> granularity, commercial sensitivity. The underlying beliefs may not.
+
+---
+
+## Journey 7 — The beneficiary
+
+**Who:** the people the organization exists to serve — an energy community's households, a
+cooperative's customers, a neighbourhood.
+**Wants:** to know what to expect, and to be heard when reality doesn't match it.
+
+1. They see what the organization has committed to that affects them, in plain language, without
+   reading governance records.
+2. They report **what actually happened** — the bill went up, the service failed, the promise landed.
+3. **That report is the organization's outcome signal.** This is the Observe step of the loop closing:
+   the organization predicted an effect, and the people on the receiving end say whether it occurred.
+4. Where beneficiary experience contradicts a stated belief, the AI surfaces the contradiction and
+   proposes revising the belief. A steward approves.
+
+**What memory does:** beneficiaries supply the ground truth that decision memory needs. Without them
+the organization grades its own homework, and its "learning" is just internal argument.
+**Why it feels intelligent:** the organization can be corrected by reality rather than only by
+whoever argues best in a meeting.
+**How we know it works:** beneficiary reports actually change beliefs. If they never do, we have
+built feedback theatre.
+
+---
+
+## Journey 8 — The partner or ecosystem steward
+
+**Who:** whoever holds a network, federation, or parent organization.
+**Wants:** to spot what one part has learned that another part needs.
+
+1. Patterns across member organizations are surfaced — the same risk appearing in three places, a
+   solution one org found that two others are still struggling with.
+2. Relevant insight is relayed between organizations as a signal, with its provenance intact.
+3. Each receiving organization decides for itself whether to adopt it. Nothing is imposed downward.
+4. Network-level memory accumulates: what tends to work, in what conditions.
+
+**What memory does:** portable, self-describing memory artifacts are what make cross-org transfer
+possible without merging anyone's data.
+**Why it feels intelligent:** organizations learn from each other's experience without surveillance
+and without central control.
+**How we know it works:** relayed insight gets adopted, and adoption improves outcomes.
+
+---
+
+## Journey 9 — The builder or integrator
+
+**Who:** someone building a specialized tool — energy modelling, CRM, impact measurement.
+**Wants:** their tool to make the whole organization smarter, without handing over their data model.
+
+1. They build their app with its own local data, in whatever shape suits it.
+2. When their app produces something the organization should _know_ — an assessment, a risk, a
+   recommendation — it promotes that as a memory artifact.
+3. Hypha never learns their schema. The shared layer is meaning, not tables.
+4. Their insight now appears in every member's digest and in every AI answer, attributed to their
+   app.
+
+**What memory does:** memory is the integration surface. This is what makes the platform
+extensible without becoming a data warehouse.
+**Why it feels intelligent:** the organization's understanding improves as tools are added, rather
+than fragmenting across them.
+**How we know it works:** an external app can contribute a genuine insight without any Hypha-side
+schema change.
+
+---
+
+## What we are deliberately not promising
+
+Naming these protects the product from the most attractive wrong turns.
+
+- **The AI does not decide.** Not on money, membership, or governance.
+- **The AI does not act unattended** on anything with external consequences.
+- **The AI does not interrupt without evidence.** If it cannot cite what it is reasoning from and
+  name who should act, it stays quiet.
+- **The AI does not silently edit memory.** Every change to what the organization believes passes
+  a human.
+- **Memory is not a search index over everything ever said.** It is a small, curated, current
+  account of what the organization believes and has decided. See the architecture document for why
+  this distinction is load-bearing.
+
+---
+
+## What success looks like
+
+Five measures, in priority order:
+
+1. **Recommendation acceptance rate** — of the things the AI proactively raised, how many did a
+   human act on? This is the single honest measure of whether we built intelligence or noise.
+2. **Time to usefulness for a new member** — how long from joining to first real contribution.
+3. **Memory health** — is the corpus small, current, and actively revised, or growing and stale?
+4. **Decisions with recorded outcomes** — what fraction of decisions can we say the result of? This
+   is the ceiling on how much the organization can learn.
+5. **Consensus-vote rate** — what share of votes pass near-unanimously with no substantive
+   discussion? This one should be _low_. A high rate means decisions that belonged at a lower tier
+   are taxing everyone's attention, and approval fatigue is being manufactured.
+
+Notably absent: messages sent, questions answered, artifacts created, **and proposals raised**.
+Those are activity, and optimizing them produces exactly the wrong product — a system that
+generates governance rather than one that resolves it.
+
+---
+
+## Related
+
+- [Organizational Intelligence — Architecture](../architecture/organizational-intelligence.md) —
+  how memory is maintained, retrieved, and bounded to serve these journeys
+- Space Intelligence & Documentation spec — the memory substrate; arrives with
+  [PR #2461](https://github.com/hypha-dao/hypha-web/pull/2461)
+- [Documents and media overview](../architecture/documents-and-media-overview.md) — where raw files
+  live

--- a/docs/product/user-journeys.md
+++ b/docs/product/user-journeys.md
@@ -197,11 +197,10 @@ pot with no job is not a mandate; that is the slush fund we already rejected.
 
 Where the draft comes from, in order of honesty:
 
-1. **Unmatched work** — tickets that had no steward, aggregated. This is the default after
-   founding. Three unfilled tasks in one area is one job that does not exist yet.
+1. **A ticket with no steward** — the AI must draft the mandate on that first ticket. Further
+   tickets in the same gap attach to the same proposal. This is the default after founding.
 2. **Founding** — the AI proposes the first set; the founder confirms.
-3. **A Shaper proposes** — allowed, and weaker. An assertion without a pattern of unmet need
-   should have to argue harder than a pile of open tickets.
+3. **A Shaper proposes** — allowed, and weaker than a ticket the matcher could not place.
 
 There is not a separate "strategy vote" that later spawns a mandate. If a belief change implies a
 new job, the AI puts the mandate on the same item: here is what we would now believe, and here is
@@ -214,9 +213,10 @@ the job it creates. One queue, one decision.
 - A steward may set standing rules ("auto-approve tickets of type X under size Y"). That is them
   using the mandate, not a new decision class, and it is how they avoid becoming a per-ticket
   bottleneck.
-- **No matching steward:** the ticket stays open, labelled with the capability it needs, and
-  becomes evidence for a "we need this steward" vote. It is not silently dumped on a Shaper as
-  permanent work.
+- **No matching steward:** the AI must file a mandate proposal to the Shapers at once — this
+  domain, this pot, this review date, a steward if it can name one. The ticket stays open and
+  attaches to that proposal. It is not silently dumped on a Shaper as permanent work, and it does
+  not wait to "accumulate."
 - The contributor then claims, declines, or acts. That is a personal decision, not an organizational
   one.
 
@@ -388,11 +388,12 @@ end of the
 
 **Steward — _"What implementations are waiting on me, and is my domain drifting?"_**
 Every AI-created ticket inside their mandate that has not yet been green-lit — the specific work
-that strategy has become — plus envelope burn measured against the review date. They approve,
-reject, or hold **before anyone starts the work** — and **a hold must carry a resumption trigger**,
-a date or a condition, because a hold without one is a silent no that nobody has to own. Repeated
-rejections of similar items are evidence that the routing or the mandate boundary is wrong, not
-that the steward is being difficult.
+that strategy has become, already carrying a recommended contributor — plus envelope burn measured
+against the review date. They approve, reject, or hold **before anyone starts**, and they can
+change the named person. **A hold must carry a resumption trigger**, a date or a condition, because
+a hold without one is a silent no that nobody has to own. Repeated rejections of similar items are
+evidence that the routing or the mandate boundary is wrong, not that the steward is being
+difficult.
 
 **Contributor — _"What needs me?"_**
 A queue with one item at the top, not a dashboard: steward-approved work routed to them, plus
@@ -545,39 +546,37 @@ next Friday.
 
 Three things happen at three different speeds here, and conflating them is a design error:
 
-|                                                              | Cadence                         | Why                                                  |
-| ------------------------------------------------------------ | ------------------------------- | ---------------------------------------------------- |
-| **Detection** — something needs doing                        | continuous                      | delay here is pure loss                              |
-| **Steward gate** — approve, reject, or hold                  | continuous                      | work should never sit unrouted waiting for a cycle   |
-| **Routing** — an approved ticket reaches a contributor queue | continuous, after approval      | the steward decides whether; the matcher decides who |
-| **Interruption** — a push, email, or ping                    | rate-limited, urgency overrides | the only genuinely scarce resource is attention      |
+|                                                              | Cadence                         | Why                                                |
+| ------------------------------------------------------------ | ------------------------------- | -------------------------------------------------- |
+| **Detection** — something needs doing                        | continuous                      | delay here is pure loss                            |
+| **Steward gate** — approve, reject, or hold, and confirm who | continuous                      | work should never sit unrouted waiting for a cycle |
+| **Routing** — an approved ticket reaches the named queue     | continuous, after approval      | the steward confirms whether and who               |
+| **Interruption** — a push, email, or ping                    | rate-limited, urgency overrides | the only genuinely scarce resource is attention    |
 
 So the queue is always current; the digest is a **catch-up for people who haven't looked**, not the
 delivery mechanism; and the interrupt is reserved for things that will go wrong if they wait.
 
-1. **The moment a need is detected, the AI creates a ticket and routes it to the matching
-   steward.** Detection is continuous. The ticket is a recommendation, not work.
-2. **The steward green-lights it — approve, reject, or hold — before anyone starts.** A standing
-   rule the steward has already set ("auto-approve tickets of type X under size Y") counts as this
-   step. Until then the ticket does not reach a contributor.
-3. **Once approved, the AI proposes a person rather than assigning one.** It identifies who fits,
-   based on stated skills, demonstrated history, and whose mandate the work falls under — then
-   checks that against what that person has said they can take on. The work appears in the
-   suggested person's queue with the reasoning visible, and stays claimable by anyone else. In a
-   voluntary organization you cannot allocate work — you can only put it in front of the person
-   most likely to pick it up, and make it easy to say yes.
-4. Each item names a person, states one concrete next action, and shows the evidence behind it.
-   Anything that can't do all three isn't routed to a human at all.
-5. **When nobody fits, or no steward exists for the domain, that is information, not a failure.**
-   The AI says so explicitly rather than quietly dropping the work on whoever answers fastest —
-   the most common and most corrosive default in every organization. The item stays open, visible,
-   and labelled with the capability it needs.
-6. **Unmatched work escalates as a capacity signal** to whoever holds that domain, or as evidence
-   for a "we need this steward" vote if nobody does. Repeated misses aggregate: three unfilled
-   tasks in the same area over a month is not three problems, it is one role that needs filling.
-7. The person acts, defers, declines, or the work stays open. Declining is a first-class action and
-   is recorded — it is how the matcher learns.
-8. When they act, the AI has already drafted the artifact — the proposal text, the summary, the
+1. **The moment a need is detected, the AI creates a ticket with a recommended contributor
+   already on it** — who fits, based on stated skills, demonstrated history, the mandate, and
+   declared capacity — and sends it to the matching steward. Detection is continuous. The ticket
+   is a recommendation, not work. If nobody fits, it says so on the ticket rather than inventing
+   a name.
+2. **The steward green-lights it — approve, reject, or hold — and can change the recommended
+   person before anyone starts.** A standing rule ("auto-approve tickets of type X under size Y")
+   counts as approval of both the work and the named person. Until the steward confirms, the
+   ticket does not reach a contributor queue. In a voluntary organization the named person is
+   still a suggestion: the work stays claimable by anyone else.
+3. Each item names a person (or says nobody fits), states one concrete next action, and shows the
+   evidence behind it. Anything that can't do the last two isn't routed to a human at all.
+4. **If there is no steward for this ticket, the AI must propose a new mandate to the Shapers
+   immediately** — this domain, a steward if it can name one, this pot (which may be zero), this
+   review date. It does not wait for a pile of similar tickets, and it does not dump the work on
+   whoever answers fastest. The ticket stays open, labelled with the capability it needs, and
+   attaches to that proposal. Further tickets in the same gap attach to the same open mandate
+   rather than opening a second vote.
+5. The named person acts, defers, declines, or the work stays open. Declining is a first-class
+   action and is recorded — it is how the matcher learns. The steward can re-route.
+6. When they act, the AI has already drafted the artifact — the proposal text, the summary, the
    update — so acting is editing.
 
 **On matching without ossifying roles.** Matching purely on demonstrated history is the obvious
@@ -621,9 +620,8 @@ organization admits when it is short-handed instead of overloading its most cons
 noise. Time from detection to a claimed owner. And the share of work that finds someone without
 escalation, which is the honest read on whether the org has the people it needs.
 
-> Unmatched work accumulating in a domain is the evidence base for a new mandate — which is a Tier 3
-> decision, because it creates an ongoing obligation. This is where "we need a developer and a
-> budget" should come from: an observed pattern of unmet need, not an assertion. See
+> A ticket with no steward is itself the evidence for a new mandate. The AI drafts that mandate
+> for the Shapers on the first such ticket, not the third. See
 > [decision rights](../architecture/organizational-intelligence.md#8-decision-rights--what-becomes-a-proposal).
 
 ---
@@ -646,8 +644,8 @@ becoming the person who does every next task.
    steward is also a Shaper.
 4. They review memory changes — strategy or domain — and approve, edit, or reject them. A steward
    may draft; only Shapers write it into the corpus.
-5. Unmatched work that has no steward is the usual evidence for a new mandate. They decide that
-   one object rather than absorbing the tickets themselves.
+5. A ticket with no steward arrives as a mandate the AI has already drafted. They decide that
+   object rather than absorbing the tickets themselves.
 
 **What memory does:** this journey is memory _maintenance_ at the strategic layer — the gardening
 that keeps the corpus small, current, and trusted.

--- a/docs/product/user-journeys.md
+++ b/docs/product/user-journeys.md
@@ -21,7 +21,7 @@ exists to serve. Written for the whole team — no code required.
 
 Everything below is a way of delivering that sentence to a specific kind of person on a specific
 kind of day. Both halves of it — _what matters_ and _what to do next_ — resolve differently for a
-contributor, a steward, and an investor; see
+contributor, a steward, and a Shaper; see
 [what each stakeholder opens the app for](#what-each-stakeholder-opens-the-app-for).
 
 ---
@@ -40,32 +40,6 @@ them, it isn't an intelligent-organization journey — it's just software with a
 3. **Nothing the organization learns is lost.** Every decision, and every recommendation you
    accepted or rejected, leaves a trace that shapes what the AI says next month. The org gets
    sharper with use.
-
----
-
-## The trust ladder
-
-The AI does not arrive with full autonomy. It climbs. Each rung must be earned by demonstrated
-accuracy at the rung below, and we should be able to say out loud which rung we are on for any
-given space.
-
-| Rung         | The AI...                                         | Human role         |
-| ------------ | ------------------------------------------------- | ------------------ |
-| 1. Observe   | records and organizes what happened               | reads              |
-| 2. Brief     | explains what changed and what it means           | reads, corrects    |
-| 3. Recommend | names an owner and a next action, with evidence   | accepts or rejects |
-| 4. Draft     | writes the proposal, memo, or memory update       | edits and approves |
-| 5. Propose   | files it into the real workflow, pending approval | approves           |
-| — Decide     | **never**                                         | always human       |
-
-The last row is a product commitment, not a technical limitation. Money, membership, and
-governance outcomes are decided by people. This is what makes the memory trustworthy enough to be
-worth having.
-
-One nuance about rung 5. Filing something into the workflow includes choosing _which_ workflow —
-whether this needs one owner's nod, a quiet objection window, or a full vote. Routing well is more
-valuable than drafting well, and the AI's bias must always run toward the lightest channel that
-fits, never toward the vote. See [Journey 5](#journey-5--the-organization-decides-and-then-learns).
 
 ---
 
@@ -120,8 +94,8 @@ They stake attention.
 | Stakeholder     | Stakes                  | Memory access                                  | Decision rights                                                      | Journey |
 | --------------- | ----------------------- | ---------------------------------------------- | -------------------------------------------------------------------- | ------- |
 | Founder         | purpose, reputation     | writes the seed corpus                         | sets the organization up once; then only as Shaper and/or other hats | 1       |
-| Shaper          | judgment over the whole | reads all; decides memory                      | strategy, who is a Shaper, pots, memory, the steward set             | 4, 5    |
-| Steward         | domain accountability   | reads all; may suggest, does not decide memory | approves implementations and spends inside their mandate             | 3       |
+| Shaper          | judgment over the whole | reads all; decides memory                      | strategy, who is a Shaper, pots, memory, the steward set             | 5       |
+| Steward         | domain accountability   | reads all; may suggest, does not decide memory | approves implementations and spends inside their mandate             | 4       |
 | Contributor     | time, judgment          | reads all                                      | does the work; shapes only if also a Shaper                          | 2, 3    |
 | Investor/funder | capital                 | curated view, including unsettled arguments    | consent on reserved matters only                                     | 6       |
 | Beneficiary     | dependency on outcome   | published subset; contributes outcome reports  | none; consulted when decisions land on them                          | 7       |
@@ -162,7 +136,7 @@ The founder confirms; the AI does not invent a slot they never spoke to.
 - Entry and exit method.
 - The first mandates: one per real near-term job — domain, steward, pot, review date, optional
   cosigners.
-- The starting [trust-ladder](#the-trust-ladder) rung for the AI.
+- A reminder the AI never decides money, membership, or memory. People do.
 
 After this, "founder" is a historical fact, not a queue. Ongoing strategy, funding, and memory sit
 with the Shapers.
@@ -430,7 +404,7 @@ shared commitments surface to both.
 
 **Prospective member — _"Is this real, and is there something here for me?"_**
 The public brief, evidence the organization is actually doing things, and — the important part —
-open work nobody has picked up that matches what they say they can do. Journey 3's unmatched queue
+open work nobody has picked up that matches what they say they can do. The unmatched queue
 _is_ the recruitment surface: the capacity gap and the joining funnel are one list read from two
 directions. They express interest against a specific piece of work, so joining arrives with a first
 task attached instead of a generic welcome.
@@ -493,7 +467,7 @@ theory first.
      want that hat. Not automatic.
    - **First mandates** — one per real job in those 90 days: domain, steward (someone already
      doing it, or open if nobody is), pot, review date, cosigners only where they were uneasy.
-   - Entry and exit, and the starting [trust-ladder](#the-trust-ladder) rung.
+   - Entry and exit. The AI never decides money, membership, or memory.
 
    Empty answers stay empty. It does not invent a legal steward because the form had a slot. An
    unmatched 90-day job with no name becomes an open mandate — the first recruitment surface.
@@ -538,160 +512,119 @@ new members stop asking questions that are already answered in memory.
 
 ---
 
-## Journey 3 — Work finds the right person (the core loop)
+## Journey 3 — The contributor uses the app
 
-**Who:** an active member with limited attention and a real job.
-**Wants:** to be handed the thing that genuinely needs them, when it arises — not to discover it
-next Friday.
+**Who:** someone who does the work. They may also be a steward or a Shaper; this is the hat they
+wear when they open the app to _do_ something.
+**Wants:** one next thing, already scoped, already allowed, already drafted.
 
-Three things happen at three different speeds here, and conflating them is a design error:
+They open the app. The first thing they see is **What needs me?** — not a dashboard, not a chat.
 
-|                                                              | Cadence                         | Why                                                |
-| ------------------------------------------------------------ | ------------------------------- | -------------------------------------------------- |
-| **Detection** — something needs doing                        | continuous                      | delay here is pure loss                            |
-| **Steward gate** — approve, reject, or hold, and confirm who | continuous                      | work should never sit unrouted waiting for a cycle |
-| **Routing** — an approved ticket reaches the named queue     | continuous, after approval      | the steward confirms whether and who               |
-| **Interruption** — a push, email, or ping                    | rate-limited, urgency overrides | the only genuinely scarce resource is attention    |
+1. **If nothing needs them, it says so.** An empty queue is a successful screen. They can leave.
+   If they have work already in progress, that sits under the empty line: one card per open item,
+   last action, next suggested step.
+2. **If something needs them, one ticket is on top.** A steward has already said this work should
+   happen and that they are the person. The card shows why them, one concrete next action, and the
+   evidence. The AI has drafted the artifact — the update, the proposal text, the summary.
+3. **They claim, decline, or act.**
+   - Claim: the ticket is theirs. They can still walk away later.
+   - Decline: they must pick _not my thing_ or _no room right now_. Those teach the matcher
+     different lessons. They can set or revise how much they can take on — a coarse number of
+     concurrent items, not hours.
+   - Act: they edit the draft, not a blank page. When they are done they mark it done. The steward
+     can see it finished; they do not re-approve the work unless the mandate said so.
+4. **They can ask, in the ticket, what this is for.** The answer cites memory and the mandate, not
+   a guess. They should never have to hunt a chat history to start.
+5. **Work they already own stays visible until it is done or they decline it.** A change to that
+   work (new context, a blocked dependency) surfaces on the same card. It does not become a second
+   queue.
+6. **If they wear another hat, they switch.** Steward tickets and Shaper decisions are other
+   surfaces, not mixed into this queue. Mixing them is how contributors stop trusting "What needs
+   me?"
 
-So the queue is always current; the digest is a **catch-up for people who haven't looked**, not the
-delivery mechanism; and the interrupt is reserved for things that will go wrong if they wait.
+Capacity is theirs to declare. The system may say "this would be your fifth and you said three";
+it may never refuse on their behalf. Matching must not only pick people who have done this before
+— a minority of tickets should be stretch — but that is the steward's call when they confirm the
+name, not something the contributor has to negotiate.
 
-1. **The moment a need is detected, the AI creates a ticket with a recommended contributor
-   already on it** — who fits, based on stated skills, demonstrated history, the mandate, and
-   declared capacity — and sends it to the matching steward. Detection is continuous. The ticket
-   is a recommendation, not work. If nobody fits, it says so on the ticket rather than inventing
-   a name.
-2. **The steward green-lights it — approve, reject, or hold — and can change the recommended
-   person before anyone starts.** A standing rule ("auto-approve tickets of type X under size Y")
-   counts as approval of both the work and the named person. Until the steward confirms, the
-   ticket does not reach a contributor queue. In a voluntary organization the named person is
-   still a suggestion: the work stays claimable by anyone else.
-3. Each item names a person (or says nobody fits), states one concrete next action, and shows the
-   evidence behind it. Anything that can't do the last two isn't routed to a human at all.
-4. **If there is no steward for this ticket, the AI must propose a new mandate to the Shapers
-   immediately** — this domain, a steward if it can name one, this pot (which may be zero), this
-   review date. It does not wait for a pile of similar tickets, and it does not dump the work on
-   whoever answers fastest. The ticket stays open, labelled with the capability it needs, and
-   attaches to that proposal. Further tickets in the same gap attach to the same open mandate
-   rather than opening a second vote.
-5. The named person acts, defers, declines, or the work stays open. Declining is a first-class
-   action and is recorded — it is how the matcher learns. The steward can re-route.
-6. When they act, the AI has already drafted the artifact — the proposal text, the summary, the
-   update — so acting is editing.
-
-**On matching without ossifying roles.** Matching purely on demonstrated history is the obvious
-approach and it slowly calcifies the organization: whoever did the treasury work keeps getting the
-treasury work, nobody else ever learns it, and the org acquires a bus-factor problem it cannot see.
-The matcher needs a deliberate minority of stretch routing — to people who plausibly _could_ do
-this, not only those who already have — and should treat single-person capabilities as a risk worth
-surfacing to the steward.
-
-**On capacity: the person decides, the system only holds up a mirror.** How much someone can take
-on is theirs to declare, not ours to infer. Most of what determines it — a day job, a sick child,
-the other three things they committed to elsewhere — is invisible to the platform, so any load we
-compute from platform activity is inferred from a sliver of the truth. Worse, the obvious proxy
-(count of open items) punishes exactly the people doing slow, hard work.
-
-So capacity is **declared**, coarse, and revisable: a band or a number of concurrent commitments,
-not hours, because nobody knows their hours and asking invites timesheet thinking. Two consequences
-worth being deliberate about:
-
-- **Capacity gates flow; it does not decide fit.** Match on who is right for the work, then let
-  declared capacity govern how much reaches them. Otherwise an available mediocre fit beats a
-  stretched excellent one. If the best-fit person is full, the work waits, moves to the next
-  candidate, or stays open — it is never force-fed.
-- **Observation informs, it never overrides.** The system may say "this would be your fifth open
-  item and you said three"; it may never refuse on someone's behalf. Self-declaration is not a
-  burnout fix on its own — conscientious people over-commit, and the org must not treat "they said
-  yes" as absolution.
-
-This also sharpens Journey 3's escalation rather than weakening it. "Everyone who fits is at the
-limit they set for themselves" is a far cleaner capacity signal than any inferred-load heuristic,
-because a person stated it. Relatedly, declining should distinguish _not my thing_ from _no room
-right now_: the first is evidence about fit, the second about capacity, and they should not be
-learned from interchangeably.
-
-**What memory does:** memory supplies the interpretation ("this matters because of the commitment we
-made in March") and the profiles, mandates, and declared capacity that make matching possible; the
-activity ledger supplies the detection ("this changed").
-**Why it feels intelligent:** work reaches people instead of waiting to be discovered, and the
-organization admits when it is short-handed instead of overloading its most conscientious member.
-**How we know it works:** three numbers. Acceptance rate — below roughly a third and the channel is
-noise. Time from detection to a claimed owner. And the share of work that finds someone without
-escalation, which is the honest read on whether the org has the people it needs.
-
-> A ticket with no steward is itself the evidence for a new mandate. The AI drafts that mandate
-> for the Shapers on the first such ticket, not the third. See
-> [decision rights](../architecture/organizational-intelligence.md#8-decision-rights--what-becomes-a-proposal).
+**What memory does:** it is why the ticket is already written and why "why me" has a citation.
+**Why it feels intelligent:** they open the app, do one thing or leave. They are not a dispatcher.
+**How we know it works:** time from open to first action; share of tickets claimed vs declined;
+empty-queue days that the person trusts rather than assumes are a bug.
 
 ---
 
-## Journey 4 — The shapers keep the strategy alive
+## Journey 4 — The steward uses the app
 
-**Who:** whoever holds the Shaper grant — often including the founder, and often including people
-who are also stewards or contributors.
-**Wants:** the organization to keep pointing at the thing it exists to do, without any one of them
-becoming the person who does every next task.
+**Who:** someone accountable for a domain, with a pot and a review date.
+**Wants:** to say yes or no to work in their patch, and to keep the pot honest — not to become
+the person who does every ticket.
 
-1. They see where **stated strategy and actual behaviour have diverged** — we said this was the
-   priority, and here is where the attention and money actually went.
-2. They see which beliefs have gone **stale** (nobody has revisited this in a year) or **contested**
-   (two parts of the org are acting on incompatible assumptions).
-3. They decide the high-level correction. If it is only a belief, they update memory. If it
-   implies a new job, the AI has already drafted the mandate onto the same item — domain, steward,
-   pot, review date — so they are not asked twice. They then **pass the more specific work to the
-   matching steward**. They do not approve the implementations; the steward does, even when that
-   steward is also a Shaper.
-4. They review memory changes — strategy or domain — and approve, edit, or reject them. A steward
-   may draft; only Shapers write it into the corpus.
-5. A ticket with no steward arrives as a mandate the AI has already drafted. They decide that
-   object rather than absorbing the tickets themselves.
+They open the app. The first thing they see is **What is waiting on me?**
 
-**What memory does:** this journey is memory _maintenance_ at the strategic layer — the gardening
-that keeps the corpus small, current, and trusted.
-**Why it feels intelligent:** the organization can be wrong out loud, and strategy turns into work
-without the Shapers becoming the work.
-**How we know it works:** the memory corpus stays small enough for a person to read in an
-afternoon, and the Shaper queue is strategy, funding, and gaps — not a dump of every open ticket.
+1. **Tickets to green-light.** Each one already has a recommended contributor, a next action, and
+   evidence. They approve, reject, or hold. They can change the person. A hold needs a date or a
+   condition to resume. A standing rule ("auto-approve type X under size Y") covers both the work
+   and the name, so they are not a per-ticket bottleneck.
+2. **Until they confirm, the ticket does not reach a contributor.** After they confirm, it does.
+   They can re-route later if the person declines.
+3. **Their pot.** How much is left, what went out, whether a cosigner is sitting on a payment they
+   started. They pay from the pot; they do not ask Shapers to sign unless this pot named
+   cosigners. If the pot is large they can carve a sub-mandate — narrower job, person, amount,
+   review date — without a Shaper vote.
+4. **Review date.** How the domain is doing against what the mandate said. They do not edit
+   organizational memory here. They can draft a belief ("this risk is overstated") and send it to
+   Shapers.
+5. **What they do not see as their job:** a ticket with no steward. That is already a mandate on
+   the Shaper queue. They are not the overflow.
+
+Matching must not only pick people who have done this before. They should change the name toward
+stretch some of the time, and treat a capability only one person holds as a risk to mention at
+review.
+
+**What memory does:** it tells them why this ticket exists and whether the pot still matches the
+job.
+**Why it feels intelligent:** they are a gate, not a project manager of the whole org.
+**How we know it works:** time from ticket-in to steward call; share of standing-rule approvals;
+holds that actually resume; pot overflow that did not happen.
 
 ---
 
-## Journey 5 — The organization decides, and then learns
+## Journey 5 — The shaper uses the app
 
-**Who:** the Shapers, at a governance moment.
-**Wants:** to decide well, without being asked to approve everything.
+**Who:** whoever holds the Shaper grant. They may also be a steward or contributor; this surface
+is only the decisions that belong to Shapers.
+**Wants:** to keep strategy, money-as-pots, and memory true — without doing the work or signing
+every payment.
 
-The failure mode this journey has to avoid is approval fatigue. If every good idea becomes
-something everyone must vote on, participation collapses and the votes that matter get rubber-
-stamped alongside the ones that don't. **Most decisions must never reach a vote.** So the journey
-begins with routing, not drafting.
+They open the app. The first thing they see is **What needs a Shaper?** If the answer is nothing,
+it says so.
 
-1. **The decision is routed to a tier.** The AI proposes the lowest tier that fits, names the
-   mandate it believes already covers this, and has to argue for escalation rather than default to
-   it. See [decision rights](../architecture/organizational-intelligence.md#8-decision-rights--what-becomes-a-proposal)
-   for the test and the tiers.
-2. **Most things stop here** — done inside an existing mandate and logged, or waved through by the
-   one person who holds that envelope, or opened for a short objection window that closes in silence.
-3. **What remains goes to the Shapers** — not "the members" by default. The founder named the
-   first of them; they decide commitments of shared resources beyond an existing mandate, changes
-   to the rules, changes to who counts as a member, and changes to the steward set. The AI drafts
-   it grounded in memory, and states what it is assuming and what would make the proposal wrong.
-4. Shapers can see what the organization decided before on similar questions, and what happened as
-   a result.
-5. The decision is made by people, on-chain where it matters.
-6. **The outcome is recorded against the decision** — did it do what we expected?
-7. Later, when reality disagrees with the prediction, the AI proposes updating the belief that
-   produced it. The Shapers approve. A steward may have drafted it; they do not decide memory.
+1. **New mandates.** A ticket the AI could not place with a steward is already drafted as a
+   mandate: domain, steward if it can name one, pot, review date, optional cosigners. They
+   approve, amend, or reject. Further tickets in that gap are attached to this item, not a second
+   vote.
+2. **Pots.** The handful of top-level pots they filled: remaining, burn, review dates. They
+   refill, resize, close, or add/clear cosigners. They do not see Rafi's mobile invoices. They
+   release a payment only if they are named as a cosigner on that pot.
+3. **Memory.** Beliefs to confirm, retire, or correct — purpose, strategy, a domain claim the
+   steward drafted, an assertion the ledger does not support. They write the corpus. No one else
+   does.
+4. **Who is a Shaper.** Add or remove. This is rare and hard on purpose.
+5. **When something is actually a decision among Shapers** — a new pot, a purpose change, who is
+   a Shaper — the AI has already drafted it, named what it assumes, and shown what happened last
+   time the org decided something similar. They decide. The outcome is recorded. Later, if
+   reality disagrees, the AI proposes updating the belief; they approve that too.
+6. **They do not green-light tickets and they do not do the work** on this surface, even when the
+   same person is also steward or contributor. Those hats have their own queues.
 
-**What memory does:** step 1 depends on memory knowing the organization's mandates; step 6 is what
-turns a record into learning. Without step 6 the organization has a filing cabinet, not
-intelligence.
-**Why it feels intelligent:** the organization protects its own attention. Being asked to vote
-means something, because it happens rarely and only about things that are genuinely shared.
-**How we know it works:** two numbers. The share of votes that pass near-unanimously with no real
-discussion should be _low_ — a high rate means we are taxing everyone with decisions that belonged
-at a lower tier. And the same argument should stop recurring, with beliefs carrying a visible
-history of revision.
+Most things never reach this screen. Work inside a live mandate is the steward's. A payment
+inside a pot is the steward's. The Shaper queue staying short is the design working.
+
+**What memory does:** it is the thing they maintain, and the thing every other journey reads.
+**Why it feels intelligent:** they steer. They do not operate.
+**How we know it works:** the queue is short; pots get reviewed on their date; the same argument
+does not recur; the corpus still fits in an afternoon.
 
 ---
 

--- a/docs/product/user-journeys.md
+++ b/docs/product/user-journeys.md
@@ -90,10 +90,9 @@ They stake time and judgment. They read memory freely and can propose changes to
 - **Founder** — the person who initially sets up the organization. A one-time role. They name the
   first Shapers, the first steward mandates, and the entry and exit methods, then they are a member
   like anyone else — usually also a Shaper, but "founder" is not an ongoing decision right.
-- **Shaper** — a grant, not an exclusive role. Shapers decide high-level strategy, funding beyond
-  a mandate, and organizational memory. A steward or a contributor can also be a Shaper; being one
-  is what used to get called voting power. Strategy becomes more specific work that passes to
-  stewards.
+- **Shaper** — a grant, not an exclusive role. Shapers decide high-level strategy, who holds a pot
+  of money and how big it is, and organizational memory. A steward or a contributor can also be a
+  Shaper. Strategy becomes more specific work that passes to stewards.
 - **Steward** — accountable for a domain; holds a mandate and a budget envelope; approves the
   implementations that strategy has become.
 - **Contributor** — does the work the steward has approved. The majority. A Shaper only if granted
@@ -121,7 +120,7 @@ They stake attention.
 | Stakeholder     | Stakes                  | Memory access                                 | Decision rights                                                      | Journey |
 | --------------- | ----------------------- | --------------------------------------------- | -------------------------------------------------------------------- | ------- |
 | Founder         | purpose, reputation     | writes the seed corpus                        | sets the organization up once; then only as Shaper and/or other hats | 1       |
-| Shaper          | judgment over the whole | reads all; approves strategic memory          | strategy, funding beyond a mandate, memory, the steward set          | 4, 5    |
+| Shaper          | judgment over the whole | reads all; approves strategic memory          | strategy, fill or change pots, memory, the steward set               | 4, 5    |
 | Steward         | domain accountability   | approves changes in their domain              | approves implementations and spends inside their mandate             | 3       |
 | Contributor     | time, judgment          | reads all; proposes changes                   | does the work; shapes only if also a Shaper                          | 2, 3    |
 | Investor/funder | capital                 | curated view, including unsettled arguments   | consent on reserved matters only                                     | 6       |
@@ -142,14 +141,15 @@ person or body takes each one**. Four sentences hold the whole catalog:
 
 1. **The founder sets the organization up once:** purpose, who the first Shapers are, how votes
    work, entry and exit, and the first steward mandates. The AI proposes; the founder confirms.
-2. **Shapers decide high-level strategy, funding beyond a mandate, and organizational memory.**
-   They are the body that can change the constitution or the steward set. A steward or contributor
-   can hold this grant; the founder usually does after setup, but not because they founded it.
-3. **Stewards approve implementations.** Strategy becomes more specific work that passes to them.
-   An AI ticket is a recommendation. It does not become work until the matching steward approves,
-   rejects, or holds it.
-4. **Contributors do the approved work.** Money inside a mandate is the steward's; money beyond
-   any mandate is a Shaper decision.
+2. **Shapers decide high-level strategy, who holds a pot of money and how big it is, and
+   organizational memory.** They are the body that can change the constitution or the steward set.
+   A steward or contributor can hold this grant; the founder usually does after setup, but not
+   because they founded it.
+3. **Stewards approve implementations and spend from their pot.** Strategy becomes more specific
+   work that passes to them. An AI ticket is a recommendation. It does not become work until the
+   matching steward approves, rejects, or holds it.
+4. **Contributors do the approved work.** Shapers do not sign every payment. They fill a pot once;
+   the steward spends from it in public.
 
 #### A. Founding — founder confirms, AI proposes
 
@@ -191,13 +191,38 @@ Tier 3, or Tier 4 when the decision changes how decisions get made.
 
 #### D. Funding
 
-- Spend or commit **inside** an existing envelope → the steward of that mandate (Tier 1).
-- A new allocation, a spend **beyond** every envelope, or an ongoing obligation nobody owns →
-  Shapers (Tier 3).
-- Dispose of major assets or dilute holders → Shapers **and** investor consent (reserved matter).
+A **mandate** is a job with a pot attached: this domain, this steward, this much money, until this
+review date. **Funding a mandate** is the Shapers filling that pot. It is one decision. After it,
+the steward spends without asking again.
 
-This is what "funding is a Shaper decision" means without sending every in-mandate reimbursement
-to them — the failure the architecture already named.
+That is the whole point. The alternatives fail the aim — minimum bureaucracy, full transparency,
+trust — in opposite directions:
+
+- **Shapers approve every money movement.** Maximum control, and the bureaucracy we are trying to
+  kill. The treasury becomes a queue of invoices. Trust is replaced by surveillance.
+- **Shapers just hand a person a budget, with no domain or review date.** Almost the same idea,
+  but the pot is a slush fund. When the person leaves, the money is unexplained. When they overspend,
+  there is no job to point at. Trust without a scope is how treasuries get drained by conscientious
+  people who thought they were allowed to.
+- **No pot at all, steward spends freely, everything visible.** Transparency without a bound. Someone
+  still has to watch every payment, which is option one with extra steps.
+
+So the pot is not extra process. It is the _minimum_ process that lets Shapers stop looking. Trust
+is granted up to a number, for a job, until a date. Every payment is still on the ledger — full
+transparency — and a Shaper can set a standing watch ("tell me if this pot is 80% gone"). They do
+not sign the payment.
+
+What Shapers decide, and only this:
+
+- Fill, refill, enlarge, shrink, or close a pot (create or change a mandate).
+- A payment that **no pot covers** — there is no steward for this, or this one spend would overflow
+  the pot. That is the only sense in which they "fund beyond a mandate."
+- Dispose of major assets or dilute holders, with investor consent where that is reserved.
+
+What they do not decide: the contractor invoice, the tool subscription, the contributor payment
+that already sits inside a live pot. That is the steward doing their job. If Shapers disagree with
+how a pot is being used, they resize or close it at the review date — or sooner, as a structure
+decision — they do not start countersigning.
 
 #### E. Membership — follows the entry method the founder set
 
@@ -249,8 +274,9 @@ Once those are confirmed, this surface closes. Anything later that looks like st
 question — even if the same person is looking at it.
 
 **Shaper — _"Is the strategy still right, and is it becoming work?"_**
-Direction, purpose, funding beyond any mandate, and the beliefs those rest on — plus work that
-still has no steward, which is a strategic gap rather than a ticket they should do themselves. They
+Direction, purpose, whether each pot is the right size, and the beliefs those rest on — plus work
+that still has no steward, which is a strategic gap rather than a ticket they should do themselves.
+They
 confirm, revise, or retire a claim, and they pass more specific work to the matching steward.
 Adding a steward is a Shaper decision, not a mandate one person creates alone. A steward or
 contributor who is also a Shaper sees this surface as well as their other one. This is the human

--- a/docs/product/user-journeys.md
+++ b/docs/product/user-journeys.md
@@ -77,22 +77,22 @@ Two things to hold before reading the list.
 shaper, steward _and_ beneficiary at once. The taxonomy answers "what does this person need right
 now", not "what is their job title". Someone can move between rings, and most people do.
 
-**What someone stakes should determine their authority over memory.** This is the organizing
-principle. A person who stakes their time and judgment gets to change what the organization
-believes. A person who stakes capital gets to see honestly and to be heard — but not to direct. A
-person who stakes nothing yet gets to read what the organization chooses to publish. Getting this
-mapping wrong in either direction is how organizations either capture themselves or lose trust.
+**Shapers decide memory, and Shapers decide who is a Shaper.** The founder names the first set.
+After that, only Shapers can add or remove Shapers, and only Shapers can change what the
+organization believes. Stake still governs the _view_ — capital gets to see honestly and be heard,
+a person with no stake yet reads what the organization publishes — but it does not grant a write
+to memory. A contributor who is not a Shaper does the work; they do not edit the corpus.
 
 ### Ring 1 — Inside: members who hold decision rights
 
-They stake time and judgment. They read memory freely and can propose changes to it.
+They stake time and judgment. They read memory. Only Shapers change it.
 
 - **Founder** — the person who initially sets up the organization. A one-time role. They name the
   first Shapers, the first steward mandates, and the entry and exit methods, then they are a member
   like anyone else — usually also a Shaper, but "founder" is not an ongoing decision right.
-- **Shaper** — a grant, not an exclusive role. Shapers decide high-level strategy, who holds a pot
-  of money and how big it is, and organizational memory. A steward or a contributor can also be a
-  Shaper. Strategy becomes more specific work that passes to stewards.
+- **Shaper** — a grant, not an exclusive role. Shapers decide high-level strategy, who else is a
+  Shaper, who holds a pot of money and how big it is, and organizational memory. A steward or a
+  contributor can also be a Shaper. Strategy becomes more specific work that passes to stewards.
 - **Steward** — accountable for a domain; holds a mandate and a budget envelope; approves the
   implementations that strategy has become.
 - **Contributor** — does the work the steward has approved. The majority. A Shaper only if granted
@@ -117,18 +117,18 @@ They stake attention.
 
 ### The mapping
 
-| Stakeholder     | Stakes                  | Memory access                                 | Decision rights                                                      | Journey |
-| --------------- | ----------------------- | --------------------------------------------- | -------------------------------------------------------------------- | ------- |
-| Founder         | purpose, reputation     | writes the seed corpus                        | sets the organization up once; then only as Shaper and/or other hats | 1       |
-| Shaper          | judgment over the whole | reads all; approves strategic memory          | strategy, fill or change pots, memory, the steward set               | 4, 5    |
-| Steward         | domain accountability   | approves changes in their domain              | approves implementations and spends inside their mandate             | 3       |
-| Contributor     | time, judgment          | reads all; proposes changes                   | does the work; shapes only if also a Shaper                          | 2, 3    |
-| Investor/funder | capital                 | curated view, including unsettled arguments   | consent on reserved matters only                                     | 6       |
-| Beneficiary     | dependency on outcome   | published subset; contributes outcome reports | none; consulted when decisions land on them                          | 7       |
-| Partner org     | joint commitments       | artifacts relayed to them                     | decides for itself                                                   | 8       |
-| Prospective     | attention               | the public brief                              | none                                                                 | 2       |
-| Builder         | effort, reputation      | writes via app identity; proposes only        | none                                                                 | 9       |
-| Verifier        | their own assurance     | specified claims plus on-chain proof          | none                                                                 | 6       |
+| Stakeholder     | Stakes                  | Memory access                                  | Decision rights                                                      | Journey |
+| --------------- | ----------------------- | ---------------------------------------------- | -------------------------------------------------------------------- | ------- |
+| Founder         | purpose, reputation     | writes the seed corpus                         | sets the organization up once; then only as Shaper and/or other hats | 1       |
+| Shaper          | judgment over the whole | reads all; decides memory                      | strategy, who is a Shaper, pots, memory, the steward set             | 4, 5    |
+| Steward         | domain accountability   | reads all; may suggest, does not decide memory | approves implementations and spends inside their mandate             | 3       |
+| Contributor     | time, judgment          | reads all                                      | does the work; shapes only if also a Shaper                          | 2, 3    |
+| Investor/funder | capital                 | curated view, including unsettled arguments    | consent on reserved matters only                                     | 6       |
+| Beneficiary     | dependency on outcome   | published subset; contributes outcome reports  | none; consulted when decisions land on them                          | 7       |
+| Partner org     | joint commitments       | artifacts relayed to them                      | decides for itself                                                   | 8       |
+| Prospective     | attention               | the public brief                               | none                                                                 | 2       |
+| Builder         | effort, reputation      | writes via app identity; proposes only         | none                                                                 | 9       |
+| Verifier        | their own assurance     | specified claims plus on-chain proof           | none                                                                 | 6       |
 
 Journeys 1–5 sit inside the organization, 6–7 at the committed edge, 8–9 outside it. The catalog
 below is what "decision rights" actually means.
@@ -141,10 +141,10 @@ person or body takes each one**. Four sentences hold the whole catalog:
 
 1. **The founder sets the organization up once:** purpose, who the first Shapers are, how votes
    work, entry and exit, and the first steward mandates. The AI proposes; the founder confirms.
-2. **Shapers decide high-level strategy, who holds a pot of money and how big it is, and
-   organizational memory.** They are the body that can change the constitution or the steward set.
-   A steward or contributor can hold this grant; the founder usually does after setup, but not
-   because they founded it.
+2. **Shapers decide high-level strategy, who is a Shaper, who holds a pot of money and how big it
+   is, and organizational memory.** They are the body that can change the constitution or the
+   steward set. A steward or contributor can hold this grant if the Shapers add them; the founder
+   usually names themselves in the first set, but that is a choice.
 3. **Stewards approve implementations and spend from their pot.** Strategy becomes more specific
    work that passes to them. An AI ticket is a recommendation. It does not become work until the
    matching steward approves, rejects, or holds it.
@@ -336,9 +336,8 @@ follows that method. Changing the method is a vote. This catalog does not invent
 
 #### F. Memory
 
-- An AI-proposed belief update that changes strategy, purpose, or a cross-cutting assumption → the
-  Shapers.
-- An AI-proposed belief update inside a domain → the steward of that domain.
+- Any change to what the organization believes — purpose, strategy, a domain assessment, a
+  retired claim — → the Shapers. The AI or anyone else may draft; only Shapers approve.
 - An assertion with no ledger support, a contradiction between artifacts, or stalled onboarding →
   the Shapers confirm, retire, or escalate.
 
@@ -645,8 +644,8 @@ becoming the person who does every next task.
    pot, review date — so they are not asked twice. They then **pass the more specific work to the
    matching steward**. They do not approve the implementations; the steward does, even when that
    steward is also a Shaper.
-4. They review memory changes that touch strategy, and approve, edit, or reject them. Domain-level
-   memory stays with the steward.
+4. They review memory changes — strategy or domain — and approve, edit, or reject them. A steward
+   may draft; only Shapers write it into the corpus.
 5. Unmatched work that has no steward is the usual evidence for a new mandate. They decide that
    one object rather than absorbing the tickets themselves.
 
@@ -684,8 +683,7 @@ begins with routing, not drafting.
 5. The decision is made by people, on-chain where it matters.
 6. **The outcome is recorded against the decision** — did it do what we expected?
 7. Later, when reality disagrees with the prediction, the AI proposes updating the belief that
-   produced it. The Shapers approve if it is strategic; the matching steward approves if it is
-   inside a domain.
+   produced it. The Shapers approve. A steward may have drafted it; they do not decide memory.
 
 **What memory does:** step 1 depends on memory knowing the organization's mandates; step 6 is what
 turns a record into learning. Without step 6 the organization has a filing cabinet, not

--- a/docs/product/user-journeys.md
+++ b/docs/product/user-journeys.md
@@ -153,12 +153,15 @@ person or body takes each one**. Four sentences hold the whole catalog:
 
 #### A. Founding — founder confirms, AI proposes
 
-- Purpose, boundaries, and success signals (the seed memory).
-- **Who the first Shapers are** — a named set of people, which may include the founder, some
-  stewards, some contributors, or all of them. This is a grant, not an exclusive role.
-- Voting method, quorum, and unity.
+The interview that produces these is in [Journey 1](#journey-1--the-founder-starts-an-organization).
+The founder confirms; the AI does not invent a slot they never spoke to.
+
+- Purpose, who it serves, boundaries, and success signals (the seed memory).
+- First strategic objectives for the next 90 days.
+- **Who the first Shapers are** — drafted from "who do you trust to decide," not from job titles.
 - Entry and exit method.
-- The first steward mandates: domain, named person, envelope, review date.
+- The first mandates: one per real near-term job — domain, steward, pot, review date, optional
+  cosigners.
 - The starting [trust-ladder](#the-trust-ladder) rung for the AI.
 
 After this, "founder" is a historical fact, not a queue. Ongoing strategy, funding, and memory sit
@@ -450,22 +453,61 @@ verification that depends on trusting the platform is not verification.
 theory first.
 
 1. They describe what they're trying to do, in their own words, in conversation.
-2. The AI interviews them — not a form. It asks what the organization is for, who it serves, what
-   it will not do, and how they will know it's working. It draws on patterns from comparable
-   organizations in the network to ask sharper questions.
-3. It proposes a structure the founder edits rather than invents: the space, sensible entry and
-   decision methods, **who the first Shapers are**, and **a first set of steward mandates** —
-   domain, named person, envelope, review date. The founder confirms each, or changes it. They
-   usually name themselves as a Shaper; that is a choice, not automatic.
-4. **The conversation becomes the organization's first memory.** The purpose, the boundaries, and
-   the success signals are written as the founding artifacts — not buried in a chat log.
+2. **The AI interviews them — not a form.** It is trying to learn the few things without which it
+   cannot recommend Shapers, objectives, mandates, or stewards. It draws on comparable
+   organizations to ask sharper questions, and it stops when it can draft. The key things:
+
+   **What this is** — so strategy has somewhere to sit.
+
+   - What is this for, in a sentence they would say to a stranger?
+   - Who is it for — who is helped if it works?
+   - What will you not do, even if it would be easy or funded?
+   - In six months, what would you point at and say "this is working"?
+
+   **Who is already here** — so Shapers and stewards are named from reality, not an org chart.
+
+   - Who is already doing work, and what do they actually do?
+   - If you disappeared for a month, who do you trust to decide? Those names are the first
+     Shaper draft.
+   - Who would you not hand the treasury to yet? That is the first cosign signal, not a judgment
+     of character.
+
+   **What must happen next** — so the first mandates are jobs, not departments.
+
+   - What has to get done in the next 90 days?
+   - What is already blocked for lack of a person or of money?
+   - If you could spend tomorrow, on what?
+
+   **Money and the door** — so pots, entry, and capital have a first setting.
+
+   - Is there a treasury yet, roughly how much, and who can move it today?
+   - Any pot that should need a second signature from the start?
+   - How does someone join? Who puts money in, and what do they get to say about it?
+
+3. It proposes a structure the founder edits rather than invents, each piece grounded in an
+   answer above:
+
+   - Seed memory: purpose, who it serves, boundaries, success signals.
+   - First strategic objectives for the next 90 days, written as outcomes, not a slogan.
+   - **Who the first Shapers are** — usually "who you trust to decide," plus themselves if they
+     want that hat. Not automatic.
+   - **First mandates** — one per real job in those 90 days: domain, steward (someone already
+     doing it, or open if nobody is), pot, review date, cosigners only where they were uneasy.
+   - Entry and exit, and the starting [trust-ladder](#the-trust-ladder) rung.
+
+   Empty answers stay empty. It does not invent a legal steward because the form had a slot. An
+   unmatched 90-day job with no name becomes an open mandate — the first recruitment surface.
+
+4. **The conversation becomes the organization's first memory.** Purpose, boundaries, success
+   signals, the first objectives, and the first mandates are written as founding artifacts — not
+   buried in a chat log.
 5. The founder is shown what was recorded and asked to confirm it. This is the first approval.
 
 **What memory does:** this journey _creates_ the seed corpus. Nothing else works well without it.
-**Why it feels intelligent:** the founder never sees an empty form, and the organization can
-already answer "what are we for?" on day one.
+**Why it feels intelligent:** the founder never sees an empty form, and the first recommendations
+are about their next 90 days, not a generic DAO template.
 **How we know it works:** the founding artifacts are still being cited and revised six months
-later, instead of abandoned.
+later, instead of abandoned — and the first mandates still match work that actually happened.
 
 ---
 

--- a/docs/product/user-journeys.md
+++ b/docs/product/user-journeys.md
@@ -251,6 +251,44 @@ that already sits inside a live pot. That is the steward doing their job. If Sha
 how a pot is being used, they resize or close it at the review date — or sooner, as a structure
 decision — they do not start countersigning.
 
+#### Will this still work at 10,000 members?
+
+A **member** is not a Shaper. Ten thousand people doing the work does not mean ten thousand people
+filling pots. Contributors scale; the Shaper set must not. If it grows with membership, every
+mandate becomes a town meeting and the design is dead. The founder names a small first set; adding
+a Shaper stays hard (Tier 4) on purpose.
+
+At **small scale** — five people, one of them founder, Shaper, and steward — the system has to
+collapse to one object without ceremony: one mandate, pot equals the treasury, review date in a
+few months. The second mandate appears when unmatched work says a second job exists, not because
+the software wants a chart.
+
+At **large scale** a flat list of pots dies. A Shaper body can hold in its head about as many
+top-level mandates as a decent manager can hold reports — call it five to eight. Fifty pots, and
+they are either rubber-stamping reviews or they become the invoice queue we already rejected.
+Transparency dies the same way: a complete ledger that dumps ten thousand payments on a home
+screen is not transparency, it is noise.
+
+So mandates **nest**. Same object, one more rule: a steward may carve a sub-mandate from their own
+pot — this narrower job, this person, this much (not more than remains), this review date — without
+asking the org Shapers. They are Shaper _of that pot_, not of the organization. The org Shapers
+still see five to eight top-level jobs. Two or three levels of nesting covers thousands of people
+(eight times eight times eight is already five hundred work cells). Close or freeze a parent and
+the children freeze with it. The parent steward stays accountable for the whole, including what
+they delegated.
+
+That is one mechanism at both sizes, not a small-org mode and a large-org mode. The pot _is_ the
+coordination layer that hierarchy used to be. What used to travel through status meetings travels
+as burn rate, unmatched work, and review dates.
+
+What still requires discipline, and will not be saved by software:
+
+- Keep the Shaper set small. A 10,000-member org with two hundred Shapers has rebuilt a parliament.
+- Do not let "payment no pot covers" become the overflow drain. If that queue is busy, the tree is
+  wrong — carve a pot, don't countersign.
+- A small Shaper set at that scale is an oligarchy unless the ledger is public, review dates are
+  real, and changing who is a Shaper is possible. Those are the checks. They are not optional.
+
 #### E. Membership — follows the entry method the founder set
 
 The _method_ is a founding decision. Each _instance_ — this person joins, this person leaves —

--- a/docs/product/user-journeys.md
+++ b/docs/product/user-journeys.md
@@ -74,8 +74,8 @@ fits, never toward the vote. See [Journey 5](#journey-5--the-organization-decide
 Two things to hold before reading the list.
 
 **These are roles, not people.** In a five-person organization, one person is plausibly founder,
-steward, coordinator _and_ beneficiary at once. The taxonomy answers "what does this person need
-right now", not "what is their job title". Someone can move between rings, and most people do.
+steward _and_ beneficiary at once. The taxonomy answers "what does this person need right now", not
+"what is their job title". Someone can move between rings, and most people do.
 
 **What someone stakes should determine their authority over memory.** This is the organizing
 principle. A person who stakes their time and judgment gets to change what the organization
@@ -85,13 +85,17 @@ mapping wrong in either direction is how organizations either capture themselves
 
 ### Ring 1 — Inside: members who hold decision rights
 
-They stake time and judgment. They read memory freely, propose changes to it, and vote.
+They stake time and judgment. They read memory freely and can propose changes to it. **Voting power
+is a grant, not a property of being inside.** The founder decides who holds it when the organization
+is created; a contributor or steward may or may not have it.
 
-- **Founder / initiator** — defines purpose and initial structure. A deliberately temporary role
-  that should dissolve into the others.
-- **Contributor** — does the work and holds a vote. The majority.
-- **Steward** — accountable for a domain; holds a mandate and a budget envelope; approves at Tier 1.
-- **Coordinator** — keeps rhythms, onboarding, and memory hygiene running. Custodian of the corpus.
+- **Founder** — holds high-level strategy: purpose, direction, which domains exist, and whether
+  what the organization believes is still true. Strategy becomes more specific work that passes to
+  stewards. There is no separate coordinator role.
+- **Steward** — accountable for a domain; holds a mandate and a budget envelope; approves the
+  implementations that strategy has become.
+- **Contributor** — does the work the steward has approved. The majority. Votes only if granted
+  voting power.
 
 ### Ring 2 — The committed edge: a formal stake, no operational vote
 
@@ -112,20 +116,111 @@ They stake attention.
 
 ### The mapping
 
-| Stakeholder     | Stakes                | Memory access                                 | Decision rights                          | Journey |
-| --------------- | --------------------- | --------------------------------------------- | ---------------------------------------- | ------- |
-| Founder         | purpose, reputation   | writes the seed corpus                        | all tiers                                | 1       |
-| Contributor     | time, judgment        | reads all; proposes changes                   | votes at Tier 3                          | 2, 3    |
-| Steward         | domain accountability | approves changes in their domain              | approves Tier 1 inside their mandate     | 4       |
-| Coordinator     | the org's coherence   | curates and consolidates                      | routes and schedules; no extra authority | 4, 5    |
-| Investor/funder | capital               | curated view, including unsettled arguments   | consent on reserved matters only         | 6       |
-| Beneficiary     | dependency on outcome | published subset; contributes outcome reports | none; files observations                 | 7       |
-| Partner org     | joint commitments     | artifacts relayed to them                     | decides for itself                       | 8       |
-| Prospective     | attention             | the public brief                              | none                                     | 2       |
-| Builder         | effort, reputation    | writes via app identity; proposes only        | none                                     | 9       |
-| Verifier        | their own assurance   | specified claims plus on-chain proof          | none                                     | 6       |
+| Stakeholder     | Stakes                | Memory access                                 | Decision rights                                                 | Journey |
+| --------------- | --------------------- | --------------------------------------------- | --------------------------------------------------------------- | ------- |
+| Founder         | purpose, reputation   | writes and keeps the strategic corpus         | high-level strategy; memory hygiene; proposes new steward needs | 1, 4    |
+| Steward         | domain accountability | approves changes in their domain              | approves implementations and spends inside their mandate        | 3       |
+| Contributor     | time, judgment        | reads all; proposes changes                   | does the work; votes only if granted voting power               | 2, 3    |
+| Investor/funder | capital               | curated view, including unsettled arguments   | consent on reserved matters only                                | 6       |
+| Beneficiary     | dependency on outcome | published subset; contributes outcome reports | none; consulted when decisions land on them                     | 7       |
+| Partner org     | joint commitments     | artifacts relayed to them                     | decides for itself                                              | 8       |
+| Prospective     | attention             | the public brief                              | none                                                            | 2       |
+| Builder         | effort, reputation    | writes via app identity; proposes only        | none                                                            | 9       |
+| Verifier        | their own assurance   | specified claims plus on-chain proof          | none                                                            | 6       |
 
-Journeys 1–5 sit inside the organization, 6–7 at the committed edge, 8–9 outside it.
+Journeys 1–5 sit inside the organization, 6–7 at the committed edge, 8–9 outside it. The catalog
+below is what "decision rights" actually means.
+
+### What has to be decided, and by whom
+
+The tiers in the [architecture](../architecture/organizational-intelligence.md#8-decision-rights--what-becomes-a-proposal)
+say how much agreement a decision needs. This section says **which decisions exist** and **which
+person or body takes each one**. Four sentences hold the whole catalog:
+
+1. **The founder decides high-level strategy** — at creation and after: purpose, direction, who
+   has voting power, which domains the organization needs, and whether its beliefs still hold. The
+   AI proposes; the founder confirms.
+2. **Strategy becomes more specific work that passes to stewards.** Voting power is the body that
+   can change the constitution or the steward set — add, remove, replace, or resize a mandate —
+   usually on a proposal the founder raises from an observed strategic gap.
+3. **Stewards approve implementations.** An AI ticket is a recommendation. It does not become work
+   until the matching steward approves, rejects, or holds it.
+4. **Contributors do the approved work.** Money inside a mandate is the steward's; money beyond
+   any mandate is a vote.
+
+#### A. Founding — founder confirms, AI proposes
+
+- Purpose, boundaries, and success signals (the seed memory).
+- **Who holds voting power** — all members, a named subset, token holders, or another rule the
+  founder chooses. This is a grant, not a role.
+- Voting method, quorum, and unity.
+- Entry and exit method.
+- The first steward mandates: domain, named person, envelope, review date.
+- The starting [trust-ladder](#the-trust-ladder) rung for the AI.
+
+The founder role does not dissolve. After creation they keep the strategic layer: direction,
+whether beliefs still hold, and which new domains the work is asking for. They do not approve
+tickets or do the work — that is the cascade below.
+
+#### B. Structure — voting power
+
+Tier 3, or Tier 4 when the decision changes how decisions get made.
+
+- Add a steward or create a mandate. Evidence is unmatched work accumulating in a domain, or anyone
+  with voting power proposing. The AI may draft the proposal; the electorate decides.
+- Remove or replace a steward. A steward can resign without a vote; filling the seat is a vote. A
+  steward cannot fire themselves out of accountability.
+- Renew, expand, or shrink an envelope.
+- Change the electorate, the voting method, the purpose, or entry and exit.
+- Issue, mint, or burn tokens; space-to-space membership; activating a space.
+
+#### C. Work tickets — matching steward, before anyone starts
+
+- Approve, reject, or hold. A hold must carry a resumption trigger — a date or a condition —
+  because a hold without one is a silent no that nobody has to own.
+- A steward may set standing rules ("auto-approve tickets of type X under size Y"). That is them
+  using the mandate, not a new decision class, and it is how they avoid becoming a per-ticket
+  bottleneck.
+- **No matching steward:** the ticket stays open, labelled with the capability it needs, and
+  becomes evidence for a "we need this steward" vote. It is not silently dumped on the founder as
+  permanent work.
+- The contributor then claims, declines, or acts. That is a personal decision, not an organizational
+  one.
+
+#### D. Funding
+
+- Spend or commit **inside** an existing envelope → the steward of that mandate (Tier 1).
+- A new allocation, a spend **beyond** every envelope, or an ongoing obligation nobody owns →
+  voting power (Tier 3).
+- Dispose of major assets or dilute holders → voting power **and** investor consent (reserved
+  matter).
+
+This is what "funding is a vote" means without sending every in-mandate reimbursement to the
+electorate — the failure the architecture already named.
+
+#### E. Membership — follows the entry method the founder set
+
+The _method_ is a founding decision. Each _instance_ — this person joins, this person leaves —
+follows that method. Changing the method is a vote. This catalog does not invent a default
+"steward admits members"; the founder chose the gate.
+
+#### F. Memory
+
+- An AI-proposed belief update that changes strategy, purpose, or a cross-cutting assumption → the
+  founder.
+- An AI-proposed belief update inside a domain → the steward of that domain.
+- An assertion with no ledger support, a contradiction between artifacts, or stalled onboarding →
+  the founder confirms, retires, or escalates. This is strategy maintenance, not a separate role.
+
+#### G. Reserved matters and the edge — heard is not authority
+
+- Purpose change, dilution, major-asset disposal → voting power **plus** investor consent.
+- Decisions that land on the people the organization serves → voting power decides; beneficiaries
+  are consulted.
+- Partner commitments → each organization decides for itself.
+- An investor adding, holding, or exiting; a beneficiary reporting an outcome; a prospect
+  expressing interest — individual actions, listed here so they are not mistaken for organizational
+  decisions.
 
 ### What each stakeholder opens the app for
 
@@ -133,7 +228,7 @@ The promise at the top of this document — _knows what matters and what to do n
 different for each of them. Below is that sentence made specific: the one question each arrives
 with, what answers it, and what they can actually do about it.
 
-Four rules govern all ten:
+Four rules govern all nine:
 
 1. **One question, answered before anything is asked of them.** The landing state is the answer, not
    a dashboard of everything with the answer somewhere inside it.
@@ -147,30 +242,26 @@ Four rules govern all ten:
 
 #### Ring 1 — inside
 
-**Founder — _"Am I still the bottleneck?"_**
-Decisions still routing through them that a mandate could absorb, and people whose track record now
-justifies holding one. The next action is a handoff: create the mandate, name the steward. This is
-the one surface designed to make its own user redundant — the founder role dissolves by being used,
-and progress is measured by how much stops arriving here.
+**Founder — _"Is the strategy still right, and is it becoming work?"_**
+Direction, purpose, and the beliefs those rest on — plus work that still has no steward, which is
+a strategic gap rather than a ticket they should do themselves. They confirm, revise, or retire a
+claim, and they pass more specific work to the matching steward. Adding a steward is a vote they
+typically raise, not a mandate they create alone. This is the human end of the
+[behavioural-evidence rule](../architecture/organizational-intelligence.md#1-four-layers-of-memory).
+
+**Steward — _"What implementations are waiting on me, and is my domain drifting?"_**
+Every AI-created ticket inside their mandate that has not yet been green-lit — the specific work
+that strategy has become — plus envelope burn measured against the review date. They approve,
+reject, or hold **before anyone starts the work** — and **a hold must carry a resumption trigger**,
+a date or a condition, because a hold without one is a silent no that nobody has to own. Repeated
+rejections of similar items are evidence that the routing or the mandate boundary is wrong, not
+that the steward is being difficult.
 
 **Contributor — _"What needs me?"_**
-A queue with one item at the top, not a dashboard: work routed to them, plus changes to work they
-already own. They claim, decline, or act on an artifact the AI has already drafted. Declining
-distinguishes _not my thing_ from _no room right now_. When nothing needs them it says so plainly —
-the willingness to show an empty queue is what makes a full one credible.
-
-**Steward — _"What is waiting on me, and is my domain drifting?"_**
-Every item inside their mandate awaiting a call, plus envelope burn measured against the review
-date. They approve, reject, or hold — and **a hold must carry a resumption trigger**, a date or a
-condition, because a hold without one is a silent no that nobody has to own. Repeated rejections of
-similar items are evidence that the routing or the mandate boundary is wrong, not that the steward
-is being difficult.
-
-**Coordinator — _"Is what we believe still true?"_**
-The hygiene queue: assertions no ledger fact supports, contradictions between artifacts, onboarding
-that has stalled. They confirm, retire, or escalate a specific claim. This is the human end of the
-[behavioural-evidence rule](../architecture/organizational-intelligence.md#1-four-layers-of-memory)
-— someone has to adjudicate when the record and the reality diverge.
+A queue with one item at the top, not a dashboard: steward-approved work routed to them, plus
+changes to work they already own. They claim, decline, or act on an artifact the AI has already
+drafted. Declining distinguishes _not my thing_ from _no room right now_. When nothing needs them it
+says so plainly — the willingness to show an empty queue is what makes a full one credible.
 
 #### Ring 2 — the committed edge
 
@@ -227,8 +318,9 @@ theory first.
 2. The AI interviews them — not a form. It asks what the organization is for, who it serves, what
    it will not do, and how they will know it's working. It draws on patterns from comparable
    organizations in the network to ask sharper questions.
-3. It proposes a structure: the space, sensible entry and decision methods, a first set of roles.
-   The founder edits rather than invents.
+3. It proposes a structure the founder edits rather than invents: the space, sensible entry and
+   decision methods, **who holds voting power**, and **a first set of steward mandates** — domain,
+   named person, envelope, review date. The founder confirms each, or changes it.
 4. **The conversation becomes the organization's first memory.** The purpose, the boundaries, and
    the success signals are written as the founding artifacts — not buried in a chat log.
 5. The founder is shown what was recorded and asked to confirm it. This is the first approval.
@@ -276,33 +368,39 @@ next Friday.
 
 Three things happen at three different speeds here, and conflating them is a design error:
 
-|                                                   | Cadence                         | Why                                                |
-| ------------------------------------------------- | ------------------------------- | -------------------------------------------------- |
-| **Detection** — something needs doing             | continuous                      | delay here is pure loss                            |
-| **Routing** — it reaches the right person's queue | continuous                      | work should never sit unrouted waiting for a cycle |
-| **Interruption** — a push, email, or ping         | rate-limited, urgency overrides | the only genuinely scarce resource is attention    |
+|                                                              | Cadence                         | Why                                                  |
+| ------------------------------------------------------------ | ------------------------------- | ---------------------------------------------------- |
+| **Detection** — something needs doing                        | continuous                      | delay here is pure loss                              |
+| **Steward gate** — approve, reject, or hold                  | continuous                      | work should never sit unrouted waiting for a cycle   |
+| **Routing** — an approved ticket reaches a contributor queue | continuous, after approval      | the steward decides whether; the matcher decides who |
+| **Interruption** — a push, email, or ping                    | rate-limited, urgency overrides | the only genuinely scarce resource is attention      |
 
 So the queue is always current; the digest is a **catch-up for people who haven't looked**, not the
 delivery mechanism; and the interrupt is reserved for things that will go wrong if they wait.
 
-1. **The moment a need is detected, the AI routes it.** It identifies who fits, based on stated
-   skills, demonstrated history, and whose mandate the work falls under — then checks that against
-   what that person has said they can take on.
-2. **It proposes rather than assigns.** The work appears in the suggested person's queue with the
-   reasoning visible, and stays claimable by anyone else. In a voluntary organization you cannot
-   allocate work — you can only put it in front of the person most likely to pick it up, and make it
-   easy to say yes.
-3. Each item names a person, states one concrete next action, and shows the evidence behind it.
+1. **The moment a need is detected, the AI creates a ticket and routes it to the matching
+   steward.** Detection is continuous. The ticket is a recommendation, not work.
+2. **The steward green-lights it — approve, reject, or hold — before anyone starts.** A standing
+   rule the steward has already set ("auto-approve tickets of type X under size Y") counts as this
+   step. Until then the ticket does not reach a contributor.
+3. **Once approved, the AI proposes a person rather than assigning one.** It identifies who fits,
+   based on stated skills, demonstrated history, and whose mandate the work falls under — then
+   checks that against what that person has said they can take on. The work appears in the
+   suggested person's queue with the reasoning visible, and stays claimable by anyone else. In a
+   voluntary organization you cannot allocate work — you can only put it in front of the person
+   most likely to pick it up, and make it easy to say yes.
+4. Each item names a person, states one concrete next action, and shows the evidence behind it.
    Anything that can't do all three isn't routed to a human at all.
-4. **When nobody fits, that is information, not a failure.** The AI says so explicitly rather than
-   quietly dropping the work on whoever answers fastest — the most common and most corrosive default
-   in every organization. The item stays open, visible, and labelled with the capability it needs.
-5. **Unmatched work escalates as a capacity signal** to whoever holds that domain, or to the
-   founders if nobody does. Repeated misses aggregate: three unfilled tasks in the same area over a
-   month is not three problems, it is one role that needs filling.
-6. The person acts, defers, declines, or the work stays open. Declining is a first-class action and
+5. **When nobody fits, or no steward exists for the domain, that is information, not a failure.**
+   The AI says so explicitly rather than quietly dropping the work on whoever answers fastest —
+   the most common and most corrosive default in every organization. The item stays open, visible,
+   and labelled with the capability it needs.
+6. **Unmatched work escalates as a capacity signal** to whoever holds that domain, or as evidence
+   for a "we need this steward" vote if nobody does. Repeated misses aggregate: three unfilled
+   tasks in the same area over a month is not three problems, it is one role that needs filling.
+7. The person acts, defers, declines, or the work stays open. Declining is a first-class action and
    is recorded — it is how the matcher learns.
-7. When they act, the AI has already drafted the artifact — the proposal text, the summary, the
+8. When they act, the AI has already drafted the artifact — the proposal text, the summary, the
    update — so acting is editing.
 
 **On matching without ossifying roles.** Matching purely on demonstrated history is the obvious
@@ -353,31 +451,36 @@ escalation, which is the honest read on whether the org has the people it needs.
 
 ---
 
-## Journey 4 — The steward keeps the organization coherent
+## Journey 4 — The founder keeps the strategy alive
 
-**Who:** whoever holds responsibility for the organization staying true to itself.
-**Wants:** to notice drift before it becomes a crisis.
+**Who:** whoever holds high-level strategy — usually the founder, sometimes more than one.
+**Wants:** the organization to keep pointing at the thing it exists to do, without becoming the
+person who does every next task.
 
-1. They see where **stated intent and actual behaviour have diverged** — we said this was the
+1. They see where **stated strategy and actual behaviour have diverged** — we said this was the
    priority, and here is where the attention and money actually went.
 2. They see which beliefs have gone **stale** (nobody has revisited this in a year) or **contested**
    (two parts of the org are acting on incompatible assumptions).
-3. They review memory changes proposed by the AI and by connected apps, and approve, edit, or
-   reject them. This is the main way memory quality is maintained.
-4. They can retire beliefs that no longer hold, with the reason recorded.
+3. They decide the high-level correction — a revised purpose, a new domain, a retired belief —
+   and **pass the more specific work to the matching steward**. They do not approve the
+   implementations; the steward does.
+4. They review memory changes that touch strategy, and approve, edit, or reject them. Domain-level
+   memory stays with the steward.
+5. Unmatched work that has no steward is a strategic signal: this capability does not exist yet.
+   They raise it to the electorate rather than absorbing the tickets themselves.
 
-**What memory does:** this journey is memory _maintenance_ — the gardening that keeps the corpus
-small, current, and trusted.
-**Why it feels intelligent:** the organization can be wrong out loud. Surfacing contradiction is
-more valuable than projecting false consensus.
+**What memory does:** this journey is memory _maintenance_ at the strategic layer — the gardening
+that keeps the corpus small, current, and trusted.
+**Why it feels intelligent:** the organization can be wrong out loud, and strategy turns into work
+without the founder becoming the work.
 **How we know it works:** the memory corpus stays small enough for a person to read in an
-afternoon, and its age profile stays healthy.
+afternoon, and the founder's queue is strategy and gaps — not a dump of every open ticket.
 
 ---
 
 ## Journey 5 — The organization decides, and then learns
 
-**Who:** the membership, at a governance moment.
+**Who:** whoever holds voting power, at a governance moment.
 **Wants:** to decide well, without being asked to approve everything.
 
 The failure mode this journey has to avoid is approval fatigue. If every good idea becomes
@@ -391,15 +494,18 @@ begins with routing, not drafting.
    for the test and the tiers.
 2. **Most things stop here** — done inside an existing mandate and logged, or waved through by the
    one person who holds that envelope, or opened for a short objection window that closes in silence.
-3. **What remains goes to a vote**: commitments of shared resources beyond an existing mandate,
-   changes to the rules, and changes to who counts as a member. The AI drafts it grounded in memory,
-   and states what it is assuming and what would make the proposal wrong.
-4. Members can see what the organization decided before on similar questions, and what happened as
+3. **What remains goes to a vote of the configured electorate** — not "the members" by default.
+   The founder named who holds voting power; that body decides commitments of shared resources
+   beyond an existing mandate, changes to the rules, changes to who counts as a member, and changes
+   to the steward set. The AI drafts it grounded in memory, and states what it is assuming and what
+   would make the proposal wrong.
+4. Voters can see what the organization decided before on similar questions, and what happened as
    a result.
 5. The decision is made by people, on-chain where it matters.
 6. **The outcome is recorded against the decision** — did it do what we expected?
 7. Later, when reality disagrees with the prediction, the AI proposes updating the belief that
-   produced it. A steward approves.
+   produced it. The founder approves if it is strategic; the matching steward approves if it is
+   inside a domain.
 
 **What memory does:** step 1 depends on memory knowing the organization's mandates; step 6 is what
 turns a record into learning. Without step 6 the organization has a filing cabinet, not


### PR DESCRIPTION
## Summary

Two target-state documents to align on what the **intelligent organization** actually is, before we build it. Docs only — no code changes.

- **[`docs/product/user-journeys.md`](../blob/docs/intelligent-org-architecture/docs/product/user-journeys.md)** — stakeholder taxonomy and nine target-state journeys, written for the whole team.
- **[`docs/architecture/organizational-intelligence.md`](../blob/docs/intelligent-org-architecture/docs/architecture/organizational-intelligence.md)** — how memory is maintained, retrieved, and bounded; plus decision rights.
- `docs/index.md` — both registered in the hub.

## Why

We have a memory substrate arriving in #2461 and a proactive signal loop already on `main`, but no shared written account of the product they serve or the principles they should follow. These two documents are meant to be argued with and amended, then used as the reference for sequencing the build.

## What the journeys document says

Stakeholders are grouped into three rings by **what they stake**, because that is what should determine their authority over organizational memory:

- **Inside** (founder, contributor, steward, coordinator) — stake time and judgment, so they can change what the org believes.
- **Committed edge** (investor/funder, beneficiary, partner org) — stake capital, dependency, or reputation. They see honestly and can file observations; they do not direct operations.
- **Outside** (prospect, builder, verifier) — stake attention.

Nine journeys map onto those stakeholders. Two points worth reviewing specifically:

- **Investors write signals, not proposals.** An observation enters normal triage — visible, owned, answerable — without becoming an instruction. Consent is required only on reserved matters.
- **One organization, one memory, different views.** If an investor-facing narrative is maintained separately from what members see, we have built an investor-relations tool and lost the trust that made it worth building.

## What the architecture document says

- **Four memory layers** — raw substrate, activity ledger, semantic memory (the curated artifacts), and decision memory. Today L1 exists, L3 arrives with #2461, L2 is an unused table, and **L4 does not exist** — which is why the loop cannot yet close.
- **Retrieval by context budget, not search.** The full text of an org's artifacts is roughly 60k tokens; the *index* of them is roughly 1.5k. So always send the map, load contents on demand. A budgeted turn lands near 15.5k tokens against roughly 28k for an advisory task today — better grounded and cheaper.
- **Curation is an accuracy requirement, not a cost optimization.** The cost argument erodes as prices fall; attention dilution does not. If inference were free tomorrow the design would not change.
- **Deterministic triggers, model explanations.** Rules detect that something changed; the model explains what it means. Today's orchestrator uses arithmetic for both, which is why its output reads like a fortune cookie.
- **Decision rights.** Most decisions must never reach a vote. A decision class is a **threshold plus a constituency**, and the missing tier is a visible objection window that closes in silence.

Sizing and cost figures are grounded in the measured model on the `docs/hypha-ai-cost-per-space` branch (in-space system prompt ~5.6k tokens, ~4.66M input tokens/month for a typical space, ~96% of spend on input).

## Platform gaps these documents name

Recorded as open questions rather than decisions:

- `quorum` / `unity` are configurable per **space**, not per decision class.
- No objection-window mechanism (the missing tier).
- No mandate / budget-envelope primitive, so nothing can be classified as "inside an existing mandate".
- Decision classes cannot name **who** must consent, only how many.
- Per-artifact cap is 256 KiB (~64k tokens) — one artifact could consume an entire context budget.

## Review notes

- Prose is aimed at the whole team, technical and non-technical — concepts over code.
- Prettier clean; both docs carry the repo's frontmatter convention.
- Two references point at documents on other branches (#2461 and `docs/hypha-ai-cost-per-space`) and are labelled as such rather than linked, to avoid dead links on `main`.

## Test plan

- [ ] Read both documents end to end and disagree where warranted — they are meant to be amended.
- [ ] Confirm the stakeholder rings match how we actually think about investors and beneficiaries.
- [ ] Sanity-check the token and cost arithmetic in §3 and §4 against the cost model.
- [ ] Confirm the decision-rights tiers are compatible with the contracts' quorum/unity model.

Made with [Cursor](https://cursor.com)