### PR TITLE
feat(treasury): include held tokens in proposal token pickers

### DIFF
--- a/apps/web/src/app/api/v1/spaces/[spaceSlug]/assets-without-balances/route.ts
+++ b/apps/web/src/app/api/v1/spaces/[spaceSlug]/assets-without-balances/route.ts
@@ -5,6 +5,12 @@ import {
   getTokenBalancesByAddress,
   web3Client,
   findAllTokens,
+  selectKnownHeldTokens,
+  getEnergyCommunityTokensForSpace,
+  getEnergyCommunityToken,
+  getEnergyCommunityTokenAddresses,
+  parseHttpPaginationParams,
+  buildPaginatedResponse,
 } from '@hypha-platform/core/server';
 import {
   getSpaceRegularTokens,
@@ -14,15 +20,16 @@ import {
   TOKENS,
   ALLOWED_SPACES,
   isHiddenToken,
-  selectKnownHeldTokens,
-  getEnergyCommunityTokensForSpace,
-  getEnergyCommunityToken,
-  getEnergyCommunityTokenAddresses,
 } from '@hypha-platform/core/client';
 import { db } from '@hypha-platform/storage-postgres';
 import { hasEmojiOrLink } from '@hypha-platform/ui-utils';
 import { checkSpaceAccess } from '@web/utils/check-space-access';
 
+/**
+ * Catalogue of tokens a space can pick in proposal forms (issued + held).
+ * Paginated via `page` / `pageSize`; pickers request a large page so the
+ * dropdown stays complete.
+ */
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ spaceSlug: string }> },
@@ -218,8 +225,14 @@ export async function GET(
       (token) => !isHiddenToken(token.address),
     );
 
