### PR TITLE
feat(treasury): show held tokens issued by other spaces

### DIFF
--- a/apps/web/src/app/api/v1/spaces/[spaceSlug]/assets/route.ts
+++ b/apps/web/src/app/api/v1/spaces/[spaceSlug]/assets/route.ts
@@ -3,6 +3,7 @@ import {
   web3Client,
   findSpaceBySlug,
   getTokenPrice,
+  getTokenBalancesByAddress,
   getBalance,
   getTokenMeta,
   findAllTokens,
@@ -20,9 +21,11 @@ import {
   ALLOWED_SPACES,
   getTokenDecimals,
   isHiddenToken,
+  selectKnownHeldTokens,
   getEnergyCommunityTokensForSpace,
   getAllEnergyCommunityTokens,
   getEnergyCommunityToken,
+  getEnergyCommunityTokenAddresses,
   getEnergyCommunityDisplayDecimals,
   isHyphaToken,
   HYPHA_PRICE_USD,
@@ -218,9 +221,30 @@ export async function GET(
       }
     });
 
-    // Do not merge Alchemy ERC-20 discovery here — it floods the treasury with
-    // spam tokens that have no DB row. Balances for known addresses come from
-    // getBalance below; catalogue + space-issued + DB cover legit assets.
+    // Discover tokens this treasury holds that were issued by other spaces.
+    // Alchemy lists ERC-20s at the executor; keep only DB / catalogue /
+    // energy-community addresses so spam stays out (same filter as person
+    // wallets). Do not mark these issuedBySpace — the UI already shows
+    // non-issued tokens when their balance is > 0.
+    const dbKnownAddresses = new Set(
+      rawDbTokens
+        .filter((t) => t.address && /^0x[a-fA-F0-9]{40}$/i.test(t.address))
+        .map((t) => t.address!.toLowerCase()),
+    );
+    for (const address of getEnergyCommunityTokenAddresses()) {
+      dbKnownAddresses.add(address);
+    }
+
+    try {
+      const held = await getTokenBalancesByAddress(spaceAddress);
+      for (const token of selectKnownHeldTokens(held, dbKnownAddresses)) {
+        const lower = token.address.toLowerCase();
+        if (addressMap.has(lower)) continue;
+        addressMap.set(lower, getEnergyCommunityToken(lower) ?? token);
+      }
+    } catch (error: unknown) {
+      console.warn('Failed to fetch held token balances:', error);
+    }
 
     const allTokens: Token[] = Array.from(addressMap.values()).filter(
       (token) => !isHiddenToken(token.address),

--- a/packages/core/src/common/web3/__tests__/tokens.test.ts
+++ b/packages/core/src/common/web3/__tests__/tokens.test.ts
@@ -8,6 +8,7 @@ import {
   isCatalogueToken,
   isHyphaToken,
   isKnownTreasuryToken,
+  selectKnownHeldTokens,
 } from '../tokens';
 import {
   ASSET_PRICE_FEED_BY_TOKEN,
@@ -115,6 +116,68 @@ describe('isKnownTreasuryToken', () => {
 
   it('drops unknown spam addresses', () => {
     expect(isKnownTreasuryToken(spam, known)).toBe(false);
+  });
+});
+
+describe('selectKnownHeldTokens', () => {
+  const dbToken = '0x2222222222222222222222222222222222222222';
+  const spam = '0x1111111111111111111111111111111111111111';
+  const known = new Set([dbToken.toLowerCase()]);
+
+  it('keeps a positive-balance DB token issued by another space', () => {
+    const selected = selectKnownHeldTokens(
+      [
+        {
+          tokenAddress: dbToken,
+          balance: 12.5,
+          symbol: 'OTHR',
+          name: 'Other Space Token',
+        },
+      ],
+      known,
+    );
+    expect(selected).toHaveLength(1);
+    expect(selected[0]?.address).toBe(dbToken);
+    expect(selected[0]?.symbol).toBe('OTHR');
+  });
+
+  it('keeps catalogue tokens even when they are not in knownAddresses', () => {
+    const selected = selectKnownHeldTokens(
+      [
+        {
+          tokenAddress: TOKENS[0].address,
+          balance: 1,
+          symbol: TOKENS[0].symbol,
+        },
+      ],
+      new Set(),
+    );
+    expect(selected).toHaveLength(1);
+    expect(selected[0]?.address).toBe(TOKENS[0].address);
+  });
+
+  it('drops zero-balance, spam, and invalid addresses', () => {
+    expect(
+      selectKnownHeldTokens(
+        [
+          { tokenAddress: dbToken, balance: 0, symbol: 'OTHR' },
+          { tokenAddress: spam, balance: 99, symbol: 'SPAM' },
+          { tokenAddress: 'not-an-address', balance: 5, symbol: 'BAD' },
+        ],
+        known,
+      ),
+    ).toEqual([]);
+  });
+
+  it('dedupes the same held address', () => {
+    const selected = selectKnownHeldTokens(
+      [
+        { tokenAddress: dbToken, balance: 1, symbol: 'OTHR' },
+        { tokenAddress: dbToken.toUpperCase(), balance: 2, symbol: 'OTHR' },
+      ],
+      known,
+    );
+    expect(selected).toHaveLength(1);
   });
 });
 

--- a/packages/core/src/common/web3/tokens.ts
+++ b/packages/core/src/common/web3/tokens.ts
@@ -130,6 +130,53 @@ export function isKnownTreasuryToken(
   return knownAddresses.has(lower) || isCatalogueToken(lower);
 }
 
+const EVM_ADDRESS = /^0x[a-fA-F0-9]{40}$/i;
+
+/** Alchemy (or other indexer) ERC-20 balance row used to discover held tokens. */
+export type HeldTokenBalance = {
+  tokenAddress?: string;
+  balance?: number;
+  symbol?: string | null;
+  name?: string | null;
+  logo?: string | null;
+};
+
+/**
+ * Keep indexer-discovered holdings that are already known to the platform
+ * (DB-registered, catalogue, or otherwise in `knownAddresses`). Drops spam,
+ * zero balances, and invalid addresses. Used so a space treasury can show
+ * tokens issued by another space after they are transferred in.
+ */
+export function selectKnownHeldTokens(
+  held: readonly HeldTokenBalance[],
+  knownAddresses: ReadonlySet<string>,
+): Token[] {
+  const selected: Token[] = [];
+  const seen = new Set<string>();
+  for (const token of held) {
+    const address = token.tokenAddress;
+    if (
+      !address ||
+      (token.balance ?? 0) <= 0 ||
+      !EVM_ADDRESS.test(address) ||
+      !isKnownTreasuryToken(address, knownAddresses)
+    ) {
+      continue;
+    }
+    const lower = address.toLowerCase();
+    if (seen.has(lower)) continue;
+    seen.add(lower);
+    selected.push({
+      symbol: token.symbol || 'UNKNOWN',
+      name: token.name || 'Unnamed',
+      address: address as `0x${string}`,
+      icon: token.logo || '/placeholder/token-icon.svg',
+      type: 'utility',
+    });
+  }
+  return selected;
+}
+
 export const ERC20_TOKEN_TRANSFER_ADDRESSES = [
   '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
   '0x60a3E35Cc302bFA44Cb288Bc5a4F316Fdb1adb42',


### PR DESCRIPTION
## Summary
- Space treasuries currently list catalogue tokens plus tokens **issued by that space**. A token minted in Space A and transferred to Space B never appeared in B’s treasury.
- That gap came from `f55f0e4e61` (`fix(treasury): hide Alchemy spam tokens`), which removed Alchemy discovery from the space assets route instead of filtering it. Person wallets already keep the safer pattern: discover holdings, then drop unknown ERC-20s.
- This restores Alchemy discovery on `/api/v1/spaces/:slug/assets` and keeps only DB-registered, catalogue, and energy-community tokens via `selectKnownHeldTokens`. Spam stays out; the existing UI still shows non-issued tokens only when balance is greater than zero.

## Test plan
- [ ] Issue a token in Space A, transfer some of it to Space B’s treasury address
- [ ] Confirm the token appears on Space B’s Treasury assets list with the received balance
- [ ] Confirm Space A still lists the token even at zero remaining treasury balance (issuer always shown)
- [ ] Confirm unknown/spam ERC-20s held by the treasury still do not appear
- [ ] Confirm Energy community tokens (e.g. Ponta → Escola) still appear as before
- [ ] `pnpm --filter @hypha-platform/core exec vitest run src/common/web3/__tests__/tokens.test.ts`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Treasury asset discovery now includes eligible ERC-20 tokens held by the space executor, including tokens issued by other spaces.
  * Token details use available catalogue metadata, with sensible fallback information when needed.
  * Duplicate, invalid, zero-balance, and unrecognized token entries are filtered out.

* **Bug Fixes**
  * Improved resilience when fetching held token balances, preventing discovery failures from disrupting the assets view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->