### PR TITLE
feat(banking): email ownership confirmation before KYB binding

### DIFF
--- a/apps/web/.env.template
+++ b/apps/web/.env.template
@@ -62,6 +62,10 @@ NEXT_PUBLIC_BANKING_SUPPORTED_PAYOUT_RAILS=
 BRIDGE_API_BASE_URL=
 # Temporary local demo: shows "Simulate KYB approval" below Bank Deposits (sandbox API only).
 NEXT_PUBLIC_BRIDGE_SANDBOX_DEMO=false
+# Signing secret for the bank-email-ownership confirmation JWT (#2288). Carries the third-party
+# email + form data across the email round-trip; never generate a placeholder, use a real random
+# value (e.g. `openssl rand -hex 32`) per environment.
+INTERNAL_JWT_SECRET=
 
 # Alchemy webhooks
 WH_SPACE_CREATED_SIGN_KEY=whsec_000000000000000000000000
@@ -78,6 +82,11 @@ NEXT_PUBLIC_EMAIL_TEMPLATE_PROPOSAL_OPEN_FOR_MEMBERS=
 # OneSignal template ID — bank KYB onboarding email to contactEmail (server-only).
 # custom_data: space_title, legal_name, kyc_link, optional tos_link
 EMAIL_TEMPLATE_BANK_KYB_ONBOARDING=
+# OneSignal template ID — #2288 bank email-ownership confirmation link (server-only). Sent instead
+# of the KYB onboarding email above when the submitted Bridge customer email isn't the submitter's
+# own (people.email) — proves inbox ownership before Hypha ever calls Bridge with it.
+# custom_data: owner_label, verify_link
+EMAIL_TEMPLATE_BANK_EMAIL_CONFIRMATION=
 NEXT_PUBLIC_PUSH_TEMPLATE_PROPOSAL_OPEN_FOR_CREATOR=
 NEXT_PUBLIC_PUSH_TEMPLATE_PROPOSAL_OPEN_FOR_MEMBERS=
 

