### PR TITLE
fix(auth): keep new Privy users signed in through signup

### DIFF
--- a/apps/web/src/app/[lang]/profile/[personSlug]/@aside/edit/page.tsx
+++ b/apps/web/src/app/[lang]/profile/[personSlug]/@aside/edit/page.tsx
@@ -70,7 +70,7 @@ export default function EditProfilePage() {
         }
       >
         <EditPersonSection
-          person={person}
+          person={person ?? undefined}
           closeUrl={`/${lang}/profile/${personSlug}`}
           isLoading={isLoading || isEditing}
           onEdit={onEdit}

--- a/apps/web/src/components/aside-notification-centre-page.tsx
+++ b/apps/web/src/components/aside-notification-centre-page.tsx
@@ -22,7 +22,7 @@ export default function AsideNotificationCentrePage() {
     error,
     configuration,
     saveConfigurations,
-  } = useNotifications({ person, isLoading });
+  } = useNotifications({ person: person ?? undefined, isLoading });
   const progress = 0;
   const isBusy = isLoading;
   return (
@@ -36,7 +36,7 @@ export default function AsideNotificationCentrePage() {
         message={<></>}
       >
         <NotificationCentreForm
-          person={person}
+          person={person ?? undefined}
           closeUrl={closeUrl}
           isLoading={isBusy}
           error={error}

--- a/packages/core/src/people/client/hooks/__tests__/read-person-from-me-response.test.ts
+++ b/packages/core/src/people/client/hooks/__tests__/read-person-from-me-response.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { readPersonFromMeResponse } from '../read-person-from-me-response';
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('readPersonFromMeResponse', () => {
+  it('returns null for 404 so new Privy users can reach signup', async () => {
+    const person = await readPersonFromMeResponse(
+      jsonResponse(404, { error: 'User not found' }),
+    );
+    expect(person).toBeNull();
+  });
+
+  it('throws on 500 so error JSON is not cached as a Person', async () => {
+    await expect(
+      readPersonFromMeResponse(
+        jsonResponse(500, { error: 'Internal Server Error' }),
+      ),
+    ).rejects.toThrow('Failed to fetch profile: 500');
+  });
+
+  it('throws on 401', async () => {
+    await expect(
+      readPersonFromMeResponse(jsonResponse(401, { error: 'Unauthorized' })),
+    ).rejects.toThrow('Failed to fetch profile: 401');
+  });
+
+  it('returns the profile JSON on 200', async () => {
+    const person = await readPersonFromMeResponse(
+      jsonResponse(200, { id: 1, slug: 'ada', name: 'Ada' }),
+    );
+    expect(person).toMatchObject({ id: 1, slug: 'ada', name: 'Ada' });
+  });
+});

--- a/packages/core/src/people/client/hooks/read-person-from-me-response.ts
+++ b/packages/core/src/people/client/hooks/read-person-from-me-response.ts
@@ -16,5 +16,6 @@ export async function readPersonFromMeResponse(
   if (!res.ok) {
     throw new Error(`Failed to fetch profile: ${res.status}`);
   }
+  // JSON dates stay ISO strings; callers already treat Person dates as optional display values.
   return (await res.json()) as Person;
 }

--- a/packages/core/src/people/client/hooks/read-person-from-me-response.ts
+++ b/packages/core/src/people/client/hooks/read-person-from-me-response.ts
@@ -1,0 +1,20 @@
+import type { Person } from '../../types';
+
+/**
+ * GET /me returns 404 when Privy auth succeeded but no `people` row exists yet.
+ * That is the new-user signup path — not a fetch failure.
+ *
+ * Other non-OK statuses must not be parsed as a Person (a 500 `{ error }` body
+ * used to be cached as a profile and wiped `slug`).
+ */
+export async function readPersonFromMeResponse(
+  res: Response,
+): Promise<Person | null> {
+  if (res.status === 404) {
+    return null;
+  }
+  if (!res.ok) {
+    throw new Error(`Failed to fetch profile: ${res.status}`);
+  }
+  return (await res.json()) as Person;
+}

--- a/packages/core/src/people/client/hooks/use-me.ts
+++ b/packages/core/src/people/client/hooks/use-me.ts
@@ -3,15 +3,18 @@
 import React from 'react';
 import useSWR from 'swr';
 import { Person, useJwt } from '@hypha-platform/core/client';
+import { readPersonFromMeResponse } from './read-person-from-me-response';
 
 export const useMe = (): {
-  person: Person | undefined;
+  /** `undefined` while loading; `null` when authenticated but no profile row (GET /me 404). */
+  person: Person | null | undefined;
   isLoading: boolean;
+  meError: Error | undefined;
   /**
    * Refetch `/me`, or set cache from a known-good `Person` (e.g. right after save)
    * without waiting for a network round-trip.
    */
-  revalidate: (next?: Person) => Promise<Person | undefined>;
+  revalidate: (next?: Person) => Promise<Person | null | undefined>;
   isMe: (personSlug: string) => boolean;
 } => {
   const { jwt, isLoadingJwt } = useJwt();
@@ -21,8 +24,9 @@ export const useMe = (): {
   const {
     data: person,
     isLoading: isLoadingPerson,
+    error: meError,
     mutate,
-  } = useSWR<Person>(
+  } = useSWR<Person | null>(
     jwt ? [endpoint, jwt] : null,
     async ([endpoint, jwt]) => {
       const res = await fetch(endpoint, {
@@ -31,12 +35,7 @@ export const useMe = (): {
           'Content-Type': 'application/json',
         },
       });
-      // A 500 body like `{ error: "..." }` must not be cached as a Person —
-      // that clears `slug` and sends the wallet into a full-page loader.
-      if (!res.ok) {
-        throw new Error(`Failed to fetch profile: ${res.status}`);
-      }
-      return (await res.json()) as Person;
+      return readPersonFromMeResponse(res);
     },
     {
       // JWT refresh changes the SWR key; keep the last good profile so the
@@ -55,7 +54,7 @@ export const useMe = (): {
   );
 
   const revalidate = React.useCallback(
-    (next?: Person): Promise<Person | undefined> => {
+    (next?: Person): Promise<Person | null | undefined> => {
       if (next) {
         return mutate(next, { revalidate: false });
       }
@@ -67,6 +66,7 @@ export const useMe = (): {
   return {
     person,
     isLoading: isLoadingJwt || isLoadingPerson,
+    meError: meError as Error | undefined,
     revalidate,
     isMe,
   };

--- a/packages/core/src/people/client/hooks/useJwt.ts
+++ b/packages/core/src/people/client/hooks/useJwt.ts
@@ -8,7 +8,16 @@ export const useJwt = () => {
     useAuthentication();
   const { data: jwt, isLoading: isLoadingJwt } = useSWR(
     !isLoading && isAuthenticated && user?.id ? [user.id, 'jwt'] : null,
-    () => getAccessToken(),
+    async () => {
+      const token = await getAccessToken();
+      // Privy can report `authenticated` before the first Bearer token exists
+      // (typical for brand-new email/Gmail signups). Caching `null` would
+      // skip `/me` until the 5-minute refresh and look like "no profile".
+      if (!token) {
+        throw new Error('Access token not ready');
+      }
+      return token;
+    },
     {
       // Privy returns a cached token and only refreshes it when it is close to
       // expiry, so there is no need to poll every second. Refreshing every few
@@ -23,5 +32,9 @@ export const useJwt = () => {
     },
   );
 
-  return { jwt, isLoadingJwt };
+  return {
+    jwt,
+    isLoadingJwt:
+      isLoading || isLoadingJwt || Boolean(isAuthenticated && user?.id && !jwt),
+  };
 };

--- a/packages/epics/src/people/components/button-profile.connected.tsx
+++ b/packages/epics/src/people/components/button-profile.connected.tsx
@@ -29,19 +29,6 @@ type ConnectedButtonProfileProps = {
   compact?: boolean;
 };
 
-type ErrorUser = {
-  error: string;
-};
-
-const isErrorUser = (obj: unknown): obj is ErrorUser => {
-  return (
-    typeof obj === 'object' &&
-    obj !== null &&
-    'error' in obj &&
-    typeof (obj as { error?: unknown }).error === 'string'
-  );
-};
-
 export const ConnectedButtonProfile = ({
   useAuthentication,
   useMe,
@@ -62,7 +49,7 @@ export const ConnectedButtonProfile = ({
     user,
     isLoading: isAuthLoading,
   } = useAuthentication();
-  const { person, isLoading: isPersonLoading } = useMe();
+  const { person, isLoading: isPersonLoading, meError } = useMe();
 
   const router = useRouter();
   const pathname = usePathname();
@@ -95,36 +82,46 @@ export const ConnectedButtonProfile = ({
     if (isAuthLoading || isPersonLoading || !isAuthenticated) {
       return;
     }
-    if (user) {
-      if (person) {
-        if (isErrorUser(person)) {
-          if (person.error !== 'Internal Server Error') {
-            router.push(localizedSignupPath);
-          }
-        } else if (
-          isLoggingIn &&
-          pathname !== newUserRedirectPath &&
-          pathname !== localizedSignupPath
-        ) {
-          if (!pathname.includes('/onboarding')) {
-            router.push(
-              resolvePostAuthRedirectPathOrDefault({
-                pathname,
-                lang: typeof lang === 'string' ? lang : undefined,
-                baseRedirectPath,
-              }),
-            );
-          }
-          setLoggingIn(false);
-        }
-      } else {
-        logout();
+    // /me 5xx (or a not-yet-ready JWT) must not log the user out or send them
+    // to signup — that is what broke brand-new Privy email/Gmail sessions.
+    if (meError) {
+      return;
+    }
+    if (!user) {
+      return;
+    }
+    if (person === null) {
+      if (
+        pathname !== newUserRedirectPath &&
+        pathname !== localizedSignupPath &&
+        !pathname.includes('/profile/signup')
+      ) {
+        router.push(localizedSignupPath);
       }
+      return;
+    }
+    if (
+      person &&
+      isLoggingIn &&
+      pathname !== newUserRedirectPath &&
+      pathname !== localizedSignupPath
+    ) {
+      if (!pathname.includes('/onboarding')) {
+        router.push(
+          resolvePostAuthRedirectPathOrDefault({
+            pathname,
+            lang: typeof lang === 'string' ? lang : undefined,
+            baseRedirectPath,
+          }),
+        );
+      }
+      setLoggingIn(false);
     }
   }, [
     isPersonLoading,
     isAuthLoading,
     isAuthenticated,
+    meError,
     person,
     user,
     router,
@@ -171,7 +168,7 @@ export const ConnectedButtonProfile = ({
   return (
     <ButtonProfile
       address={user?.wallet?.address}
-      person={person}
+      person={person ?? undefined}
       isConnected={isAuthenticated}
       onLogin={login}
       onLogout={handleLogout}

--- a/packages/epics/src/people/hooks/types.ts
+++ b/packages/epics/src/people/hooks/types.ts
@@ -6,8 +6,10 @@ import {
 } from '@hypha-platform/core/client';
 
 export type UseMeReturn = {
-  person: Person | undefined;
+  /** `undefined` while loading; `null` when authenticated but no profile (GET /me 404). */
+  person: Person | null | undefined;
   isLoading: boolean;
+  meError?: Error;
 };
 export type UseMe = () => UseMeReturn;
 


### PR DESCRIPTION
## Summary
- New Gmail/email signups complete in Privy (user created, account linked) but the Hypha UI snaps back to **Sign in**. That matches the profile header calling `logout()` after `/api/v1/people/me` returns 404 for a brand-new user who has no `people` row yet.
- Regression from #2452: `useMe` started throwing on every non-OK `/me` response so a 404 was no longer the `{ error }` object the header used to send people to `/profile/signup`. Missing profile now looks empty, and the header logs the user out. Privy then shows the session as Inactive.
- This restores the signup path without undoing the wallet flicker protection: 404 → `null` (go to signup), 5xx still throws (do not cache error JSON as a Person, do not log out). `useJwt` also retries when Privy reports authenticated before the first Bearer token exists.

## Test plan
- [ ] On production-equivalent preview: open an incognito window, click Sign in, complete Privy Gmail (or email) as a **new** user
- [ ] Confirm the Privy modal success is followed by a stay-logged-in state and redirect to `/{lang}/profile/signup` (not back to Sign in)
- [ ] Confirm an **existing** user can still sign in and land on the normal post-auth path
- [ ] Confirm a 500 from `/me` does not log the user out or send them to signup
- [ ] Confirm wallet / profile still keep the last good person across JWT refresh (the #2452 keepPreviousData behavior)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved support for authenticated users who have not yet created a profile, directing them to signup when appropriate.
  * Added clearer profile loading, missing-profile, and error states.
  * Authentication remains in a loading state until a JWT is available.

* **Bug Fixes**
  * Prevented missing authentication tokens from being cached.
  * Improved profile request error handling while allowing new users to continue to signup.
  * Prevented redirects or logout actions during temporary profile-loading and request-error states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->