### PR TITLE
feat(signals): add summary logging to cron/ops orchestration endpoints

### DIFF
--- a/apps/web/src/app/api/cron/signals-orchestrate/route.ts
+++ b/apps/web/src/app/api/cron/signals-orchestrate/route.ts
@@ -43,6 +43,11 @@ export async function GET(request: Request) {
       : 200;
     return NextResponse.json(result, { status });
   } catch (error) {
+    console.error('[cron.signals-orchestrate] batch failed', {
+      limit,
+      dryRun,
+      error: error instanceof Error ? error.message : String(error),
+    });
     return NextResponse.json(
       {
         error: 'Failed to orchestrate signals',

--- a/apps/web/src/app/api/v1/ops/signals/orchestrate/route.ts
+++ b/apps/web/src/app/api/v1/ops/signals/orchestrate/route.ts
@@ -63,6 +63,11 @@ export async function POST(request: NextRequest) {
       : 200;
     return NextResponse.json(result, { status });
   } catch (error) {
+    console.error('[ops.signals.orchestrate] batch failed', {
+      limit: parsedPayload.data.limit,
+      dryRun: parsedPayload.data.dry_run,
+      error: error instanceof Error ? error.message : String(error),
+    });
     return NextResponse.json(
       {
         error: 'Failed to orchestrate signals',

--- a/apps/web/src/app/api/v1/ops/space-memory/refresh-discussions/run-refresh-discussions.ts
+++ b/apps/web/src/app/api/v1/ops/space-memory/refresh-discussions/run-refresh-discussions.ts
@@ -63,6 +63,7 @@ async function withTimeout<T>(
 export async function runRefreshDiscussions(
   input: RefreshDiscussionsInput = {},
 ): Promise<{ status: number; body: RefreshDiscussionsResult }> {
+  const startedAt = Date.now();
   const limit = input.limit ?? 100;
   const includeArchived = input.includeArchived ?? false;
   const dryRun = input.dryRun ?? false;
@@ -115,6 +116,10 @@ export async function runRefreshDiscussions(
   }
 
   if (dryRun) {
+    console.log('[space-memory.refresh-discussions] dry run complete', {
+      targetCount: targetSlugs.length,
+      durationMs: Date.now() - startedAt,
+    });
     return {
       status: 200,
       body: {
@@ -193,6 +198,21 @@ export async function runRefreshDiscussions(
 
   const success_count = summaries.filter((s) => s.ok).length;
   const failure_count = summaries.length - success_count;
+  const failureReasons = summaries
+    .filter((s) => !s.ok)
+    .reduce<Record<string, number>>((acc, s) => {
+      const reason = s.error ?? 'unknown';
+      acc[reason] = (acc[reason] ?? 0) + 1;
+      return acc;
+    }, {});
+
+  console.log('[space-memory.refresh-discussions] batch complete', {
+    targetCount: targetSlugs.length,
+    successCount: success_count,
+    failureCount: failure_count,
+    failureReasons,
+    durationMs: Date.now() - startedAt,
+  });
 
   return {
     status: failure_count === 0 ? 200 : 207,

--- a/apps/web/src/app/api/v1/ops/space-memory/refresh-discussions/run-refresh-discussions.ts
+++ b/apps/web/src/app/api/v1/ops/space-memory/refresh-discussions/run-refresh-discussions.ts
@@ -33,6 +33,27 @@ export type RefreshDiscussionsResult = {
 const SUMMARY_CONCURRENCY = 6;
 const SUMMARY_TIMEOUT_MS = 45_000;
 
+// Stable, non-parameterized failure strings returned by createSpaceDiscussionSummary /
+// withTimeout — safe to use as log-aggregation keys as-is. Anything else (DB/network errors,
+// unexpected throws) can carry high-cardinality detail, so it gets bucketed and truncated
+// instead of aggregated verbatim.
+const KNOWN_FAILURE_REASONS = new Set([
+  'Space not found',
+  'Space has no chat room',
+  'No eligible discussion rooms found',
+  'No chat messages available for summary',
+  'Failed to persist summary',
+  'Summary generation timed out',
+]);
+const FAILURE_REASON_MAX_LEN = 60;
+
+function normalizeFailureReason(rawError: string | undefined): string {
+  const reason = rawError?.trim();
+  if (!reason) return 'unknown';
+  if (KNOWN_FAILURE_REASONS.has(reason)) return reason;
+  return `other: ${reason.slice(0, FAILURE_REASON_MAX_LEN)}`;
+}
+
 async function withTimeout<T>(
   task: (signal: AbortSignal) => Promise<T>,
   timeoutMs: number,
@@ -201,7 +222,7 @@ export async function runRefreshDiscussions(
   const failureReasons = summaries
     .filter((s) => !s.ok)
     .reduce<Record<string, number>>((acc, s) => {
-      const reason = s.error ?? 'unknown';
+      const reason = normalizeFailureReason(s.error);
       acc[reason] = (acc[reason] ?? 0) + 1;
       return acc;
     }, {});

--- a/packages/core/src/coherence/server/signal-orchestrator.ts
+++ b/packages/core/src/coherence/server/signal-orchestrator.ts
@@ -494,6 +494,7 @@ export async function processSignalOrchestratorBatch(
   }: ProcessBatchInput,
   { db }: DbConfig,
 ) {
+  const startedAt = Date.now();
   const rows = await db
     .select()
     .from(signalOrchestratorQueue)
@@ -874,6 +875,19 @@ export async function processSignalOrchestratorBatch(
       results.push({ queue_id: lock.id, status: 'error', message });
     }
   }
+
+  const statusCounts = results.reduce<Record<string, number>>((acc, r) => {
+    acc[r.status] = (acc[r.status] ?? 0) + 1;
+    return acc;
+  }, {});
+  console.log('[signal-orchestrator] batch complete', {
+    dryRun,
+    system: useSystemIdentity,
+    scanned: rows.length,
+    processed: results.length,
+    ...statusCounts,
+    durationMs: Date.now() - startedAt,
+  });
 
   return {
     ok: true as const,


### PR DESCRIPTION
## Summary
- Both signal-orchestrator batches and space-memory discussion-refresh batches run unattended via Vercel Cron every 10min / 2h, but had **zero server-side logging** — the only outcome data was the JSON response body, which nobody inspects on a scheduled run.
- Adds one structured summary log line per batch:
  - `[signal-orchestrator] batch complete` — dryRun, system flag, scanned/processed counts, per-status breakdown (emitted/relay_emitted/discarded/suppressed/error), durationMs.
  - `[space-memory.refresh-discussions] batch complete` (and a dry-run variant) — target/success/failure counts, failure-reason breakdown, durationMs.
- Adds `console.error` on the two previously-silent top-level catch blocks (`GET /api/cron/signals-orchestrate`, `POST /api/v1/ops/signals/orchestrate`) so hard failures surface in Vercel function logs instead of only in the HTTP response.
- No behavior change — pure observability addition, same code paths, same responses.

Follow-up from #2420 (PR #2403) — flagged during that work that unattended cron runs had no way to sanity-check "is this working, and roughly how" without manually reading the raw response body.

## Test plan
- [x] `tsc --noEmit` clean on all touched files (pre-existing unrelated errors elsewhere in the package untouched)
- [ ] Manual local run against `/api/cron/signals-orchestrate` and `/api/v1/ops/space-memory/refresh-discussions/*` to confirm log lines appear with sane counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved operational monitoring for signal processing and discussion refresh workflows.
  * Added clearer completion summaries, including processing totals, outcomes, failure reasons, execution mode, and duration.
  * Enhanced error reporting with relevant request settings and normalized error details.
  * Existing API behavior and error responses remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->