--- a/apps/web/src/app/[lang]/dho/[id]/_components/treasury-tabs.tsx
+++ b/apps/web/src/app/[lang]/dho/[id]/_components/treasury-tabs.tsx
@@ -11,7 +11,6 @@ import {
   useBankCustomerStatus,
   useTransfers,
   useVaults,
-  useVirtualAccounts,
 } from '@hypha-platform/epics';
 import {
   Tabs,
@@ -49,14 +48,12 @@ export function TreasuryTabs({
   const { transfers } = useTransfers({ spaceSlug });
   const { vaults } = useVaults({ spaceSlug });
   const { status: bankCustomerStatus } = useBankCustomerStatus({ spaceSlug });
-  const { accounts: virtualAccounts } = useVirtualAccounts({
-    spaceSlug,
-    enabled: Boolean(bankCustomerStatus),
-  });
   const walletCount = assets.filter((asset) => asset.value > 0).length;
   const transactionCount = transfers.length;
   const vaultCount = vaults.length;
-  const bankAccountCount = virtualAccounts.length;
+  // Count linked Bridge customers, not currencies (a bundled #2288 fix) — one space has at most
+  // one bank customer per provider, regardless of how many deposit currencies it uses.
+  const bankAccountCount = bankCustomerStatus?.hasCustomer ? 1 : 0;
 
   return (
     <div className="flex w-full flex-col gap-4 py-4">

--- a/apps/web/src/app/[lang]/verify/banking/_components/verify-banking-page.tsx
+++ b/apps/web/src/app/[lang]/verify/banking/_components/verify-banking-page.tsx
@@ -8,7 +8,10 @@ import { Container } from '@hypha-platform/ui';
 type ConfirmState =
   | { status: 'loading' }
   | { status: 'success'; ownerLabel: string }
-  | { status: 'error'; reason: 'expired' | 'invalid' | 'already_confirmed' | 'generic' };
+  | {
+      status: 'error';
+      reason: 'expired' | 'invalid' | 'already_confirmed' | 'generic';
+    };
 
 type VerifyBankingPageProps = {
   token: string | null;

--- a/apps/web/src/app/[lang]/verify/banking/_components/verify-banking-page.tsx
+++ b/apps/web/src/app/[lang]/verify/banking/_components/verify-banking-page.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { FC, useEffect, useState } from 'react';
+import { CheckCircle2, Loader2, XCircle } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { Container } from '@hypha-platform/ui';
+
+type ConfirmState =
+  | { status: 'loading' }
+  | { status: 'success'; ownerLabel: string }
+  | { status: 'error'; reason: 'expired' | 'invalid' | 'already_confirmed' | 'generic' };
+
+type VerifyBankingPageProps = {
+  token: string | null;
+};
+
+/**
+ * Public page (#2288) — no Privy auth: the token in the URL is the authorization (D4). Confirms
+ * the submitter's email ownership before Hypha ever calls Bridge with it, then reports success or
+ * a clear reason for failure inline (never a redirect, per decisions.md "Resolved").
+ */
+export const VerifyBankingPage: FC<VerifyBankingPageProps> = ({ token }) => {
+  const t = useTranslations('VerifyBanking');
+  const [state, setState] = useState<ConfirmState>({ status: 'loading' });
+
+  useEffect(() => {
+    if (!token) {
+      setState({ status: 'error', reason: 'invalid' });
+      return;
+    }
+
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const res = await fetch('/api/v1/banking/token-confirmation', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ token }),
+        });
+        const body = (await res.json().catch(() => ({}))) as {
+          ok?: boolean;
+          reason?: 'expired' | 'invalid' | 'already_confirmed';
+          ownerLabel?: string;
+        };
+
+        if (cancelled) return;
+
+        if (res.ok && body.ok) {
+          setState({ status: 'success', ownerLabel: body.ownerLabel ?? '' });
+          return;
+        }
+
+        setState({
+          status: 'error',
+          reason: body.reason ?? 'generic',
+        });
+      } catch {
+        if (!cancelled) {
+          setState({ status: 'error', reason: 'generic' });
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [token]);
+
+  const errorCopy: Record<
+    'expired' | 'invalid' | 'already_confirmed' | 'generic',
+    { title: string; description: string }
+  > = {
+    expired: {
+      title: t('errorExpiredTitle'),
+      description: t('errorExpiredDescription'),
+    },
+    invalid: {
+      title: t('errorInvalidTitle'),
+      description: t('errorInvalidDescription'),
+    },
+    already_confirmed: {
+      title: t('errorAlreadyConfirmedTitle'),
+      description: t('errorAlreadyConfirmedDescription'),
+    },
+    generic: {
+      title: t('errorGenericTitle'),
+      description: t('errorGenericDescription'),
+    },
+  };
+
+  return (
+    <Container className="flex min-h-[60vh] flex-col items-center justify-center gap-4 py-16 text-center">
+      {state.status === 'loading' ? (
+        <>
+          <Loader2 className="h-10 w-10 animate-spin text-muted-foreground" />
+          <p className="text-3 font-semibold text-foreground">
+            {t('loadingTitle')}
+          </p>
+          <p className="max-w-md text-2 text-muted-foreground">
+            {t('loadingDescription')}
+          </p>
+        </>
+      ) : state.status === 'success' ? (
+        <>
+          <CheckCircle2 className="h-10 w-10 text-success-9" />
+          <p className="text-3 font-semibold text-foreground">
+            {t('successTitle')}
+          </p>
+          <p className="max-w-md text-2 text-muted-foreground">
+            {t('successDescription', { ownerLabel: state.ownerLabel })}
+          </p>
+        </>
+      ) : (
+        <>
+          <XCircle className="h-10 w-10 text-destructive" />
+          <p className="text-3 font-semibold text-foreground">
+            {errorCopy[state.reason].title}
+          </p>
+          <p className="max-w-md text-2 text-muted-foreground">
+            {errorCopy[state.reason].description}
+          </p>
+        </>
+      )}
+    </Container>
+  );
+};

--- a/apps/web/src/app/[lang]/verify/banking/page.tsx
+++ b/apps/web/src/app/[lang]/verify/banking/page.tsx
@@ -1,0 +1,13 @@
+import { VerifyBankingPage } from './_components/verify-banking-page';
+
+type PageProps = {
+  searchParams?: Promise<{ token?: string }>;
+};
+
+/** Public page (#2288) — no Privy auth gate. See VerifyBankingPage for details. */
+export default async function Page(props: PageProps) {
+  const searchParams = await props.searchParams;
+  const token = searchParams?.token?.trim() || null;
+
+  return <VerifyBankingPage token={token} />;
+}

--- a/apps/web/src/app/api/v1/banking/token-confirmation/route.ts
+++ b/apps/web/src/app/api/v1/banking/token-confirmation/route.ts
@@ -1,0 +1,58 @@
+import { confirmBankEmail } from '@hypha-platform/core/server';
+import { db } from '@hypha-platform/storage-postgres';
+import { NextRequest, NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * Public endpoint (#2288) — no Privy auth: the confirmation JWT itself is the authorization (D4).
+ * Owner-agnostic — the JWT payload carries whether it's a space or a person.
+ */
+export async function POST(request: NextRequest) {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const token =
+    typeof body === 'object' && body !== null && 'token' in body
+      ? (body as { token: unknown }).token
+      : null;
+
+  if (typeof token !== 'string' || !token) {
+    return NextResponse.json({ error: 'Missing token' }, { status: 400 });
+  }
+
+  try {
+    const result = await confirmBankEmail(token, { db });
+
+    if (!result.ok) {
+      const status = result.reason === 'already_confirmed' ? 409 : 400;
+      return NextResponse.json(
+        { ok: false, reason: result.reason },
+        { status, headers: { 'Cache-Control': 'private, no-store' } },
+      );
+    }
+
+    return NextResponse.json(
+      {
+        ok: true,
+        ownerType: result.ownerType,
+        ownerLabel: result.ownerLabel,
+        kycLink: result.kycLink,
+      },
+      { headers: { 'Cache-Control': 'private, no-store' } },
+    );
+  } catch (error) {
+    console.error(
+      'banking/token-confirmation POST failed:',
+      error instanceof Error ? error.message : error,
+    );
+    return NextResponse.json(
+      { error: 'Failed to confirm bank email' },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/src/app/api/v1/people/[personSlug]/banking/bank-customers/route.ts
+++ b/apps/web/src/app/api/v1/people/[personSlug]/banking/bank-customers/route.ts
@@ -9,6 +9,7 @@ import { NextRequest, NextResponse } from 'next/server';
 
 import { authenticatePersonalBankCustomerRequest } from '@web/lib/bank-customers/authenticate-personal-bank-customer-request';
 import { sendBankOnboardingEmail } from '@web/lib/bank-customers/send-onboarding-email';
+import { sendBankEmailConfirmationEmail } from '@web/lib/bank-customers/send-email-confirmation';
 
 type Params = { personSlug: string };
 
@@ -95,6 +96,14 @@ export async function POST(
         requestedRails: requestedRails ?? endorsements,
       },
       { db },
+      {
+        sendConfirmationEmail: ({ token, ownerLabel }) =>
+          sendBankEmailConfirmationEmail({
+            recipientEmail: contactEmail,
+            ownerLabel,
+            token,
+          }),
+      },
     );
 
     if (result.created && result.kycLink) {

--- a/apps/web/src/app/api/v1/spaces/[spaceSlug]/banking/bank-customers/route.ts
+++ b/apps/web/src/app/api/v1/spaces/[spaceSlug]/banking/bank-customers/route.ts
@@ -12,6 +12,7 @@ import {
   extractBearerToken,
 } from '@web/lib/bank-customers/authenticate-bank-customer-request';
 import { sendBankOnboardingEmail } from '@web/lib/bank-customers/send-onboarding-email';
+import { sendBankEmailConfirmationEmail } from '@web/lib/bank-customers/send-email-confirmation';
 
 type Params = { spaceSlug: string };
 
@@ -93,6 +94,14 @@ export async function POST(
         requestedRails: requestedRails ?? endorsements,
       },
       { db },
+      {
+        sendConfirmationEmail: ({ token, ownerLabel }) =>
+          sendBankEmailConfirmationEmail({
+            recipientEmail: contactEmail,
+            ownerLabel,
+            token,
+          }),
+      },
     );
 
     if (result.created && result.kycLink) {

--- a/apps/web/src/lib/bank-customers/send-email-confirmation.ts
+++ b/apps/web/src/lib/bank-customers/send-email-confirmation.ts
@@ -46,12 +46,13 @@ export async function sendBankEmailConfirmationEmail({
         'EMAIL_TEMPLATE_BANK_EMAIL_CONFIRMATION is not set — cannot send the bank email confirmation link',
       );
     }
+    // Not redacted here (unlike the success log below): this branch is structurally
+    // unreachable in production (the throw above always fires there instead), so the token can
+    // only ever land in a developer's local console — and doing so is the point, since this is
+    // the supported way to test the confirmation flow without a real OneSignal template.
     console.log(
       '[bank-email-confirmation] Skipping OneSignal send — EMAIL_TEMPLATE_BANK_EMAIL_CONFIRMATION is not set. Would send:',
-      {
-        recipientEmail,
-        customData: { ...customData, verify_link: redactedVerifyLink },
-      },
+      { recipientEmail, customData },
     );
     return;
   }

--- a/apps/web/src/lib/bank-customers/send-email-confirmation.ts
+++ b/apps/web/src/lib/bank-customers/send-email-confirmation.ts
@@ -1,3 +1,4 @@
+import 'server-only';
 import { sendEmailNotificationsTemplateToEmails } from '@hypha-platform/notifications/server';
 import { getAbsoluteAppUrl } from '@hypha-platform/core/server';
 

--- a/apps/web/src/lib/bank-customers/send-email-confirmation.ts
+++ b/apps/web/src/lib/bank-customers/send-email-confirmation.ts
@@ -1,0 +1,62 @@
+import { sendEmailNotificationsTemplateToEmails } from '@hypha-platform/notifications/server';
+import { getAbsoluteAppUrl } from '@hypha-platform/core/server';
+
+type SendBankEmailConfirmationEmailInput = {
+  recipientEmail: string;
+  ownerLabel: string;
+  token: string;
+};
+
+/**
+ * Sends the #2288 email-ownership confirmation link — a consent step distinct from the KYB
+ * onboarding email (`sendBankOnboardingEmail`): this goes to whatever address was entered in the
+ * form, to prove the submitter doesn't control an inbox they don't actually own, before Hypha ever
+ * calls Bridge with it. When `EMAIL_TEMPLATE_BANK_EMAIL_CONFIRMATION` is unset, logs the payload
+ * and skips the API call.
+ */
+export async function sendBankEmailConfirmationEmail({
+  recipientEmail,
+  ownerLabel,
+  token,
+}: SendBankEmailConfirmationEmailInput) {
+  const templateId =
+    process.env.EMAIL_TEMPLATE_BANK_EMAIL_CONFIRMATION?.trim() ?? '';
+
+  const verifyLink = getAbsoluteAppUrl(
+    `/en/verify/banking?token=${encodeURIComponent(token)}`,
+  );
+
+  /** OneSignal template keys: owner_label, verify_link */
+  const customData: Record<string, string> = {
+    owner_label: ownerLabel,
+    verify_link: verifyLink,
+  };
+
+  if (!templateId) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.log(
+        '[bank-email-confirmation] Skipping OneSignal send — EMAIL_TEMPLATE_BANK_EMAIL_CONFIRMATION is not set. Would send:',
+        {
+          recipientEmail,
+          customData,
+        },
+      );
+    }
+    return;
+  }
+
+  await sendEmailNotificationsTemplateToEmails({
+    templateId,
+    customData,
+    emails: [recipientEmail],
+  });
+
+  if (process.env.NODE_ENV !== 'production') {
+    console.log('[bank-email-confirmation] OneSignal confirmation email sent', {
+      recipientEmail,
+      templateId,
+      // Never log the token itself — it's a bearer credential for the confirmation.
+      verifyLink: verifyLink.split('?')[0] + '?token=<redacted>',
+    });
+  }
+}

--- a/apps/web/src/lib/bank-customers/send-email-confirmation.ts
+++ b/apps/web/src/lib/bank-customers/send-email-confirmation.ts
@@ -11,8 +11,13 @@ type SendBankEmailConfirmationEmailInput = {
  * Sends the #2288 email-ownership confirmation link — a consent step distinct from the KYB
  * onboarding email (`sendBankOnboardingEmail`): this goes to whatever address was entered in the
  * form, to prove the submitter doesn't control an inbox they don't actually own, before Hypha ever
- * calls Bridge with it. When `EMAIL_TEMPLATE_BANK_EMAIL_CONFIRMATION` is unset, logs the payload
- * and skips the API call.
+ * calls Bridge with it.
+ *
+ * Unlike `sendBankOnboardingEmail`, an unset `EMAIL_TEMPLATE_BANK_EMAIL_CONFIRMATION` is only
+ * tolerated outside production (logs the payload and skips the API call, for local testing without
+ * an OneSignal template) — in production it throws, so a missing template surfaces as a failed
+ * request instead of silently leaving the submitter stuck in "pending confirmation" forever with no
+ * way to receive the link.
  */
 export async function sendBankEmailConfirmationEmail({
   recipientEmail,
@@ -25,6 +30,8 @@ export async function sendBankEmailConfirmationEmail({
   const verifyLink = getAbsoluteAppUrl(
     `/en/verify/banking?token=${encodeURIComponent(token)}`,
   );
+  // Never log the token itself — it's a bearer credential for the confirmation.
+  const redactedVerifyLink = verifyLink.split('?')[0] + '?token=<redacted>';
 
   /** OneSignal template keys: owner_label, verify_link */
   const customData: Record<string, string> = {
@@ -33,15 +40,18 @@ export async function sendBankEmailConfirmationEmail({
   };
 
   if (!templateId) {
-    if (process.env.NODE_ENV !== 'production') {
-      console.log(
-        '[bank-email-confirmation] Skipping OneSignal send — EMAIL_TEMPLATE_BANK_EMAIL_CONFIRMATION is not set. Would send:',
-        {
-          recipientEmail,
-          customData,
-        },
+    if (process.env.NODE_ENV === 'production') {
+      throw new Error(
+        'EMAIL_TEMPLATE_BANK_EMAIL_CONFIRMATION is not set — cannot send the bank email confirmation link',
       );
     }
+    console.log(
+      '[bank-email-confirmation] Skipping OneSignal send — EMAIL_TEMPLATE_BANK_EMAIL_CONFIRMATION is not set. Would send:',
+      {
+        recipientEmail,
+        customData: { ...customData, verify_link: redactedVerifyLink },
+      },
+    );
     return;
   }
 
@@ -55,8 +65,7 @@ export async function sendBankEmailConfirmationEmail({
     console.log('[bank-email-confirmation] OneSignal confirmation email sent', {
       recipientEmail,
       templateId,
-      // Never log the token itself — it's a bearer credential for the confirmation.
-      verifyLink: verifyLink.split('?')[0] + '?token=<redacted>',
+      verifyLink: redactedVerifyLink,
     });
   }
 }

--- a/apps/web/src/lib/bank-customers/send-onboarding-email.ts
+++ b/apps/web/src/lib/bank-customers/send-onboarding-email.ts
@@ -1,3 +1,4 @@
+import 'server-only';
 import { sendEmailNotificationsTemplateToEmails } from '@hypha-platform/notifications/server';
 
 type SendBankOnboardingEmailInput = {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,6 +19,7 @@
     "@hypha-platform/ui-utils": "workspace:*",
     "@privy-io/node": "^0.12.0",
     "@wagmi/cli": "^2.2.0",
+    "jose": "^5.9.6",
     "livekit-client": "^2.18.1",
     "livekit-server-sdk": "^2.18.0",
     "matrix-js-sdk": "^40.0.0",

--- a/packages/core/src/banking/__tests__/normalize-email-for-bypass.test.ts
+++ b/packages/core/src/banking/__tests__/normalize-email-for-bypass.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  isBypassEligible,
+  normalizeEmailForBypass,
+} from '../normalize-email-for-bypass';
+
+describe('normalizeEmailForBypass', () => {
+  it('lowercases and trims', () => {
+    expect(normalizeEmailForBypass('  Me@Example.com  ')).toBe(
+      'me@example.com',
+    );
+  });
+
+  it('strips a plus-address suffix from the local part only', () => {
+    expect(normalizeEmailForBypass('me+test@example.com')).toBe(
+      'me@example.com',
+    );
+  });
+
+  it('leaves a + in the domain (malformed input) untouched beyond lowercasing', () => {
+    expect(normalizeEmailForBypass('me')).toBe('me');
+  });
+});
+
+describe('isBypassEligible', () => {
+  it('is eligible when the submitted email is a plus-addressed variant of the submitter email', () => {
+    expect(isBypassEligible('me@example.com', 'me+sandbox@example.com')).toBe(
+      true,
+    );
+  });
+
+  it('is eligible for an exact case-insensitive match', () => {
+    expect(isBypassEligible('Me@Example.com', 'me@example.com')).toBe(true);
+  });
+
+  it('is not eligible for a different email entirely', () => {
+    expect(isBypassEligible('me@example.com', 'someone-else@example.com')).toBe(
+      false,
+    );
+  });
+
+  it('is not eligible when the submitter has no email on file', () => {
+    expect(isBypassEligible(null, 'me@example.com')).toBe(false);
+  });
+});

--- a/packages/core/src/banking/constants.ts
+++ b/packages/core/src/banking/constants.ts
@@ -1,8 +1,15 @@
-import type { BankProvider } from './types';
+import type { BankProvider, BankValidationRequirement } from './types';
 import type { BridgeEndorsement } from './server/providers/bridge/endorsements';
 
 /** Default banking provider for space onboarding (Stage 1). */
 export const DEFAULT_BANK_PROVIDER: BankProvider = 'bridge';
+
+/** Placeholder tos/kyc validation shown while a #2288 email-ownership confirmation is pending. */
+export const PENDING_EMAIL_CONFIRMATION_VALIDATION: BankValidationRequirement = {
+  key: 'pending_email_confirmation',
+  status: null,
+  isComplete: false,
+};
 
 /** Source currencies supported for Bridge virtual accounts (Stage 2). */
 export const BANK_VIRTUAL_ACCOUNT_CURRENCIES = [

--- a/packages/core/src/banking/constants.ts
+++ b/packages/core/src/banking/constants.ts
@@ -5,11 +5,12 @@ import type { BridgeEndorsement } from './server/providers/bridge/endorsements';
 export const DEFAULT_BANK_PROVIDER: BankProvider = 'bridge';
 
 /** Placeholder tos/kyc validation shown while a #2288 email-ownership confirmation is pending. */
-export const PENDING_EMAIL_CONFIRMATION_VALIDATION: BankValidationRequirement = {
-  key: 'pending_email_confirmation',
-  status: null,
-  isComplete: false,
-};
+export const PENDING_EMAIL_CONFIRMATION_VALIDATION: BankValidationRequirement =
+  {
+    key: 'pending_email_confirmation',
+    status: null,
+    isComplete: false,
+  };
 
 /** Source currencies supported for Bridge virtual accounts (Stage 2). */
 export const BANK_VIRTUAL_ACCOUNT_CURRENCIES = [

--- a/packages/core/src/banking/normalize-email-for-bypass.ts
+++ b/packages/core/src/banking/normalize-email-for-bypass.ts
@@ -1,0 +1,35 @@
+/**
+ * Strips a `+tag` plus-address suffix and lowercases, for the bypass ownership compare only
+ * (decision D5) — `me+test@x.com` ≡ `me@x.com` when checking "is the submitter the email owner".
+ * The original, unmodified email is always what's sent to Bridge and stored: Bridge treats
+ * `user+tag@x.com` as a distinct customer, which is intentional for sandbox testing.
+ */
+export function normalizeEmailForBypass(email: string): string {
+  const trimmed = email.trim().toLowerCase();
+  const atIndex = trimmed.indexOf('@');
+  if (atIndex === -1) {
+    return trimmed;
+  }
+
+  const localPart = trimmed.slice(0, atIndex);
+  const domain = trimmed.slice(atIndex);
+  const plusIndex = localPart.indexOf('+');
+  const normalizedLocalPart =
+    plusIndex === -1 ? localPart : localPart.slice(0, plusIndex);
+
+  return `${normalizedLocalPart}${domain}`;
+}
+
+/** Is `submitterEmail` (the authorized submitter's own `people.email`) the owner of `contactEmail`? */
+export function isBypassEligible(
+  submitterEmail: string | null,
+  contactEmail: string,
+): boolean {
+  if (!submitterEmail) {
+    return false;
+  }
+  return (
+    normalizeEmailForBypass(submitterEmail) ===
+    normalizeEmailForBypass(contactEmail)
+  );
+}

--- a/packages/core/src/banking/server/__tests__/bank-onboarding-confirmation.test.ts
+++ b/packages/core/src/banking/server/__tests__/bank-onboarding-confirmation.test.ts
@@ -205,7 +205,7 @@ describe('requestBankOnboardingWithConfirmation', () => {
     expect(insertBankCustomer).not.toHaveBeenCalled();
   });
 
-  it('finalizes an existing pending row on bypass instead of inserting a duplicate', async () => {
+  it('claims and finalizes an existing pending row on bypass instead of inserting a duplicate', async () => {
     findBankCustomerBySpaceAndProvider.mockResolvedValue({
       id: 7,
       providerKycLinkId: null,
@@ -213,7 +213,8 @@ describe('requestBankOnboardingWithConfirmation', () => {
       jwtNonce: 'old-nonce',
       requestedRails: ['eur'],
     });
-    updateBankCustomer.mockResolvedValue({ id: 7 });
+    claimBankCustomerForConfirmation.mockResolvedValue({ id: 7 });
+    finalizeClaimedBankCustomer.mockResolvedValue({ id: 7 });
 
     const result = await requestBankOnboardingWithConfirmation(
       {
@@ -232,10 +233,72 @@ describe('requestBankOnboardingWithConfirmation', () => {
 
     expect(result.kind).toBe('created');
     expect(insertBankCustomer).not.toHaveBeenCalled();
-    expect(updateBankCustomer).toHaveBeenCalledWith(
+    expect(claimBankCustomerForConfirmation).toHaveBeenCalledWith(
+      { id: 7, expectedNonce: 'old-nonce' },
+      expect.any(Object),
+    );
+    expect(finalizeClaimedBankCustomer).toHaveBeenCalledWith(
       expect.objectContaining({ id: 7, providerKycLinkId: 'link_1' }),
       expect.any(Object),
     );
+  });
+
+  it('rejects a bypass request when the row is already claimed by an in-flight confirmation', async () => {
+    findBankCustomerBySpaceAndProvider.mockResolvedValue({
+      id: 7,
+      providerKycLinkId: null,
+      providerCustomerId: null,
+      jwtNonce: null,
+      requestedRails: ['eur'],
+    });
+
+    await expect(
+      requestBankOnboardingWithConfirmation(
+        {
+          ownerRef: spaceOwner,
+          entityType: 'business',
+          legalName: 'Acme Foundation Ltd.',
+          contactEmail: 'me+sandbox@example.com',
+          requestedRails: ['eur'],
+          submitterPersonId: 10,
+          submitterEmail: 'me@example.com',
+          sendConfirmationEmail,
+        },
+        { db: mockDb },
+        { kycProvider: mockProvider },
+      ),
+    ).rejects.toThrow(/already being processed/i);
+    expect(mockProvider.createKycLink).not.toHaveBeenCalled();
+    expect(claimBankCustomerForConfirmation).not.toHaveBeenCalled();
+  });
+
+  it('rejects a bypass request that loses the claim to a concurrent resend or confirm', async () => {
+    findBankCustomerBySpaceAndProvider.mockResolvedValue({
+      id: 7,
+      providerKycLinkId: null,
+      providerCustomerId: null,
+      jwtNonce: 'old-nonce',
+      requestedRails: ['eur'],
+    });
+    claimBankCustomerForConfirmation.mockResolvedValue(null);
+
+    await expect(
+      requestBankOnboardingWithConfirmation(
+        {
+          ownerRef: spaceOwner,
+          entityType: 'business',
+          legalName: 'Acme Foundation Ltd.',
+          contactEmail: 'me+sandbox@example.com',
+          requestedRails: ['eur'],
+          submitterPersonId: 10,
+          submitterEmail: 'me@example.com',
+          sendConfirmationEmail,
+        },
+        { db: mockDb },
+        { kycProvider: mockProvider },
+      ),
+    ).rejects.toThrow(/just changed/i);
+    expect(mockProvider.createKycLink).not.toHaveBeenCalled();
   });
 
   it('rotates the nonce and clears any in-flight claim on resend instead of inserting a duplicate', async () => {

--- a/packages/core/src/banking/server/__tests__/bank-onboarding-confirmation.test.ts
+++ b/packages/core/src/banking/server/__tests__/bank-onboarding-confirmation.test.ts
@@ -1,0 +1,335 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('server-only', () => ({}));
+
+process.env.INTERNAL_JWT_SECRET = 'test-secret-at-least-32-bytes-long!!';
+
+import {
+  confirmBankEmail,
+  requestBankOnboardingWithConfirmation,
+  type BankOnboardingOwnerRef,
+} from '../bank-onboarding-confirmation';
+import type { BankKycProvider } from '../providers/types';
+import { signBankConfirmationJwt } from '../../../common/server/sign-bank-confirmation-jwt';
+
+const findBankCustomerBySpaceAndProvider = vi.fn();
+const findBankCustomerByPersonAndProvider = vi.fn();
+const findBankCustomerByNonce = vi.fn();
+const insertBankCustomer = vi.fn();
+const updateBankCustomer = vi.fn();
+const bridgeGetKycLink = vi.fn();
+const bridgeFindCustomerByEmail = vi.fn();
+
+vi.mock('../queries', () => ({
+  findBankCustomerBySpaceAndProvider: (...args: unknown[]) =>
+    findBankCustomerBySpaceAndProvider(...args),
+  findBankCustomerByPersonAndProvider: (...args: unknown[]) =>
+    findBankCustomerByPersonAndProvider(...args),
+  findBankCustomerByNonce: (...args: unknown[]) =>
+    findBankCustomerByNonce(...args),
+}));
+
+vi.mock('../mutations', () => ({
+  insertBankCustomer: (...args: unknown[]) => insertBankCustomer(...args),
+  updateBankCustomer: (...args: unknown[]) => updateBankCustomer(...args),
+}));
+
+vi.mock('../../../common/server/bridge-client', async () => {
+  const actual = await vi.importActual<
+    typeof import('../../../common/server/bridge-client')
+  >('../../../common/server/bridge-client');
+  return {
+    ...actual,
+    bridgeGetKycLink: (...args: unknown[]) => bridgeGetKycLink(...args),
+    bridgeFindCustomerByEmail: (...args: unknown[]) =>
+      bridgeFindCustomerByEmail(...args),
+  };
+});
+
+const mockDb = {} as never;
+
+const mockProvider: BankKycProvider = {
+  provider: 'bridge',
+  provisionVirtualAccount: vi.fn(),
+  createTransfer: vi.fn(),
+  registerExternalAccount: vi.fn(),
+  createLiquidationAddress: vi.fn(),
+  createKycLink: vi.fn().mockResolvedValue({
+    providerCustomerId: 'cust_1',
+    providerKycLinkId: 'link_1',
+    kycStatus: 'not_started',
+    isApproved: false,
+    tosStatus: 'pending',
+    kycLink: 'https://bridge.example/kyc',
+    tosLink: 'https://bridge.example/tos',
+  }),
+};
+
+const spaceOwner: BankOnboardingOwnerRef = {
+  type: 'space',
+  id: 1,
+  slug: 'acme',
+  label: 'Acme',
+};
+
+const sendConfirmationEmail = vi.fn().mockResolvedValue(undefined);
+
+describe('requestBankOnboardingWithConfirmation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    findBankCustomerBySpaceAndProvider.mockResolvedValue(null);
+    insertBankCustomer.mockResolvedValue({ id: 1 });
+    sendConfirmationEmail.mockClear();
+  });
+
+  it('creates directly when the submitter is the email owner (bypass, D5)', async () => {
+    const result = await requestBankOnboardingWithConfirmation(
+      {
+        ownerRef: spaceOwner,
+        entityType: 'business',
+        legalName: 'Acme Foundation Ltd.',
+        contactEmail: 'me+sandbox@example.com',
+        requestedRails: ['eur'],
+        submitterPersonId: 10,
+        submitterEmail: 'me@example.com',
+        sendConfirmationEmail,
+      },
+      { db: mockDb },
+      { kycProvider: mockProvider },
+    );
+
+    expect(result.kind).toBe('created');
+    expect(mockProvider.createKycLink).toHaveBeenCalledWith(
+      expect.objectContaining({ contactEmail: 'me+sandbox@example.com' }),
+    );
+    expect(sendConfirmationEmail).not.toHaveBeenCalled();
+    expect(insertBankCustomer).toHaveBeenCalledWith(
+      expect.objectContaining({ spaceId: 1, providerKycLinkId: 'link_1' }),
+      expect.any(Object),
+    );
+  });
+
+  it('signs a JWT and sends a confirmation email when the submitter is not the email owner', async () => {
+    const result = await requestBankOnboardingWithConfirmation(
+      {
+        ownerRef: spaceOwner,
+        entityType: 'business',
+        legalName: 'Acme Foundation Ltd.',
+        contactEmail: 'compliance@acme.org',
+        requestedRails: ['eur'],
+        submitterPersonId: 10,
+        submitterEmail: 'me@example.com',
+        sendConfirmationEmail,
+      },
+      { db: mockDb },
+      { kycProvider: mockProvider },
+    );
+
+    expect(result.kind).toBe('pendingConfirmation');
+    expect(mockProvider.createKycLink).not.toHaveBeenCalled();
+    expect(sendConfirmationEmail).toHaveBeenCalledTimes(1);
+    const sentArg = sendConfirmationEmail.mock.calls[0][0];
+    expect(sentArg.ownerLabel).toBe('Acme');
+    expect(sentArg.contactEmail).toBe('compliance@acme.org');
+    expect(typeof sentArg.token).toBe('string');
+    expect(insertBankCustomer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        spaceId: 1,
+        providerKycLinkId: null,
+        providerCustomerId: null,
+        jwtNonce: expect.any(String),
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it('never includes the confirmation token in the returned result', async () => {
+    const result = await requestBankOnboardingWithConfirmation(
+      {
+        ownerRef: spaceOwner,
+        entityType: 'business',
+        legalName: 'Acme Foundation Ltd.',
+        contactEmail: 'compliance@acme.org',
+        submitterPersonId: 10,
+        submitterEmail: 'me@example.com',
+        sendConfirmationEmail,
+      },
+      { db: mockDb },
+      { kycProvider: mockProvider },
+    );
+
+    expect(JSON.stringify(result)).not.toContain('eyJ'); // no JWT-looking substring
+    expect('confirmationToken' in result).toBe(false);
+  });
+
+  it('returns existing status without calling the provider when already linked (idempotent)', async () => {
+    findBankCustomerBySpaceAndProvider.mockResolvedValue({
+      id: 1,
+      providerKycLinkId: 'link_1',
+      providerCustomerId: 'cust_1',
+      requestedRails: ['eur'],
+      jwtNonce: null,
+    });
+    bridgeGetKycLink.mockResolvedValue({
+      id: 'link_1',
+      customer_id: 'cust_1',
+      kyc_link: 'https://bridge.example/kyc',
+      kyc_status: 'under_review',
+    });
+
+    const result = await requestBankOnboardingWithConfirmation(
+      {
+        ownerRef: spaceOwner,
+        entityType: 'business',
+        legalName: 'Acme Foundation Ltd.',
+        contactEmail: 'compliance@acme.org',
+        submitterPersonId: 10,
+        submitterEmail: 'me@example.com',
+        sendConfirmationEmail,
+      },
+      { db: mockDb },
+      { kycProvider: mockProvider },
+    );
+
+    expect(result.kind).toBe('existing');
+    expect(mockProvider.createKycLink).not.toHaveBeenCalled();
+    expect(insertBankCustomer).not.toHaveBeenCalled();
+  });
+
+  it('rotates the nonce on the existing pending row on resend instead of inserting a duplicate', async () => {
+    findBankCustomerBySpaceAndProvider.mockResolvedValue({
+      id: 1,
+      providerKycLinkId: null,
+      providerCustomerId: null,
+      jwtNonce: 'old-nonce',
+      requestedRails: ['eur'],
+    });
+
+    const result = await requestBankOnboardingWithConfirmation(
+      {
+        ownerRef: spaceOwner,
+        entityType: 'business',
+        legalName: 'Acme Foundation Ltd.',
+        contactEmail: 'compliance@acme.org',
+        submitterPersonId: 10,
+        submitterEmail: 'me@example.com',
+        sendConfirmationEmail,
+      },
+      { db: mockDb },
+      { kycProvider: mockProvider },
+    );
+
+    expect(result.kind).toBe('pendingConfirmation');
+    expect(insertBankCustomer).not.toHaveBeenCalled();
+    expect(updateBankCustomer).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 1, jwtNonce: expect.any(String) }),
+      expect.any(Object),
+    );
+    const newNonce = updateBankCustomer.mock.calls[0][0].jwtNonce;
+    expect(newNonce).not.toBe('old-nonce');
+  });
+});
+
+describe('confirmBankEmail', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    bridgeFindCustomerByEmail.mockResolvedValue(null);
+  });
+
+  async function signAndStorePending(nonce?: string) {
+    const signed = await signBankConfirmationJwt({
+      ownerType: 'space',
+      ownerId: 1,
+      ownerSlug: 'acme',
+      ownerLabel: 'Acme',
+      entityType: 'business',
+      legalName: 'Acme Foundation Ltd.',
+      contactEmail: 'compliance@acme.org',
+      requestedRails: ['eur'],
+      submitterPersonId: 10,
+    });
+    findBankCustomerByNonce.mockResolvedValue({
+      id: 1,
+      jwtNonce: nonce ?? signed.nonce,
+      providerKycLinkId: null,
+    });
+    return signed.token;
+  }
+
+  it('finalizes a pending row and calls the Bridge pre-check (informational, D7)', async () => {
+    const token = await signAndStorePending();
+    bridgeFindCustomerByEmail.mockResolvedValue({
+      id: 'existing_cust',
+      type: 'business',
+    });
+    updateBankCustomer.mockResolvedValue({ id: 1 });
+
+    const result = await confirmBankEmail(
+      token,
+      { db: mockDb },
+      { kycProvider: mockProvider },
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.existingBridgeCustomer).toEqual({
+        id: 'existing_cust',
+        type: 'business',
+      });
+      expect(result.ownerLabel).toBe('Acme');
+    }
+    expect(mockProvider.createKycLink).toHaveBeenCalled();
+    expect(updateBankCustomer).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 1, jwtNonce: null }),
+      expect.any(Object),
+    );
+  });
+
+  it('rejects an invalid token', async () => {
+    const result = await confirmBankEmail(
+      'not-a-real-token',
+      { db: mockDb },
+      { kycProvider: mockProvider },
+    );
+    expect(result).toEqual({ ok: false, reason: 'invalid' });
+  });
+
+  it('rejects when the nonce no longer matches (rotated by a resend, D3)', async () => {
+    const token = await signAndStorePending('a-different-current-nonce');
+
+    const result = await confirmBankEmail(
+      token,
+      { db: mockDb },
+      { kycProvider: mockProvider },
+    );
+    expect(result).toEqual({ ok: false, reason: 'invalid' });
+    expect(mockProvider.createKycLink).not.toHaveBeenCalled();
+  });
+
+  it('rejects an already-confirmed row', async () => {
+    const { token, nonce } = await signBankConfirmationJwt({
+      ownerType: 'space',
+      ownerId: 1,
+      ownerSlug: 'acme',
+      ownerLabel: 'Acme',
+      entityType: 'business',
+      legalName: 'Acme Foundation Ltd.',
+      contactEmail: 'compliance@acme.org',
+      requestedRails: [],
+      submitterPersonId: 10,
+    });
+    findBankCustomerByNonce.mockResolvedValue({
+      id: 1,
+      jwtNonce: nonce,
+      providerKycLinkId: 'already-linked',
+    });
+
+    const result = await confirmBankEmail(
+      token,
+      { db: mockDb },
+      { kycProvider: mockProvider },
+    );
+    expect(result).toEqual({ ok: false, reason: 'already_confirmed' });
+    expect(mockProvider.createKycLink).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/banking/server/__tests__/bank-onboarding-confirmation.test.ts
+++ b/packages/core/src/banking/server/__tests__/bank-onboarding-confirmation.test.ts
@@ -264,6 +264,39 @@ describe('requestBankOnboardingWithConfirmation', () => {
     const newNonce = updateBankCustomer.mock.calls[0][0].jwtNonce;
     expect(newNonce).not.toBe('old-nonce');
   });
+
+  it('updates (not inserts) on resend even while a concurrent confirm has momentarily cleared the nonce', async () => {
+    // Simulates the mid-claim window: a confirm claimed the row (jwtNonce -> null) but hasn't
+    // finalized providerKycLinkId yet.
+    findBankCustomerBySpaceAndProvider.mockResolvedValue({
+      id: 1,
+      providerKycLinkId: null,
+      providerCustomerId: null,
+      jwtNonce: null,
+      requestedRails: ['eur'],
+    });
+
+    const result = await requestBankOnboardingWithConfirmation(
+      {
+        ownerRef: spaceOwner,
+        entityType: 'business',
+        legalName: 'Acme Foundation Ltd.',
+        contactEmail: 'compliance@acme.org',
+        submitterPersonId: 10,
+        submitterEmail: 'me@example.com',
+        sendConfirmationEmail,
+      },
+      { db: mockDb },
+      { kycProvider: mockProvider },
+    );
+
+    expect(result.kind).toBe('pendingConfirmation');
+    expect(insertBankCustomer).not.toHaveBeenCalled();
+    expect(updateBankCustomer).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 1, jwtNonce: expect.any(String) }),
+      expect.any(Object),
+    );
+  });
 });
 
 describe('confirmBankEmail', () => {
@@ -362,6 +395,28 @@ describe('confirmBankEmail', () => {
     );
     expect(result).toEqual({ ok: false, reason: 'invalid' });
     expect(mockProvider.createKycLink).not.toHaveBeenCalled();
+  });
+
+  it('uses a stable per-token idempotency key so a retried finalize replays instead of duplicating', async () => {
+    const token = await signAndStorePending();
+    updateBankCustomer.mockResolvedValue({ id: 1 });
+
+    await confirmBankEmail(
+      token,
+      { db: mockDb },
+      { kycProvider: mockProvider },
+    );
+    await confirmBankEmail(
+      token,
+      { db: mockDb },
+      { kycProvider: mockProvider },
+    );
+
+    const keys = (
+      mockProvider.createKycLink as ReturnType<typeof vi.fn>
+    ).mock.calls.map(([arg]) => arg.idempotencyKey);
+    expect(keys).toHaveLength(2);
+    expect(keys[0]).toBe(keys[1]);
   });
 
   it('restores the nonce if the provider call fails after claiming, so the link stays usable', async () => {

--- a/packages/core/src/banking/server/__tests__/bank-onboarding-confirmation.test.ts
+++ b/packages/core/src/banking/server/__tests__/bank-onboarding-confirmation.test.ts
@@ -18,6 +18,7 @@ const findBankCustomerByNonce = vi.fn();
 const insertBankCustomer = vi.fn();
 const updateBankCustomer = vi.fn();
 const claimBankCustomerForConfirmation = vi.fn();
+const finalizeClaimedBankCustomer = vi.fn();
 const bridgeGetKycLink = vi.fn();
 const bridgeFindCustomerByEmail = vi.fn();
 
@@ -35,6 +36,8 @@ vi.mock('../mutations', () => ({
   updateBankCustomer: (...args: unknown[]) => updateBankCustomer(...args),
   claimBankCustomerForConfirmation: (...args: unknown[]) =>
     claimBankCustomerForConfirmation(...args),
+  finalizeClaimedBankCustomer: (...args: unknown[]) =>
+    finalizeClaimedBankCustomer(...args),
 }));
 
 vi.mock('../../../common/server/bridge-client', async () => {
@@ -232,7 +235,7 @@ describe('requestBankOnboardingWithConfirmation', () => {
     );
   });
 
-  it('rotates the nonce on the existing pending row on resend instead of inserting a duplicate', async () => {
+  it('rotates the nonce and clears any in-flight claim on resend instead of inserting a duplicate', async () => {
     findBankCustomerBySpaceAndProvider.mockResolvedValue({
       id: 1,
       providerKycLinkId: null,
@@ -258,21 +261,28 @@ describe('requestBankOnboardingWithConfirmation', () => {
     expect(result.kind).toBe('pendingConfirmation');
     expect(insertBankCustomer).not.toHaveBeenCalled();
     expect(updateBankCustomer).toHaveBeenCalledWith(
-      expect.objectContaining({ id: 1, jwtNonce: expect.any(String) }),
+      expect.objectContaining({
+        id: 1,
+        jwtNonce: expect.any(String),
+        // D3: clearing confirmingNonce is what makes resend an instant revocation of an
+        // in-flight confirmation, not only of future clicks of the old link.
+        confirmingNonce: null,
+      }),
       expect.any(Object),
     );
     const newNonce = updateBankCustomer.mock.calls[0][0].jwtNonce;
     expect(newNonce).not.toBe('old-nonce');
   });
 
-  it('updates (not inserts) on resend even while a concurrent confirm has momentarily cleared the nonce', async () => {
-    // Simulates the mid-claim window: a confirm claimed the row (jwtNonce -> null) but hasn't
+  it('updates (not inserts) on resend even while a confirm has the row claimed', async () => {
+    // Simulates the claimed window: a confirm claimed the row (confirmingNonce set) but hasn't
     // finalized providerKycLinkId yet.
     findBankCustomerBySpaceAndProvider.mockResolvedValue({
       id: 1,
       providerKycLinkId: null,
       providerCustomerId: null,
-      jwtNonce: null,
+      jwtNonce: 'old-nonce',
+      confirmingNonce: 'claimed-nonce',
       requestedRails: ['eur'],
     });
 
@@ -293,7 +303,11 @@ describe('requestBankOnboardingWithConfirmation', () => {
     expect(result.kind).toBe('pendingConfirmation');
     expect(insertBankCustomer).not.toHaveBeenCalled();
     expect(updateBankCustomer).toHaveBeenCalledWith(
-      expect.objectContaining({ id: 1, jwtNonce: expect.any(String) }),
+      expect.objectContaining({
+        id: 1,
+        jwtNonce: expect.any(String),
+        confirmingNonce: null,
+      }),
       expect.any(Object),
     );
   });
@@ -303,11 +317,27 @@ describe('confirmBankEmail', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     bridgeFindCustomerByEmail.mockResolvedValue(null);
-    // Default: the compare-and-swap claim succeeds (row still matches the nonce being confirmed).
+    // Default: the compare-and-swap claim succeeds (row still matches the nonce being confirmed,
+    // and nothing else has it claimed).
     claimBankCustomerForConfirmation.mockImplementation(
-      async ({ id }: { id: number; expectedNonce: string }) => ({
+      async ({ id, expectedNonce }: { id: number; expectedNonce: string }) => ({
         id,
+        confirmingNonce: expectedNonce,
         providerKycLinkId: null,
+      }),
+    );
+    // Default: the final CAS write succeeds (nothing revoked the claim in the meantime).
+    finalizeClaimedBankCustomer.mockImplementation(
+      async (input: {
+        id: number;
+        providerCustomerId: string | null;
+        providerKycLinkId: string;
+        requestedRails: string[];
+      }) => ({
+        id: input.id,
+        providerCustomerId: input.providerCustomerId,
+        providerKycLinkId: input.providerKycLinkId,
+        requestedRails: input.requestedRails,
       }),
     );
   });
@@ -338,7 +368,6 @@ describe('confirmBankEmail', () => {
       id: 'existing_cust',
       type: 'business',
     });
-    updateBankCustomer.mockResolvedValue({ id: 1 });
 
     const result = await confirmBankEmail(
       token,
@@ -355,8 +384,8 @@ describe('confirmBankEmail', () => {
       expect(result.ownerLabel).toBe('Acme');
     }
     expect(mockProvider.createKycLink).toHaveBeenCalled();
-    expect(updateBankCustomer).toHaveBeenCalledWith(
-      expect.objectContaining({ id: 1, jwtNonce: null }),
+    expect(finalizeClaimedBankCustomer).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 1, providerKycLinkId: 'link_1' }),
       expect.any(Object),
     );
   });
@@ -384,8 +413,8 @@ describe('confirmBankEmail', () => {
 
   it('rejects a concurrent confirm that loses the compare-and-swap claim', async () => {
     const token = await signAndStorePending();
-    // Simulates a second in-flight confirm of the same token: the row's nonce no longer matches by
-    // the time this request tries to claim it (already claimed by the first request).
+    // Simulates a second in-flight confirm of the same token: the row is already claimed by the
+    // first request (confirmingNonce already set).
     claimBankCustomerForConfirmation.mockResolvedValue(null);
 
     const result = await confirmBankEmail(
@@ -397,9 +426,30 @@ describe('confirmBankEmail', () => {
     expect(mockProvider.createKycLink).not.toHaveBeenCalled();
   });
 
+  it('rejects (without throwing) when a resend revokes this claim while the provider call is in flight', async () => {
+    const token = await signAndStorePending();
+    // Simulates: claim succeeded, but a resend cleared confirmingNonce before the final write —
+    // finalizeClaimedBankCustomer's CAS then matches 0 rows and returns null.
+    finalizeClaimedBankCustomer.mockResolvedValue(null);
+
+    const result = await confirmBankEmail(
+      token,
+      { db: mockDb },
+      { kycProvider: mockProvider },
+    );
+
+    expect(result).toEqual({ ok: false, reason: 'invalid' });
+    // The provider call itself still happened (and, per D7/D8, Bridge's own email-based dedup
+    // means the resent link's eventual confirmation lands on the same customer) — what matters is
+    // that this superseded attempt doesn't report success or corrupt the row.
+    expect(mockProvider.createKycLink).toHaveBeenCalled();
+    // No restoration write here: a resend already moved the row on to a new nonce/claim state,
+    // and clobbering that back would reintroduce the exact bug being fixed.
+    expect(updateBankCustomer).not.toHaveBeenCalled();
+  });
+
   it('uses a stable per-token idempotency key so a retried finalize replays instead of duplicating', async () => {
     const token = await signAndStorePending();
-    updateBankCustomer.mockResolvedValue({ id: 1 });
 
     await confirmBankEmail(
       token,
@@ -419,7 +469,7 @@ describe('confirmBankEmail', () => {
     expect(keys[0]).toBe(keys[1]);
   });
 
-  it('restores the nonce if the provider call fails after claiming, so the link stays usable', async () => {
+  it('releases the claim if the provider call fails, so a retry or resend can proceed', async () => {
     const token = await signAndStorePending();
     (
       mockProvider.createKycLink as ReturnType<typeof vi.fn>
@@ -430,7 +480,7 @@ describe('confirmBankEmail', () => {
     ).rejects.toThrow('bridge down');
 
     expect(updateBankCustomer).toHaveBeenCalledWith(
-      { id: 1, jwtNonce: expect.any(String) },
+      { id: 1, confirmingNonce: null },
       expect.any(Object),
     );
   });

--- a/packages/core/src/banking/server/__tests__/bank-onboarding-confirmation.test.ts
+++ b/packages/core/src/banking/server/__tests__/bank-onboarding-confirmation.test.ts
@@ -19,6 +19,7 @@ const insertBankCustomer = vi.fn();
 const updateBankCustomer = vi.fn();
 const claimBankCustomerForConfirmation = vi.fn();
 const finalizeClaimedBankCustomer = vi.fn();
+const releaseBankCustomerClaim = vi.fn();
 const bridgeGetKycLink = vi.fn();
 const bridgeFindCustomerByEmail = vi.fn();
 
@@ -38,6 +39,8 @@ vi.mock('../mutations', () => ({
     claimBankCustomerForConfirmation(...args),
   finalizeClaimedBankCustomer: (...args: unknown[]) =>
     finalizeClaimedBankCustomer(...args),
+  releaseBankCustomerClaim: (...args: unknown[]) =>
+    releaseBankCustomerClaim(...args),
 }));
 
 vi.mock('../../../common/server/bridge-client', async () => {
@@ -261,13 +264,7 @@ describe('requestBankOnboardingWithConfirmation', () => {
     expect(result.kind).toBe('pendingConfirmation');
     expect(insertBankCustomer).not.toHaveBeenCalled();
     expect(updateBankCustomer).toHaveBeenCalledWith(
-      expect.objectContaining({
-        id: 1,
-        jwtNonce: expect.any(String),
-        // D3: clearing confirmingNonce is what makes resend an instant revocation of an
-        // in-flight confirmation, not only of future clicks of the old link.
-        confirmingNonce: null,
-      }),
+      expect.objectContaining({ id: 1, jwtNonce: expect.any(String) }),
       expect.any(Object),
     );
     const newNonce = updateBankCustomer.mock.calls[0][0].jwtNonce;
@@ -275,14 +272,13 @@ describe('requestBankOnboardingWithConfirmation', () => {
   });
 
   it('updates (not inserts) on resend even while a confirm has the row claimed', async () => {
-    // Simulates the claimed window: a confirm claimed the row (confirmingNonce set) but hasn't
-    // finalized providerKycLinkId yet.
+    // Simulates the claimed window: a confirm claimed the row (jwtNonce -> null, per
+    // claimBankCustomerForConfirmation) but hasn't finalized providerKycLinkId yet.
     findBankCustomerBySpaceAndProvider.mockResolvedValue({
       id: 1,
       providerKycLinkId: null,
       providerCustomerId: null,
-      jwtNonce: 'old-nonce',
-      confirmingNonce: 'claimed-nonce',
+      jwtNonce: null,
       requestedRails: ['eur'],
     });
 
@@ -303,11 +299,7 @@ describe('requestBankOnboardingWithConfirmation', () => {
     expect(result.kind).toBe('pendingConfirmation');
     expect(insertBankCustomer).not.toHaveBeenCalled();
     expect(updateBankCustomer).toHaveBeenCalledWith(
-      expect.objectContaining({
-        id: 1,
-        jwtNonce: expect.any(String),
-        confirmingNonce: null,
-      }),
+      expect.objectContaining({ id: 1, jwtNonce: expect.any(String) }),
       expect.any(Object),
     );
   });
@@ -317,12 +309,11 @@ describe('confirmBankEmail', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     bridgeFindCustomerByEmail.mockResolvedValue(null);
-    // Default: the compare-and-swap claim succeeds (row still matches the nonce being confirmed,
-    // and nothing else has it claimed).
+    // Default: the compare-and-swap claim succeeds (row still matches the nonce being confirmed).
     claimBankCustomerForConfirmation.mockImplementation(
-      async ({ id, expectedNonce }: { id: number; expectedNonce: string }) => ({
+      async ({ id }: { id: number; expectedNonce: string }) => ({
         id,
-        confirmingNonce: expectedNonce,
+        jwtNonce: null,
         providerKycLinkId: null,
       }),
     );
@@ -414,7 +405,7 @@ describe('confirmBankEmail', () => {
   it('rejects a concurrent confirm that loses the compare-and-swap claim', async () => {
     const token = await signAndStorePending();
     // Simulates a second in-flight confirm of the same token: the row is already claimed by the
-    // first request (confirmingNonce already set).
+    // first request (jwt_nonce already cleared, so this claim's WHERE no longer matches).
     claimBankCustomerForConfirmation.mockResolvedValue(null);
 
     const result = await confirmBankEmail(
@@ -428,8 +419,9 @@ describe('confirmBankEmail', () => {
 
   it('rejects (without throwing) when a resend revokes this claim while the provider call is in flight', async () => {
     const token = await signAndStorePending();
-    // Simulates: claim succeeded, but a resend cleared confirmingNonce before the final write —
-    // finalizeClaimedBankCustomer's CAS then matches 0 rows and returns null.
+    // Simulates: claim succeeded (jwt_nonce -> null), but a resend rotated jwt_nonce to a new
+    // value before the final write — finalizeClaimedBankCustomer's CAS then matches 0 rows and
+    // returns null.
     finalizeClaimedBankCustomer.mockResolvedValue(null);
 
     const result = await confirmBankEmail(
@@ -443,9 +435,10 @@ describe('confirmBankEmail', () => {
     // means the resent link's eventual confirmation lands on the same customer) — what matters is
     // that this superseded attempt doesn't report success or corrupt the row.
     expect(mockProvider.createKycLink).toHaveBeenCalled();
-    // No restoration write here: a resend already moved the row on to a new nonce/claim state,
-    // and clobbering that back would reintroduce the exact bug being fixed.
+    // No restoration write here: nothing threw, so the failure-recovery path never runs — a
+    // resend already moved the row on, and there's nothing to release or restore.
     expect(updateBankCustomer).not.toHaveBeenCalled();
+    expect(releaseBankCustomerClaim).not.toHaveBeenCalled();
   });
 
   it('uses a stable per-token idempotency key so a retried finalize replays instead of duplicating', async () => {
@@ -479,8 +472,8 @@ describe('confirmBankEmail', () => {
       confirmBankEmail(token, { db: mockDb }, { kycProvider: mockProvider }),
     ).rejects.toThrow('bridge down');
 
-    expect(updateBankCustomer).toHaveBeenCalledWith(
-      { id: 1, confirmingNonce: null },
+    expect(releaseBankCustomerClaim).toHaveBeenCalledWith(
+      { id: 1, restoreNonce: expect.any(String) },
       expect.any(Object),
     );
   });

--- a/packages/core/src/banking/server/__tests__/bank-onboarding-confirmation.test.ts
+++ b/packages/core/src/banking/server/__tests__/bank-onboarding-confirmation.test.ts
@@ -17,6 +17,7 @@ const findBankCustomerByPersonAndProvider = vi.fn();
 const findBankCustomerByNonce = vi.fn();
 const insertBankCustomer = vi.fn();
 const updateBankCustomer = vi.fn();
+const claimBankCustomerForConfirmation = vi.fn();
 const bridgeGetKycLink = vi.fn();
 const bridgeFindCustomerByEmail = vi.fn();
 
@@ -32,6 +33,8 @@ vi.mock('../queries', () => ({
 vi.mock('../mutations', () => ({
   insertBankCustomer: (...args: unknown[]) => insertBankCustomer(...args),
   updateBankCustomer: (...args: unknown[]) => updateBankCustomer(...args),
+  claimBankCustomerForConfirmation: (...args: unknown[]) =>
+    claimBankCustomerForConfirmation(...args),
 }));
 
 vi.mock('../../../common/server/bridge-client', async () => {
@@ -196,6 +199,39 @@ describe('requestBankOnboardingWithConfirmation', () => {
     expect(insertBankCustomer).not.toHaveBeenCalled();
   });
 
+  it('finalizes an existing pending row on bypass instead of inserting a duplicate', async () => {
+    findBankCustomerBySpaceAndProvider.mockResolvedValue({
+      id: 7,
+      providerKycLinkId: null,
+      providerCustomerId: null,
+      jwtNonce: 'old-nonce',
+      requestedRails: ['eur'],
+    });
+    updateBankCustomer.mockResolvedValue({ id: 7 });
+
+    const result = await requestBankOnboardingWithConfirmation(
+      {
+        ownerRef: spaceOwner,
+        entityType: 'business',
+        legalName: 'Acme Foundation Ltd.',
+        contactEmail: 'me+sandbox@example.com',
+        requestedRails: ['eur'],
+        submitterPersonId: 10,
+        submitterEmail: 'me@example.com',
+        sendConfirmationEmail,
+      },
+      { db: mockDb },
+      { kycProvider: mockProvider },
+    );
+
+    expect(result.kind).toBe('created');
+    expect(insertBankCustomer).not.toHaveBeenCalled();
+    expect(updateBankCustomer).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 7, providerKycLinkId: 'link_1' }),
+      expect.any(Object),
+    );
+  });
+
   it('rotates the nonce on the existing pending row on resend instead of inserting a duplicate', async () => {
     findBankCustomerBySpaceAndProvider.mockResolvedValue({
       id: 1,
@@ -234,6 +270,13 @@ describe('confirmBankEmail', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     bridgeFindCustomerByEmail.mockResolvedValue(null);
+    // Default: the compare-and-swap claim succeeds (row still matches the nonce being confirmed).
+    claimBankCustomerForConfirmation.mockImplementation(
+      async ({ id }: { id: number; expectedNonce: string }) => ({
+        id,
+        providerKycLinkId: null,
+      }),
+    );
   });
 
   async function signAndStorePending(nonce?: string) {
@@ -304,6 +347,37 @@ describe('confirmBankEmail', () => {
     );
     expect(result).toEqual({ ok: false, reason: 'invalid' });
     expect(mockProvider.createKycLink).not.toHaveBeenCalled();
+  });
+
+  it('rejects a concurrent confirm that loses the compare-and-swap claim', async () => {
+    const token = await signAndStorePending();
+    // Simulates a second in-flight confirm of the same token: the row's nonce no longer matches by
+    // the time this request tries to claim it (already claimed by the first request).
+    claimBankCustomerForConfirmation.mockResolvedValue(null);
+
+    const result = await confirmBankEmail(
+      token,
+      { db: mockDb },
+      { kycProvider: mockProvider },
+    );
+    expect(result).toEqual({ ok: false, reason: 'invalid' });
+    expect(mockProvider.createKycLink).not.toHaveBeenCalled();
+  });
+
+  it('restores the nonce if the provider call fails after claiming, so the link stays usable', async () => {
+    const token = await signAndStorePending();
+    (
+      mockProvider.createKycLink as ReturnType<typeof vi.fn>
+    ).mockRejectedValueOnce(new Error('bridge down'));
+
+    await expect(
+      confirmBankEmail(token, { db: mockDb }, { kycProvider: mockProvider }),
+    ).rejects.toThrow('bridge down');
+
+    expect(updateBankCustomer).toHaveBeenCalledWith(
+      { id: 1, jwtNonce: expect.any(String) },
+      expect.any(Object),
+    );
   });
 
   it('rejects an already-confirmed row', async () => {

--- a/packages/core/src/banking/server/__tests__/request-personal-bank-onboarding.test.ts
+++ b/packages/core/src/banking/server/__tests__/request-personal-bank-onboarding.test.ts
@@ -6,6 +6,7 @@ import { requestPersonalBankOnboarding } from '../request-personal-bank-onboardi
 import type { BankKycProvider } from '../providers/types';
 
 const findPersonBySlug = vi.fn();
+const findPersonById = vi.fn();
 const authorizePersonalBankOnboarding = vi.fn();
 const findBankCustomerByPersonAndProvider = vi.fn();
 const insertBankCustomer = vi.fn();
@@ -13,6 +14,7 @@ const bridgeGetKycLink = vi.fn();
 
 vi.mock('../../../people/server/queries', () => ({
   findPersonBySlug: (...args: unknown[]) => findPersonBySlug(...args),
+  findPersonById: (...args: unknown[]) => findPersonById(...args),
 }));
 
 vi.mock('../authorize-personal-bank-onboarding', () => ({
@@ -66,6 +68,8 @@ const mockProvider: BankKycProvider = {
   }),
 };
 
+const sendConfirmationEmail = vi.fn().mockResolvedValue(undefined);
+
 describe('requestPersonalBankOnboarding', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -78,6 +82,13 @@ describe('requestPersonalBankOnboarding', () => {
     authorizePersonalBankOnboarding.mockResolvedValue({
       authorized: true,
       person: { id: 10, slug: 'alice' },
+    });
+    // Submitter's own email matches contactEmail below — bypass-eligible (D5), so these tests
+    // exercise the direct-create path (no confirmation email round-trip).
+    findPersonById.mockResolvedValue({
+      id: 10,
+      slug: 'alice',
+      email: 'alice@example.org',
     });
     findBankCustomerByPersonAndProvider.mockResolvedValue(null);
     insertBankCustomer.mockResolvedValue({
@@ -97,7 +108,7 @@ describe('requestPersonalBankOnboarding', () => {
           requestedRails: [...onboardingInput.requestedRails],
         },
         { db: mockDb },
-        { kycProvider: mockProvider },
+        { kycProvider: mockProvider, sendConfirmationEmail },
       ),
     ).rejects.toMatchObject({
       status: 404,
@@ -119,7 +130,7 @@ describe('requestPersonalBankOnboarding', () => {
           requestedRails: [...onboardingInput.requestedRails],
         },
         { db: mockDb },
-        { kycProvider: mockProvider },
+        { kycProvider: mockProvider, sendConfirmationEmail },
       ),
     ).rejects.toMatchObject({ status: 403 });
     expect(mockProvider.createKycLink).not.toHaveBeenCalled();
@@ -148,7 +159,7 @@ describe('requestPersonalBankOnboarding', () => {
         requestedRails: [...onboardingInput.requestedRails],
       },
       { db: mockDb },
-      { kycProvider: mockProvider },
+      { kycProvider: mockProvider, sendConfirmationEmail },
     );
 
     expect(result.created).toBe(false);
@@ -169,7 +180,7 @@ describe('requestPersonalBankOnboarding', () => {
         requestedRails: [...onboardingInput.requestedRails],
       },
       { db: mockDb },
-      { kycProvider: mockProvider },
+      { kycProvider: mockProvider, sendConfirmationEmail },
     );
 
     expect(mockProvider.createKycLink).toHaveBeenCalledWith(

--- a/packages/core/src/banking/server/__tests__/request-space-bank-onboarding.test.ts
+++ b/packages/core/src/banking/server/__tests__/request-space-bank-onboarding.test.ts
@@ -7,12 +7,17 @@ import type { BankKycProvider } from '../providers/types';
 
 const findSpaceBySlug = vi.fn();
 const authorizeSpaceBankOnboarding = vi.fn();
+const findPersonById = vi.fn();
 const findBankCustomerBySpaceAndProvider = vi.fn();
 const insertBankCustomer = vi.fn();
 const bridgeGetKycLink = vi.fn();
 
 vi.mock('../../../space/server/queries', () => ({
   findSpaceBySlug: (...args: unknown[]) => findSpaceBySlug(...args),
+}));
+
+vi.mock('../../../people/server/queries', () => ({
+  findPersonById: (...args: unknown[]) => findPersonById(...args),
 }));
 
 vi.mock('../authorize-space-bank-onboarding', () => ({
@@ -66,6 +71,8 @@ const mockProvider: BankKycProvider = {
   }),
 };
 
+const sendConfirmationEmail = vi.fn().mockResolvedValue(undefined);
+
 describe('requestSpaceBankOnboarding', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -79,6 +86,13 @@ describe('requestSpaceBankOnboarding', () => {
     authorizeSpaceBankOnboarding.mockResolvedValue({
       authorized: true,
       person: { id: 10, slug: 'alice' },
+    });
+    // Submitter's own email matches contactEmail below — bypass-eligible (D5), so these tests
+    // exercise the direct-create path (no confirmation email round-trip).
+    findPersonById.mockResolvedValue({
+      id: 10,
+      slug: 'alice',
+      email: 'compliance@acme.org',
     });
     findBankCustomerBySpaceAndProvider.mockResolvedValue(null);
     insertBankCustomer.mockResolvedValue({
@@ -98,7 +112,7 @@ describe('requestSpaceBankOnboarding', () => {
           requestedRails: [...onboardingInput.requestedRails],
         },
         { db: mockDb },
-        { kycProvider: mockProvider },
+        { kycProvider: mockProvider, sendConfirmationEmail },
       ),
     ).rejects.toMatchObject({
       status: 404,
@@ -129,7 +143,7 @@ describe('requestSpaceBankOnboarding', () => {
         requestedRails: [...onboardingInput.requestedRails],
       },
       { db: mockDb },
-      { kycProvider: mockProvider },
+      { kycProvider: mockProvider, sendConfirmationEmail },
     );
 
     expect(result.created).toBe(false);
@@ -150,7 +164,7 @@ describe('requestSpaceBankOnboarding', () => {
         requestedRails: [...onboardingInput.requestedRails],
       },
       { db: mockDb },
-      { kycProvider: mockProvider },
+      { kycProvider: mockProvider, sendConfirmationEmail },
     );
 
     expect(mockProvider.createKycLink).toHaveBeenCalledWith(

--- a/packages/core/src/banking/server/bank-onboarding-confirmation.ts
+++ b/packages/core/src/banking/server/bank-onboarding-confirmation.ts
@@ -1,0 +1,358 @@
+import { randomUUID } from 'node:crypto';
+
+import type { DatabaseInstance } from '../../common/server/types';
+import {
+  bridgeFindCustomerByEmail,
+  bridgeGetKycLink,
+  type BridgeGetCustomerResponse,
+} from '../../common/server/bridge-client';
+import {
+  signBankConfirmationJwt,
+  verifyBankConfirmationJwt,
+  type BankConfirmationJwtClaims,
+} from '../../common/server/sign-bank-confirmation-jwt';
+import { isBypassEligible } from '../normalize-email-for-bypass';
+import { DEFAULT_BANK_PROVIDER, currenciesToEndorsements } from '../constants';
+import type { BankEntityType, BankValidationRequirement } from '../types';
+import {
+  findBankCustomerByNonce,
+  findBankCustomerBySpaceAndProvider,
+  findBankCustomerByPersonAndProvider,
+} from './queries';
+import { insertBankCustomer, updateBankCustomer } from './mutations';
+import { getBankKycProvider } from './providers';
+import type { BankKycProvider } from './providers/types';
+import { buildCustomerValidations } from './providers/bridge/banking-provider-state';
+
+/**
+ * Owner-agnostic reference for the shared #2288 gate — one implementation for both space and
+ * personal Bridge onboarding (decision D6). `label` personalizes the confirmation email / verify
+ * page copy (space title or person display name).
+ */
+export type BankOnboardingOwnerRef = {
+  type: 'space' | 'person';
+  id: number;
+  slug: string;
+  label: string;
+};
+
+export type BankOnboardingConfirmationOptions = {
+  kycProvider?: BankKycProvider;
+};
+
+type KycLinkAndValidations = {
+  normalizedRails: string[];
+  providerCustomerId: string | null;
+  providerKycLinkId: string;
+  kycLink: string | null;
+  tosLink: string | null;
+  procedures: {
+    tos: BankValidationRequirement;
+    kyc: BankValidationRequirement;
+  };
+};
+
+async function buildKycLinkAndValidations(
+  input: {
+    entityType: BankEntityType;
+    legalName: string;
+    contactEmail: string;
+    requestedRails?: string[];
+    redirectUri?: string;
+  },
+  options?: BankOnboardingConfirmationOptions,
+): Promise<KycLinkAndValidations> {
+  const normalizedRails = input.requestedRails?.map((r) => r.toLowerCase()) ?? [];
+  const endorsements = currenciesToEndorsements(normalizedRails);
+  const idempotencyKey = randomUUID();
+  const kycProvider =
+    options?.kycProvider ?? getBankKycProvider(DEFAULT_BANK_PROVIDER);
+
+  const kycLinkResult = await kycProvider.createKycLink({
+    entityType: input.entityType,
+    legalName: input.legalName,
+    contactEmail: input.contactEmail,
+    idempotencyKey,
+    endorsements,
+    redirectUri: input.redirectUri,
+  });
+
+  const validations = buildCustomerValidations({
+    id: kycLinkResult.providerKycLinkId,
+    kyc_link: kycLinkResult.kycLink,
+    kyc_status: kycLinkResult.kycStatus,
+    tos_status: kycLinkResult.tosStatus,
+    tos_link: kycLinkResult.tosLink,
+    customer_id: kycLinkResult.providerCustomerId,
+  });
+
+  return {
+    normalizedRails,
+    providerCustomerId: kycLinkResult.providerCustomerId,
+    providerKycLinkId: kycLinkResult.providerKycLinkId,
+    kycLink: validations.kycLink,
+    tosLink: validations.tosLink,
+    procedures: { tos: validations.tos, kyc: validations.kyc },
+  };
+}
+
+function ownerIdColumns(
+  ownerRef: BankOnboardingOwnerRef,
+): { spaceId: number } | { personId: number } {
+  return ownerRef.type === 'space'
+    ? { spaceId: ownerRef.id }
+    : { personId: ownerRef.id };
+}
+
+async function findExistingBankCustomerForOwner(
+  ownerRef: BankOnboardingOwnerRef,
+  { db }: { db: DatabaseInstance },
+) {
+  return ownerRef.type === 'space'
+    ? findBankCustomerBySpaceAndProvider(
+        { spaceId: ownerRef.id, provider: DEFAULT_BANK_PROVIDER },
+        { db },
+      )
+    : findBankCustomerByPersonAndProvider(
+        { personId: ownerRef.id, provider: DEFAULT_BANK_PROVIDER },
+        { db },
+      );
+}
+
+/** Bypass or resend-of-an-already-linked-customer path: create + insert directly. */
+export async function createBankCustomerWithKycLink(
+  ownerRef: BankOnboardingOwnerRef,
+  input: {
+    entityType: BankEntityType;
+    legalName: string;
+    contactEmail: string;
+    requestedRails?: string[];
+    redirectUri?: string;
+  },
+  { db }: { db: DatabaseInstance },
+  options?: BankOnboardingConfirmationOptions,
+): Promise<KycLinkAndValidations> {
+  const result = await buildKycLinkAndValidations(input, options);
+
+  await insertBankCustomer(
+    {
+      ...ownerIdColumns(ownerRef),
+      entityType: input.entityType,
+      provider: DEFAULT_BANK_PROVIDER,
+      providerCustomerId: result.providerCustomerId,
+      providerKycLinkId: result.providerKycLinkId,
+      requestedRails: result.normalizedRails,
+    },
+    { db },
+  );
+
+  return result;
+}
+
+/** Confirm path (D6) — finalizes a pending row (created by `requestBankOnboardingWithConfirmation` below). */
+async function finalizePendingBankCustomerWithKycLink(
+  bankCustomerId: number,
+  input: {
+    entityType: BankEntityType;
+    legalName: string;
+    contactEmail: string;
+    requestedRails?: string[];
+    redirectUri?: string;
+  },
+  { db }: { db: DatabaseInstance },
+  options?: BankOnboardingConfirmationOptions,
+): Promise<KycLinkAndValidations> {
+  const result = await buildKycLinkAndValidations(input, options);
+
+  await updateBankCustomer(
+    {
+      id: bankCustomerId,
+      providerCustomerId: result.providerCustomerId,
+      providerKycLinkId: result.providerKycLinkId,
+      requestedRails: result.normalizedRails,
+      jwtNonce: null,
+    },
+    { db },
+  );
+
+  return result;
+}
+
+export type RequestBankOnboardingWithConfirmationInput = {
+  ownerRef: BankOnboardingOwnerRef;
+  entityType: BankEntityType;
+  legalName: string;
+  contactEmail: string;
+  requestedRails?: string[];
+  redirectUri?: string;
+  /** Already auth-gated (D4) — the person who submitted the form. */
+  submitterPersonId: number;
+  /** The submitter's own verified `people.email`, or null if unset. */
+  submitterEmail: string | null;
+  /**
+   * Server-only callback that receives the confirmation token to email out. The token is never
+   * included in this function's return value — it must not reach the HTTP response layer, or the
+   * submitter could self-confirm an email they don't own, defeating the whole gate.
+   */
+  sendConfirmationEmail: (input: {
+    token: string;
+    ownerLabel: string;
+    contactEmail: string;
+  }) => Promise<void>;
+};
+
+export type RequestBankOnboardingWithConfirmationResult =
+  | ({ kind: 'created' | 'existing' } & KycLinkAndValidations)
+  | { kind: 'pendingConfirmation' };
+
+/**
+ * The shared #2288 gate (D6). Owns the per-owner idempotency dedup (D7) internally, so both
+ * `requestSpaceBankOnboarding` and `requestPersonalBankOnboarding` can stay thin wrappers around
+ * their owner-specific auth check. Bypass decision is entirely server-side — never trust a
+ * client-supplied bypass flag.
+ */
+export async function requestBankOnboardingWithConfirmation(
+  input: RequestBankOnboardingWithConfirmationInput,
+  { db }: { db: DatabaseInstance },
+  options?: BankOnboardingConfirmationOptions,
+): Promise<RequestBankOnboardingWithConfirmationResult> {
+  const {
+    ownerRef,
+    entityType,
+    legalName,
+    contactEmail,
+    requestedRails,
+    redirectUri,
+    submitterEmail,
+    sendConfirmationEmail,
+  } = input;
+
+  const existing = await findExistingBankCustomerForOwner(ownerRef, { db });
+
+  if (existing?.providerKycLinkId) {
+    const kycLink = await bridgeGetKycLink(existing.providerKycLinkId);
+    const validations = buildCustomerValidations(kycLink);
+    return {
+      kind: 'existing',
+      normalizedRails: existing.requestedRails ?? [],
+      providerCustomerId: existing.providerCustomerId,
+      providerKycLinkId: existing.providerKycLinkId,
+      kycLink: validations.kycLink,
+      tosLink: validations.tosLink,
+      procedures: { tos: validations.tos, kyc: validations.kyc },
+    };
+  }
+
+  if (isBypassEligible(submitterEmail, contactEmail)) {
+    const result = await createBankCustomerWithKycLink(
+      ownerRef,
+      { entityType, legalName, contactEmail, requestedRails, redirectUri },
+      { db },
+      options,
+    );
+    return { kind: 'created', ...result };
+  }
+
+  const normalizedRails = requestedRails?.map((r) => r.toLowerCase()) ?? [];
+  const { token, nonce } = await signBankConfirmationJwt({
+    ownerType: ownerRef.type,
+    ownerId: ownerRef.id,
+    ownerSlug: ownerRef.slug,
+    ownerLabel: ownerRef.label,
+    entityType,
+    legalName,
+    contactEmail,
+    requestedRails: normalizedRails,
+    redirectUri,
+    submitterPersonId: input.submitterPersonId,
+  });
+
+  if (existing?.jwtNonce) {
+    // Resend: rotate the nonce on the existing pending row (D3) instead of inserting a duplicate
+    // (would violate the owner+provider unique index anyway).
+    await updateBankCustomer(
+      { id: existing.id, jwtNonce: nonce, requestedRails: normalizedRails },
+      { db },
+    );
+  } else {
+    await insertBankCustomer(
+      {
+        ...ownerIdColumns(ownerRef),
+        entityType,
+        provider: DEFAULT_BANK_PROVIDER,
+        providerCustomerId: null,
+        providerKycLinkId: null,
+        jwtNonce: nonce,
+        requestedRails: normalizedRails,
+      },
+      { db },
+    );
+  }
+
+  await sendConfirmationEmail({ token, ownerLabel: ownerRef.label, contactEmail });
+
+  return { kind: 'pendingConfirmation' };
+}
+
+export type ConfirmBankEmailResult =
+  | ({
+      ok: true;
+      ownerType: 'space' | 'person';
+      ownerId: number;
+      ownerSlug: string;
+      ownerLabel: string;
+      /** Informational only (D7) — an existing Bridge customer under this email is fine once ownership is proven. */
+      existingBridgeCustomer: BridgeGetCustomerResponse | null;
+    } & KycLinkAndValidations)
+  | { ok: false; reason: 'expired' | 'invalid' | 'already_confirmed' };
+
+/** Called from the public `/verify/banking` confirmation endpoint — no Privy auth (D4: the JWT *is* the authorization). */
+export async function confirmBankEmail(
+  token: string,
+  { db }: { db: DatabaseInstance },
+  options?: BankOnboardingConfirmationOptions,
+): Promise<ConfirmBankEmailResult> {
+  const verified = await verifyBankConfirmationJwt(token);
+  if (!verified.valid) {
+    return { ok: false, reason: verified.reason };
+  }
+
+  const claims: BankConfirmationJwtClaims = verified.claims;
+  const row = await findBankCustomerByNonce(claims.jti, { db });
+
+  if (!row || row.jwtNonce !== claims.jti) {
+    // Nonce rotated (resend) or row gone — the link that was clicked is no longer live (D3).
+    return { ok: false, reason: 'invalid' };
+  }
+
+  if (row.providerKycLinkId) {
+    return { ok: false, reason: 'already_confirmed' };
+  }
+
+  const existingBridgeCustomer = await bridgeFindCustomerByEmail(
+    claims.contactEmail,
+  ).catch(() => null);
+
+  const result = await finalizePendingBankCustomerWithKycLink(
+    row.id,
+    {
+      entityType: claims.entityType,
+      legalName: claims.legalName,
+      contactEmail: claims.contactEmail,
+      requestedRails: claims.requestedRails,
+      redirectUri: claims.redirectUri,
+    },
+    { db },
+    options,
+  );
+
+  return {
+    ok: true,
+    ownerType: claims.ownerType,
+    ownerId: claims.ownerId,
+    ownerSlug: claims.ownerSlug,
+    ownerLabel: claims.ownerLabel,
+    existingBridgeCustomer,
+    ...result,
+  };
+}

--- a/packages/core/src/banking/server/bank-onboarding-confirmation.ts
+++ b/packages/core/src/banking/server/bank-onboarding-confirmation.ts
@@ -63,13 +63,20 @@ async function buildKycLinkAndValidations(
     contactEmail: string;
     requestedRails?: string[];
     redirectUri?: string;
+    /**
+     * Stable across retries of the *same* confirmation (e.g. the confirm path passes the token's
+     * `jti`) so a retry after a persistence failure replays against Bridge instead of minting a
+     * second KYC link for the same request. Defaults to a fresh key for call sites that don't need
+     * that (direct/bypass create has no retry-after-partial-failure path to protect).
+     */
+    idempotencyKey?: string;
   },
   options?: BankOnboardingConfirmationOptions,
 ): Promise<KycLinkAndValidations> {
   const normalizedRails =
     input.requestedRails?.map((r) => r.toLowerCase()) ?? [];
   const endorsements = currenciesToEndorsements(normalizedRails);
-  const idempotencyKey = randomUUID();
+  const idempotencyKey = input.idempotencyKey ?? randomUUID();
   const kycProvider =
     options?.kycProvider ?? getBankKycProvider(DEFAULT_BANK_PROVIDER);
 
@@ -163,6 +170,7 @@ async function finalizePendingBankCustomerWithKycLink(
     contactEmail: string;
     requestedRails?: string[];
     redirectUri?: string;
+    idempotencyKey?: string;
   },
   { db }: { db: DatabaseInstance },
   options?: BankOnboardingConfirmationOptions,
@@ -282,9 +290,13 @@ export async function requestBankOnboardingWithConfirmation(
     submitterPersonId: input.submitterPersonId,
   });
 
-  if (existing?.jwtNonce) {
-    // Resend: rotate the nonce on the existing pending row (D3) instead of inserting a duplicate
-    // (would violate the owner+provider unique index anyway).
+  if (existing) {
+    // Resend (or a retry landing here while a confirm-in-progress has momentarily cleared the
+    // nonce, mid-claim): rotate/set the nonce on the existing pending row (D3) instead of
+    // inserting a duplicate (would violate the owner+provider unique index anyway). Keyed on
+    // `existing` rather than `existing.jwtNonce` so this still works while a row is claimed
+    // (jwtNonce temporarily null) — `existing` only ever reaches this branch unconfirmed
+    // (the providerKycLinkId check above already returned for a linked row).
     await updateBankCustomer(
       { id: existing.id, jwtNonce: nonce, requestedRails: normalizedRails },
       { db },
@@ -368,6 +380,12 @@ export async function confirmBankEmail(
     result = await finalizePendingBankCustomerWithKycLink(
       claimed.id,
       {
+        // Stable per-token idempotency key (not a fresh randomUUID() per attempt): if
+        // finalization fails after Bridge already created the KYC link (e.g. the DB update
+        // throws, or a resend/retry replays this same claim), Bridge treats a retry with the
+        // same key as the original request and returns the existing resource instead of
+        // minting a second one.
+        idempotencyKey: `bank-confirm:${claims.jti}`,
         entityType: claims.entityType,
         legalName: claims.legalName,
         contactEmail: claims.contactEmail,

--- a/packages/core/src/banking/server/bank-onboarding-confirmation.ts
+++ b/packages/core/src/banking/server/bank-onboarding-confirmation.ts
@@ -21,6 +21,7 @@ import {
 } from './queries';
 import {
   claimBankCustomerForConfirmation,
+  finalizeClaimedBankCustomer,
   insertBankCustomer,
   updateBankCustomer,
 } from './mutations';
@@ -191,6 +192,43 @@ async function finalizePendingBankCustomerWithKycLink(
   return result;
 }
 
+/**
+ * Confirm path's final write (#2288) — conditioned on `confirming_nonce` still matching the claim
+ * this attempt holds, not just the row id (see `finalizeClaimedBankCustomer`). Returns `null`,
+ * rather than throwing, if a resend revoked this attempt's claim while the provider call was in
+ * flight: that's not a failure of the provider call (which may well have succeeded), it means this
+ * attempt lost the race and must not report success — see `confirmBankEmail`.
+ */
+async function finalizeClaimedBankCustomerWithKycLink(
+  bankCustomerId: number,
+  expectedConfirmingNonce: string,
+  input: {
+    entityType: BankEntityType;
+    legalName: string;
+    contactEmail: string;
+    requestedRails?: string[];
+    redirectUri?: string;
+    idempotencyKey?: string;
+  },
+  { db }: { db: DatabaseInstance },
+  options?: BankOnboardingConfirmationOptions,
+): Promise<KycLinkAndValidations | null> {
+  const result = await buildKycLinkAndValidations(input, options);
+
+  const row = await finalizeClaimedBankCustomer(
+    {
+      id: bankCustomerId,
+      expectedConfirmingNonce,
+      providerCustomerId: result.providerCustomerId,
+      providerKycLinkId: result.providerKycLinkId,
+      requestedRails: result.normalizedRails,
+    },
+    { db },
+  );
+
+  return row ? result : null;
+}
+
 export type RequestBankOnboardingWithConfirmationInput = {
   ownerRef: BankOnboardingOwnerRef;
   entityType: BankEntityType;
@@ -291,14 +329,25 @@ export async function requestBankOnboardingWithConfirmation(
   });
 
   if (existing) {
-    // Resend (or a retry landing here while a confirm-in-progress has momentarily cleared the
-    // nonce, mid-claim): rotate/set the nonce on the existing pending row (D3) instead of
+    // Resend (or a retry landing here while a confirm-in-progress has claimed the row, its
+    // `confirming_nonce` set): rotate/set the nonce on the existing pending row (D3) instead of
     // inserting a duplicate (would violate the owner+provider unique index anyway). Keyed on
-    // `existing` rather than `existing.jwtNonce` so this still works while a row is claimed
-    // (jwtNonce temporarily null) — `existing` only ever reaches this branch unconfirmed
-    // (the providerKycLinkId check above already returned for a linked row).
+    // `existing` rather than `existing.jwtNonce` so this still works while a row is claimed —
+    // `existing` only ever reaches this branch unconfirmed (the providerKycLinkId check above
+    // already returned for a linked row).
+    //
+    // Also clears `confirmingNonce`: this is what makes resend an *instant* revocation of an
+    // in-flight confirmation, not just of future clicks of the old link — without it, a
+    // confirmation already claimed under the old nonce could still finish and overwrite this
+    // resend's new nonce (see `finalizeClaimedBankCustomer`'s CAS on confirmingNonce for the
+    // other half of this).
     await updateBankCustomer(
-      { id: existing.id, jwtNonce: nonce, requestedRails: normalizedRails },
+      {
+        id: existing.id,
+        jwtNonce: nonce,
+        confirmingNonce: null,
+        requestedRails: normalizedRails,
+      },
       { db },
     );
   } else {
@@ -375,10 +424,11 @@ export async function confirmBankEmail(
     claims.contactEmail,
   ).catch(() => null);
 
-  let result: KycLinkAndValidations;
+  let result: KycLinkAndValidations | null;
   try {
-    result = await finalizePendingBankCustomerWithKycLink(
+    result = await finalizeClaimedBankCustomerWithKycLink(
       claimed.id,
+      claims.jti,
       {
         // Stable per-token idempotency key (not a fresh randomUUID() per attempt): if
         // finalization fails after Bridge already created the KYC link (e.g. the DB update
@@ -396,10 +446,20 @@ export async function confirmBankEmail(
       options,
     );
   } catch (error) {
-    // Restore the nonce so the same confirmation link (or a resend) can still complete the row
-    // instead of leaving it permanently stuck: not pending (no nonce) but not confirmed either.
-    await updateBankCustomer({ id: claimed.id, jwtNonce: claims.jti }, { db });
+    // Release the claim (not "restore the nonce" — jwt_nonce was never touched by the claim
+    // step) so a retry of this same link, or a resend, can proceed instead of finding the row
+    // stuck mid-claim forever.
+    await updateBankCustomer({ id: claimed.id, confirmingNonce: null }, { db });
     throw error;
+  }
+
+  if (!result) {
+    // A resend revoked this attempt's claim while the provider call was in flight (D3): the row
+    // has already moved on to a new nonce. Don't report success for a link that's no longer the
+    // live one — the resent link's own confirmation will complete normally, and Bridge's
+    // email-based dedup (D7/D8) means it lands on the same customer this call may have just
+    // created, so nothing is lost.
+    return { ok: false, reason: 'invalid' };
   }
 
   return {

--- a/packages/core/src/banking/server/bank-onboarding-confirmation.ts
+++ b/packages/core/src/banking/server/bank-onboarding-confirmation.ts
@@ -27,6 +27,7 @@ import {
   updateBankCustomer,
 } from './mutations';
 import { getBankKycProvider } from './providers';
+import { BankOnboardingError } from './errors';
 import type { BankKycProvider } from './providers/types';
 import { buildCustomerValidations } from './providers/bridge/banking-provider-state';
 
@@ -163,36 +164,6 @@ export async function createBankCustomerWithKycLink(
   return result;
 }
 
-/** Confirm path (D6) — finalizes a pending row (created by `requestBankOnboardingWithConfirmation` below). */
-async function finalizePendingBankCustomerWithKycLink(
-  bankCustomerId: number,
-  input: {
-    entityType: BankEntityType;
-    legalName: string;
-    contactEmail: string;
-    requestedRails?: string[];
-    redirectUri?: string;
-    idempotencyKey?: string;
-  },
-  { db }: { db: DatabaseInstance },
-  options?: BankOnboardingConfirmationOptions,
-): Promise<KycLinkAndValidations> {
-  const result = await buildKycLinkAndValidations(input, options);
-
-  await updateBankCustomer(
-    {
-      id: bankCustomerId,
-      providerCustomerId: result.providerCustomerId,
-      providerKycLinkId: result.providerKycLinkId,
-      requestedRails: result.normalizedRails,
-      jwtNonce: null,
-    },
-    { db },
-  );
-
-  return result;
-}
-
 /**
  * Confirm path's final write (#2288) — conditioned on `jwt_nonce` still being `NULL` (the state
  * the claim step left it in), not just the row id (see `finalizeClaimedBankCustomer`). Returns
@@ -295,21 +266,52 @@ export async function requestBankOnboardingWithConfirmation(
 
   if (isBypassEligible(submitterEmail, contactEmail)) {
     // A pending (unconfirmed) row from an earlier non-bypass attempt already occupies the
-    // owner+provider unique slot — finalize it in place rather than inserting a duplicate, which
-    // would violate that constraint after Bridge's KYC link is already created.
-    const result = existing
-      ? await finalizePendingBankCustomerWithKycLink(
-          existing.id,
-          { entityType, legalName, contactEmail, requestedRails, redirectUri },
-          { db },
-          options,
-        )
-      : await createBankCustomerWithKycLink(
-          ownerRef,
-          { entityType, legalName, contactEmail, requestedRails, redirectUri },
-          { db },
-          options,
+    // owner+provider unique slot — take it over rather than inserting a duplicate, which would
+    // violate that constraint after Bridge's KYC link is already created. Goes through the same
+    // claim/finalize CAS as the confirm path (not a plain update by id): a resend or an in-flight
+    // confirmation racing this bypass request must not have either write silently clobber the
+    // other's result.
+    let result: KycLinkAndValidations;
+    if (existing) {
+      if (!existing.jwtNonce) {
+        // Already claimed by an in-flight confirmation (nonce cleared, not yet finalized) —
+        // nothing valid to atomically take over from here.
+        throw new BankOnboardingError(
+          'A confirmation for this owner is already being processed. Please try again in a moment.',
+          409,
         );
+      }
+      const claimed = await claimBankCustomerForConfirmation(
+        { id: existing.id, expectedNonce: existing.jwtNonce },
+        { db },
+      );
+      if (!claimed) {
+        throw new BankOnboardingError(
+          'This request just changed — please try again.',
+          409,
+        );
+      }
+      const finalized = await finalizeClaimedBankCustomerWithKycLink(
+        claimed.id,
+        { entityType, legalName, contactEmail, requestedRails, redirectUri },
+        { db },
+        options,
+      );
+      if (!finalized) {
+        throw new BankOnboardingError(
+          'This request just changed — please try again.',
+          409,
+        );
+      }
+      result = finalized;
+    } else {
+      result = await createBankCustomerWithKycLink(
+        ownerRef,
+        { entityType, legalName, contactEmail, requestedRails, redirectUri },
+        { db },
+        options,
+      );
+    }
     return { kind: 'created', ...result };
   }
 

--- a/packages/core/src/banking/server/bank-onboarding-confirmation.ts
+++ b/packages/core/src/banking/server/bank-onboarding-confirmation.ts
@@ -23,6 +23,7 @@ import {
   claimBankCustomerForConfirmation,
   finalizeClaimedBankCustomer,
   insertBankCustomer,
+  releaseBankCustomerClaim,
   updateBankCustomer,
 } from './mutations';
 import { getBankKycProvider } from './providers';
@@ -193,15 +194,14 @@ async function finalizePendingBankCustomerWithKycLink(
 }
 
 /**
- * Confirm path's final write (#2288) — conditioned on `confirming_nonce` still matching the claim
- * this attempt holds, not just the row id (see `finalizeClaimedBankCustomer`). Returns `null`,
- * rather than throwing, if a resend revoked this attempt's claim while the provider call was in
+ * Confirm path's final write (#2288) — conditioned on `jwt_nonce` still being `NULL` (the state
+ * the claim step left it in), not just the row id (see `finalizeClaimedBankCustomer`). Returns
+ * `null`, rather than throwing, if a resend rotated `jwt_nonce` while the provider call was in
  * flight: that's not a failure of the provider call (which may well have succeeded), it means this
  * attempt lost the race and must not report success — see `confirmBankEmail`.
  */
 async function finalizeClaimedBankCustomerWithKycLink(
   bankCustomerId: number,
-  expectedConfirmingNonce: string,
   input: {
     entityType: BankEntityType;
     legalName: string;
@@ -218,7 +218,6 @@ async function finalizeClaimedBankCustomerWithKycLink(
   const row = await finalizeClaimedBankCustomer(
     {
       id: bankCustomerId,
-      expectedConfirmingNonce,
       providerCustomerId: result.providerCustomerId,
       providerKycLinkId: result.providerKycLinkId,
       requestedRails: result.normalizedRails,
@@ -329,25 +328,20 @@ export async function requestBankOnboardingWithConfirmation(
   });
 
   if (existing) {
-    // Resend (or a retry landing here while a confirm-in-progress has claimed the row, its
-    // `confirming_nonce` set): rotate/set the nonce on the existing pending row (D3) instead of
-    // inserting a duplicate (would violate the owner+provider unique index anyway). Keyed on
-    // `existing` rather than `existing.jwtNonce` so this still works while a row is claimed —
-    // `existing` only ever reaches this branch unconfirmed (the providerKycLinkId check above
-    // already returned for a linked row).
+    // Resend (or a retry landing here while a confirm-in-progress has claimed the row, jwtNonce
+    // momentarily null): set the nonce on the existing pending row (D3) instead of inserting a
+    // duplicate (would violate the owner+provider unique index anyway). Keyed on `existing`
+    // rather than `existing.jwtNonce` so this still works while a row is claimed — `existing`
+    // only ever reaches this branch unconfirmed (the providerKycLinkId check above already
+    // returned for a linked row).
     //
-    // Also clears `confirmingNonce`: this is what makes resend an *instant* revocation of an
-    // in-flight confirmation, not just of future clicks of the old link — without it, a
-    // confirmation already claimed under the old nonce could still finish and overwrite this
-    // resend's new nonce (see `finalizeClaimedBankCustomer`'s CAS on confirmingNonce for the
-    // other half of this).
+    // This unconditional write is also what makes resend an *instant* revocation of an in-flight
+    // confirmation, not just of future clicks of the old link: it always sets jwtNonce to a fresh
+    // non-null value, so a confirmation that already claimed the row (jwtNonce -> null) finds its
+    // final write's `WHERE jwt_nonce IS NULL` no longer matches once this commits — see
+    // `finalizeClaimedBankCustomer`.
     await updateBankCustomer(
-      {
-        id: existing.id,
-        jwtNonce: nonce,
-        confirmingNonce: null,
-        requestedRails: normalizedRails,
-      },
+      { id: existing.id, jwtNonce: nonce, requestedRails: normalizedRails },
       { db },
     );
   } else {
@@ -428,7 +422,6 @@ export async function confirmBankEmail(
   try {
     result = await finalizeClaimedBankCustomerWithKycLink(
       claimed.id,
-      claims.jti,
       {
         // Stable per-token idempotency key (not a fresh randomUUID() per attempt): if
         // finalization fails after Bridge already created the KYC link (e.g. the DB update
@@ -446,19 +439,23 @@ export async function confirmBankEmail(
       options,
     );
   } catch (error) {
-    // Release the claim (not "restore the nonce" — jwt_nonce was never touched by the claim
-    // step) so a retry of this same link, or a resend, can proceed instead of finding the row
-    // stuck mid-claim forever.
-    await updateBankCustomer({ id: claimed.id, confirmingNonce: null }, { db });
+    // Restore the nonce so this same confirmation link (or a resend) can still complete the row
+    // instead of leaving it permanently stuck: not pending (jwt_nonce null) but not confirmed
+    // either. Conditioned on jwt_nonce still being NULL (same recheck as the success path) — if a
+    // resend already rotated it while the provider call was failing, this is a no-op rather than
+    // clobbering the resend's new nonce.
+    await releaseBankCustomerClaim(
+      { id: claimed.id, restoreNonce: claims.jti },
+      { db },
+    );
     throw error;
   }
 
   if (!result) {
-    // A resend revoked this attempt's claim while the provider call was in flight (D3): the row
-    // has already moved on to a new nonce. Don't report success for a link that's no longer the
-    // live one — the resent link's own confirmation will complete normally, and Bridge's
-    // email-based dedup (D7/D8) means it lands on the same customer this call may have just
-    // created, so nothing is lost.
+    // A resend rotated jwt_nonce while the provider call was in flight (D3): the row has already
+    // moved on to a new link. Don't report success for one that's no longer live — the resent
+    // link's own confirmation will complete normally, and Bridge's email-based dedup (D7/D8)
+    // means it lands on the same customer this call may have just created, so nothing is lost.
     return { ok: false, reason: 'invalid' };
   }
 

--- a/packages/core/src/banking/server/bank-onboarding-confirmation.ts
+++ b/packages/core/src/banking/server/bank-onboarding-confirmation.ts
@@ -19,7 +19,11 @@ import {
   findBankCustomerBySpaceAndProvider,
   findBankCustomerByPersonAndProvider,
 } from './queries';
-import { insertBankCustomer, updateBankCustomer } from './mutations';
+import {
+  claimBankCustomerForConfirmation,
+  insertBankCustomer,
+  updateBankCustomer,
+} from './mutations';
 import { getBankKycProvider } from './providers';
 import type { BankKycProvider } from './providers/types';
 import { buildCustomerValidations } from './providers/bridge/banking-provider-state';
@@ -62,7 +66,8 @@ async function buildKycLinkAndValidations(
   },
   options?: BankOnboardingConfirmationOptions,
 ): Promise<KycLinkAndValidations> {
-  const normalizedRails = input.requestedRails?.map((r) => r.toLowerCase()) ?? [];
+  const normalizedRails =
+    input.requestedRails?.map((r) => r.toLowerCase()) ?? [];
   const endorsements = currenciesToEndorsements(normalizedRails);
   const idempotencyKey = randomUUID();
   const kycProvider =
@@ -244,12 +249,22 @@ export async function requestBankOnboardingWithConfirmation(
   }
 
   if (isBypassEligible(submitterEmail, contactEmail)) {
-    const result = await createBankCustomerWithKycLink(
-      ownerRef,
-      { entityType, legalName, contactEmail, requestedRails, redirectUri },
-      { db },
-      options,
-    );
+    // A pending (unconfirmed) row from an earlier non-bypass attempt already occupies the
+    // owner+provider unique slot — finalize it in place rather than inserting a duplicate, which
+    // would violate that constraint after Bridge's KYC link is already created.
+    const result = existing
+      ? await finalizePendingBankCustomerWithKycLink(
+          existing.id,
+          { entityType, legalName, contactEmail, requestedRails, redirectUri },
+          { db },
+          options,
+        )
+      : await createBankCustomerWithKycLink(
+          ownerRef,
+          { entityType, legalName, contactEmail, requestedRails, redirectUri },
+          { db },
+          options,
+        );
     return { kind: 'created', ...result };
   }
 
@@ -289,7 +304,11 @@ export async function requestBankOnboardingWithConfirmation(
     );
   }
 
-  await sendConfirmationEmail({ token, ownerLabel: ownerRef.label, contactEmail });
+  await sendConfirmationEmail({
+    token,
+    ownerLabel: ownerRef.label,
+    contactEmail,
+  });
 
   return { kind: 'pendingConfirmation' };
 }
@@ -329,22 +348,41 @@ export async function confirmBankEmail(
     return { ok: false, reason: 'already_confirmed' };
   }
 
+  // Atomically claim the row before calling the provider: a concurrent confirm of the same link
+  // (double-click, or a race with a resend that rotates the nonce) fails this compare-and-swap and
+  // is rejected here rather than both requests creating their own KYC link for the same owner.
+  const claimed = await claimBankCustomerForConfirmation(
+    { id: row.id, expectedNonce: claims.jti },
+    { db },
+  );
+  if (!claimed) {
+    return { ok: false, reason: 'invalid' };
+  }
+
   const existingBridgeCustomer = await bridgeFindCustomerByEmail(
     claims.contactEmail,
   ).catch(() => null);
 
-  const result = await finalizePendingBankCustomerWithKycLink(
-    row.id,
-    {
-      entityType: claims.entityType,
-      legalName: claims.legalName,
-      contactEmail: claims.contactEmail,
-      requestedRails: claims.requestedRails,
-      redirectUri: claims.redirectUri,
-    },
-    { db },
-    options,
-  );
+  let result: KycLinkAndValidations;
+  try {
+    result = await finalizePendingBankCustomerWithKycLink(
+      claimed.id,
+      {
+        entityType: claims.entityType,
+        legalName: claims.legalName,
+        contactEmail: claims.contactEmail,
+        requestedRails: claims.requestedRails,
+        redirectUri: claims.redirectUri,
+      },
+      { db },
+      options,
+    );
+  } catch (error) {
+    // Restore the nonce so the same confirmation link (or a resend) can still complete the row
+    // instead of leaving it permanently stuck: not pending (no nonce) but not confirmed either.
+    await updateBankCustomer({ id: claimed.id, jwtNonce: claims.jti }, { db });
+    throw error;
+  }
 
   return {
     ok: true,

--- a/packages/core/src/banking/server/get-space-bank-customer-public-status.ts
+++ b/packages/core/src/banking/server/get-space-bank-customer-public-status.ts
@@ -110,7 +110,9 @@ export async function buildPublicStatusFromCustomer(
       endorsementStatuses: [],
       currencyStatuses: [],
       requestedRails: customer.requestedRails ?? [],
-      pendingEmailConfirmation: { requestedRails: customer.requestedRails ?? [] },
+      pendingEmailConfirmation: {
+        requestedRails: customer.requestedRails ?? [],
+      },
     };
   }
 

--- a/packages/core/src/banking/server/get-space-bank-customer-public-status.ts
+++ b/packages/core/src/banking/server/get-space-bank-customer-public-status.ts
@@ -1,7 +1,10 @@
 import type { DatabaseInstance } from '../../common/server/types';
 import type { Space } from '../../space/types';
 import type { BankCustomer } from '@hypha-platform/storage-postgres';
-import { DEFAULT_BANK_PROVIDER } from '../constants';
+import {
+  DEFAULT_BANK_PROVIDER,
+  PENDING_EMAIL_CONFIRMATION_VALIDATION,
+} from '../constants';
 import type {
   BankEndorsementPublicStatus,
   BankPendingRequirements,
@@ -47,6 +50,12 @@ export type SpaceBankCustomerPublicStatus = {
   requestedRails: string[];
   /** Missing requirements that need user action beyond the main KYB flow. */
   pendingRequirements?: BankPendingRequirements;
+  /**
+   * Set when a #2288 email-ownership confirmation is pending — no Bridge KYC link exists yet, so
+   * none of the provider-derived fields above are meaningful. Drives the "confirm your email"
+   * task card instead of the normal onboarding/status UI.
+   */
+  pendingEmailConfirmation?: { requestedRails: string[] };
 };
 
 function mapCurrencyStatuses(
@@ -88,6 +97,23 @@ export async function buildPublicStatusFromCustomer(
   customer: BankCustomer,
   { db }: { db: DatabaseInstance },
 ): Promise<SpaceBankCustomerPublicStatus> {
+  if (!customer.providerKycLinkId) {
+    return {
+      hasCustomer: true,
+      isApproved: false,
+      approvalRegistered: false,
+      procedures: {
+        tos: PENDING_EMAIL_CONFIRMATION_VALIDATION,
+        kyc: PENDING_EMAIL_CONFIRMATION_VALIDATION,
+      },
+      railStatuses: [],
+      endorsementStatuses: [],
+      currencyStatuses: [],
+      requestedRails: customer.requestedRails ?? [],
+      pendingEmailConfirmation: { requestedRails: customer.requestedRails ?? [] },
+    };
+  }
+
   const state = await loadBankingProviderState(customer);
   const validations = buildCustomerValidations(state.kycLink);
   const railStatuses = buildRailStatuses({ customer, state });

--- a/packages/core/src/banking/server/index.ts
+++ b/packages/core/src/banking/server/index.ts
@@ -6,6 +6,7 @@ export * from './queries';
 export * from './mutations';
 export * from './authorize-space-bank-onboarding';
 export * from './request-space-bank-onboarding';
+export * from './bank-onboarding-confirmation';
 export * from './get-space-bank-customer-public-status';
 export * from './get-space-bank-virtual-accounts';
 export * from './get-space-bank-transfers';

--- a/packages/core/src/banking/server/mutations.ts
+++ b/packages/core/src/banking/server/mutations.ts
@@ -1,6 +1,6 @@
 import type { DbConfig } from '../../common/server/types';
 import type { BankEntityType, BankProvider } from '../types';
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 
 import {
   bankCustomers,
@@ -42,6 +42,27 @@ export type UpdateBankCustomerInput = {
   requestedRails?: BankCustomerRequestedRails;
   /** Pass `null` to clear (confirmation finalized), a uuid to rotate (resend, D3), or omit to leave as-is. */
   jwtNonce?: string | null;
+};
+
+/**
+ * Atomically claims a pending row for confirmation (#2288): clears `jwt_nonce` only if it still
+ * matches `expectedNonce`. Returns `null` if it doesn't (already claimed by a concurrent
+ * confirmation, or rotated by a resend) — the caller must treat that as an invalid confirmation
+ * rather than proceeding to call the provider twice for the same row.
+ */
+export const claimBankCustomerForConfirmation = async (
+  { id, expectedNonce }: { id: number; expectedNonce: string },
+  { db }: DbConfig,
+): Promise<BankCustomer | null> => {
+  const [row] = await db
+    .update(bankCustomers)
+    .set({ jwtNonce: null, updatedAt: new Date() })
+    .where(
+      and(eq(bankCustomers.id, id), eq(bankCustomers.jwtNonce, expectedNonce)),
+    )
+    .returning();
+
+  return row ?? null;
 };
 
 export const updateBankCustomer = async (

--- a/packages/core/src/banking/server/mutations.ts
+++ b/packages/core/src/banking/server/mutations.ts
@@ -1,6 +1,6 @@
 import type { DbConfig } from '../../common/server/types';
 import type { BankEntityType, BankProvider } from '../types';
-import { and, eq } from 'drizzle-orm';
+import { and, eq, isNull } from 'drizzle-orm';
 
 import {
   bankCustomers,
@@ -42,13 +42,27 @@ export type UpdateBankCustomerInput = {
   requestedRails?: BankCustomerRequestedRails;
   /** Pass `null` to clear (confirmation finalized), a uuid to rotate (resend, D3), or omit to leave as-is. */
   jwtNonce?: string | null;
+  /**
+   * Pass `null` to release/revoke an in-flight confirmation claim (resend does this, D3 — an
+   * outstanding confirmation attempt is revoked the same instant a new link is issued, not only
+   * future clicks of the old one), or omit to leave as-is. Never set to a value here — only
+   * `claimBankCustomerForConfirmation` sets it, atomically.
+   */
+  confirmingNonce?: null;
 };
 
 /**
- * Atomically claims a pending row for confirmation (#2288): clears `jwt_nonce` only if it still
- * matches `expectedNonce`. Returns `null` if it doesn't (already claimed by a concurrent
- * confirmation, or rotated by a resend) — the caller must treat that as an invalid confirmation
- * rather than proceeding to call the provider twice for the same row.
+ * Atomically claims a pending row for confirmation (#2288): sets `confirming_nonce` only if
+ * `jwt_nonce` still matches `expectedNonce` *and* no other confirmation already has it claimed
+ * (`confirming_nonce IS NULL`). Returns `null` if either fails (already claimed by a concurrent
+ * confirmation, or the link was rotated by a resend) — the caller must treat that as an invalid
+ * confirmation rather than proceeding to call the provider twice for the same row.
+ *
+ * Deliberately a separate column from `jwt_nonce` rather than clearing `jwt_nonce` itself: a
+ * resend needs to be able to revoke *this specific in-flight attempt* (by clearing
+ * `confirming_nonce` via `updateBankCustomer`) independently of rotating `jwt_nonce` to the next
+ * link, and the attempt's own final write (`finalizeClaimedBankCustomer`) needs something stable
+ * to condition on that a concurrent resend hasn't already repurposed.
  */
 export const claimBankCustomerForConfirmation = async (
   { id, expectedNonce }: { id: number; expectedNonce: string },
@@ -56,9 +70,53 @@ export const claimBankCustomerForConfirmation = async (
 ): Promise<BankCustomer | null> => {
   const [row] = await db
     .update(bankCustomers)
-    .set({ jwtNonce: null, updatedAt: new Date() })
+    .set({ confirmingNonce: expectedNonce, updatedAt: new Date() })
     .where(
-      and(eq(bankCustomers.id, id), eq(bankCustomers.jwtNonce, expectedNonce)),
+      and(
+        eq(bankCustomers.id, id),
+        eq(bankCustomers.jwtNonce, expectedNonce),
+        isNull(bankCustomers.confirmingNonce),
+      ),
+    )
+    .returning();
+
+  return row ?? null;
+};
+
+export type FinalizeClaimedBankCustomerInput = {
+  id: number;
+  /** Must match the row's current `confirming_nonce` — see `claimBankCustomerForConfirmation`. */
+  expectedConfirmingNonce: string;
+  providerCustomerId: string | null;
+  providerKycLinkId: string;
+  requestedRails: BankCustomerRequestedRails;
+};
+
+/**
+ * Persists a successful provider call for a claimed row (#2288 confirm path) — conditioned on
+ * `confirming_nonce` still matching, not just the row id. Returns `null` if a resend cleared the
+ * claim in the meantime (superseded): the caller must not report success in that case, even though
+ * the provider call itself already succeeded — see `confirmBankEmail`.
+ */
+export const finalizeClaimedBankCustomer = async (
+  input: FinalizeClaimedBankCustomerInput,
+  { db }: DbConfig,
+): Promise<BankCustomer | null> => {
+  const [row] = await db
+    .update(bankCustomers)
+    .set({
+      providerCustomerId: input.providerCustomerId,
+      providerKycLinkId: input.providerKycLinkId,
+      requestedRails: input.requestedRails,
+      jwtNonce: null,
+      confirmingNonce: null,
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(bankCustomers.id, input.id),
+        eq(bankCustomers.confirmingNonce, input.expectedConfirmingNonce),
+      ),
     )
     .returning();
 
@@ -84,6 +142,9 @@ export const updateBankCustomer = async (
   }
   if (input.jwtNonce !== undefined) {
     patch.jwtNonce = input.jwtNonce;
+  }
+  if (input.confirmingNonce !== undefined) {
+    patch.confirmingNonce = input.confirmingNonce;
   }
 
   const [row] = await db

--- a/packages/core/src/banking/server/mutations.ts
+++ b/packages/core/src/banking/server/mutations.ts
@@ -11,8 +11,11 @@ import {
 export type InsertBankCustomerInput = {
   entityType: BankEntityType;
   provider: BankProvider;
+  /** Null while an email-ownership confirmation is pending (#2288) — no KYC link exists yet. */
   providerCustomerId: string | null;
-  providerKycLinkId: string;
+  providerKycLinkId: string | null;
+  /** Set only while a confirmation is pending; unset (undefined) for a direct/bypass create. */
+  jwtNonce?: string;
   requestedRails: BankCustomerRequestedRails;
 } & (
   | { spaceId: number; personId?: undefined }
@@ -37,6 +40,8 @@ export type UpdateBankCustomerInput = {
   providerCustomerId?: string | null;
   providerKycLinkId?: string;
   requestedRails?: BankCustomerRequestedRails;
+  /** Pass `null` to clear (confirmation finalized), a uuid to rotate (resend, D3), or omit to leave as-is. */
+  jwtNonce?: string | null;
 };
 
 export const updateBankCustomer = async (
@@ -55,6 +60,9 @@ export const updateBankCustomer = async (
   }
   if (input.requestedRails !== undefined) {
     patch.requestedRails = input.requestedRails;
+  }
+  if (input.jwtNonce !== undefined) {
+    patch.jwtNonce = input.jwtNonce;
   }
 
   const [row] = await db

--- a/packages/core/src/banking/server/mutations.ts
+++ b/packages/core/src/banking/server/mutations.ts
@@ -42,27 +42,13 @@ export type UpdateBankCustomerInput = {
   requestedRails?: BankCustomerRequestedRails;
   /** Pass `null` to clear (confirmation finalized), a uuid to rotate (resend, D3), or omit to leave as-is. */
   jwtNonce?: string | null;
-  /**
-   * Pass `null` to release/revoke an in-flight confirmation claim (resend does this, D3 — an
-   * outstanding confirmation attempt is revoked the same instant a new link is issued, not only
-   * future clicks of the old one), or omit to leave as-is. Never set to a value here — only
-   * `claimBankCustomerForConfirmation` sets it, atomically.
-   */
-  confirmingNonce?: null;
 };
 
 /**
- * Atomically claims a pending row for confirmation (#2288): sets `confirming_nonce` only if
- * `jwt_nonce` still matches `expectedNonce` *and* no other confirmation already has it claimed
- * (`confirming_nonce IS NULL`). Returns `null` if either fails (already claimed by a concurrent
- * confirmation, or the link was rotated by a resend) — the caller must treat that as an invalid
- * confirmation rather than proceeding to call the provider twice for the same row.
- *
- * Deliberately a separate column from `jwt_nonce` rather than clearing `jwt_nonce` itself: a
- * resend needs to be able to revoke *this specific in-flight attempt* (by clearing
- * `confirming_nonce` via `updateBankCustomer`) independently of rotating `jwt_nonce` to the next
- * link, and the attempt's own final write (`finalizeClaimedBankCustomer`) needs something stable
- * to condition on that a concurrent resend hasn't already repurposed.
+ * Atomically claims a pending row for confirmation (#2288): clears `jwt_nonce` only if it still
+ * matches `expectedNonce`. Returns `null` if it doesn't (already claimed by a concurrent
+ * confirmation, or rotated by a resend) — the caller must treat that as an invalid confirmation
+ * rather than proceeding to call the provider twice for the same row.
  */
 export const claimBankCustomerForConfirmation = async (
   { id, expectedNonce }: { id: number; expectedNonce: string },
@@ -70,13 +56,9 @@ export const claimBankCustomerForConfirmation = async (
 ): Promise<BankCustomer | null> => {
   const [row] = await db
     .update(bankCustomers)
-    .set({ confirmingNonce: expectedNonce, updatedAt: new Date() })
+    .set({ jwtNonce: null, updatedAt: new Date() })
     .where(
-      and(
-        eq(bankCustomers.id, id),
-        eq(bankCustomers.jwtNonce, expectedNonce),
-        isNull(bankCustomers.confirmingNonce),
-      ),
+      and(eq(bankCustomers.id, id), eq(bankCustomers.jwtNonce, expectedNonce)),
     )
     .returning();
 
@@ -85,8 +67,6 @@ export const claimBankCustomerForConfirmation = async (
 
 export type FinalizeClaimedBankCustomerInput = {
   id: number;
-  /** Must match the row's current `confirming_nonce` — see `claimBankCustomerForConfirmation`. */
-  expectedConfirmingNonce: string;
   providerCustomerId: string | null;
   providerKycLinkId: string;
   requestedRails: BankCustomerRequestedRails;
@@ -94,9 +74,12 @@ export type FinalizeClaimedBankCustomerInput = {
 
 /**
  * Persists a successful provider call for a claimed row (#2288 confirm path) — conditioned on
- * `confirming_nonce` still matching, not just the row id. Returns `null` if a resend cleared the
- * claim in the meantime (superseded): the caller must not report success in that case, even though
- * the provider call itself already succeeded — see `confirmBankEmail`.
+ * `jwt_nonce` still being `NULL`, i.e. still the exact state `claimBankCustomerForConfirmation`
+ * left it in, not just the row id. Returns `null` if a resend rotated `jwt_nonce` to a new value in
+ * the meantime (superseded): the caller must not report success in that case, even though the
+ * provider call itself already succeeded — see `confirmBankEmail`. This recheck-at-write, not just
+ * recheck-at-read, is the actual fix for the race: a resend arriving between the claim and this
+ * write is what a plain `WHERE id = ?` write misses.
  */
 export const finalizeClaimedBankCustomer = async (
   input: FinalizeClaimedBankCustomerInput,
@@ -108,19 +91,31 @@ export const finalizeClaimedBankCustomer = async (
       providerCustomerId: input.providerCustomerId,
       providerKycLinkId: input.providerKycLinkId,
       requestedRails: input.requestedRails,
-      jwtNonce: null,
-      confirmingNonce: null,
       updatedAt: new Date(),
     })
-    .where(
-      and(
-        eq(bankCustomers.id, input.id),
-        eq(bankCustomers.confirmingNonce, input.expectedConfirmingNonce),
-      ),
-    )
+    .where(and(eq(bankCustomers.id, input.id), isNull(bankCustomers.jwtNonce)))
     .returning();
 
   return row ?? null;
+};
+
+/**
+ * Releases a claim after a failed provider call (#2288 confirm path), restoring `jwt_nonce` so the
+ * same link (or a resend) can retry — conditioned on `jwt_nonce` still being `NULL`, same as
+ * `finalizeClaimedBankCustomer`. If a resend already rotated it in the meantime, this is a no-op:
+ * restoring the *old* nonce unconditionally would silently undo that resend, the exact bug this
+ * whole claim/finalize design exists to prevent, just on the failure path instead of the success
+ * one.
+ */
+export const releaseBankCustomerClaim = async (
+  { id, restoreNonce }: { id: number; restoreNonce: string },
+  { db }: DbConfig,
+): Promise<void> => {
+  await db
+    .update(bankCustomers)
+    .set({ jwtNonce: restoreNonce, updatedAt: new Date() })
+    .where(and(eq(bankCustomers.id, id), isNull(bankCustomers.jwtNonce)))
+    .execute();
 };
 
 export const updateBankCustomer = async (
@@ -142,9 +137,6 @@ export const updateBankCustomer = async (
   }
   if (input.jwtNonce !== undefined) {
     patch.jwtNonce = input.jwtNonce;
-  }
-  if (input.confirmingNonce !== undefined) {
-    patch.confirmingNonce = input.confirmingNonce;
   }
 
   const [row] = await db

--- a/packages/core/src/banking/server/providers/bridge/banking-provider-state.ts
+++ b/packages/core/src/banking/server/providers/bridge/banking-provider-state.ts
@@ -35,6 +35,7 @@ import type {
   BankRailPublicStatus,
   BankValidationRequirement,
 } from '../../../types';
+import { BankOnboardingError } from '../../errors';
 
 const PENDING_BRIDGE_ENDORSEMENT_STATUSES = new Set([
   'incomplete',
@@ -77,6 +78,15 @@ export function laPairKey(
 export async function loadBankingProviderState(
   customer: BankCustomer,
 ): Promise<BankingProviderState> {
+  if (!customer.providerKycLinkId) {
+    // Should not happen: callers only reach here for a customer with a confirmed Bridge link
+    // (#2288 — a pending-email-confirmation row is handled upstream, before this is called).
+    throw new BankOnboardingError(
+      'Bank customer has no Bridge KYC link yet.',
+      422,
+    );
+  }
+
   const kycLink = await bridgeGetKycLink(customer.providerKycLinkId);
 
   let bridgeCustomer: BridgeGetCustomerResponse | null = null;

--- a/packages/core/src/banking/server/queries.ts
+++ b/packages/core/src/banking/server/queries.ts
@@ -52,3 +52,17 @@ export const findBankCustomerByPersonAndProvider = async (
 
   return row ?? null;
 };
+
+/** Looks up the pending confirmation row a confirmation-JWT `jti` correlates to (#2288). */
+export const findBankCustomerByNonce = async (
+  jwtNonce: string,
+  { db }: DbConfig,
+): Promise<BankCustomer | null> => {
+  const [row] = await db
+    .select()
+    .from(bankCustomers)
+    .where(eq(bankCustomers.jwtNonce, jwtNonce))
+    .limit(1);
+
+  return row ?? null;
+};

--- a/packages/core/src/banking/server/request-bridge-endorsement-kyc-link.ts
+++ b/packages/core/src/banking/server/request-bridge-endorsement-kyc-link.ts
@@ -49,7 +49,7 @@ export async function requestBridgeEndorsementKycLink(
         endorsement: parsedEndorsement,
         email: bridgeEmail,
       },
-      { existingKycLinkId: customer.providerKycLinkId },
+      { existingKycLinkId: customer.providerKycLinkId ?? providerCustomerId },
     );
 
     const shouldUpdateKycLinkId =

--- a/packages/core/src/banking/server/request-personal-bank-onboarding.ts
+++ b/packages/core/src/banking/server/request-personal-bank-onboarding.ts
@@ -1,30 +1,39 @@
-import { randomUUID } from 'node:crypto';
-
 import type { DatabaseInstance } from '../../common/server/types';
-import { DEFAULT_BANK_PROVIDER } from '../constants';
-import { findPersonBySlug } from '../../people/server/queries';
+import {
+  DEFAULT_BANK_PROVIDER,
+  PENDING_EMAIL_CONFIRMATION_VALIDATION,
+} from '../constants';
+import { findPersonBySlug, findPersonById } from '../../people/server/queries';
 import type {
   PersonalBankOnboardingResult,
   RequestPersonalBankOnboardingInput,
 } from '../types';
 import { authorizePersonalBankOnboarding } from './authorize-personal-bank-onboarding';
 import { BankOnboardingError } from './errors';
-import { insertBankCustomer } from './mutations';
 import { getBankKycProvider } from './providers';
 import type { BankKycProvider } from './providers/types';
-import { currenciesToEndorsements } from '../constants';
-import { buildCustomerValidations } from './providers/bridge/banking-provider-state';
-import { bridgeGetKycLink } from '../../common/server/bridge-client';
-import { findBankCustomerByPersonAndProvider } from './queries';
+import {
+  requestBankOnboardingWithConfirmation,
+  type BankOnboardingOwnerRef,
+} from './bank-onboarding-confirmation';
 
 export type RequestPersonalBankOnboardingOptions = {
   kycProvider?: BankKycProvider;
+  /**
+   * Sends the #2288 ownership-confirmation email. Never receives anything but the token to embed
+   * in the link — the token itself must never appear in this function's return value (D6).
+   */
+  sendConfirmationEmail: (input: {
+    token: string;
+    ownerLabel: string;
+    contactEmail: string;
+  }) => Promise<void>;
 };
 
 export async function requestPersonalBankOnboarding(
   input: RequestPersonalBankOnboardingInput,
   { db }: { db: DatabaseInstance },
-  options?: RequestPersonalBankOnboardingOptions,
+  options: RequestPersonalBankOnboardingOptions,
 ): Promise<PersonalBankOnboardingResult> {
   const {
     personSlug,
@@ -49,78 +58,54 @@ export async function requestPersonalBankOnboarding(
     throw new BankOnboardingError(auth.message, auth.httpStatus);
   }
 
-  const requesterSlug = auth.person.slug ?? null;
+  const submitter = await findPersonById({ id: auth.person.id }, { db });
 
-  const existing = await findBankCustomerByPersonAndProvider(
-    { personId: person.id, provider: DEFAULT_BANK_PROVIDER },
+  const ownerRef: BankOnboardingOwnerRef = {
+    type: 'person',
+    id: person.id,
+    slug: person.slug ?? personSlug,
+    label: legalName,
+  };
+
+  const result = await requestBankOnboardingWithConfirmation(
+    {
+      ownerRef,
+      entityType: 'individual',
+      legalName,
+      contactEmail,
+      requestedRails,
+      redirectUri,
+      submitterPersonId: auth.person.id,
+      submitterEmail: submitter?.email ?? null,
+      sendConfirmationEmail: options.sendConfirmationEmail,
+    },
     { db },
+    { kycProvider: options.kycProvider ?? getBankKycProvider(DEFAULT_BANK_PROVIDER) },
   );
 
-  if (existing) {
-    const kycLink = await bridgeGetKycLink(existing.providerKycLinkId);
-    const validations = buildCustomerValidations(kycLink);
-
+  if (result.kind === 'pendingConfirmation') {
     return {
       provider: DEFAULT_BANK_PROVIDER,
       created: false,
+      pendingEmailConfirmation: true,
       ownerName: legalName,
-      requesterSlug,
-      kycLink: validations.kycLink,
-      tosLink: validations.tosLink,
+      requesterSlug: auth.person.slug ?? null,
+      kycLink: null,
+      tosLink: null,
       procedures: {
-        tos: validations.tos,
-        kyc: validations.kyc,
+        tos: PENDING_EMAIL_CONFIRMATION_VALIDATION,
+        kyc: PENDING_EMAIL_CONFIRMATION_VALIDATION,
       },
     };
   }
 
-  const normalizedRails = requestedRails?.map((r) => r.toLowerCase()) ?? [];
-  const endorsements = currenciesToEndorsements(normalizedRails);
-
-  const idempotencyKey = randomUUID();
-  const kycProvider =
-    options?.kycProvider ?? getBankKycProvider(DEFAULT_BANK_PROVIDER);
-
-  const kycLinkResult = await kycProvider.createKycLink({
-    entityType: 'individual',
-    legalName,
-    contactEmail,
-    idempotencyKey,
-    endorsements,
-    redirectUri,
-  });
-
-  await insertBankCustomer(
-    {
-      personId: person.id,
-      entityType: 'individual',
-      provider: DEFAULT_BANK_PROVIDER,
-      providerCustomerId: kycLinkResult.providerCustomerId,
-      providerKycLinkId: kycLinkResult.providerKycLinkId,
-      requestedRails: normalizedRails,
-    },
-    { db },
-  );
-
-  const validations = buildCustomerValidations({
-    id: kycLinkResult.providerKycLinkId,
-    kyc_link: kycLinkResult.kycLink,
-    kyc_status: kycLinkResult.kycStatus,
-    tos_status: kycLinkResult.tosStatus,
-    tos_link: kycLinkResult.tosLink,
-    customer_id: kycLinkResult.providerCustomerId,
-  });
-
   return {
     provider: DEFAULT_BANK_PROVIDER,
-    created: true,
+    created: result.kind === 'created',
     ownerName: legalName,
-    requesterSlug,
-    kycLink: validations.kycLink,
-    tosLink: validations.tosLink,
-    procedures: {
-      tos: validations.tos,
-      kyc: validations.kyc,
-    },
+    requesterSlug: auth.person.slug ?? null,
+    kycLink: result.kycLink,
+    tosLink: result.tosLink,
+    procedures: result.procedures,
   };
 }

--- a/packages/core/src/banking/server/request-personal-bank-onboarding.ts
+++ b/packages/core/src/banking/server/request-personal-bank-onboarding.ts
@@ -80,7 +80,10 @@ export async function requestPersonalBankOnboarding(
       sendConfirmationEmail: options.sendConfirmationEmail,
     },
     { db },
-    { kycProvider: options.kycProvider ?? getBankKycProvider(DEFAULT_BANK_PROVIDER) },
+    {
+      kycProvider:
+        options.kycProvider ?? getBankKycProvider(DEFAULT_BANK_PROVIDER),
+    },
   );
 
   if (result.kind === 'pendingConfirmation') {

--- a/packages/core/src/banking/server/request-space-bank-onboarding.ts
+++ b/packages/core/src/banking/server/request-space-bank-onboarding.ts
@@ -81,7 +81,10 @@ export async function requestSpaceBankOnboarding(
       sendConfirmationEmail: options.sendConfirmationEmail,
     },
     { db },
-    { kycProvider: options.kycProvider ?? getBankKycProvider(DEFAULT_BANK_PROVIDER) },
+    {
+      kycProvider:
+        options.kycProvider ?? getBankKycProvider(DEFAULT_BANK_PROVIDER),
+    },
   );
 
   if (result.kind === 'pendingConfirmation') {

--- a/packages/core/src/banking/server/request-space-bank-onboarding.ts
+++ b/packages/core/src/banking/server/request-space-bank-onboarding.ts
@@ -1,30 +1,40 @@
-import { randomUUID } from 'node:crypto';
-
 import type { DatabaseInstance } from '../../common/server/types';
-import { DEFAULT_BANK_PROVIDER } from '../constants';
+import {
+  DEFAULT_BANK_PROVIDER,
+  PENDING_EMAIL_CONFIRMATION_VALIDATION,
+} from '../constants';
 import { findSpaceBySlug } from '../../space/server/queries';
+import { findPersonById } from '../../people/server/queries';
 import type {
   BankOnboardingResult,
   RequestSpaceBankOnboardingInput,
 } from '../types';
 import { authorizeSpaceBankOnboarding } from './authorize-space-bank-onboarding';
 import { BankOnboardingError } from './errors';
-import { insertBankCustomer } from './mutations';
 import { getBankKycProvider } from './providers';
 import type { BankKycProvider } from './providers/types';
-import { currenciesToEndorsements } from '../constants';
-import { buildCustomerValidations } from './providers/bridge/banking-provider-state';
-import { bridgeGetKycLink } from '../../common/server/bridge-client';
-import { findBankCustomerBySpaceAndProvider } from './queries';
+import {
+  requestBankOnboardingWithConfirmation,
+  type BankOnboardingOwnerRef,
+} from './bank-onboarding-confirmation';
 
 export type RequestSpaceBankOnboardingOptions = {
   kycProvider?: BankKycProvider;
+  /**
+   * Sends the #2288 ownership-confirmation email. Never receives anything but the token to embed
+   * in the link — the token itself must never appear in this function's return value (D6).
+   */
+  sendConfirmationEmail: (input: {
+    token: string;
+    ownerLabel: string;
+    contactEmail: string;
+  }) => Promise<void>;
 };
 
 export async function requestSpaceBankOnboarding(
   input: RequestSpaceBankOnboardingInput,
   { db }: { db: DatabaseInstance },
-  options?: RequestSpaceBankOnboardingOptions,
+  options: RequestSpaceBankOnboardingOptions,
 ): Promise<BankOnboardingResult> {
   const {
     spaceSlug,
@@ -49,81 +59,54 @@ export async function requestSpaceBankOnboarding(
     throw new BankOnboardingError(auth.message, auth.httpStatus);
   }
 
-  const emailMeta = {
-    spaceTitle: space.title,
-    requesterSlug: auth.person.slug ?? null,
+  const submitter = await findPersonById({ id: auth.person.id }, { db });
+
+  const ownerRef: BankOnboardingOwnerRef = {
+    type: 'space',
+    id: space.id,
+    slug: space.slug,
+    label: space.title,
   };
 
-  const existing = await findBankCustomerBySpaceAndProvider(
-    { spaceId: space.id, provider: DEFAULT_BANK_PROVIDER },
+  const result = await requestBankOnboardingWithConfirmation(
+    {
+      ownerRef,
+      entityType: 'business',
+      legalName,
+      contactEmail,
+      requestedRails,
+      redirectUri,
+      submitterPersonId: auth.person.id,
+      submitterEmail: submitter?.email ?? null,
+      sendConfirmationEmail: options.sendConfirmationEmail,
+    },
     { db },
+    { kycProvider: options.kycProvider ?? getBankKycProvider(DEFAULT_BANK_PROVIDER) },
   );
 
-  if (existing) {
-    const kycLink = await bridgeGetKycLink(existing.providerKycLinkId);
-    const validations = buildCustomerValidations(kycLink);
-
+  if (result.kind === 'pendingConfirmation') {
     return {
       provider: DEFAULT_BANK_PROVIDER,
       created: false,
-      spaceTitle: emailMeta.spaceTitle,
-      requesterSlug: emailMeta.requesterSlug,
-      kycLink: validations.kycLink,
-      tosLink: validations.tosLink,
+      pendingEmailConfirmation: true,
+      spaceTitle: space.title,
+      requesterSlug: auth.person.slug ?? null,
+      kycLink: null,
+      tosLink: null,
       procedures: {
-        tos: validations.tos,
-        kyc: validations.kyc,
+        tos: PENDING_EMAIL_CONFIRMATION_VALIDATION,
+        kyc: PENDING_EMAIL_CONFIRMATION_VALIDATION,
       },
     };
   }
 
-  const normalizedRails = requestedRails?.map((r) => r.toLowerCase()) ?? [];
-  const endorsements = currenciesToEndorsements(normalizedRails);
-
-  const idempotencyKey = randomUUID();
-  const kycProvider =
-    options?.kycProvider ?? getBankKycProvider(DEFAULT_BANK_PROVIDER);
-
-  const kycLinkResult = await kycProvider.createKycLink({
-    entityType: 'business',
-    legalName,
-    contactEmail,
-    idempotencyKey,
-    endorsements,
-    redirectUri,
-  });
-
-  await insertBankCustomer(
-    {
-      spaceId: space.id,
-      entityType: 'business',
-      provider: DEFAULT_BANK_PROVIDER,
-      providerCustomerId: kycLinkResult.providerCustomerId,
-      providerKycLinkId: kycLinkResult.providerKycLinkId,
-      requestedRails: normalizedRails,
-    },
-    { db },
-  );
-
-  const validations = buildCustomerValidations({
-    id: kycLinkResult.providerKycLinkId,
-    kyc_link: kycLinkResult.kycLink,
-    kyc_status: kycLinkResult.kycStatus,
-    tos_status: kycLinkResult.tosStatus,
-    tos_link: kycLinkResult.tosLink,
-    customer_id: kycLinkResult.providerCustomerId,
-  });
-
   return {
     provider: DEFAULT_BANK_PROVIDER,
-    created: true,
-    spaceTitle: emailMeta.spaceTitle,
-    requesterSlug: emailMeta.requesterSlug,
-    kycLink: validations.kycLink,
-    tosLink: validations.tosLink,
-    procedures: {
-      tos: validations.tos,
-      kyc: validations.kyc,
-    },
+    created: result.kind === 'created',
+    spaceTitle: space.title,
+    requesterSlug: auth.person.slug ?? null,
+    kycLink: result.kycLink,
+    tosLink: result.tosLink,
+    procedures: result.procedures,
   };
 }

--- a/packages/core/src/banking/server/resolve-bridge-customer-email.ts
+++ b/packages/core/src/banking/server/resolve-bridge-customer-email.ts
@@ -26,6 +26,13 @@ function readEmailFromRecord(value: unknown): string | null {
 export async function resolveBridgeCustomerEmail(
   customer: Pick<BankCustomer, 'providerKycLinkId' | 'providerCustomerId'>,
 ): Promise<string> {
+  if (!customer.providerKycLinkId) {
+    throw new BankOnboardingError(
+      'Could not resolve contact email from Bridge. Complete base verification first.',
+      422,
+    );
+  }
+
   const kycLink = await bridgeGetKycLink(customer.providerKycLinkId);
   const fromLink = readEmailFromRecord(kycLink);
   if (fromLink) {

--- a/packages/core/src/banking/server/resolve-bridge-customer-id.ts
+++ b/packages/core/src/banking/server/resolve-bridge-customer-id.ts
@@ -12,6 +12,13 @@ export async function resolveBridgeCustomerId(
     return { customerId: customer.providerCustomerId, customer };
   }
 
+  if (!customer.providerKycLinkId) {
+    throw new BankOnboardingError(
+      'Bridge customer ID is not available yet. Open the verification form once, then try again.',
+      422,
+    );
+  }
+
   const link = await bridgeGetKycLink(customer.providerKycLinkId);
   const customerId = link.customer_id ?? null;
 

--- a/packages/core/src/banking/types.ts
+++ b/packages/core/src/banking/types.ts
@@ -56,6 +56,8 @@ export type BankEndorsementPublicStatus = {
 export type BankOnboardingResult = {
   provider: BankProvider;
   created: boolean;
+  /** Set when a #2288 email-ownership confirmation was sent instead of creating the customer now. */
+  pendingEmailConfirmation?: boolean;
   spaceTitle: string;
   requesterSlug: string | null;
   kycLink: string | null;
@@ -88,6 +90,8 @@ export type RequestPersonalBankOnboardingInput = {
 export type PersonalBankOnboardingResult = {
   provider: BankProvider;
   created: boolean;
+  /** Set when a #2288 email-ownership confirmation was sent instead of creating the customer now. */
+  pendingEmailConfirmation?: boolean;
   /** Person display/legal name — used to personalize the KYC email. */
   ownerName: string;
   requesterSlug: string | null;

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -27,3 +27,7 @@ export {
   BANK_VIRTUAL_ACCOUNT_CURRENCIES,
 } from './banking/constants';
 export type { BankProvider } from './banking/types';
+export {
+  isBypassEligible,
+  normalizeEmailForBypass,
+} from './banking/normalize-email-for-bypass';

--- a/packages/core/src/common/server/__tests__/sign-bank-confirmation-jwt.test.ts
+++ b/packages/core/src/common/server/__tests__/sign-bank-confirmation-jwt.test.ts
@@ -38,6 +38,20 @@ describe('signBankConfirmationJwt / verifyBankConfirmationJwt', () => {
     }
   });
 
+  it('does not leak claims in plaintext — encrypted (JWE), not just signed', async () => {
+    const { token } = await signBankConfirmationJwt(payload);
+
+    // A bare signed JWS would have a base64url-readable payload segment; decoding every segment
+    // of this token without the key must not reveal any claim value.
+    const segments = token.split('.');
+    for (const segment of segments) {
+      if (!segment) continue;
+      const decoded = Buffer.from(segment, 'base64url').toString('utf8');
+      expect(decoded).not.toContain(payload.contactEmail);
+      expect(decoded).not.toContain(payload.legalName);
+    }
+  });
+
   it('produces a fresh nonce on every sign call', async () => {
     const first = await signBankConfirmationJwt(payload);
     const second = await signBankConfirmationJwt(payload);
@@ -46,7 +60,12 @@ describe('signBankConfirmationJwt / verifyBankConfirmationJwt', () => {
 
   it('rejects a tampered token as invalid', async () => {
     const { token } = await signBankConfirmationJwt(payload);
-    const tampered = token.slice(0, -1) + (token.endsWith('a') ? 'b' : 'a');
+    // Flip a character in the middle (ciphertext/IV), not the last one: the final base64url
+    // character of a segment can carry unused padding bits, so flipping only that one
+    // occasionally decodes to the same underlying bytes and doesn't actually corrupt anything.
+    const mid = Math.floor(token.length / 2);
+    const flipped = token[mid] === 'a' ? 'b' : 'a';
+    const tampered = token.slice(0, mid) + flipped + token.slice(mid + 1);
 
     const result = await verifyBankConfirmationJwt(tampered);
     expect(result.valid).toBe(false);

--- a/packages/core/src/common/server/__tests__/sign-bank-confirmation-jwt.test.ts
+++ b/packages/core/src/common/server/__tests__/sign-bank-confirmation-jwt.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('server-only', () => ({}));
+
+import {
+  signBankConfirmationJwt,
+  verifyBankConfirmationJwt,
+  type BankConfirmationJwtPayload,
+} from '../sign-bank-confirmation-jwt';
+
+const payload: BankConfirmationJwtPayload = {
+  ownerType: 'space',
+  ownerId: 1,
+  ownerSlug: 'acme',
+  ownerLabel: 'Acme',
+  entityType: 'business',
+  legalName: 'Acme Foundation Ltd.',
+  contactEmail: 'compliance@acme.org',
+  requestedRails: ['eur', 'usd'],
+  submitterPersonId: 10,
+};
+
+describe('signBankConfirmationJwt / verifyBankConfirmationJwt', () => {
+  beforeEach(() => {
+    process.env.INTERNAL_JWT_SECRET = 'test-secret-at-least-32-bytes-long!!';
+  });
+
+  it('round-trips the payload through sign + verify', async () => {
+    const { token, nonce } = await signBankConfirmationJwt(payload);
+    const result = await verifyBankConfirmationJwt(token);
+
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.claims.jti).toBe(nonce);
+      expect(result.claims.contactEmail).toBe('compliance@acme.org');
+      expect(result.claims.ownerType).toBe('space');
+      expect(result.claims.requestedRails).toEqual(['eur', 'usd']);
+    }
+  });
+
+  it('produces a fresh nonce on every sign call', async () => {
+    const first = await signBankConfirmationJwt(payload);
+    const second = await signBankConfirmationJwt(payload);
+    expect(first.nonce).not.toBe(second.nonce);
+  });
+
+  it('rejects a tampered token as invalid', async () => {
+    const { token } = await signBankConfirmationJwt(payload);
+    const tampered = token.slice(0, -1) + (token.endsWith('a') ? 'b' : 'a');
+
+    const result = await verifyBankConfirmationJwt(tampered);
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.reason).toBe('invalid');
+    }
+  });
+
+  it('rejects a token signed with a different secret', async () => {
+    const { token } = await signBankConfirmationJwt(payload);
+    process.env.INTERNAL_JWT_SECRET = 'a-completely-different-secret-value!!';
+
+    const result = await verifyBankConfirmationJwt(token);
+    expect(result.valid).toBe(false);
+  });
+
+  it('throws when INTERNAL_JWT_SECRET is unset', async () => {
+    delete process.env.INTERNAL_JWT_SECRET;
+    await expect(signBankConfirmationJwt(payload)).rejects.toThrow(
+      'INTERNAL_JWT_SECRET',
+    );
+  });
+});

--- a/packages/core/src/common/server/bridge-client.ts
+++ b/packages/core/src/common/server/bridge-client.ts
@@ -526,6 +526,26 @@ export async function bridgeUpdateCustomer(
   });
 }
 
+/**
+ * Bridge dedups customers by email (#2288) — this surfaces an existing customer under `email`
+ * *before* calling `bridgeCreateKycLink`, so the ownership-confirmation flow can inform the user
+ * rather than only finding out via `bridgeCreateKycLink`'s reactive `existing_kyc_link` 400-fallback
+ * (which stays in place as a safety net regardless — see decisions D7/D8). Called only after
+ * ownership of `email` is proven (bypass match or clicked confirmation link) — result informs, does
+ * not block (D7).
+ */
+export async function bridgeFindCustomerByEmail(
+  email: string,
+): Promise<BridgeGetCustomerResponse | null> {
+  const parsed = await bridgeRequest(
+    `/v0/customers?email=${encodeURIComponent(email)}`,
+    { method: 'GET' },
+  );
+
+  const { data } = parseBridgeListResponse(parsed, isBridgeCustomerRecord);
+  return data[0] ?? null;
+}
+
 export async function bridgeCreateVirtualAccount(
   customerId: string,
   body: BridgeCreateVirtualAccountRequest,

--- a/packages/core/src/common/server/index.ts
+++ b/packages/core/src/common/server/index.ts
@@ -13,6 +13,7 @@ export * from './get-token-balances-by-address';
 
 export * from './alchemy-client';
 export * from './bridge-client';
+export * from './sign-bank-confirmation-jwt';
 export * from './bridge-sandbox';
 export * from './get-app-url';
 export * from './verify-privy-auth-token';

--- a/packages/core/src/common/server/sign-bank-confirmation-jwt.ts
+++ b/packages/core/src/common/server/sign-bank-confirmation-jwt.ts
@@ -32,7 +32,9 @@ const BANK_CONFIRMATION_JWT_EXPIRY_SECONDS = 72 * 60 * 60; // 72h, per decisions
 function getInternalJwtSecret(): Uint8Array {
   const secret = process.env.INTERNAL_JWT_SECRET;
   if (!secret) {
-    throw new Error('Missing required environment variable: INTERNAL_JWT_SECRET');
+    throw new Error(
+      'Missing required environment variable: INTERNAL_JWT_SECRET',
+    );
   }
   return new TextEncoder().encode(secret);
 }
@@ -72,10 +74,7 @@ export async function verifyBankConfirmationJwt(
       claims: payload as unknown as BankConfirmationJwtClaims,
     };
   } catch (error) {
-    if (
-      error instanceof Error &&
-      error.name === 'JWTExpired'
-    ) {
+    if (error instanceof Error && error.name === 'JWTExpired') {
       return { valid: false, reason: 'expired' };
     }
     return { valid: false, reason: 'invalid' };

--- a/packages/core/src/common/server/sign-bank-confirmation-jwt.ts
+++ b/packages/core/src/common/server/sign-bank-confirmation-jwt.ts
@@ -1,11 +1,17 @@
 import 'server-only';
-import { randomUUID } from 'node:crypto';
-import { jwtVerify, SignJWT } from 'jose';
+import { hkdfSync, randomUUID } from 'node:crypto';
+import { EncryptJWT, jwtDecrypt } from 'jose';
 
 /**
  * Carries the bank-onboarding form data + the third-party email across the confirmation
  * email round-trip (#2288). Lives only in the email URL, never at rest in the DB — the DB row
  * (`bank_customers.jwt_nonce`) tracks state only, no PII. See decisions D1/D6.
+ *
+ * Encrypted (JWE, not a bare signed JWS): the URL this rides in can end up in browser history,
+ * email-link scanners, or logs before it's used/rotated, and a signed-only token would let anyone
+ * who obtains it read `legalName`/`contactEmail` off the claims even without the secret. AES-256-GCM
+ * is authenticated encryption, so it still catches tampering the same way a signature would — this
+ * isn't sign-then-encrypt, one layer covers both confidentiality and integrity here.
  */
 export type BankConfirmationJwtPayload = {
   ownerType: 'space' | 'person';
@@ -29,14 +35,29 @@ export type BankConfirmationJwtClaims = BankConfirmationJwtPayload & {
 
 const BANK_CONFIRMATION_JWT_EXPIRY_SECONDS = 72 * 60 * 60; // 72h, per decisions.md "Resolved"
 
-function getInternalJwtSecret(): Uint8Array {
+/**
+ * Derives a 32-byte A256GCM content-encryption key from `INTERNAL_JWT_SECRET` via HKDF, rather
+ * than feeding the raw secret bytes straight into AES: keeps the encryption key independent of the
+ * secret's own length/entropy, and avoids using the exact same key material for two different
+ * cryptographic primitives if this secret is ever reused for HMAC signing elsewhere. The `info`
+ * string scopes the derivation to this one purpose, so a single `INTERNAL_JWT_SECRET` env var is
+ * enough — no separate encryption secret to provision per environment.
+ */
+function getInternalJweKey(): Uint8Array {
   const secret = process.env.INTERNAL_JWT_SECRET;
   if (!secret) {
     throw new Error(
       'Missing required environment variable: INTERNAL_JWT_SECRET',
     );
   }
-  return new TextEncoder().encode(secret);
+  const derived = hkdfSync(
+    'sha256',
+    Buffer.from(secret, 'utf8'),
+    Buffer.alloc(0),
+    'hypha:bank-confirmation-jwe',
+    32,
+  );
+  return new Uint8Array(derived);
 }
 
 export type SignedBankConfirmationJwt = {
@@ -50,12 +71,12 @@ export async function signBankConfirmationJwt(
 ): Promise<SignedBankConfirmationJwt> {
   const nonce = randomUUID();
 
-  const token = await new SignJWT({ ...payload })
-    .setProtectedHeader({ alg: 'HS256' })
+  const token = await new EncryptJWT({ ...payload })
+    .setProtectedHeader({ alg: 'dir', enc: 'A256GCM' })
     .setJti(nonce)
     .setIssuedAt()
     .setExpirationTime(`${BANK_CONFIRMATION_JWT_EXPIRY_SECONDS}s`)
-    .sign(getInternalJwtSecret());
+    .encrypt(getInternalJweKey());
 
   return { token, nonce };
 }
@@ -68,7 +89,7 @@ export async function verifyBankConfirmationJwt(
   token: string,
 ): Promise<VerifyBankConfirmationJwtResult> {
   try {
-    const { payload } = await jwtVerify(token, getInternalJwtSecret());
+    const { payload } = await jwtDecrypt(token, getInternalJweKey());
     return {
       valid: true,
       claims: payload as unknown as BankConfirmationJwtClaims,

--- a/packages/core/src/common/server/sign-bank-confirmation-jwt.ts
+++ b/packages/core/src/common/server/sign-bank-confirmation-jwt.ts
@@ -1,0 +1,83 @@
+import 'server-only';
+import { randomUUID } from 'node:crypto';
+import { jwtVerify, SignJWT } from 'jose';
+
+/**
+ * Carries the bank-onboarding form data + the third-party email across the confirmation
+ * email round-trip (#2288). Lives only in the email URL, never at rest in the DB — the DB row
+ * (`bank_customers.jwt_nonce`) tracks state only, no PII. See decisions D1/D6.
+ */
+export type BankConfirmationJwtPayload = {
+  ownerType: 'space' | 'person';
+  ownerId: number;
+  ownerSlug: string;
+  /** Space title or person display name — used to personalize the confirmation/verify UI. */
+  ownerLabel: string;
+  entityType: 'business' | 'individual';
+  legalName: string;
+  contactEmail: string;
+  requestedRails: string[];
+  redirectUri?: string;
+  /** Person who submitted the onboarding request (already auth-gated, D4). */
+  submitterPersonId: number;
+};
+
+export type BankConfirmationJwtClaims = BankConfirmationJwtPayload & {
+  jti: string;
+  exp: number;
+};
+
+const BANK_CONFIRMATION_JWT_EXPIRY_SECONDS = 72 * 60 * 60; // 72h, per decisions.md "Resolved"
+
+function getInternalJwtSecret(): Uint8Array {
+  const secret = process.env.INTERNAL_JWT_SECRET;
+  if (!secret) {
+    throw new Error('Missing required environment variable: INTERNAL_JWT_SECRET');
+  }
+  return new TextEncoder().encode(secret);
+}
+
+export type SignedBankConfirmationJwt = {
+  token: string;
+  /** Also stored in `bank_customers.jwt_nonce` to correlate a confirmation click back to its row. */
+  nonce: string;
+};
+
+export async function signBankConfirmationJwt(
+  payload: BankConfirmationJwtPayload,
+): Promise<SignedBankConfirmationJwt> {
+  const nonce = randomUUID();
+
+  const token = await new SignJWT({ ...payload })
+    .setProtectedHeader({ alg: 'HS256' })
+    .setJti(nonce)
+    .setIssuedAt()
+    .setExpirationTime(`${BANK_CONFIRMATION_JWT_EXPIRY_SECONDS}s`)
+    .sign(getInternalJwtSecret());
+
+  return { token, nonce };
+}
+
+export type VerifyBankConfirmationJwtResult =
+  | { valid: true; claims: BankConfirmationJwtClaims }
+  | { valid: false; reason: 'expired' | 'invalid' };
+
+export async function verifyBankConfirmationJwt(
+  token: string,
+): Promise<VerifyBankConfirmationJwtResult> {
+  try {
+    const { payload } = await jwtVerify(token, getInternalJwtSecret());
+    return {
+      valid: true,
+      claims: payload as unknown as BankConfirmationJwtClaims,
+    };
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      error.name === 'JWTExpired'
+    ) {
+      return { valid: false, reason: 'expired' };
+    }
+    return { valid: false, reason: 'invalid' };
+  }
+}

--- a/packages/epics/src/banking/components/banking-initial-setup.tsx
+++ b/packages/epics/src/banking/components/banking-initial-setup.tsx
@@ -5,6 +5,7 @@ import { Loader2 } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { Button, Input, Label } from '@hypha-platform/ui';
 import { cn } from '@hypha-platform/ui-utils';
+import { isBypassEligible } from '@hypha-platform/core/client';
 
 import {
   BANK_CURRENCY_METAS,
@@ -130,6 +131,11 @@ export const BankingInitialSetup: FC<BankingInitialSetupProps> = ({
               required
               disabled={isSubmitting}
             />
+            <p className="text-1 text-muted-foreground">
+              {isBypassEligible(initialContactEmail, contactEmail)
+                ? t('bypassEligibleHint')
+                : t('confirmationRequiredHint')}
+            </p>
           </div>
         </div>
       </section>

--- a/packages/epics/src/banking/components/banking-section.tsx
+++ b/packages/epics/src/banking/components/banking-section.tsx
@@ -39,6 +39,7 @@ import { CreateTransferDialog } from './create-transfer-dialog';
 import { BankingInitialSetup } from './banking-initial-setup';
 import { BankingPageSkeleton } from './banking-page-skeleton';
 import { BankingProviderStatusPanel } from './banking-provider-status-panel';
+import { PendingEmailConfirmationCard } from './pending-email-confirmation-card';
 import { openBankVerificationFlowLink } from '../open-bank-verification-tos';
 
 type BankingSectionProps = {
@@ -126,6 +127,9 @@ export const BankingSection: FC<BankingSectionProps> = ({
   const [addPayoutDialogOpen, setAddPayoutDialogOpen] = useState(false);
   const [detailAccount, setDetailAccount] =
     useState<BankPayoutAccountPublic | null>(null);
+  /** #2288 — re-shows BankingInitialSetup so the submitter can retype the email and resend. */
+  const [showEmailConfirmationResend, setShowEmailConfirmationResend] =
+    useState(false);
 
   const needsProviderStatusRefresh =
     hasCustomer && status != null && !status.approvalRegistered;
@@ -224,6 +228,7 @@ export const BankingSection: FC<BankingSectionProps> = ({
         contactEmail: input.contactEmail,
         requestedRails: input.currencies,
       });
+      setShowEmailConfirmationResend(false);
       const updated = await refresh();
       openBankVerificationFlowLink(updated ?? undefined);
     },
@@ -242,7 +247,7 @@ export const BankingSection: FC<BankingSectionProps> = ({
     );
   }
 
-  if (!hasCustomer) {
+  if (!hasCustomer || (status?.pendingEmailConfirmation && showEmailConfirmationResend)) {
     if (!canManage) {
       return (
         <p className="text-2 text-muted-foreground">
@@ -258,6 +263,14 @@ export const BankingSection: FC<BankingSectionProps> = ({
         isSubmitting={isOnboarding}
         error={onboardingError}
         onSubmit={handleInitialSetupSubmit}
+      />
+    );
+  }
+
+  if (status?.pendingEmailConfirmation) {
+    return (
+      <PendingEmailConfirmationCard
+        onResend={() => setShowEmailConfirmationResend(true)}
       />
     );
   }

--- a/packages/epics/src/banking/components/banking-section.tsx
+++ b/packages/epics/src/banking/components/banking-section.tsx
@@ -247,7 +247,10 @@ export const BankingSection: FC<BankingSectionProps> = ({
     );
   }
 
-  if (!hasCustomer || (status?.pendingEmailConfirmation && showEmailConfirmationResend)) {
+  if (
+    !hasCustomer ||
+    (status?.pendingEmailConfirmation && showEmailConfirmationResend)
+  ) {
     if (!canManage) {
       return (
         <p className="text-2 text-muted-foreground">
@@ -270,7 +273,9 @@ export const BankingSection: FC<BankingSectionProps> = ({
   if (status?.pendingEmailConfirmation) {
     return (
       <PendingEmailConfirmationCard
-        onResend={() => setShowEmailConfirmationResend(true)}
+        onResend={
+          canManage ? () => setShowEmailConfirmationResend(true) : undefined
+        }
       />
     );
   }

--- a/packages/epics/src/banking/components/pending-email-confirmation-card.tsx
+++ b/packages/epics/src/banking/components/pending-email-confirmation-card.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { FC } from 'react';
+import { MailCheck } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { Button } from '@hypha-platform/ui';
+
+import { BANKING_EMPTY_STATE_CLASS } from '../banking-ui';
+
+export type PendingEmailConfirmationCardProps = {
+  /** Re-opens the setup form so the submitter can retype the email and resend (#2288, D3: rotates the nonce). */
+  onResend: () => void;
+};
+
+/**
+ * Shown instead of the normal onboarding/status UI while a #2288 email-ownership confirmation is
+ * pending — no Bridge KYC link exists yet, so there's nothing to show verification status for.
+ * Shared between space and personal onboarding (D6) — no owner-specific copy needed here.
+ */
+export const PendingEmailConfirmationCard: FC<
+  PendingEmailConfirmationCardProps
+> = ({ onResend }) => {
+  const t = useTranslations('BankingTab.pendingEmailConfirmation');
+
+  return (
+    <div className={BANKING_EMPTY_STATE_CLASS}>
+      <MailCheck className="h-8 w-8 text-muted-foreground" />
+      <p className="text-3 font-semibold text-foreground">{t('title')}</p>
+      <p className="max-w-md text-2 text-muted-foreground">
+        {t('description')}
+      </p>
+      <Button
+        type="button"
+        variant="outline"
+        colorVariant="neutral"
+        onClick={onResend}
+      >
+        {t('resendCta')}
+      </Button>
+    </div>
+  );
+};

--- a/packages/epics/src/banking/components/pending-email-confirmation-card.tsx
+++ b/packages/epics/src/banking/components/pending-email-confirmation-card.tsx
@@ -8,8 +8,12 @@ import { Button } from '@hypha-platform/ui';
 import { BANKING_EMPTY_STATE_CLASS } from '../banking-ui';
 
 export type PendingEmailConfirmationCardProps = {
-  /** Re-opens the setup form so the submitter can retype the email and resend (#2288, D3: rotates the nonce). */
-  onResend: () => void;
+  /**
+   * Re-opens the setup form so the submitter can retype the email and resend (#2288, D3: rotates
+   * the nonce). Omit for viewers who can't manage banking — resend requires filling in the form
+   * again, so it's only offered to whoever `canManage` gates the rest of this tab for.
+   */
+  onResend?: () => void;
 };
 
 /**
@@ -29,14 +33,16 @@ export const PendingEmailConfirmationCard: FC<
       <p className="max-w-md text-2 text-muted-foreground">
         {t('description')}
       </p>
-      <Button
-        type="button"
-        variant="outline"
-        colorVariant="neutral"
-        onClick={onResend}
-      >
-        {t('resendCta')}
-      </Button>
+      {onResend ? (
+        <Button
+          type="button"
+          variant="outline"
+          colorVariant="neutral"
+          onClick={onResend}
+        >
+          {t('resendCta')}
+        </Button>
+      ) : null}
     </div>
   );
 };

--- a/packages/epics/src/banking/components/profile-banking-section.tsx
+++ b/packages/epics/src/banking/components/profile-banking-section.tsx
@@ -244,7 +244,10 @@ export const ProfileBankingSection: FC<ProfileBankingSectionProps> = ({
     );
   }
 
-  if (!hasCustomer || (status?.pendingEmailConfirmation && showEmailConfirmationResend)) {
+  if (
+    !hasCustomer ||
+    (status?.pendingEmailConfirmation && showEmailConfirmationResend)
+  ) {
     if (!canManage) {
       return (
         <p className="text-2 text-muted-foreground">
@@ -268,7 +271,9 @@ export const ProfileBankingSection: FC<ProfileBankingSectionProps> = ({
   if (status?.pendingEmailConfirmation) {
     return (
       <PendingEmailConfirmationCard
-        onResend={() => setShowEmailConfirmationResend(true)}
+        onResend={
+          canManage ? () => setShowEmailConfirmationResend(true) : undefined
+        }
       />
     );
   }

--- a/packages/epics/src/banking/components/profile-banking-section.tsx
+++ b/packages/epics/src/banking/components/profile-banking-section.tsx
@@ -29,6 +29,7 @@ import { BankingAdvancedDialog } from './banking-advanced-dialog';
 import { BankingInitialSetup } from './banking-initial-setup';
 import { BankingPageSkeleton } from './banking-page-skeleton';
 import { BankingProviderStatusPanel } from './banking-provider-status-panel';
+import { PendingEmailConfirmationCard } from './pending-email-confirmation-card';
 import { CreateTransferDialog } from './create-transfer-dialog';
 import { PayoutAccountDetailDialog } from './payout-account-detail-dialog';
 import { openBankVerificationFlowLink } from '../open-bank-verification-tos';
@@ -131,6 +132,9 @@ export const ProfileBankingSection: FC<ProfileBankingSectionProps> = ({
   const [addPayoutDialogOpen, setAddPayoutDialogOpen] = useState(false);
   const [detailAccount, setDetailAccount] =
     useState<BankPayoutAccountPublic | null>(null);
+  /** #2288 — re-shows BankingInitialSetup so the submitter can retype the email and resend. */
+  const [showEmailConfirmationResend, setShowEmailConfirmationResend] =
+    useState(false);
 
   const needsProviderStatusRefresh =
     hasCustomer && status != null && !status.approvalRegistered;
@@ -223,6 +227,7 @@ export const ProfileBankingSection: FC<ProfileBankingSectionProps> = ({
         contactEmail: input.contactEmail,
         requestedRails: input.currencies,
       });
+      setShowEmailConfirmationResend(false);
       const updated = await refresh();
       openBankVerificationFlowLink(updated ?? undefined);
     },
@@ -239,7 +244,7 @@ export const ProfileBankingSection: FC<ProfileBankingSectionProps> = ({
     );
   }
 
-  if (!hasCustomer) {
+  if (!hasCustomer || (status?.pendingEmailConfirmation && showEmailConfirmationResend)) {
     if (!canManage) {
       return (
         <p className="text-2 text-muted-foreground">
@@ -256,6 +261,14 @@ export const ProfileBankingSection: FC<ProfileBankingSectionProps> = ({
         error={onboardingError}
         ownerContext="person"
         onSubmit={handleInitialSetupSubmit}
+      />
+    );
+  }
+
+  if (status?.pendingEmailConfirmation) {
+    return (
+      <PendingEmailConfirmationCard
+        onResend={() => setShowEmailConfirmationResend(true)}
       />
     );
   }

--- a/packages/epics/src/banking/hooks/types.ts
+++ b/packages/epics/src/banking/hooks/types.ts
@@ -88,6 +88,8 @@ export type BankCustomerPublicStatus = {
   railStatuses: BankRailPublicStatus[];
   requestedRails: string[];
   pendingRequirements?: BankPendingRequirements;
+  /** Set when a #2288 email-ownership confirmation is pending — no Bridge KYC link exists yet. */
+  pendingEmailConfirmation?: { requestedRails: string[] };
 };
 
 export type ProviderFormData = {

--- a/packages/i18n/src/messages/de.json
+++ b/packages/i18n/src/messages/de.json
@@ -1105,7 +1105,9 @@
         "organizationHint": "Ihre Angaben werden zur Verifizierung an unseren Banking-Partner übermittelt und nicht auf Hypha gespeichert.",
         "legalName": "Vollständiger Name",
         "currenciesDescription": "Wählen Sie die Währungen aus, die Sie für Bankauszahlungen verwenden möchten. Sie werden einmalig von unserem Banking-Partner verifiziert."
-      }
+      },
+      "bypassEligibleHint": "This is your own verified email — no extra confirmation step needed.",
+      "confirmationRequiredHint": "We'll send a confirmation link to this address before enabling it, since it's not your own verified email on file."
     },
     "corridors": {
       "provisioning": "Wird eingerichtet…",
@@ -1254,6 +1256,12 @@
         "simulateFillingKybRequiredData": "Ausfüllen der erforderlichen KYC-Daten simulieren",
         "cta": "KYC-Freigabe simulieren"
       }
+    },
+    "pendingEmailConfirmation": {
+      "title": "Confirm your Bridge customer email",
+      "description": "We sent a confirmation link to the email address you entered. Click it to continue setting up banking — we won't contact Bridge until you confirm.",
+      "resendCta": "Resend confirmation email",
+      "resending": "Resending…"
     }
   },
   "TreasuryTab": {
@@ -4407,5 +4415,19 @@
     "support": "Der ruhige Workspace für kollektives Handeln — Governance, Treasury und Community an einem Ort.",
     "ctaEnter": "Eintreten",
     "ctaExplore": "Netzwerk erkunden"
+  },
+  "VerifyBanking": {
+    "loadingTitle": "Confirming your email…",
+    "loadingDescription": "Hang tight while we verify your confirmation link.",
+    "successTitle": "Email confirmed",
+    "successDescription": "Thanks — {ownerLabel} can now continue with Bridge verification.",
+    "errorExpiredTitle": "Link expired",
+    "errorExpiredDescription": "This confirmation link has expired. Go back to Banking settings and resend it.",
+    "errorInvalidTitle": "Link no longer valid",
+    "errorInvalidDescription": "This confirmation link is no longer valid — it may have already been used, or replaced by a newer request.",
+    "errorAlreadyConfirmedTitle": "Already confirmed",
+    "errorAlreadyConfirmedDescription": "This email has already been confirmed.",
+    "errorGenericTitle": "Something went wrong",
+    "errorGenericDescription": "We could not confirm this email. Please try again later."
   }
 }

--- a/packages/i18n/src/messages/de.json
+++ b/packages/i18n/src/messages/de.json
@@ -1051,7 +1051,7 @@
     },
     "tosStatus": {
       "pending": {
-        "title": "Bedingungen nicht akzeptiert",
+        "title": "Verifizierung nicht gestartet",
         "description": "Akzeptieren Sie die Nutzungsbedingungen, um fortzufahren."
       },
       "approved": {
@@ -1095,7 +1095,7 @@
       "organizationLegend": "Organisationsdetails",
       "organizationHint": "Organisationsdetails werden zur Verifizierung an unseren Banking-Partner übermittelt und nicht auf Hypha gespeichert.",
       "legalName": "Rechtlicher Name der Organisation",
-      "contactEmail": "Kontakt-E-Mail",
+      "contactEmail": "Bridge-Kunden-E-Mail",
       "currenciesTitle": "Gewünschte Währungen",
       "currenciesDescription": "Wählen Sie die Währungen, die dieser Space für Bankeinzahlungen und Auszahlungen verwenden soll. Ihre Organisation wird einmalig von unserem Banking-Partner verifiziert.",
       "currenciesHint": "Weitere Währungen können Sie später in den Banking-Einstellungen hinzufügen.",
@@ -1106,8 +1106,8 @@
         "legalName": "Vollständiger Name",
         "currenciesDescription": "Wählen Sie die Währungen aus, die Sie für Bankauszahlungen verwenden möchten. Sie werden einmalig von unserem Banking-Partner verifiziert."
       },
-      "bypassEligibleHint": "This is your own verified email — no extra confirmation step needed.",
-      "confirmationRequiredHint": "We'll send a confirmation link to this address before enabling it, since it's not your own verified email on file."
+      "bypassEligibleHint": "Dies ist Ihre eigene verifizierte E-Mail-Adresse — kein zusätzlicher Bestätigungsschritt erforderlich.",
+      "confirmationRequiredHint": "Wir senden einen Bestätigungslink an diese Adresse, bevor sie aktiviert wird, da dies nicht Ihre eigene hinterlegte, verifizierte E-Mail-Adresse ist."
     },
     "corridors": {
       "provisioning": "Wird eingerichtet…",
@@ -1258,10 +1258,10 @@
       }
     },
     "pendingEmailConfirmation": {
-      "title": "Confirm your Bridge customer email",
-      "description": "We sent a confirmation link to the email address you entered. Click it to continue setting up banking — we won't contact Bridge until you confirm.",
-      "resendCta": "Resend confirmation email",
-      "resending": "Resending…"
+      "title": "Bestätigen Sie Ihre Bridge-Kunden-E-Mail",
+      "description": "Wir haben einen Bestätigungslink an die von Ihnen eingegebene E-Mail-Adresse gesendet. Klicken Sie darauf, um mit der Einrichtung des Bankings fortzufahren — wir kontaktieren Bridge erst, wenn Sie bestätigt haben.",
+      "resendCta": "Bestätigungs-E-Mail erneut senden",
+      "resending": "Wird erneut gesendet…"
     }
   },
   "TreasuryTab": {
@@ -4417,17 +4417,17 @@
     "ctaExplore": "Netzwerk erkunden"
   },
   "VerifyBanking": {
-    "loadingTitle": "Confirming your email…",
-    "loadingDescription": "Hang tight while we verify your confirmation link.",
-    "successTitle": "Email confirmed",
-    "successDescription": "Thanks — {ownerLabel} can now continue with Bridge verification.",
-    "errorExpiredTitle": "Link expired",
-    "errorExpiredDescription": "This confirmation link has expired. Go back to Banking settings and resend it.",
-    "errorInvalidTitle": "Link no longer valid",
-    "errorInvalidDescription": "This confirmation link is no longer valid — it may have already been used, or replaced by a newer request.",
-    "errorAlreadyConfirmedTitle": "Already confirmed",
-    "errorAlreadyConfirmedDescription": "This email has already been confirmed.",
-    "errorGenericTitle": "Something went wrong",
-    "errorGenericDescription": "We could not confirm this email. Please try again later."
+    "loadingTitle": "E-Mail wird bestätigt…",
+    "loadingDescription": "Einen Moment, wir überprüfen Ihren Bestätigungslink.",
+    "successTitle": "E-Mail bestätigt",
+    "successDescription": "Danke — {ownerLabel} kann nun mit der Bridge-Verifizierung fortfahren.",
+    "errorExpiredTitle": "Link abgelaufen",
+    "errorExpiredDescription": "Dieser Bestätigungslink ist abgelaufen. Gehen Sie zurück zu den Banking-Einstellungen und senden Sie ihn erneut.",
+    "errorInvalidTitle": "Link nicht mehr gültig",
+    "errorInvalidDescription": "Dieser Bestätigungslink ist nicht mehr gültig — er wurde möglicherweise bereits verwendet oder durch eine neuere Anfrage ersetzt.",
+    "errorAlreadyConfirmedTitle": "Bereits bestätigt",
+    "errorAlreadyConfirmedDescription": "Diese E-Mail-Adresse wurde bereits bestätigt.",
+    "errorGenericTitle": "Etwas ist schiefgelaufen",
+    "errorGenericDescription": "Wir konnten diese E-Mail-Adresse nicht bestätigen. Bitte versuchen Sie es später erneut."
   }
 }

--- a/packages/i18n/src/messages/en.json
+++ b/packages/i18n/src/messages/en.json
@@ -982,7 +982,7 @@
     },
     "tosStatus": {
       "pending": {
-        "title": "Terms not accepted",
+        "title": "Verification not started",
         "description": "Accept the terms of service to continue."
       },
       "approved": {
@@ -1026,7 +1026,9 @@
       "organizationLegend": "Organization details",
       "organizationHint": "Organization details are sent to our banking partner for verification and are not stored on Hypha.",
       "legalName": "Legal entity name",
-      "contactEmail": "Contact email",
+      "contactEmail": "Bridge customer email",
+      "bypassEligibleHint": "This is your own verified email — no extra confirmation step needed.",
+      "confirmationRequiredHint": "We'll send a confirmation link to this address before enabling it, since it's not your own verified email on file.",
       "currenciesTitle": "Currencies you want to use",
       "currenciesDescription": "Select the currencies this space will use for bank deposits and payouts. Your organization will be verified once with our banking partner.",
       "currenciesHint": "You can add more currencies later from Banking settings.",
@@ -1037,6 +1039,12 @@
         "legalName": "Full name",
         "currenciesDescription": "Select the currencies you want to use for bank payouts. You'll be verified once with our banking partner."
       }
+    },
+    "pendingEmailConfirmation": {
+      "title": "Confirm your Bridge customer email",
+      "description": "We sent a confirmation link to the email address you entered. Click it to continue setting up banking — we won't contact Bridge until you confirm.",
+      "resendCta": "Resend confirmation email",
+      "resending": "Resending…"
     },
     "notStarted": {
       "description": "Banking is not set up for this space yet.",
@@ -4415,5 +4423,19 @@
     "support": "The calm workspace for collective action — governance, treasury, and community in one place.",
     "ctaEnter": "Enter",
     "ctaExplore": "Explore network"
+  },
+  "VerifyBanking": {
+    "loadingTitle": "Confirming your email…",
+    "loadingDescription": "Hang tight while we verify your confirmation link.",
+    "successTitle": "Email confirmed",
+    "successDescription": "Thanks — {ownerLabel} can now continue with Bridge verification.",
+    "errorExpiredTitle": "Link expired",
+    "errorExpiredDescription": "This confirmation link has expired. Go back to Banking settings and resend it.",
+    "errorInvalidTitle": "Link no longer valid",
+    "errorInvalidDescription": "This confirmation link is no longer valid — it may have already been used, or replaced by a newer request.",
+    "errorAlreadyConfirmedTitle": "Already confirmed",
+    "errorAlreadyConfirmedDescription": "This email has already been confirmed.",
+    "errorGenericTitle": "Something went wrong",
+    "errorGenericDescription": "We could not confirm this email. Please try again later."
   }
 }

--- a/packages/i18n/src/messages/es.json
+++ b/packages/i18n/src/messages/es.json
@@ -3532,7 +3532,7 @@
     },
     "tosStatus": {
       "pending": {
-        "title": "Términos no aceptados",
+        "title": "Verificación no iniciada",
         "description": "Acepte los términos del servicio para continuar."
       },
       "approved": {
@@ -3576,7 +3576,7 @@
       "organizationLegend": "Datos de la organización",
       "organizationHint": "Los datos de la organización se envían a nuestro socio bancario para verificación y no se almacenan en Hypha.",
       "legalName": "Nombre legal de la entidad",
-      "contactEmail": "Correo de contacto",
+      "contactEmail": "Correo del cliente de Bridge",
       "currenciesTitle": "Monedas que desea utilizar",
       "currenciesDescription": "Seleccione las monedas que este space utilizará para depósitos y pagos bancarios. Su organización será verificada una vez con nuestro socio bancario.",
       "currenciesHint": "Puede añadir más monedas más tarde desde la configuración bancaria.",
@@ -3587,8 +3587,8 @@
         "legalName": "Nombre completo",
         "currenciesDescription": "Seleccione las monedas que desea utilizar para pagos bancarios. Será verificado una vez con nuestro socio bancario."
       },
-      "bypassEligibleHint": "This is your own verified email — no extra confirmation step needed.",
-      "confirmationRequiredHint": "We'll send a confirmation link to this address before enabling it, since it's not your own verified email on file."
+      "bypassEligibleHint": "Este es su propio correo verificado — no se necesita un paso de confirmación adicional.",
+      "confirmationRequiredHint": "Enviaremos un enlace de confirmación a esta dirección antes de habilitarla, ya que no es su propio correo verificado registrado."
     },
     "notStarted": {
       "description": "La banca aún no está configurada para este space.",
@@ -3807,10 +3807,10 @@
       }
     },
     "pendingEmailConfirmation": {
-      "title": "Confirm your Bridge customer email",
-      "description": "We sent a confirmation link to the email address you entered. Click it to continue setting up banking — we won't contact Bridge until you confirm.",
-      "resendCta": "Resend confirmation email",
-      "resending": "Resending…"
+      "title": "Confirme su correo del cliente de Bridge",
+      "description": "Enviamos un enlace de confirmación a la dirección de correo que ingresó. Haga clic en él para continuar con la configuración bancaria — no contactaremos a Bridge hasta que confirme.",
+      "resendCta": "Reenviar correo de confirmación",
+      "resending": "Reenviando…"
     }
   },
   "Calendar": {
@@ -4417,17 +4417,17 @@
     "ctaExplore": "Explorar red"
   },
   "VerifyBanking": {
-    "loadingTitle": "Confirming your email…",
-    "loadingDescription": "Hang tight while we verify your confirmation link.",
-    "successTitle": "Email confirmed",
-    "successDescription": "Thanks — {ownerLabel} can now continue with Bridge verification.",
-    "errorExpiredTitle": "Link expired",
-    "errorExpiredDescription": "This confirmation link has expired. Go back to Banking settings and resend it.",
-    "errorInvalidTitle": "Link no longer valid",
-    "errorInvalidDescription": "This confirmation link is no longer valid — it may have already been used, or replaced by a newer request.",
-    "errorAlreadyConfirmedTitle": "Already confirmed",
-    "errorAlreadyConfirmedDescription": "This email has already been confirmed.",
-    "errorGenericTitle": "Something went wrong",
-    "errorGenericDescription": "We could not confirm this email. Please try again later."
+    "loadingTitle": "Confirmando su correo…",
+    "loadingDescription": "Espere un momento mientras verificamos su enlace de confirmación.",
+    "successTitle": "Correo confirmado",
+    "successDescription": "Gracias — {ownerLabel} ya puede continuar con la verificación de Bridge.",
+    "errorExpiredTitle": "Enlace expirado",
+    "errorExpiredDescription": "Este enlace de confirmación ha expirado. Vuelva a la configuración de Banca y reenvíelo.",
+    "errorInvalidTitle": "Enlace ya no válido",
+    "errorInvalidDescription": "Este enlace de confirmación ya no es válido — es posible que ya se haya usado o que haya sido reemplazado por una solicitud más reciente.",
+    "errorAlreadyConfirmedTitle": "Ya confirmado",
+    "errorAlreadyConfirmedDescription": "Este correo ya ha sido confirmado.",
+    "errorGenericTitle": "Algo salió mal",
+    "errorGenericDescription": "No pudimos confirmar este correo. Inténtelo de nuevo más tarde."
   }
 }

--- a/packages/i18n/src/messages/es.json
+++ b/packages/i18n/src/messages/es.json
@@ -3586,7 +3586,9 @@
         "organizationHint": "Sus datos se envían a nuestro socio bancario para verificación y no se almacenan en Hypha.",
         "legalName": "Nombre completo",
         "currenciesDescription": "Seleccione las monedas que desea utilizar para pagos bancarios. Será verificado una vez con nuestro socio bancario."
-      }
+      },
+      "bypassEligibleHint": "This is your own verified email — no extra confirmation step needed.",
+      "confirmationRequiredHint": "We'll send a confirmation link to this address before enabling it, since it's not your own verified email on file."
     },
     "notStarted": {
       "description": "La banca aún no está configurada para este space.",
@@ -3803,6 +3805,12 @@
         "title": "Estado no disponible",
         "description": "No pudimos determinar el estado de verificación actual. Intente actualizar."
       }
+    },
+    "pendingEmailConfirmation": {
+      "title": "Confirm your Bridge customer email",
+      "description": "We sent a confirmation link to the email address you entered. Click it to continue setting up banking — we won't contact Bridge until you confirm.",
+      "resendCta": "Resend confirmation email",
+      "resending": "Resending…"
     }
   },
   "Calendar": {
@@ -4407,5 +4415,19 @@
     "support": "El espacio de trabajo calmado para la acción colectiva.",
     "ctaEnter": "Entrar",
     "ctaExplore": "Explorar red"
+  },
+  "VerifyBanking": {
+    "loadingTitle": "Confirming your email…",
+    "loadingDescription": "Hang tight while we verify your confirmation link.",
+    "successTitle": "Email confirmed",
+    "successDescription": "Thanks — {ownerLabel} can now continue with Bridge verification.",
+    "errorExpiredTitle": "Link expired",
+    "errorExpiredDescription": "This confirmation link has expired. Go back to Banking settings and resend it.",
+    "errorInvalidTitle": "Link no longer valid",
+    "errorInvalidDescription": "This confirmation link is no longer valid — it may have already been used, or replaced by a newer request.",
+    "errorAlreadyConfirmedTitle": "Already confirmed",
+    "errorAlreadyConfirmedDescription": "This email has already been confirmed.",
+    "errorGenericTitle": "Something went wrong",
+    "errorGenericDescription": "We could not confirm this email. Please try again later."
   }
 }

--- a/packages/i18n/src/messages/fr.json
+++ b/packages/i18n/src/messages/fr.json
@@ -3528,7 +3528,7 @@
     },
     "tosStatus": {
       "pending": {
-        "title": "Conditions non acceptées",
+        "title": "Vérification non commencée",
         "description": "Acceptez les conditions d'utilisation pour continuer."
       },
       "approved": {
@@ -3572,7 +3572,7 @@
       "organizationLegend": "Informations sur l'organisation",
       "organizationHint": "Les informations sur l'organisation sont envoyées à notre partenaire bancaire pour vérification et ne sont pas stockées sur Hypha.",
       "legalName": "Nom légal de l'entité",
-      "contactEmail": "E-mail de contact",
+      "contactEmail": "E-mail du client Bridge",
       "currenciesTitle": "Devises que vous souhaitez utiliser",
       "currenciesDescription": "Sélectionnez les devises que cet espace utilisera pour les dépôts et paiements bancaires. Votre organisation sera vérifiée une fois avec notre partenaire bancaire.",
       "currenciesHint": "Vous pourrez ajouter d'autres devises plus tard depuis les paramètres bancaires.",
@@ -3583,8 +3583,8 @@
         "legalName": "Nom complet",
         "currenciesDescription": "Sélectionnez les devises que vous souhaitez utiliser pour les paiements bancaires. Vous serez vérifié une fois avec notre partenaire bancaire."
       },
-      "bypassEligibleHint": "This is your own verified email — no extra confirmation step needed.",
-      "confirmationRequiredHint": "We'll send a confirmation link to this address before enabling it, since it's not your own verified email on file."
+      "bypassEligibleHint": "Il s'agit de votre propre e-mail vérifié — aucune étape de confirmation supplémentaire n'est nécessaire.",
+      "confirmationRequiredHint": "Nous enverrons un lien de confirmation à cette adresse avant de l'activer, car ce n'est pas votre e-mail vérifié enregistré."
     },
     "notStarted": {
       "description": "Les services bancaires ne sont pas encore configurés pour ce space.",
@@ -3803,10 +3803,10 @@
       }
     },
     "pendingEmailConfirmation": {
-      "title": "Confirm your Bridge customer email",
-      "description": "We sent a confirmation link to the email address you entered. Click it to continue setting up banking — we won't contact Bridge until you confirm.",
-      "resendCta": "Resend confirmation email",
-      "resending": "Resending…"
+      "title": "Confirmez votre e-mail client Bridge",
+      "description": "Nous avons envoyé un lien de confirmation à l'adresse e-mail que vous avez indiquée. Cliquez dessus pour continuer la configuration bancaire — nous ne contacterons pas Bridge tant que vous n'aurez pas confirmé.",
+      "resendCta": "Renvoyer l'e-mail de confirmation",
+      "resending": "Envoi en cours…"
     }
   },
   "Calendar": {
@@ -4413,17 +4413,17 @@
     "ctaExplore": "Explorer le réseau"
   },
   "VerifyBanking": {
-    "loadingTitle": "Confirming your email…",
-    "loadingDescription": "Hang tight while we verify your confirmation link.",
-    "successTitle": "Email confirmed",
-    "successDescription": "Thanks — {ownerLabel} can now continue with Bridge verification.",
-    "errorExpiredTitle": "Link expired",
-    "errorExpiredDescription": "This confirmation link has expired. Go back to Banking settings and resend it.",
-    "errorInvalidTitle": "Link no longer valid",
-    "errorInvalidDescription": "This confirmation link is no longer valid — it may have already been used, or replaced by a newer request.",
-    "errorAlreadyConfirmedTitle": "Already confirmed",
-    "errorAlreadyConfirmedDescription": "This email has already been confirmed.",
-    "errorGenericTitle": "Something went wrong",
-    "errorGenericDescription": "We could not confirm this email. Please try again later."
+    "loadingTitle": "Confirmation de votre e-mail…",
+    "loadingDescription": "Un instant, nous vérifions votre lien de confirmation.",
+    "successTitle": "E-mail confirmé",
+    "successDescription": "Merci — {ownerLabel} peut désormais poursuivre la vérification Bridge.",
+    "errorExpiredTitle": "Lien expiré",
+    "errorExpiredDescription": "Ce lien de confirmation a expiré. Retournez aux paramètres bancaires et renvoyez-le.",
+    "errorInvalidTitle": "Lien non valide",
+    "errorInvalidDescription": "Ce lien de confirmation n'est plus valide — il a peut-être déjà été utilisé ou remplacé par une demande plus récente.",
+    "errorAlreadyConfirmedTitle": "Déjà confirmé",
+    "errorAlreadyConfirmedDescription": "Cet e-mail a déjà été confirmé.",
+    "errorGenericTitle": "Un problème est survenu",
+    "errorGenericDescription": "Nous n'avons pas pu confirmer cet e-mail. Veuillez réessayer plus tard."
   }
 }

--- a/packages/i18n/src/messages/fr.json
+++ b/packages/i18n/src/messages/fr.json
@@ -3582,7 +3582,9 @@
         "organizationHint": "Vos informations sont envoyées à notre partenaire bancaire pour vérification et ne sont pas stockées sur Hypha.",
         "legalName": "Nom complet",
         "currenciesDescription": "Sélectionnez les devises que vous souhaitez utiliser pour les paiements bancaires. Vous serez vérifié une fois avec notre partenaire bancaire."
-      }
+      },
+      "bypassEligibleHint": "This is your own verified email — no extra confirmation step needed.",
+      "confirmationRequiredHint": "We'll send a confirmation link to this address before enabling it, since it's not your own verified email on file."
     },
     "notStarted": {
       "description": "Les services bancaires ne sont pas encore configurés pour ce space.",
@@ -3799,6 +3801,12 @@
         "title": "Statut indisponible",
         "description": "Impossible de déterminer le statut de vérification actuel. Essayez d'actualiser."
       }
+    },
+    "pendingEmailConfirmation": {
+      "title": "Confirm your Bridge customer email",
+      "description": "We sent a confirmation link to the email address you entered. Click it to continue setting up banking — we won't contact Bridge until you confirm.",
+      "resendCta": "Resend confirmation email",
+      "resending": "Resending…"
     }
   },
   "Calendar": {
@@ -4403,5 +4411,19 @@
     "support": "L’espace de travail calme pour l’action collective — gouvernance, trésorerie et communauté.",
     "ctaEnter": "Entrer",
     "ctaExplore": "Explorer le réseau"
+  },
+  "VerifyBanking": {
+    "loadingTitle": "Confirming your email…",
+    "loadingDescription": "Hang tight while we verify your confirmation link.",
+    "successTitle": "Email confirmed",
+    "successDescription": "Thanks — {ownerLabel} can now continue with Bridge verification.",
+    "errorExpiredTitle": "Link expired",
+    "errorExpiredDescription": "This confirmation link has expired. Go back to Banking settings and resend it.",
+    "errorInvalidTitle": "Link no longer valid",
+    "errorInvalidDescription": "This confirmation link is no longer valid — it may have already been used, or replaced by a newer request.",
+    "errorAlreadyConfirmedTitle": "Already confirmed",
+    "errorAlreadyConfirmedDescription": "This email has already been confirmed.",
+    "errorGenericTitle": "Something went wrong",
+    "errorGenericDescription": "We could not confirm this email. Please try again later."
   }
 }

--- a/packages/i18n/src/messages/mk.json
+++ b/packages/i18n/src/messages/mk.json
@@ -1016,7 +1016,9 @@
         "organizationHint": "Your details are sent to our banking partner for verification and are not stored on Hypha.",
         "legalName": "Full name",
         "currenciesDescription": "Select the currencies you want to use for bank payouts. You'll be verified once with our banking partner."
-      }
+      },
+      "bypassEligibleHint": "This is your own verified email — no extra confirmation step needed.",
+      "confirmationRequiredHint": "We'll send a confirmation link to this address before enabling it, since it's not your own verified email on file."
     },
     "notStarted": {
       "description": "Банкарството сè уште не е поставено за овој простор.",
@@ -1233,6 +1235,12 @@
         "title": "Статусот не е достапен",
         "description": "Не можевме да го утврдиме тековниот статус на верификацијата. Обидете се да освежите."
       }
+    },
+    "pendingEmailConfirmation": {
+      "title": "Confirm your Bridge customer email",
+      "description": "We sent a confirmation link to the email address you entered. Click it to continue setting up banking — we won't contact Bridge until you confirm.",
+      "resendCta": "Resend confirmation email",
+      "resending": "Resending…"
     }
   },
   "TreasuryTab": {
@@ -4394,5 +4402,19 @@
     "support": "Мирниот работен простор за колективно дејствување.",
     "ctaEnter": "Влези",
     "ctaExplore": "Истражи мрежа"
+  },
+  "VerifyBanking": {
+    "loadingTitle": "Confirming your email…",
+    "loadingDescription": "Hang tight while we verify your confirmation link.",
+    "successTitle": "Email confirmed",
+    "successDescription": "Thanks — {ownerLabel} can now continue with Bridge verification.",
+    "errorExpiredTitle": "Link expired",
+    "errorExpiredDescription": "This confirmation link has expired. Go back to Banking settings and resend it.",
+    "errorInvalidTitle": "Link no longer valid",
+    "errorInvalidDescription": "This confirmation link is no longer valid — it may have already been used, or replaced by a newer request.",
+    "errorAlreadyConfirmedTitle": "Already confirmed",
+    "errorAlreadyConfirmedDescription": "This email has already been confirmed.",
+    "errorGenericTitle": "Something went wrong",
+    "errorGenericDescription": "We could not confirm this email. Please try again later."
   }
 }

--- a/packages/i18n/src/messages/mk.json
+++ b/packages/i18n/src/messages/mk.json
@@ -1009,13 +1009,13 @@
       "currenciesDescription": "Изберете ги валутите што овој простор ќе ги користи за банкарски депозити и исплати. Вашата организација ќе биде верификувана еднаш кај нашиот банкарски партнер.",
       "currenciesHint": "Можете да додадете повеќе валути подоцна од Банкарските поставки.",
       "submit": "Продолжи",
-      "legalName": "Legal entity name",
+      "legalName": "Правно име на субјектот",
       "contactEmail": "Е-пошта на клиентот на Bridge",
       "person": {
-        "organizationLegend": "Your details",
-        "organizationHint": "Your details are sent to our banking partner for verification and are not stored on Hypha.",
-        "legalName": "Full name",
-        "currenciesDescription": "Select the currencies you want to use for bank payouts. You'll be verified once with our banking partner."
+        "organizationLegend": "Вашите податоци",
+        "organizationHint": "Вашите податоци се испраќаат до нашиот банкарски партнер за верификација и не се чуваат на Hypha.",
+        "legalName": "Целосно име",
+        "currenciesDescription": "Изберете ги валутите што сакате да ги користите за банкарски исплати. Ќе бидете верификувани еднаш кај нашиот банкарски партнер."
       },
       "bypassEligibleHint": "Ова е вашата сопствена верификувана е-пошта — не е потребен дополнителен чекор за потврда.",
       "confirmationRequiredHint": "Ќе испратиме линк за потврда на оваа адреса пред да ја овозможиме, бидејќи не е вашата сопствена верификувана е-пошта."

--- a/packages/i18n/src/messages/mk.json
+++ b/packages/i18n/src/messages/mk.json
@@ -962,7 +962,7 @@
     },
     "tosStatus": {
       "pending": {
-        "title": "Условите не се прифатени",
+        "title": "Верификацијата не е започната",
         "description": "Прифатете ги условите за користење за да продолжите."
       },
       "approved": {
@@ -1010,15 +1010,15 @@
       "currenciesHint": "Можете да додадете повеќе валути подоцна од Банкарските поставки.",
       "submit": "Продолжи",
       "legalName": "Legal entity name",
-      "contactEmail": "Contact email",
+      "contactEmail": "Е-пошта на клиентот на Bridge",
       "person": {
         "organizationLegend": "Your details",
         "organizationHint": "Your details are sent to our banking partner for verification and are not stored on Hypha.",
         "legalName": "Full name",
         "currenciesDescription": "Select the currencies you want to use for bank payouts. You'll be verified once with our banking partner."
       },
-      "bypassEligibleHint": "This is your own verified email — no extra confirmation step needed.",
-      "confirmationRequiredHint": "We'll send a confirmation link to this address before enabling it, since it's not your own verified email on file."
+      "bypassEligibleHint": "Ова е вашата сопствена верификувана е-пошта — не е потребен дополнителен чекор за потврда.",
+      "confirmationRequiredHint": "Ќе испратиме линк за потврда на оваа адреса пред да ја овозможиме, бидејќи не е вашата сопствена верификувана е-пошта."
     },
     "notStarted": {
       "description": "Банкарството сè уште не е поставено за овој простор.",
@@ -1237,10 +1237,10 @@
       }
     },
     "pendingEmailConfirmation": {
-      "title": "Confirm your Bridge customer email",
-      "description": "We sent a confirmation link to the email address you entered. Click it to continue setting up banking — we won't contact Bridge until you confirm.",
-      "resendCta": "Resend confirmation email",
-      "resending": "Resending…"
+      "title": "Потврдете ја вашата е-пошта на клиентот на Bridge",
+      "description": "Испративме линк за потврда на е-поштата што ја внесовте. Кликнете на него за да продолжите со поставувањето на банкарството — нема да контактираме со Bridge додека не потврдите.",
+      "resendCta": "Испрати ја повторно е-поштата за потврда",
+      "resending": "Се испраќа повторно…"
     }
   },
   "TreasuryTab": {
@@ -4404,17 +4404,17 @@
     "ctaExplore": "Истражи мрежа"
   },
   "VerifyBanking": {
-    "loadingTitle": "Confirming your email…",
-    "loadingDescription": "Hang tight while we verify your confirmation link.",
-    "successTitle": "Email confirmed",
-    "successDescription": "Thanks — {ownerLabel} can now continue with Bridge verification.",
-    "errorExpiredTitle": "Link expired",
-    "errorExpiredDescription": "This confirmation link has expired. Go back to Banking settings and resend it.",
-    "errorInvalidTitle": "Link no longer valid",
-    "errorInvalidDescription": "This confirmation link is no longer valid — it may have already been used, or replaced by a newer request.",
-    "errorAlreadyConfirmedTitle": "Already confirmed",
-    "errorAlreadyConfirmedDescription": "This email has already been confirmed.",
-    "errorGenericTitle": "Something went wrong",
-    "errorGenericDescription": "We could not confirm this email. Please try again later."
+    "loadingTitle": "Ја потврдуваме вашата е-пошта…",
+    "loadingDescription": "Почекајте додека го верификуваме вашиот линк за потврда.",
+    "successTitle": "Е-поштата е потврдена",
+    "successDescription": "Ви благодариме — {ownerLabel} сега може да продолжи со верификацијата на Bridge.",
+    "errorExpiredTitle": "Линкот истече",
+    "errorExpiredDescription": "Овој линк за потврда истече. Вратете се во поставките за банкарство и испратете го повторно.",
+    "errorInvalidTitle": "Линкот повеќе не е валиден",
+    "errorInvalidDescription": "Овој линк за потврда повеќе не е валиден — можеби веќе бил искористен или заменет со поново барање.",
+    "errorAlreadyConfirmedTitle": "Веќе потврдено",
+    "errorAlreadyConfirmedDescription": "Оваа е-пошта е веќе потврдена.",
+    "errorGenericTitle": "Нешто тргна наопаку",
+    "errorGenericDescription": "Не можевме да ја потврдиме оваа е-пошта. Обидете се повторно подоцна."
   }
 }

--- a/packages/i18n/src/messages/nl.json
+++ b/packages/i18n/src/messages/nl.json
@@ -1257,7 +1257,7 @@
       }
     },
     "pendingEmailConfirmation": {
-      "title": "Bevestig uw e-mailadres van de Bridge-klant",
+      "title": "Bevestig het e-mailadres van de Bridge-klant",
       "description": "We hebben een bevestigingslink gestuurd naar het e-mailadres dat u hebt ingevoerd. Klik erop om door te gaan met het instellen van banking — we nemen pas contact op met Bridge zodra u heeft bevestigd.",
       "resendCta": "Bevestigingsmail opnieuw versturen",
       "resending": "Opnieuw verzenden…"

--- a/packages/i18n/src/messages/nl.json
+++ b/packages/i18n/src/messages/nl.json
@@ -1036,7 +1036,9 @@
         "organizationHint": "Je gegevens worden ter verificatie naar onze bankpartner gestuurd en worden niet op Hypha opgeslagen.",
         "legalName": "Volledige naam",
         "currenciesDescription": "Selecteer de valuta die u wilt gebruiken voor bankuitbetalingen. U wordt eenmalig geverifieerd bij onze bankpartner."
-      }
+      },
+      "bypassEligibleHint": "This is your own verified email — no extra confirmation step needed.",
+      "confirmationRequiredHint": "We'll send a confirmation link to this address before enabling it, since it's not your own verified email on file."
     },
     "notStarted": {
       "description": "Bankieren is nog niet ingesteld voor deze ruimte.",
@@ -1253,6 +1255,12 @@
         "title": "Status niet beschikbaar",
         "description": "We kunnen de huidige verificatiestatus niet vaststellen. Probeer te vernieuwen."
       }
+    },
+    "pendingEmailConfirmation": {
+      "title": "Confirm your Bridge customer email",
+      "description": "We sent a confirmation link to the email address you entered. Click it to continue setting up banking — we won't contact Bridge until you confirm.",
+      "resendCta": "Resend confirmation email",
+      "resending": "Resending…"
     }
   },
   "TreasuryTab": {
@@ -4413,5 +4421,19 @@
     "support": "De rustige werkruimte voor collectieve actie.",
     "ctaEnter": "Binnenkomen",
     "ctaExplore": "Netwerk verkennen"
+  },
+  "VerifyBanking": {
+    "loadingTitle": "Confirming your email…",
+    "loadingDescription": "Hang tight while we verify your confirmation link.",
+    "successTitle": "Email confirmed",
+    "successDescription": "Thanks — {ownerLabel} can now continue with Bridge verification.",
+    "errorExpiredTitle": "Link expired",
+    "errorExpiredDescription": "This confirmation link has expired. Go back to Banking settings and resend it.",
+    "errorInvalidTitle": "Link no longer valid",
+    "errorInvalidDescription": "This confirmation link is no longer valid — it may have already been used, or replaced by a newer request.",
+    "errorAlreadyConfirmedTitle": "Already confirmed",
+    "errorAlreadyConfirmedDescription": "This email has already been confirmed.",
+    "errorGenericTitle": "Something went wrong",
+    "errorGenericDescription": "We could not confirm this email. Please try again later."
   }
 }

--- a/packages/i18n/src/messages/nl.json
+++ b/packages/i18n/src/messages/nl.json
@@ -982,7 +982,7 @@
     },
     "tosStatus": {
       "pending": {
-        "title": "Voorwaarden niet geaccepteerd",
+        "title": "Verificatie nog niet gestart",
         "description": "Accepteer de servicevoorwaarden om door te gaan."
       },
       "approved": {
@@ -1026,7 +1026,7 @@
       "organizationLegend": "Organisatiegegevens",
       "organizationHint": "Organisatiegegevens worden ter verificatie naar onze bankpartner gestuurd en worden niet op Hypha opgeslagen.",
       "legalName": "Naam van juridische entiteit",
-      "contactEmail": "E-mailadres voor contact",
+      "contactEmail": "E-mailadres van de Bridge-klant",
       "currenciesTitle": "Valuta's die u wilt gebruiken",
       "currenciesDescription": "Selecteer de valuta's die deze ruimte zal gebruiken voor bankstortingen en uitbetalingen. Uw organisatie wordt eenmalig geverifieerd bij onze bankpartner.",
       "currenciesHint": "U kunt later meer valuta's toevoegen via Bankinstellingen.",
@@ -1037,8 +1037,8 @@
         "legalName": "Volledige naam",
         "currenciesDescription": "Selecteer de valuta die u wilt gebruiken voor bankuitbetalingen. U wordt eenmalig geverifieerd bij onze bankpartner."
       },
-      "bypassEligibleHint": "This is your own verified email — no extra confirmation step needed.",
-      "confirmationRequiredHint": "We'll send a confirmation link to this address before enabling it, since it's not your own verified email on file."
+      "bypassEligibleHint": "Dit is uw eigen geverifieerde e-mailadres — geen extra bevestigingsstap nodig.",
+      "confirmationRequiredHint": "We sturen een bevestigingslink naar dit adres voordat we het inschakelen, omdat dit niet uw eigen geverifieerde e-mailadres is."
     },
     "notStarted": {
       "description": "Bankieren is nog niet ingesteld voor deze ruimte.",
@@ -1257,10 +1257,10 @@
       }
     },
     "pendingEmailConfirmation": {
-      "title": "Confirm your Bridge customer email",
-      "description": "We sent a confirmation link to the email address you entered. Click it to continue setting up banking — we won't contact Bridge until you confirm.",
-      "resendCta": "Resend confirmation email",
-      "resending": "Resending…"
+      "title": "Bevestig uw e-mailadres van de Bridge-klant",
+      "description": "We hebben een bevestigingslink gestuurd naar het e-mailadres dat u hebt ingevoerd. Klik erop om door te gaan met het instellen van banking — we nemen pas contact op met Bridge zodra u heeft bevestigd.",
+      "resendCta": "Bevestigingsmail opnieuw versturen",
+      "resending": "Opnieuw verzenden…"
     }
   },
   "TreasuryTab": {
@@ -4423,17 +4423,17 @@
     "ctaExplore": "Netwerk verkennen"
   },
   "VerifyBanking": {
-    "loadingTitle": "Confirming your email…",
-    "loadingDescription": "Hang tight while we verify your confirmation link.",
-    "successTitle": "Email confirmed",
-    "successDescription": "Thanks — {ownerLabel} can now continue with Bridge verification.",
-    "errorExpiredTitle": "Link expired",
-    "errorExpiredDescription": "This confirmation link has expired. Go back to Banking settings and resend it.",
-    "errorInvalidTitle": "Link no longer valid",
-    "errorInvalidDescription": "This confirmation link is no longer valid — it may have already been used, or replaced by a newer request.",
-    "errorAlreadyConfirmedTitle": "Already confirmed",
-    "errorAlreadyConfirmedDescription": "This email has already been confirmed.",
-    "errorGenericTitle": "Something went wrong",
-    "errorGenericDescription": "We could not confirm this email. Please try again later."
+    "loadingTitle": "Uw e-mail wordt bevestigd…",
+    "loadingDescription": "Een moment geduld terwijl we uw bevestigingslink verifiëren.",
+    "successTitle": "E-mail bevestigd",
+    "successDescription": "Bedankt — {ownerLabel} kan nu doorgaan met de Bridge-verificatie.",
+    "errorExpiredTitle": "Link verlopen",
+    "errorExpiredDescription": "Deze bevestigingslink is verlopen. Ga terug naar de bankinstellingen en verstuur deze opnieuw.",
+    "errorInvalidTitle": "Link niet meer geldig",
+    "errorInvalidDescription": "Deze bevestigingslink is niet meer geldig — deze is mogelijk al gebruikt of vervangen door een nieuwer verzoek.",
+    "errorAlreadyConfirmedTitle": "Al bevestigd",
+    "errorAlreadyConfirmedDescription": "Dit e-mailadres is al bevestigd.",
+    "errorGenericTitle": "Er is iets misgegaan",
+    "errorGenericDescription": "We konden dit e-mailadres niet bevestigen. Probeer het later opnieuw."
   }
 }

--- a/packages/i18n/src/messages/no.json
+++ b/packages/i18n/src/messages/no.json
@@ -1025,7 +1025,7 @@
       "organizationLegend": "Organisasjonsdetaljer",
       "organizationHint": "Organisasjonsdetaljer sendes til bankpartneren vår for verifisering og lagres ikke på Hypha.",
       "legalName": "Juridisk enhetsnavn",
-      "contactEmail": "E-post for Bridge-kunde",
+      "contactEmail": "E-postadresse til Bridge-kunden",
       "currenciesTitle": "Valutaer du vil bruke",
       "currenciesDescription": "Velg valutaene dette rommet skal bruke til bankinnskudd og utbetalinger. Organisasjonen din verifiseres én gang hos bankpartneren vår.",
       "currenciesHint": "Du kan legge til flere valutaer senere fra Bankinnstillinger.",
@@ -1256,7 +1256,7 @@
       }
     },
     "pendingEmailConfirmation": {
-      "title": "Bekreft e-posten din for Bridge-kunde",
+      "title": "Bekreft e-postadressen til Bridge-kunden",
       "description": "Vi har sendt en bekreftelseslenke til e-postadressen du oppga. Klikk på den for å fortsette å sette opp banktjenester — vi kontakter ikke Bridge før du har bekreftet.",
       "resendCta": "Send bekreftelses-e-post på nytt",
       "resending": "Sender på nytt…"

--- a/packages/i18n/src/messages/no.json
+++ b/packages/i18n/src/messages/no.json
@@ -981,7 +981,7 @@
     },
     "tosStatus": {
       "pending": {
-        "title": "Vilkår ikke godtatt",
+        "title": "Verifisering ikke startet",
         "description": "Godta tjenestevilkårene for å fortsette."
       },
       "approved": {
@@ -1025,7 +1025,7 @@
       "organizationLegend": "Organisasjonsdetaljer",
       "organizationHint": "Organisasjonsdetaljer sendes til bankpartneren vår for verifisering og lagres ikke på Hypha.",
       "legalName": "Juridisk enhetsnavn",
-      "contactEmail": "Kontakt-e-post",
+      "contactEmail": "E-post for Bridge-kunde",
       "currenciesTitle": "Valutaer du vil bruke",
       "currenciesDescription": "Velg valutaene dette rommet skal bruke til bankinnskudd og utbetalinger. Organisasjonen din verifiseres én gang hos bankpartneren vår.",
       "currenciesHint": "Du kan legge til flere valutaer senere fra Bankinnstillinger.",
@@ -1036,8 +1036,8 @@
         "legalName": "Fullt navn",
         "currenciesDescription": "Velg valutaene du vil bruke til bankutbetalinger. Du verifiseres én gang hos bankpartneren vår."
       },
-      "bypassEligibleHint": "This is your own verified email — no extra confirmation step needed.",
-      "confirmationRequiredHint": "We'll send a confirmation link to this address before enabling it, since it's not your own verified email on file."
+      "bypassEligibleHint": "Dette er din egen verifiserte e-post — ingen ekstra bekreftelse nødvendig.",
+      "confirmationRequiredHint": "Vi sender en bekreftelseslenke til denne adressen før den aktiveres, siden det ikke er din egen registrerte, verifiserte e-post."
     },
     "notStarted": {
       "description": "Bank er ikke satt opp for dette rommet ennå.",
@@ -1256,10 +1256,10 @@
       }
     },
     "pendingEmailConfirmation": {
-      "title": "Confirm your Bridge customer email",
-      "description": "We sent a confirmation link to the email address you entered. Click it to continue setting up banking — we won't contact Bridge until you confirm.",
-      "resendCta": "Resend confirmation email",
-      "resending": "Resending…"
+      "title": "Bekreft e-posten din for Bridge-kunde",
+      "description": "Vi har sendt en bekreftelseslenke til e-postadressen du oppga. Klikk på den for å fortsette å sette opp banktjenester — vi kontakter ikke Bridge før du har bekreftet.",
+      "resendCta": "Send bekreftelses-e-post på nytt",
+      "resending": "Sender på nytt…"
     }
   },
   "TreasuryTab": {
@@ -4422,17 +4422,17 @@
     "ctaExplore": "Utforsk nettverk"
   },
   "VerifyBanking": {
-    "loadingTitle": "Confirming your email…",
-    "loadingDescription": "Hang tight while we verify your confirmation link.",
-    "successTitle": "Email confirmed",
-    "successDescription": "Thanks — {ownerLabel} can now continue with Bridge verification.",
-    "errorExpiredTitle": "Link expired",
-    "errorExpiredDescription": "This confirmation link has expired. Go back to Banking settings and resend it.",
-    "errorInvalidTitle": "Link no longer valid",
-    "errorInvalidDescription": "This confirmation link is no longer valid — it may have already been used, or replaced by a newer request.",
-    "errorAlreadyConfirmedTitle": "Already confirmed",
-    "errorAlreadyConfirmedDescription": "This email has already been confirmed.",
-    "errorGenericTitle": "Something went wrong",
-    "errorGenericDescription": "We could not confirm this email. Please try again later."
+    "loadingTitle": "Bekrefter e-posten din…",
+    "loadingDescription": "Vent litt mens vi verifiserer bekreftelseslenken din.",
+    "successTitle": "E-post bekreftet",
+    "successDescription": "Takk — {ownerLabel} kan nå fortsette med Bridge-verifiseringen.",
+    "errorExpiredTitle": "Lenken har utløpt",
+    "errorExpiredDescription": "Denne bekreftelseslenken har utløpt. Gå tilbake til bankinnstillingene og send den på nytt.",
+    "errorInvalidTitle": "Lenken er ikke lenger gyldig",
+    "errorInvalidDescription": "Denne bekreftelseslenken er ikke lenger gyldig — den kan allerede være brukt, eller erstattet av en nyere forespørsel.",
+    "errorAlreadyConfirmedTitle": "Allerede bekreftet",
+    "errorAlreadyConfirmedDescription": "Denne e-posten er allerede bekreftet.",
+    "errorGenericTitle": "Noe gikk galt",
+    "errorGenericDescription": "Vi kunne ikke bekrefte denne e-posten. Prøv igjen senere."
   }
 }

--- a/packages/i18n/src/messages/no.json
+++ b/packages/i18n/src/messages/no.json
@@ -1035,7 +1035,9 @@
         "organizationHint": "Detaljene dine sendes til bankpartneren vår for verifisering og lagres ikke på Hypha.",
         "legalName": "Fullt navn",
         "currenciesDescription": "Velg valutaene du vil bruke til bankutbetalinger. Du verifiseres én gang hos bankpartneren vår."
-      }
+      },
+      "bypassEligibleHint": "This is your own verified email — no extra confirmation step needed.",
+      "confirmationRequiredHint": "We'll send a confirmation link to this address before enabling it, since it's not your own verified email on file."
     },
     "notStarted": {
       "description": "Bank er ikke satt opp for dette rommet ennå.",
@@ -1252,6 +1254,12 @@
         "title": "Status utilgjengelig",
         "description": "Vi kunne ikke fastslå gjeldende verifiseringsstatus. Prøv å oppdatere."
       }
+    },
+    "pendingEmailConfirmation": {
+      "title": "Confirm your Bridge customer email",
+      "description": "We sent a confirmation link to the email address you entered. Click it to continue setting up banking — we won't contact Bridge until you confirm.",
+      "resendCta": "Resend confirmation email",
+      "resending": "Resending…"
     }
   },
   "TreasuryTab": {
@@ -4412,5 +4420,19 @@
     "support": "Det rolige arbeidsområdet for kollektiv handling.",
     "ctaEnter": "Gå inn",
     "ctaExplore": "Utforsk nettverk"
+  },
+  "VerifyBanking": {
+    "loadingTitle": "Confirming your email…",
+    "loadingDescription": "Hang tight while we verify your confirmation link.",
+    "successTitle": "Email confirmed",
+    "successDescription": "Thanks — {ownerLabel} can now continue with Bridge verification.",
+    "errorExpiredTitle": "Link expired",
+    "errorExpiredDescription": "This confirmation link has expired. Go back to Banking settings and resend it.",
+    "errorInvalidTitle": "Link no longer valid",
+    "errorInvalidDescription": "This confirmation link is no longer valid — it may have already been used, or replaced by a newer request.",
+    "errorAlreadyConfirmedTitle": "Already confirmed",
+    "errorAlreadyConfirmedDescription": "This email has already been confirmed.",
+    "errorGenericTitle": "Something went wrong",
+    "errorGenericDescription": "We could not confirm this email. Please try again later."
   }
 }

--- a/packages/i18n/src/messages/pt.json
+++ b/packages/i18n/src/messages/pt.json
@@ -3530,7 +3530,7 @@
     },
     "tosStatus": {
       "pending": {
-        "title": "Termos não aceitos",
+        "title": "Verificação não iniciada",
         "description": "Aceite os termos de serviço para continuar."
       },
       "approved": {
@@ -3574,7 +3574,7 @@
       "organizationLegend": "Dados da organização",
       "organizationHint": "Os dados da organização são enviados ao nosso parceiro bancário para verificação e não são armazenados na Hypha.",
       "legalName": "Nome legal da entidade",
-      "contactEmail": "E-mail de contato",
+      "contactEmail": "E-mail do cliente Bridge",
       "currenciesTitle": "Moedas que deseja utilizar",
       "currenciesDescription": "Selecione as moedas que este space utilizará para depósitos e pagamentos bancários. Sua organização será verificada uma vez com nosso parceiro bancário.",
       "currenciesHint": "Você pode adicionar mais moedas depois nas configurações bancárias.",
@@ -3585,8 +3585,8 @@
         "legalName": "Nome completo",
         "currenciesDescription": "Selecione as moedas que deseja utilizar para pagamentos bancários. Você será verificado uma vez com nosso parceiro bancário."
       },
-      "bypassEligibleHint": "This is your own verified email — no extra confirmation step needed.",
-      "confirmationRequiredHint": "We'll send a confirmation link to this address before enabling it, since it's not your own verified email on file."
+      "bypassEligibleHint": "Este é o seu próprio e-mail verificado — nenhuma etapa de confirmação extra é necessária.",
+      "confirmationRequiredHint": "Enviaremos um link de confirmação para este endereço antes de habilitá-lo, já que não é o seu próprio e-mail verificado registrado."
     },
     "notStarted": {
       "description": "Os serviços bancários ainda não estão configurados para este space.",
@@ -3805,10 +3805,10 @@
       }
     },
     "pendingEmailConfirmation": {
-      "title": "Confirm your Bridge customer email",
-      "description": "We sent a confirmation link to the email address you entered. Click it to continue setting up banking — we won't contact Bridge until you confirm.",
-      "resendCta": "Resend confirmation email",
-      "resending": "Resending…"
+      "title": "Confirme seu e-mail do cliente Bridge",
+      "description": "Enviamos um link de confirmação para o endereço de e-mail que você informou. Clique nele para continuar configurando o banking — não entraremos em contato com a Bridge até que você confirme.",
+      "resendCta": "Reenviar e-mail de confirmação",
+      "resending": "Reenviando…"
     }
   },
   "Calendar": {
@@ -4415,17 +4415,17 @@
     "ctaExplore": "Explorar rede"
   },
   "VerifyBanking": {
-    "loadingTitle": "Confirming your email…",
-    "loadingDescription": "Hang tight while we verify your confirmation link.",
-    "successTitle": "Email confirmed",
-    "successDescription": "Thanks — {ownerLabel} can now continue with Bridge verification.",
-    "errorExpiredTitle": "Link expired",
-    "errorExpiredDescription": "This confirmation link has expired. Go back to Banking settings and resend it.",
-    "errorInvalidTitle": "Link no longer valid",
-    "errorInvalidDescription": "This confirmation link is no longer valid — it may have already been used, or replaced by a newer request.",
-    "errorAlreadyConfirmedTitle": "Already confirmed",
-    "errorAlreadyConfirmedDescription": "This email has already been confirmed.",
-    "errorGenericTitle": "Something went wrong",
-    "errorGenericDescription": "We could not confirm this email. Please try again later."
+    "loadingTitle": "Confirmando seu e-mail…",
+    "loadingDescription": "Aguarde enquanto verificamos seu link de confirmação.",
+    "successTitle": "E-mail confirmado",
+    "successDescription": "Obrigado — {ownerLabel} já pode continuar com a verificação da Bridge.",
+    "errorExpiredTitle": "Link expirado",
+    "errorExpiredDescription": "Este link de confirmação expirou. Volte para as configurações de Banking e reenvie-o.",
+    "errorInvalidTitle": "Link não é mais válido",
+    "errorInvalidDescription": "Este link de confirmação não é mais válido — ele pode já ter sido usado ou substituído por uma solicitação mais recente.",
+    "errorAlreadyConfirmedTitle": "Já confirmado",
+    "errorAlreadyConfirmedDescription": "Este e-mail já foi confirmado.",
+    "errorGenericTitle": "Algo deu errado",
+    "errorGenericDescription": "Não foi possível confirmar este e-mail. Tente novamente mais tarde."
   }
 }

--- a/packages/i18n/src/messages/pt.json
+++ b/packages/i18n/src/messages/pt.json
@@ -3584,7 +3584,9 @@
         "organizationHint": "Seus dados são enviados ao nosso parceiro bancário para verificação e não são armazenados na Hypha.",
         "legalName": "Nome completo",
         "currenciesDescription": "Selecione as moedas que deseja utilizar para pagamentos bancários. Você será verificado uma vez com nosso parceiro bancário."
-      }
+      },
+      "bypassEligibleHint": "This is your own verified email — no extra confirmation step needed.",
+      "confirmationRequiredHint": "We'll send a confirmation link to this address before enabling it, since it's not your own verified email on file."
     },
     "notStarted": {
       "description": "Os serviços bancários ainda não estão configurados para este space.",
@@ -3801,6 +3803,12 @@
         "title": "Status indisponível",
         "description": "Não foi possível determinar o status de verificação atual. Tente atualizar."
       }
+    },
+    "pendingEmailConfirmation": {
+      "title": "Confirm your Bridge customer email",
+      "description": "We sent a confirmation link to the email address you entered. Click it to continue setting up banking — we won't contact Bridge until you confirm.",
+      "resendCta": "Resend confirmation email",
+      "resending": "Resending…"
     }
   },
   "Calendar": {
@@ -4405,5 +4413,19 @@
     "support": "O espaço calmo para ação coletiva — governança, tesouraria e comunidade.",
     "ctaEnter": "Entrar",
     "ctaExplore": "Explorar rede"
+  },
+  "VerifyBanking": {
+    "loadingTitle": "Confirming your email…",
+    "loadingDescription": "Hang tight while we verify your confirmation link.",
+    "successTitle": "Email confirmed",
+    "successDescription": "Thanks — {ownerLabel} can now continue with Bridge verification.",
+    "errorExpiredTitle": "Link expired",
+    "errorExpiredDescription": "This confirmation link has expired. Go back to Banking settings and resend it.",
+    "errorInvalidTitle": "Link no longer valid",
+    "errorInvalidDescription": "This confirmation link is no longer valid — it may have already been used, or replaced by a newer request.",
+    "errorAlreadyConfirmedTitle": "Already confirmed",
+    "errorAlreadyConfirmedDescription": "This email has already been confirmed.",
+    "errorGenericTitle": "Something went wrong",
+    "errorGenericDescription": "We could not confirm this email. Please try again later."
   }
 }

--- a/packages/notifications/src/mutations.ts
+++ b/packages/notifications/src/mutations.ts
@@ -228,7 +228,7 @@ export const sendEmailNotificationsToEmails = async ({
   console.log('Send email to addresses...');
   return await sendEmailByAlias({
     app_id: ONESIGNAL_APP_ID,
-    alias: { email_to: recipients },
+    alias: { include_email_tokens: recipients },
     content: { email_body: body, email_subject: subject },
   });
 };
@@ -256,7 +256,7 @@ export const sendEmailNotificationsTemplateToEmails = async ({
   console.log('Send email to addresses...');
   return await sendEmailByAlias({
     app_id: ONESIGNAL_APP_ID,
-    alias: { email_to: recipients },
+    alias: { include_email_tokens: recipients },
     content: { template_id: templateId, custom_data: customData },
   });
 };

--- a/packages/notifications/src/sdk/notify.ts
+++ b/packages/notifications/src/sdk/notify.ts
@@ -21,6 +21,14 @@ export async function notify(notification: Notification): Promise<string> {
 
     return response.id;
   } catch (error) {
+    // OneSignal's SDK throws an ApiException carrying the actual rejection reason in `body`
+    // (e.g. an invalid template_id) — log it here, since callers further up only see the
+    // generic message below and would otherwise have no way to tell what OneSignal objected to.
+    const apiError = error as { code?: number; body?: unknown };
+    console.error('[notifications] OneSignal createNotification failed', {
+      code: apiError?.code,
+      body: apiError?.body,
+    });
     throw new Error('Failed to create a notification', { cause: error });
   }
 }

--- a/packages/notifications/src/sdk/types/email.ts
+++ b/packages/notifications/src/sdk/types/email.ts
@@ -1,10 +1,18 @@
 import type { Alias, Filter, Segment } from './audience';
 import type { Template } from './template';
 
-/** `email_to` alone is valid for OneSignal; `include_aliases` is used for subscribed Hypha users. */
+/**
+ * `include_email_tokens` alone is valid for OneSignal (sends directly to raw email addresses,
+ * no subscribed Hypha user required); `include_aliases` is used for subscribed Hypha users.
+ * Note: this is NOT `email_to` — that isn't a field OneSignal's Notification API recognizes, and
+ * the SDK's typed serializer silently drops unknown fields rather than erroring, so a plain
+ * `email_to` here (a bug fixed in this codebase, see git history) reaches the API as a
+ * notification with no targeting at all, and OneSignal 400s with "You must include which
+ * players, segments, or tags you wish to send this notification to."
+ */
 export type EmailAlias = Filter & {
   include_aliases?: Alias['include_aliases'];
-  email_to?: string[];
+  include_email_tokens?: string[];
 };
 
 export type PlainEmail = {

--- a/packages/storage-postgres/migrations/0077_bank_customers_email_confirmation.sql
+++ b/packages/storage-postgres/migrations/0077_bank_customers_email_confirmation.sql
@@ -1,0 +1,13 @@
+-- #2288: email-ownership confirmation before Bridge KYB binding. Extends bank_customers in place
+-- (no new table) to carry pending-confirmation state — no PII (email) is stored here; that lives
+-- only in the signed confirmation JWT, per ADR-0002 data-minimization.
+--
+-- provider_kyc_link_id becomes nullable: unset while a confirmation is pending (no KYC link
+-- created yet). jwt_nonce correlates an inbound confirmation click back to this row and enables
+-- instant revocation via rotation (resend/change-email sets a new UUID, invalidating the previously
+-- issued JWT's jti).
+ALTER TABLE "bank_customers" ALTER COLUMN "provider_kyc_link_id" DROP NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "bank_customers" ADD COLUMN "jwt_nonce" uuid;
+--> statement-breakpoint
+CREATE UNIQUE INDEX "bank_customers_jwt_nonce_unique" ON "bank_customers" USING btree ("jwt_nonce");

--- a/packages/storage-postgres/migrations/0078_bank_customers_confirming_nonce.sql
+++ b/packages/storage-postgres/migrations/0078_bank_customers_confirming_nonce.sql
@@ -1,0 +1,7 @@
+-- #2288 follow-up: a resend rotating jwt_nonce mid-confirmation could be silently overwritten by
+-- the in-flight confirmation's own (unconditional-by-id) final write, letting a stale link
+-- complete anyway and bricking the freshly resent one. confirming_nonce tracks "this specific
+-- confirmation attempt is in flight" independently of jwt_nonce (which resend still owns), so the
+-- final write can be conditioned on it — see claimBankCustomerForConfirmation /
+-- finalizeClaimedBankCustomer in bank-onboarding-confirmation.ts.
+ALTER TABLE "bank_customers" ADD COLUMN "confirming_nonce" uuid;

--- a/packages/storage-postgres/migrations/0078_bank_customers_confirming_nonce.sql
+++ b/packages/storage-postgres/migrations/0078_bank_customers_confirming_nonce.sql
@@ -1,7 +1,0 @@
--- #2288 follow-up: a resend rotating jwt_nonce mid-confirmation could be silently overwritten by
--- the in-flight confirmation's own (unconditional-by-id) final write, letting a stale link
--- complete anyway and bricking the freshly resent one. confirming_nonce tracks "this specific
--- confirmation attempt is in flight" independently of jwt_nonce (which resend still owns), so the
--- final write can be conditioned on it — see claimBankCustomerForConfirmation /
--- finalizeClaimedBankCustomer in bank-onboarding-confirmation.ts.
-ALTER TABLE "bank_customers" ADD COLUMN "confirming_nonce" uuid;

--- a/packages/storage-postgres/migrations/meta/_journal.json
+++ b/packages/storage-postgres/migrations/meta/_journal.json
@@ -540,6 +540,13 @@
       "when": 1784000000007,
       "tag": "0076_coherence_creator_id_nullable",
       "breakpoints": true
+    },
+    {
+      "idx": 77,
+      "version": "7",
+      "when": 1784000000008,
+      "tag": "0077_bank_customers_email_confirmation",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/storage-postgres/migrations/meta/_journal.json
+++ b/packages/storage-postgres/migrations/meta/_journal.json
@@ -547,6 +547,13 @@
       "when": 1784000000008,
       "tag": "0077_bank_customers_email_confirmation",
       "breakpoints": true
+    },
+    {
+      "idx": 78,
+      "version": "7",
+      "when": 1784000000009,
+      "tag": "0078_bank_customers_confirming_nonce",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/storage-postgres/migrations/meta/_journal.json
+++ b/packages/storage-postgres/migrations/meta/_journal.json
@@ -547,13 +547,6 @@
       "when": 1784000000008,
       "tag": "0077_bank_customers_email_confirmation",
       "breakpoints": true
-    },
-    {
-      "idx": 78,
-      "version": "7",
-      "when": 1784000000009,
-      "tag": "0078_bank_customers_confirming_nonce",
-      "breakpoints": true
     }
   ]
 }

--- a/packages/storage-postgres/src/schema/bank-customer.ts
+++ b/packages/storage-postgres/src/schema/bank-customer.ts
@@ -37,18 +37,14 @@ export const bankCustomers = pgTable(
     providerKycLinkId: text('provider_kyc_link_id'),
     /**
      * The nonce a confirmation link must present (`jti` of the JWT) to be considered live for
-     * this row (#2288); cleared once confirmed. A resend rotates this to a new UUID, instantly
-     * invalidating any previously issued link.
+     * this row (#2288). Set while pending; cleared to `NULL` the instant a confirmation claims the
+     * row (before calling the provider) and stays `NULL` through to persisting the result — the
+     * confirm path's final write is itself conditioned on this still being `NULL`
+     * (`finalizeClaimedBankCustomer`), so a resend racing in in the middle (which always sets a
+     * fresh non-null value, instantly revoking whatever was claimed) makes that write a no-op
+     * instead of silently completing a stale confirmation. See `bank-onboarding-confirmation.ts`.
      */
     jwtNonce: uuid('jwt_nonce'),
-    /**
-     * Distinct from `jwt_nonce`: set only while a specific confirmation click is actively being
-     * processed (claimed, Bridge call in flight), cleared once that attempt finishes or fails.
-     * Kept separate from `jwt_nonce` so a resend arriving mid-confirmation can revoke the
-     * in-flight attempt (by clearing this) without racing the attempt's own final write, which is
-     * itself conditioned on this value still matching — see `bank-onboarding-confirmation.ts`.
-     */
-    confirmingNonce: uuid('confirming_nonce'),
     requestedRails: jsonb('requested_rails')
       .$type<BankCustomerRequestedRails>()
       .notNull()

--- a/packages/storage-postgres/src/schema/bank-customer.ts
+++ b/packages/storage-postgres/src/schema/bank-customer.ts
@@ -7,6 +7,7 @@ import {
   serial,
   text,
   uniqueIndex,
+  uuid,
 } from 'drizzle-orm/pg-core';
 import { commonDateFields } from './shared';
 import { spaces } from './space';
@@ -29,7 +30,17 @@ export const bankCustomers = pgTable(
     entityType: text('entity_type').notNull(),
     provider: text('provider').notNull(),
     providerCustomerId: text('provider_customer_id'),
-    providerKycLinkId: text('provider_kyc_link_id').notNull(),
+    /**
+     * Nullable: unset while an email-ownership confirmation is pending (#2288) — no Bridge
+     * KYC link exists yet at that point.
+     */
+    providerKycLinkId: text('provider_kyc_link_id'),
+    /**
+     * Set while an email-ownership confirmation is pending (#2288); cleared once confirmed and
+     * the KYC link is created. Resend/change-email rotates this to a new UUID, which instantly
+     * invalidates the previously issued confirmation JWT (its `jti` no longer matches).
+     */
+    jwtNonce: uuid('jwt_nonce'),
     requestedRails: jsonb('requested_rails')
       .$type<BankCustomerRequestedRails>()
       .notNull()
@@ -45,6 +56,7 @@ export const bankCustomers = pgTable(
       table.personId,
       table.provider,
     ),
+    uniqueIndex('bank_customers_jwt_nonce_unique').on(table.jwtNonce),
     check(
       'bank_customers_owner_xor',
       sql`(${table.spaceId} IS NOT NULL) <> (${table.personId} IS NOT NULL)`,

--- a/packages/storage-postgres/src/schema/bank-customer.ts
+++ b/packages/storage-postgres/src/schema/bank-customer.ts
@@ -36,11 +36,19 @@ export const bankCustomers = pgTable(
      */
     providerKycLinkId: text('provider_kyc_link_id'),
     /**
-     * Set while an email-ownership confirmation is pending (#2288); cleared once confirmed and
-     * the KYC link is created. Resend/change-email rotates this to a new UUID, which instantly
-     * invalidates the previously issued confirmation JWT (its `jti` no longer matches).
+     * The nonce a confirmation link must present (`jti` of the JWT) to be considered live for
+     * this row (#2288); cleared once confirmed. A resend rotates this to a new UUID, instantly
+     * invalidating any previously issued link.
      */
     jwtNonce: uuid('jwt_nonce'),
+    /**
+     * Distinct from `jwt_nonce`: set only while a specific confirmation click is actively being
+     * processed (claimed, Bridge call in flight), cleared once that attempt finishes or fails.
+     * Kept separate from `jwt_nonce` so a resend arriving mid-confirmation can revoke the
+     * in-flight attempt (by clearing this) without racing the attempt's own final write, which is
+     * itself conditioned on this value still matching — see `bank-onboarding-confirmation.ts`.
+     */
+    confirmingNonce: uuid('confirming_nonce'),
     requestedRails: jsonb('requested_rails')
       .$type<BankCustomerRequestedRails>()
       .notNull()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -995,10 +995,13 @@ importers:
         version: link:../ui-utils
       '@privy-io/node':
         specifier: ^0.12.0
-        version: 0.12.0(viem@2.33.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.24.3))
+        version: 0.12.0(viem@2.33.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       '@wagmi/cli':
         specifier: ^2.2.0
         version: 2.2.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
+      jose:
+        specifier: ^5.9.6
+        version: 5.10.0
       livekit-client:
         specifier: ^2.18.1
         version: 2.20.0(@types/dom-mediacapture-record@1.0.22)
@@ -26073,20 +26076,6 @@ snapshots:
       - bufferutil
       - typescript
       - utf-8-validate
-
-  '@privy-io/node@0.12.0(viem@2.33.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.24.3))':
-    dependencies:
-      '@hpke/chacha20poly1305': 1.8.0
-      '@hpke/core': 1.9.0
-      '@noble/curves': 1.9.7
-      '@noble/hashes': 1.8.0
-      '@scure/base': 1.2.6
-      canonicalize: 2.1.0
-      jose: 6.2.2
-      lru-cache: 11.2.2
-      svix: 1.89.0
-    optionalDependencies:
-      viem: 2.33.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.24.3)
 
   '@privy-io/node@0.12.0(viem@2.33.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76))':
     dependencies:


### PR DESCRIPTION
## Summary

Closes #2288. Adds an explicit email-ownership confirmation step before binding a Hypha space **or person** to a Bridge customer, closing the KYB-inheritance gap: Bridge dedups customers by email, so an owner could otherwise inherit an already-approved customer and open bank rails without its own KYB.

This is a fresh reimplementation on top of current `main` (superseding the stale #2298), extended to cover both space and personal onboarding (which shipped after #2298 was written) via **one shared implementation**, not parallel duplicated code.

## Approach

- **Bypass path** — submitter's own email (plus-address-normalized: `me+test@x.com` ≡ `me@x.com`) skips the round-trip via an inline checkbox-equivalent hint; unmodified email still goes to Bridge, keeping sandbox plus-addressing working.
- **Non-bypass path** — signs a short-lived JWT (all PII lives in the token, not the DB — DB only stores a `jwt_nonce` for correlation/instant revocation via rotation), emails a consent link to a public `/verify/banking` page; clicking it triggers the actual Bridge customer/KYC-link creation.
- **Schema**: `bank_customers` extended in place (nullable `provider_kyc_link_id`, new `jwt_nonce`) rather than a new table — migration `0077`.
- **Security**: the confirmation JWT never appears in any function's return value reachable by an HTTP response — it flows only through a `sendConfirmationEmail` callback.
- **Bundled minor fixes** (carried over from original scope): Treasury "Bank Accounts" count now counts customers, not currencies; "Terms not accepted" → "Verification not started".

## Testing

157/157 banking tests passing (21 new, covering bypass logic, JWT sign/verify/tamper/expiry, and the full shared gate: bypass-create, pending-confirmation, existing-linked idempotency, resend/nonce-rotation, confirm success/expired/invalid/already-confirmed). `tsc --noEmit` and `eslint` clean across `core`, `epics`, `web`, `storage-postgres`.

Manually smoke-tested locally: bypass path (own email + plus-alias), non-bypass path via the console-logged verify link (no OneSignal template configured locally), both space and personal onboarding.

## Known follow-ups before merge

1. Non-English i18n locales (`de`, `es`, `fr`, `mk`, `nl`, `no`, `pt`) carry English placeholder text for the new/changed strings — needs a real translation pass.
2. `EMAIL_TEMPLATE_BANK_EMAIL_CONFIRMATION` OneSignal dashboard template needs to be created (`custom_data`: `owner_label`, `verify_link`) and `INTERNAL_JWT_SECRET` needs a real per-environment value.
3. Migration `0077` needs to be run against each environment's DB (verified against dev — schema state confirmed to match after manual DB inspection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added email ownership confirmation when the banking email differs from the submitter’s verified email.
  * Added a public verification page with loading, success, expired, invalid, and already-confirmed states.
  * Added pending-confirmation status cards with resend options.
  * Added automatic confirmation bypass when the submitted email matches the submitter’s verified email.
  * Added guidance during setup explaining whether confirmation is required.
* **Bug Fixes**
  * Improved handling of incomplete banking setup states before verification.
* **Localization**
  * Added translated confirmation messaging across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->