### PR TITLE
fix(ui): remove solid green fill from card status pills

### DIFF
--- a/apps/web/src/hooks/use-space-documents.ts
+++ b/apps/web/src/hooks/use-space-documents.ts
@@ -64,7 +64,7 @@ export const useSpaceDocuments: UseDocuments = ({
           {
             label: 'Proposal',
             className: 'capitalize',
-            variant: 'solid',
+            variant: 'outline',
             colorVariant: 'accent',
           },
           {

--- a/packages/epics/src/governance/hooks/use-space-documents-with-statuses.ts
+++ b/packages/epics/src/governance/hooks/use-space-documents-with-statuses.ts
@@ -39,7 +39,7 @@ const getDocumentBadges = (document: Document, t: (key: string) => string) => {
     badges.push({
       label: t(labelMessageKey),
       className: 'capitalize',
-      variant: 'solid',
+      variant: 'outline',
       colorVariant: 'accent',
     });
   }

--- a/packages/epics/src/pipeline/components/deal-card.tsx
+++ b/packages/epics/src/pipeline/components/deal-card.tsx
@@ -15,10 +15,10 @@ type DealCardProps = {
 };
 
 const priorityClass: Record<string, string> = {
-  low: 'bg-neutral-4 text-neutral-11',
-  medium: 'bg-accent-3 text-accent-11',
-  high: 'bg-amber-3 text-amber-11',
-  critical: 'bg-red-3 text-red-11',
+  low: 'border-border/60 bg-transparent text-muted-foreground',
+  medium: 'border-accent-8/70 bg-transparent text-accent-11',
+  high: 'border-warning-8/70 bg-transparent text-warning-11',
+  critical: 'border-error-8/70 bg-transparent text-error-11',
 };
 
 export function DealCard({
@@ -55,7 +55,7 @@ export function DealCard({
         </span>
         <span
           className={cn(
-            'shrink-0 rounded px-1.5 py-0.5 text-[10px] uppercase',
+            'shrink-0 rounded border px-1.5 py-0.5 text-[10px] uppercase',
             priorityClass[deal.priority] ?? priorityClass.medium,
           )}
         >


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Alex Prate flagged (Discord DM, Anton approved) that small rounded green elements on the board “shouldn't have the background colour.” On spaces with a green/olive accent (ACAW and similar), those chips read as a solid wash on every card.

The chips are **not** progress bars. They are:

- **Pipeline deal cards** — priority label (top-right). Default `medium` used a filled `bg-accent-3`, so a green space accent painted every card.
- **Agreement / document cards** — proposal type badge used `variant: "solid"` + `colorVariant: "accent"` (solid `accent-9` fill). Status badges on the same cards were already outline.

## Change

Keep the labels (priority / document type still read). Drop the solid fill and use outline tokens that already exist on `Badge` / `ProposalHead` / `StatusBadge`.

- Deal priority: transparent + hairline border (`border-accent-8/70`, etc.)
- Document type badges: `solid` → `outline`

Success rate / voting progress is unchanged (still the `%` text on deal cards; voting bars already fill only for actual progress).

Out of scope: banking “Active” pills, buttons, and other non-board chrome.

## How to verify

1. Open a pipeline board (ACAW or any space with a green accent).
2. Confirm deal-card priority chips in the top-right have **no filled green background**; text `LOW` / `MEDIUM` / `HIGH` / `CRITICAL` remains.
3. Open an agreements grid in the same space and confirm type badges (Contribution, Proposal, …) are outline, not solid green.
4. Confirm cards with different priorities still distinguish by border/text color.

## Context

Discord DM from Alex Prate (Anton approved): *“correct the green elements… across the board on the application, we shouldn't have the background colour.”*
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0b20d051-f380-4610-9cc2-b7104bb40f20?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b20d051-f380-4610-9cc2-b7104bb40f20&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated Proposal and document badges to use an outlined appearance.
  * Refined deal priority badges with transparent backgrounds, priority-specific borders, and text colors.
  * Added a visible border to deal priority badges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->