+    const { page, pageSize, offset } = parseHttpPaginationParams(
+      new URL(request.url),
+      { defaultPageSize: 500, maxPageSize: 500 },
+    );
+    const pageTokens = allTokens.slice(offset, offset + pageSize);
+
     const assets = await Promise.all(
-      allTokens.map(async (token) => {
+      pageTokens.map(async (token) => {
         try {
           const meta = await getTokenMeta(token.address, dbTokens);
           if (hasEmojiOrLink(meta.name) || hasEmojiOrLink(meta.symbol)) {
@@ -240,7 +253,16 @@ export async function GET(
       (typeof assets)[0]
     >[];
 
-    return NextResponse.json({ assets: validAssets });
+    const payload = buildPaginatedResponse(
+      validAssets,
+      allTokens.length,
+      page,
+      pageSize,
+    );
+    return NextResponse.json({
+      ...payload,
+      assets: payload.data,
+    });
   } catch (error) {
     console.error('Failed to fetch assets:', error);
     return NextResponse.json(

--- a/apps/web/src/app/api/v1/spaces/[spaceSlug]/assets-without-balances/route.ts
+++ b/apps/web/src/app/api/v1/spaces/[spaceSlug]/assets-without-balances/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import {
   findSpaceBySlug,
   getTokenMeta,
+  getTokenBalancesByAddress,
   web3Client,
   findAllTokens,
 } from '@hypha-platform/core/server';
@@ -13,7 +14,10 @@ import {
   TOKENS,
   ALLOWED_SPACES,
   isHiddenToken,
+  selectKnownHeldTokens,
   getEnergyCommunityTokensForSpace,
+  getEnergyCommunityToken,
+  getEnergyCommunityTokenAddresses,
 } from '@hypha-platform/core/client';
 import { db } from '@hypha-platform/storage-postgres';
 import { hasEmojiOrLink } from '@hypha-platform/ui-utils';
@@ -186,8 +190,29 @@ export async function GET(
       addressMap.set(token.address.toLowerCase(), token);
     });
 
-    // Do not merge Alchemy ERC-20 discovery — spam tokens with no DB/on-chain
-    // space registration must not appear in asset pickers.
+    // Include tokens this treasury holds that were issued by other spaces so
+    // proposal pickers (Deploy Funds, Pay for Expenses, …) match the treasury
+    // list. Alchemy discovers ERC-20s; keep only DB / catalogue /
+    // energy-community addresses so spam stays out.
+    const dbKnownAddresses = new Set(
+      rawDbTokens
+        .filter((t) => t.address && /^0x[a-fA-F0-9]{40}$/i.test(t.address))
+        .map((t) => t.address!.toLowerCase()),
+    );
+    for (const address of getEnergyCommunityTokenAddresses()) {
+      dbKnownAddresses.add(address);
+    }
+
+    try {
+      const held = await getTokenBalancesByAddress(spaceAddress);
+      for (const token of selectKnownHeldTokens(held, dbKnownAddresses)) {
+        const lower = token.address.toLowerCase();
+        if (addressMap.has(lower)) continue;
+        addressMap.set(lower, getEnergyCommunityToken(lower) ?? token);
+      }
+    } catch (error: unknown) {
+      console.warn('Failed to fetch held token balances:', error);
+    }
 
     const allTokens: Token[] = Array.from(addressMap.values()).filter(
       (token) => !isHiddenToken(token.address),

--- a/apps/web/src/app/api/v1/spaces/[spaceSlug]/assets-without-balances/route.ts
+++ b/apps/web/src/app/api/v1/spaces/[spaceSlug]/assets-without-balances/route.ts
@@ -225,14 +225,8 @@ export async function GET(
       (token) => !isHiddenToken(token.address),
     );
 
-    const { page, pageSize, offset } = parseHttpPaginationParams(
-      new URL(request.url),
-      { defaultPageSize: 500, maxPageSize: 500 },
-    );
-    const pageTokens = allTokens.slice(offset, offset + pageSize);
-
-    const assets = await Promise.all(
-      pageTokens.map(async (token) => {
+    const resolvedAssets = await Promise.all(
+      allTokens.map(async (token) => {
         try {
           const meta = await getTokenMeta(token.address, dbTokens);
           if (hasEmojiOrLink(meta.name) || hasEmojiOrLink(meta.symbol)) {
@@ -249,13 +243,19 @@ export async function GET(
       }),
     );
 
-    const validAssets = assets.filter((a) => a !== null) as NonNullable<
-      (typeof assets)[0]
+    const validAssets = resolvedAssets.filter((a) => a !== null) as NonNullable<
+      (typeof resolvedAssets)[0]
     >[];
 
+    const { page, pageSize, offset } = parseHttpPaginationParams(
+      new URL(request.url),
+      { defaultPageSize: 500, maxPageSize: 500 },
+    );
+    const pageAssets = validAssets.slice(offset, offset + pageSize);
+
     const payload = buildPaginatedResponse(
-      validAssets,
-      allTokens.length,
+      pageAssets,
+      validAssets.length,
       page,
       pageSize,
     );

--- a/packages/core/src/common/server/index.ts
+++ b/packages/core/src/common/server/index.ts
@@ -8,6 +8,12 @@ export * from './get-currency-rates';
 // Pure helpers, re-exported here so server code can apply rates without
 // reaching into the client entry point.
 export * from '../web3/currency-conversion';
+export { selectKnownHeldTokens } from '../web3/tokens';
+export {
+  getEnergyCommunityTokensForSpace,
+  getEnergyCommunityToken,
+  getEnergyCommunityTokenAddresses,
+} from '../web3/energy-community-tokens';
 export * from './get-transfers-by-address';
 export * from './get-token-balances-by-address';
 

--- a/packages/epics/src/agreements/plugins/exchange-stakes-and-tokens/plugin.tsx
+++ b/packages/epics/src/agreements/plugins/exchange-stakes-and-tokens/plugin.tsx
@@ -43,7 +43,7 @@ function toPayoutTokens(tokens: ExtendedToken[]): PayoutToken[] {
     icon: token.icon,
     symbol: token.symbol,
     space: token.space,
-    type: token.type === 'liquid' ? null : token.type,
+    type: token.type,
   }));
 }
 

--- a/packages/epics/src/treasury/hooks/use-tokens.ts
+++ b/packages/epics/src/treasury/hooks/use-tokens.ts
@@ -78,11 +78,20 @@ export function useTokens({ spaceSlug }: { spaceSlug: string }) {
       const collected: ExtendedToken[] = [];
       let page = 1;
       let hasNextPage = true;
-      while (hasNextPage && page <= PICKER_MAX_PAGES) {
+      while (hasNextPage) {
+        if (page > PICKER_MAX_PAGES) {
+          throw new Error(
+            `Token picker exceeded ${PICKER_MAX_PAGES} pages of ${PICKER_PAGE_SIZE} tokens.`,
+          );
+        }
         const endpoint = `/api/v1/spaces/${slug}/assets-without-balances?page=${page}&pageSize=${PICKER_PAGE_SIZE}`;
-        const payload = (await fetch(endpoint, { headers }).then((res) =>
-          res.json(),
-        )) as AssetsWithoutBalancesPage;
+        const response = await fetch(endpoint, { headers });
+        if (!response.ok) {
+          throw new Error(
+            `Failed to fetch assets without balances: ${response.status}`,
+          );
+        }
+        const payload = (await response.json()) as AssetsWithoutBalancesPage;
         const { items, hasNextPage: more } =
           readAssetsWithoutBalancesPage(payload);
         collected.push(...items);

--- a/packages/epics/src/treasury/hooks/use-tokens.ts
+++ b/packages/epics/src/treasury/hooks/use-tokens.ts
@@ -1,15 +1,37 @@
 'use client';
 
-import { TOKENS } from '@hypha-platform/core/client';
+import {
+  TOKENS,
+  Token,
+  TokenType,
+  validTokenTypes,
+} from '@hypha-platform/core/client';
 import useSWR from 'swr';
 import React from 'react';
-import { Token } from '@hypha-platform/core/client';
 import { useAuthentication } from '@hypha-platform/authentication';
 
-export interface ExtendedToken extends Token {
+export interface ExtendedToken extends Omit<Token, 'type'> {
+  type: TokenType | null;
   space?: {
     title: string;
     slug: string;
+  };
+}
+
+function toPickerTokenType(type: Token['type']): TokenType | null {
+  if (type != null && (validTokenTypes as readonly string[]).includes(type)) {
+    return type as TokenType;
+  }
+  return null;
+}
+
+function toExtendedToken(
+  asset: Token & { space?: ExtendedToken['space'] },
+): ExtendedToken {
+  return {
+    ...asset,
+    type: toPickerTokenType(asset.type),
+    space: asset.space,
   };
 }
 
@@ -71,16 +93,8 @@ export function useTokens({ spaceSlug }: { spaceSlug: string }) {
     },
   );
 
-  const tokens = React.useMemo(() => {
-    if (!data) return TOKENS;
-    return data.map((asset) => ({
-      address: asset.address,
-      icon: asset.icon,
-      name: asset.name,
-      type: asset.type,
-      symbol: asset.symbol,
-      space: asset.space,
-    }));
+  const tokens = React.useMemo((): ExtendedToken[] => {
+    return (data ?? TOKENS).map(toExtendedToken);
   }, [data]);
 
   return {
@@ -133,14 +147,7 @@ export function useWalletTransferableTokens({
     if (!data?.assets) return [];
     return (data.assets as ExtendedToken[])
       .filter((asset) => asset.transferable !== false)
-      .map((asset) => ({
-        address: asset.address,
-        icon: asset.icon,
-        name: asset.name,
-        type: asset.type,
-        symbol: asset.symbol,
-        space: asset.space,
-      }));
+      .map(toExtendedToken);
   }, [data]);
 
   return {

--- a/packages/epics/src/treasury/hooks/use-tokens.ts
+++ b/packages/epics/src/treasury/hooks/use-tokens.ts
@@ -17,7 +17,8 @@ export function useTokens({ spaceSlug }: { spaceSlug: string }) {
   const { getAccessToken } = useAuthentication();
 
   const endpoint = React.useMemo(
-    () => `/api/v1/spaces/${spaceSlug}/assets-without-balances`,
+    () =>
+      `/api/v1/spaces/${spaceSlug}/assets-without-balances?page=1&pageSize=500`,
     [spaceSlug],
   );
 
@@ -33,8 +34,13 @@ export function useTokens({ spaceSlug }: { spaceSlug: string }) {
   });
 
   const tokens = React.useMemo(() => {
-    if (!data?.assets) return TOKENS;
-    const formattedAssets = data.assets.map((asset: ExtendedToken) => ({
+    const list = Array.isArray(data?.data)
+      ? data.data
+      : Array.isArray(data?.assets)
+      ? data.assets
+      : null;
+    if (!list) return TOKENS;
+    const formattedAssets = list.map((asset: ExtendedToken) => ({
       address: asset.address,
       icon: asset.icon,
       name: asset.name,

--- a/packages/epics/src/treasury/hooks/use-tokens.ts
+++ b/packages/epics/src/treasury/hooks/use-tokens.ts
@@ -13,34 +13,67 @@ export interface ExtendedToken extends Token {
   };
 }
 
+const PICKER_PAGE_SIZE = 500;
+const PICKER_MAX_PAGES = 20;
+
+type AssetsWithoutBalancesPage = {
+  data?: ExtendedToken[];
+  assets?: ExtendedToken[];
+  pagination?: { hasNextPage?: boolean };
+};
+
+/** Read one picker page and whether more pages remain. */
+export function readAssetsWithoutBalancesPage(
+  payload: AssetsWithoutBalancesPage | null | undefined,
+): { items: ExtendedToken[]; hasNextPage: boolean } {
+  const list = Array.isArray(payload?.data)
+    ? payload.data
+    : Array.isArray(payload?.assets)
+    ? payload.assets
+    : [];
+  return {
+    items: list,
+    hasNextPage: payload?.pagination?.hasNextPage === true,
+  };
+}
+
+/**
+ * Space token catalogue for proposal pickers. Follows
+ * `/assets-without-balances` pagination until every page is loaded.
+ */
 export function useTokens({ spaceSlug }: { spaceSlug: string }) {
   const { getAccessToken } = useAuthentication();
 
-  const endpoint = React.useMemo(
-    () =>
-      `/api/v1/spaces/${spaceSlug}/assets-without-balances?page=1&pageSize=500`,
-    [spaceSlug],
+  const { data, isLoading, mutate } = useSWR(
+    spaceSlug ? [spaceSlug, 'assets-without-balances'] : null,
+    async ([slug]: [string]) => {
+      const token = await getAccessToken();
+      const headers: HeadersInit = {};
+      if (token) {
+        headers.Authorization = `Bearer ${token}`;
+      }
+
+      const collected: ExtendedToken[] = [];
+      let page = 1;
+      let hasNextPage = true;
+      while (hasNextPage && page <= PICKER_MAX_PAGES) {
+        const endpoint = `/api/v1/spaces/${slug}/assets-without-balances?page=${page}&pageSize=${PICKER_PAGE_SIZE}`;
+        const payload = (await fetch(endpoint, { headers }).then((res) =>
+          res.json(),
+        )) as AssetsWithoutBalancesPage;
+        const { items, hasNextPage: more } =
+          readAssetsWithoutBalancesPage(payload);
+        collected.push(...items);
+        hasNextPage = more;
+        page += 1;
+      }
+      return collected;
+    },
   );
 
-  const { data, isLoading, mutate } = useSWR([endpoint], async ([endpoint]) => {
-    const token = await getAccessToken();
-    const headers: HeadersInit = {};
-
-    if (token) {
-      headers.Authorization = `Bearer ${token}`;
-    }
-
-    return fetch(endpoint, { headers }).then((res) => res.json());
-  });
-
   const tokens = React.useMemo(() => {
-    const list = Array.isArray(data?.data)
-      ? data.data
-      : Array.isArray(data?.assets)
-      ? data.assets
-      : null;
-    if (!list) return TOKENS;
-    const formattedAssets = list.map((asset: ExtendedToken) => ({
+    if (!data) return TOKENS;
+    return data.map((asset) => ({
       address: asset.address,
       icon: asset.icon,
       name: asset.name,
@@ -48,7 +81,6 @@ export function useTokens({ spaceSlug }: { spaceSlug: string }) {
       symbol: asset.symbol,
       space: asset.space,
     }));
-    return formattedAssets;
   }, [data]);
 
   return {

--- a/packages/epics/src/treasury/plugins/mint-tokens-to-space-treasury/plugin.tsx
+++ b/packages/epics/src/treasury/plugins/mint-tokens-to-space-treasury/plugin.tsx
@@ -12,21 +12,14 @@ import {
   FormLabel,
 } from '@hypha-platform/ui';
 import { TokenPayoutField } from '../../../agreements/plugins/components/common/token-payout-field';
-import { useTokens, useTokenSupply } from '../../hooks';
+import { useTokens, useTokenSupply, type ExtendedToken } from '../../hooks';
 import { useFormContext } from 'react-hook-form';
-import { DbToken, Token } from '@hypha-platform/core/client';
+import { DbToken } from '@hypha-platform/core/client';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import { useDbTokens } from '../../../hooks';
 import { formatCurrencyValue } from '@hypha-platform/ui-utils';
 import { useTranslations } from 'next-intl';
-
-interface ExtendedToken extends Token {
-  space?: {
-    title: string;
-    slug: string;
-  };
-}
 
 export const MintTokensToSpaceTreasuryPlugin = ({
   spaceSlug,


### PR DESCRIPTION
## Summary
- Deploy Funds / Pay for Expenses / contribution pickers load tokens from `/assets-without-balances` via `useTokens`. That route still listed only catalogue + space-issued tokens, so a token sitting in the treasury (including one issued by another space) did not appear in **Select a token**.
- #2480 already surfaced those holdings on the treasury assets page. This applies the same known-token Alchemy discovery to the proposal picker endpoint.
- Spam stays filtered: only DB-registered, catalogue, and energy-community tokens are merged. Mint-to-treasury still filters to tokens issued by the current space.

## Test plan
- [ ] Transfer a Space A token into Space B’s treasury
- [ ] Confirm it appears on Space B’s Treasury tab (already shipped in #2480)
- [ ] Open Deploy Funds (or Pay for Expenses) in Space B and confirm the token appears in **Select a token**
- [ ] Confirm catalogue tokens (USDC, EURC, …) still appear
- [ ] Confirm unknown/spam ERC-20s still do not appear
- [ ] Confirm Mint Tokens to Treasury still lists only tokens issued by the current space


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Asset listings now include valid tokens held by a space treasury, including previously undiscovered tokens.
  * Asset results are paginated for faster, more manageable loading.
  * Treasury token loading supports expanded result sets and improved response compatibility.

* **Bug Fixes**
  * Individual token-balance discovery failures no longer prevent asset results from loading.
  * Token type information is preserved consistently across treasury transfers and payouts.
  * Invalid or unsupported token types are handled consistently in treasury listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->